### PR TITLE
Improve how custom shuffled/starting count works

### DIFF
--- a/randovania/cli/commands/new_game.py
+++ b/randovania/cli/commands/new_game.py
@@ -223,8 +223,6 @@ def create_pickup_database(game_enum: RandovaniaGame):
                 model_name="Powerful",
                 offworld_models=frozendict(),
                 progression=("Weapon",),
-                default_shuffled_count=1,
-                default_starting_count=0,
                 preferred_location_category=LocationCategory.MAJOR,
             ),
         },

--- a/randovania/game_description/pickup/migrations.py
+++ b/randovania/game_description/pickup/migrations.py
@@ -72,6 +72,29 @@ def _migrate_v6(data: dict) -> dict:
     return data
 
 
+def _migrate_v7(data: dict) -> dict:
+    for pickup in data["standard_pickups"].values():
+        default_shuffled_count = pickup.pop("default_shuffled_count")
+        default_starting_count = pickup.pop("default_starting_count")
+
+        if default_starting_count > 0:
+            case = "starting_item"
+        elif default_shuffled_count > 0:
+            case = "shuffled"
+        else:
+            case = "missing"
+
+        pickup["expected_case_for_describer"] = case
+
+        if default_shuffled_count > 0 and default_shuffled_count != len(pickup["progression"]):
+            pickup["custom_count_for_shuffled_case"] = default_shuffled_count
+
+        if default_starting_count > 1:
+            pickup["custom_count_for_starting_case"] = default_starting_count
+
+    return data
+
+
 _MIGRATIONS = [
     None,
     _migrate_v2,
@@ -79,6 +102,7 @@ _MIGRATIONS = [
     _migrate_v4,
     _migrate_v5,
     _migrate_v6,
+    _migrate_v7,
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/randovania/game_description/pickup/standard_pickup.py
+++ b/randovania/game_description/pickup/standard_pickup.py
@@ -11,6 +11,7 @@ from randovania.game_description.pickup.pickup_category import PickupCategory
 from randovania.game_description.resources.location_category import LocationCategory
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.games.game import RandovaniaGame
+from randovania.layout.base.standard_pickup_state import StandardPickupStateCase
 
 EXCLUDE_DEFAULT = {"exclude_if_default": True}
 
@@ -24,9 +25,10 @@ class StandardPickupDefinition(JsonDataclass):
     model_name: str
     offworld_models: frozendict[RandovaniaGame, str]
     progression: tuple[str, ...]
-    default_shuffled_count: int
-    default_starting_count: int
     preferred_location_category: LocationCategory
+    expected_case_for_describer: StandardPickupStateCase = dataclasses.field(default=StandardPickupStateCase.SHUFFLED)
+    custom_count_for_shuffled_case: int | None = dataclasses.field(default=None, metadata=EXCLUDE_DEFAULT)
+    custom_count_for_starting_case: int | None = dataclasses.field(default=None, metadata=EXCLUDE_DEFAULT)
     ammo: tuple[str, ...] = dataclasses.field(default_factory=tuple, metadata=EXCLUDE_DEFAULT)
     unlocks_ammo: bool = dataclasses.field(default=False, metadata=EXCLUDE_DEFAULT)
     additional_resources: frozendict[str, int] = dataclasses.field(default_factory=frozendict, metadata=EXCLUDE_DEFAULT)
@@ -61,3 +63,11 @@ class StandardPickupDefinition(JsonDataclass):
             "broad_category": self.broad_category.name,
             **super().as_json,
         }
+
+    @property
+    def count_for_shuffled_case(self) -> int:
+        return self.custom_count_for_shuffled_case or len(self.progression)
+
+    @property
+    def count_for_starting_case(self) -> int:
+        return self.custom_count_for_shuffled_case or 1

--- a/randovania/game_description/pickup/standard_pickup.py
+++ b/randovania/game_description/pickup/standard_pickup.py
@@ -44,6 +44,12 @@ class StandardPickupDefinition(JsonDataclass):
         if not self.progression and not self.ammo:
             raise ValueError(f"Standard Pickup {self.name} has no progression nor ammo.")
 
+        if self.count_for_shuffled_case < 1:
+            raise ValueError(f"Standard Pickup {self.name} count for shuffled case is less than 1.")
+
+        if self.count_for_starting_case < 1:
+            raise ValueError(f"Standard Pickup {self.name} count for starting case is less than 1.")
+
     @classmethod
     def from_json_with_categories(
         cls, name: str, game: RandovaniaGame, pickup_categories: dict[str, PickupCategory], value: dict
@@ -66,8 +72,16 @@ class StandardPickupDefinition(JsonDataclass):
 
     @property
     def count_for_shuffled_case(self) -> int:
-        return self.custom_count_for_shuffled_case or len(self.progression)
+        """How many pickups StandardPickupStateCase.SHUFFLED includes. Defaults to length of progression.
+        Can be manually set via custom_count_for_shuffled_case. Must be at least 1."""
+        if self.custom_count_for_shuffled_case is None:
+            return len(self.progression)
+        return self.custom_count_for_shuffled_case
 
     @property
     def count_for_starting_case(self) -> int:
-        return self.custom_count_for_shuffled_case or 1
+        """How many pickups StandardPickupStateCase.STARTING_ITEM includes. Defaults to 1.
+        Can be manually set via custom_count_for_starting_case. Must be at least 1."""
+        if self.custom_count_for_starting_case is None:
+            return 1
+        return self.custom_count_for_starting_case

--- a/randovania/games/am2r/layout/preset_describer.py
+++ b/randovania/games/am2r/layout/preset_describer.py
@@ -7,13 +7,12 @@ from randovania.games.am2r.layout.hint_configuration import ItemHintMode
 from randovania.layout.preset_describer import (
     GamePresetDescriber,
     fill_template_strings_from_tree,
-    handle_progressive_expected_counts,
     has_shuffled_item,
     message_for_required_mains,
 )
 
 if TYPE_CHECKING:
-    from randovania.game_description.pickup.standard_pickup import StandardPickupDefinition
+    from randovania.games.game import ProgressiveItemTuples
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
@@ -107,13 +106,7 @@ class AM2RPresetDescriber(GamePresetDescriber):
 
         return template_strings
 
-    def expected_shuffled_pickup_count(self, configuration: BaseConfiguration) -> dict[StandardPickupDefinition, int]:
-        count = super().expected_shuffled_pickup_count(configuration)
-        majors = configuration.standard_pickup_configuration
-
+    def progressive_items(self) -> ProgressiveItemTuples:
         from randovania.games.am2r.pickup_database import progressive_items
 
-        for progressive_item_name, non_progressive_items in progressive_items.tuples():
-            handle_progressive_expected_counts(count, majors, progressive_item_name, non_progressive_items)
-
-        return count
+        return progressive_items.tuples()

--- a/randovania/games/am2r/layout/preset_describer.py
+++ b/randovania/games/am2r/layout/preset_describer.py
@@ -7,7 +7,6 @@ from randovania.games.am2r.layout.hint_configuration import ItemHintMode
 from randovania.layout.preset_describer import (
     GamePresetDescriber,
     fill_template_strings_from_tree,
-    has_shuffled_item,
     message_for_required_mains,
 )
 
@@ -55,20 +54,12 @@ _AM2R_HINT_TEXT = {
 class AM2RPresetDescriber(GamePresetDescriber):
     def format_params(self, configuration: BaseConfiguration) -> dict[str, list[str]]:
         assert isinstance(configuration, AM2RConfiguration)
-        standard_pickups = configuration.standard_pickup_configuration
-
         template_strings = super().format_params(configuration)
 
         dna_hint = _AM2R_HINT_TEXT[configuration.hints.artifacts]
         ice_beam_hint = _AM2R_HINT_TEXT[configuration.hints.ice_beam]
 
         extra_message_tree = {
-            "Item Pool": [
-                {
-                    "Progressive Jump": has_shuffled_item(standard_pickups, "Progressive Jump"),
-                    "Progressive Suit": has_shuffled_item(standard_pickups, "Progressive Suit"),
-                }
-            ],
             "Game Changes": [
                 message_for_required_mains(
                     configuration.ammo_pickup_configuration,

--- a/randovania/games/am2r/pickup_database/pickup-database.json
+++ b/randovania/games/am2r/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 7,
+    "schema_version": 8,
     "pickup_categories": {
         "beam": {
             "long_name": "Beams",
@@ -99,9 +99,8 @@
             "progression": [
                 "Power Beam"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "hide_from_gui": true
         },
         "Bombs": {
@@ -117,10 +116,9 @@
             "progression": [
                 "Bombs"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 0
         },
         "Power Grip": {
             "pickup_category": "movement",
@@ -130,9 +128,8 @@
             "progression": [
                 "Power Grip"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item"
         },
         "Spider Ball": {
             "pickup_category": "morph_ball",
@@ -147,10 +144,9 @@
             "progression": [
                 "Spider Ball"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 2,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 2
         },
         "Spring Ball": {
             "pickup_category": "morph_ball",
@@ -162,10 +158,9 @@
             "progression": [
                 "Spring Ball"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 3,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 3
         },
         "Screw Attack": {
             "pickup_category": "movement",
@@ -179,10 +174,9 @@
             "progression": [
                 "Screw Attack"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 8,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 8
         },
         "Varia Suit": {
             "pickup_category": "suit",
@@ -197,10 +191,9 @@
             "progression": [
                 "Varia Suit"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 5,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 5
         },
         "Space Jump": {
             "pickup_category": "movement",
@@ -215,10 +208,9 @@
             "progression": [
                 "Space Jump"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 6,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 6
         },
         "Speed Booster": {
             "pickup_category": "movement",
@@ -232,10 +224,9 @@
             "progression": [
                 "Speed Booster"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 7,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 7
         },
         "Hi-Jump Boots": {
             "pickup_category": "movement",
@@ -250,10 +241,9 @@
             "progression": [
                 "Hi-Jump"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 4,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 4
         },
         "Progressive Jump": {
             "pickup_category": "movement",
@@ -269,9 +259,8 @@
                 "Hi-Jump",
                 "Space Jump"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Gravity Suit": {
             "pickup_category": "suit",
@@ -286,10 +275,9 @@
             "progression": [
                 "Gravity Suit"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 9,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 9
         },
         "Progressive Suit": {
             "pickup_category": "suit",
@@ -305,9 +293,8 @@
                 "Varia Suit",
                 "Gravity Suit"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Charge Beam": {
             "pickup_category": "beam",
@@ -322,10 +309,9 @@
             "progression": [
                 "Charge Beam"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 10,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 10
         },
         "Ice Beam": {
             "pickup_category": "beam",
@@ -339,10 +325,9 @@
             "progression": [
                 "Ice Beam"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 11,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 11
         },
         "Wave Beam": {
             "pickup_category": "beam",
@@ -356,10 +341,9 @@
             "progression": [
                 "Wave Beam"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 12,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 12
         },
         "Spazer Beam": {
             "pickup_category": "beam",
@@ -373,10 +357,9 @@
             "progression": [
                 "Spazer Beam"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 13,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 13
         },
         "Plasma Beam": {
             "pickup_category": "beam",
@@ -390,10 +373,9 @@
             "progression": [
                 "Plasma Beam"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 14,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 14
         },
         "Morph Ball": {
             "pickup_category": "morph_ball",
@@ -407,9 +389,8 @@
             "progression": [
                 "Morph Ball"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item"
         },
         "Missile Launcher": {
             "pickup_category": "missile",
@@ -424,9 +405,8 @@
             "progression": [
                 "Missile Launcher"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "ammo": [
                 "Missiles"
             ],
@@ -445,14 +425,13 @@
             "progression": [
                 "Super Missile Launcher"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 206,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "Super Missiles"
             ],
-            "unlocks_ammo": true
+            "unlocks_ammo": true,
+            "original_location": 206
         },
         "Power Bomb Launcher": {
             "pickup_category": "morph_ball",
@@ -467,14 +446,13 @@
             "progression": [
                 "Power Bomb Launcher"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 253,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "Power Bombs"
             ],
-            "unlocks_ammo": true
+            "unlocks_ammo": true,
+            "original_location": 253
         },
         "Energy Tank": {
             "pickup_category": "energy_tank",
@@ -489,9 +467,9 @@
             "progression": [
                 "Energy Tank"
             ],
-            "default_shuffled_count": 10,
-            "default_starting_count": 0,
-            "preferred_location_category": "minor"
+            "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 10
         }
     },
     "ammo_pickups": {
@@ -554,8 +532,8 @@
                 "Small Health Drop"
             ],
             "preferred_location_category": "minor",
-            "description": "Refills your health by a set amount.",
-            "allows_negative": true
+            "allows_negative": true,
+            "description": "Refills your health by a set amount."
         },
         "Big Health Drop": {
             "broad_category": "misc",
@@ -565,8 +543,8 @@
                 "Big Health Drop"
             ],
             "preferred_location_category": "minor",
-            "description": "Refills your health by a set amount.",
-            "allows_negative": true
+            "allows_negative": true,
+            "description": "Refills your health by a set amount."
         },
         "Missile Drop": {
             "broad_category": "misc",
@@ -576,8 +554,8 @@
                 "Missile Drop"
             ],
             "preferred_location_category": "minor",
-            "description": "Refills your Missiles by a set amount.",
-            "allows_negative": true
+            "allows_negative": true,
+            "description": "Refills your Missiles by a set amount."
         },
         "Super Missile Drop": {
             "broad_category": "misc",
@@ -587,8 +565,8 @@
                 "Super Missile Drop"
             ],
             "preferred_location_category": "minor",
-            "description": "Refills your Super Missiles by a set amount.",
-            "allows_negative": true
+            "allows_negative": true,
+            "description": "Refills your Super Missiles by a set amount."
         },
         "Power Bomb Drop": {
             "broad_category": "misc",
@@ -598,8 +576,8 @@
                 "Power Bomb Drop"
             ],
             "preferred_location_category": "minor",
-            "description": "Refills your Power Bombs by a set amount.",
-            "allows_negative": true
+            "allows_negative": true,
+            "description": "Refills your Power Bombs by a set amount."
         },
         "Speed Booster Upgrade": {
             "broad_category": "misc",
@@ -609,8 +587,8 @@
                 "Speed Booster Upgrade"
             ],
             "preferred_location_category": "minor",
-            "description": "Reduces the amount of time it takes Speed Booster to activate.\nBy default, the game needs 106 frames to initiate Speed Booster. A recommended value is 15 frames per upgrade.\nThis was only tested with positive values.",
-            "allows_negative": true
+            "allows_negative": true,
+            "description": "Reduces the amount of time it takes Speed Booster to activate.\nBy default, the game needs 106 frames to initiate Speed Booster. A recommended value is 15 frames per upgrade.\nThis was only tested with positive values."
         },
         "Flashlight": {
             "broad_category": "misc",
@@ -620,8 +598,8 @@
                 "Flashlight"
             ],
             "preferred_location_category": "minor",
-            "description": "Brightens the room when collected (or darkens with negative values).",
-            "allows_negative": true
+            "allows_negative": true,
+            "description": "Brightens the room when collected (or darkens with negative values)."
         },
         "Blindfold": {
             "broad_category": "misc",
@@ -631,8 +609,8 @@
                 "Blindfold"
             ],
             "preferred_location_category": "minor",
-            "description": "Darkens the room when collected (or brightens with negative values).",
-            "allows_negative": true
+            "allows_negative": true,
+            "description": "Darkens the room when collected (or brightens with negative values)."
         }
     },
     "default_pickups": {},

--- a/randovania/games/am2r/pickup_database/pickup-database.json
+++ b/randovania/games/am2r/pickup_database/pickup-database.json
@@ -260,7 +260,7 @@
                 "Space Jump"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled"
+            "expected_case_for_describer": "missing"
         },
         "Gravity Suit": {
             "pickup_category": "suit",
@@ -294,7 +294,7 @@
                 "Gravity Suit"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled"
+            "expected_case_for_describer": "missing"
         },
         "Charge Beam": {
             "pickup_category": "beam",

--- a/randovania/games/blank/pickup_database/pickup-database.json
+++ b/randovania/games/blank/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 7,
+    "schema_version": 8,
     "pickup_categories": {
         "gear": {
             "long_name": "Gear",
@@ -19,9 +19,8 @@
             "progression": [
                 "Weapon"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "Ammo"
             ],
@@ -35,9 +34,8 @@
             "progression": [
                 "Explosive"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Blue Key": {
             "pickup_category": "gear",
@@ -47,9 +45,8 @@
             "progression": [
                 "BlueKey"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Health": {
             "pickup_category": "gear",
@@ -59,9 +56,8 @@
             "progression": [
                 "Health"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "preferred_location_category": "minor"
+            "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled"
         }
     },
     "ammo_pickups": {

--- a/randovania/games/cave_story/layout/preset_describer.py
+++ b/randovania/games/cave_story/layout/preset_describer.py
@@ -4,16 +4,14 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from randovania.games.cave_story.layout.cs_configuration import CSConfiguration
-from randovania.games.game import RandovaniaGame
+from randovania.games.game import ProgressiveItemTuples, RandovaniaGame
 from randovania.layout.preset_describer import (
     GamePresetDescriber,
     fill_template_strings_from_tree,
-    handle_progressive_expected_counts,
     message_for_required_mains,
 )
 
 if TYPE_CHECKING:
-    from randovania.game_description.pickup.standard_pickup import StandardPickupDefinition
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
@@ -44,16 +42,10 @@ class CSPresetDescriber(GamePresetDescriber):
 
         return template_strings
 
-    def expected_shuffled_pickup_count(self, configuration: BaseConfiguration) -> dict[StandardPickupDefinition, int]:
-        count = super().expected_shuffled_pickup_count(configuration)
-        majors = configuration.standard_pickup_configuration
-
+    def progressive_items(self) -> ProgressiveItemTuples:
         from randovania.games.cave_story.pickup_database import progressive_items
 
-        for progressive_item_name, non_progressive_items in progressive_items.tuples():
-            handle_progressive_expected_counts(count, majors, progressive_item_name, non_progressive_items)
-
-        return count
+        return progressive_items.tuples()
 
 
 hash_items = {

--- a/randovania/games/cave_story/pickup_database/pickup-database.json
+++ b/randovania/games/cave_story/pickup_database/pickup-database.json
@@ -139,6 +139,7 @@
             "ammo": [
                 "missile"
             ],
+            "custom_count_for_shuffled_case": 1,
             "unlocks_ammo": true,
             "hide_from_gui": true,
             "must_be_starting": true

--- a/randovania/games/cave_story/pickup_database/pickup-database.json
+++ b/randovania/games/cave_story/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 7,
+    "schema_version": 8,
     "pickup_categories": {
         "weapon": {
             "long_name": "Weapons",
@@ -85,9 +85,8 @@
             "progression": [
                 "polarStar"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 33,
             "extra": {
                 "script": "<EVE0+00"
@@ -103,9 +102,8 @@
             "progression": [
                 "spur"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 34,
             "extra": {
                 "script": "<EVE0+02"
@@ -122,9 +120,8 @@
                 "polarStar",
                 "spur"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "extra": {
                 "script": "<EVE0002"
             }
@@ -137,9 +134,8 @@
                 "am2r": "sItemGenericCS"
             },
             "progression": [],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "ammo": [
                 "missile"
             ],
@@ -157,9 +153,8 @@
             "progression": [
                 "missiles"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "extra": {
                 "script": "<EVE0030"
             }
@@ -174,9 +169,8 @@
             "progression": [
                 "supers"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 18,
             "extra": {
                 "script": "<EVE0038"
@@ -193,9 +187,8 @@
                 "missiles",
                 "supers"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "extra": {
                 "script": "<EVE0033"
             }
@@ -210,9 +203,8 @@
             "progression": [
                 "fireball"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 10,
             "extra": {
                 "script": "<EVE0004"
@@ -228,9 +220,8 @@
             "progression": [
                 "snake"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 24,
             "extra": {
                 "script": "<EVE0005"
@@ -246,9 +237,8 @@
             "progression": [
                 "bubbler"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 38,
             "extra": {
                 "script": "<EVE0007"
@@ -264,9 +254,8 @@
             "progression": [
                 "machineGun"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 62,
             "extra": {
                 "script": "<EVE0008"
@@ -282,9 +271,8 @@
             "progression": [
                 "blade"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 67,
             "extra": {
                 "script": "<EVE0009"
@@ -300,9 +288,8 @@
             "progression": [
                 "nemesis"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 55,
             "extra": {
                 "script": "<EVE0010"
@@ -318,9 +305,8 @@
             "progression": [
                 "map"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 35,
             "extra": {
                 "script": "<EVE0052"
@@ -336,9 +322,8 @@
             "progression": [
                 "locket"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 37,
             "extra": {
                 "script": "<EVE0054"
@@ -354,9 +339,8 @@
             "progression": [
                 "arthurKey"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 39,
             "extra": {
                 "script": "<EVE0051"
@@ -372,9 +356,8 @@
             "progression": [
                 "idCard"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 2,
             "extra": {
                 "script": "<EVE0057"
@@ -390,9 +373,8 @@
             "progression": [
                 "santaKey"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 4,
             "extra": {
                 "script": "<EVE0053"
@@ -408,9 +390,8 @@
             "progression": [
                 "lipstick"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
             "original_location": 12,
             "extra": {
                 "script": "<EVE0087"
@@ -426,9 +407,8 @@
             "progression": [
                 "Juice"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 9,
             "extra": {
                 "script": "<EVE0058"
@@ -444,9 +424,8 @@
             "progression": [
                 "charcoal"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 11,
             "extra": {
                 "script": "<EVE0062"
@@ -462,9 +441,8 @@
             "progression": [
                 "rustyKey"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 7,
             "extra": {
                 "script": "<EVE0059"
@@ -480,9 +458,8 @@
             "progression": [
                 "gumKey"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 8,
             "extra": {
                 "script": "<EVE0060"
@@ -498,9 +475,8 @@
             "progression": [
                 "gumBase"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 16,
             "extra": {
                 "script": "<EVE0061"
@@ -516,9 +492,8 @@
             "progression": [
                 "bomb"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 13,
             "extra": {
                 "script": "<EVE0063"
@@ -534,9 +509,8 @@
             "progression": [
                 "panties"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
             "original_location": 64,
             "extra": {
                 "script": "<EVE0085"
@@ -552,9 +526,8 @@
             "progression": [
                 "puppies"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 63,
             "extra": {
                 "script": "<EVE0064"
@@ -570,9 +543,8 @@
             "progression": [
                 "puppies"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 60,
             "extra": {
                 "script": "<EVE0064"
@@ -588,9 +560,8 @@
             "progression": [
                 "puppies"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 59,
             "extra": {
                 "script": "<EVE0064"
@@ -606,9 +577,8 @@
             "progression": [
                 "puppies"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 61,
             "extra": {
                 "script": "<EVE0064"
@@ -624,9 +594,8 @@
             "progression": [
                 "puppies"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 66,
             "extra": {
                 "script": "<EVE0064"
@@ -642,9 +611,8 @@
             "progression": [
                 "lifePot"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
             "original_location": 65,
             "extra": {
                 "script": "<EVE0065"
@@ -660,9 +628,8 @@
             "progression": [
                 "turbocharge"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
             "original_location": 23,
             "extra": {
                 "script": "<EVE0070"
@@ -678,9 +645,8 @@
             "progression": [
                 "clinicKey"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 26,
             "extra": {
                 "script": "<EVE0067"
@@ -696,9 +662,8 @@
             "progression": [
                 "armsBarrier"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
             "original_location": 27,
             "extra": {
                 "script": "<EVE0069"
@@ -714,9 +679,8 @@
             "progression": [
                 "cureAll"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 28,
             "extra": {
                 "script": "<EVE0066"
@@ -732,9 +696,8 @@
             "progression": [
                 "booster1"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 17,
             "extra": {
                 "script": "<EVE0+04"
@@ -750,9 +713,8 @@
             "progression": [
                 "booster2"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 43,
             "extra": {
                 "script": "<EVE0073"
@@ -769,9 +731,8 @@
                 "booster1",
                 "booster2"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "extra": {
                 "script": "<EVE0068"
             }
@@ -786,9 +747,8 @@
             "progression": [
                 "towRope"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 19,
             "extra": {
                 "script": "<EVE0080"
@@ -804,9 +764,8 @@
             "progression": [
                 "airTank"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 20,
             "extra": {
                 "script": "<EVE0071"
@@ -822,9 +781,8 @@
             "progression": [
                 "alienMedal"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
             "original_location": 21,
             "extra": {
                 "script": "<EVE0086"
@@ -840,9 +798,8 @@
             "progression": [
                 "whimStar"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
             "original_location": 25,
             "extra": {
                 "script": "<EVE0088"
@@ -858,9 +815,8 @@
             "progression": [
                 "nikumaru"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
             "original_location": 56,
             "extra": {
                 "script": "<EVE0072"
@@ -876,9 +832,8 @@
             "progression": [
                 "teleportKey"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 44,
             "extra": {
                 "script": "<EVE0075"
@@ -894,9 +849,8 @@
             "progression": [
                 "letter"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 51,
             "extra": {
                 "script": "<EVE0076"
@@ -912,9 +866,8 @@
             "progression": [
                 "mask"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 52,
             "extra": {
                 "script": "<EVE0074"
@@ -930,9 +883,8 @@
             "progression": [
                 "brokenSprinkler"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 46,
             "extra": {
                 "script": "<EVE0078"
@@ -942,15 +894,14 @@
             "pickup_category": "items",
             "broad_category": "items",
             "model_name": "",
-            "offworld_models":{
+            "offworld_models": {
                 "am2r": "sItemGenericCS"
             },
             "progression": [
                 "newSprinkler"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 50,
             "extra": {
                 "script": "<EVE0079"
@@ -966,9 +917,8 @@
             "progression": [
                 "controller"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 49,
             "extra": {
                 "script": "<EVE0077"
@@ -984,9 +934,8 @@
             "progression": [
                 "mushBadge"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 41,
             "extra": {
                 "script": "<EVE0083"
@@ -1002,9 +951,8 @@
             "progression": [
                 "maPignon"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 42,
             "extra": {
                 "script": "<EVE0084"
@@ -1020,9 +968,8 @@
             "progression": [
                 "mrLittle"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 40,
             "extra": {
                 "script": "<EVE0082"
@@ -1038,9 +985,8 @@
             "progression": [
                 "ironBond"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 45,
             "extra": {
                 "script": "<EVE0089"
@@ -1056,9 +1002,8 @@
             "progression": [
                 "clayMedal"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
             "original_location": 29,
             "extra": {
                 "script": "<EVE0081"
@@ -1074,9 +1019,9 @@
             "progression": [
                 "lifeCapsule"
             ],
-            "default_shuffled_count": 3,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 3,
             "ammo": [
                 "lifeCapsule"
             ],
@@ -1094,9 +1039,9 @@
             "progression": [
                 "lifeCapsule"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 2,
             "ammo": [
                 "lifeCapsule"
             ],
@@ -1114,9 +1059,9 @@
             "progression": [
                 "lifeCapsule"
             ],
-            "default_shuffled_count": 7,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 7,
             "ammo": [
                 "lifeCapsule"
             ],

--- a/randovania/games/dread/layout/preset_describer.py
+++ b/randovania/games/dread/layout/preset_describer.py
@@ -9,15 +9,12 @@ from randovania.games.dread.layout.dread_configuration import (
 from randovania.layout.preset_describer import (
     GamePresetDescriber,
     fill_template_strings_from_tree,
-    handle_progressive_expected_counts,
     has_shuffled_item,
     message_for_required_mains,
 )
 
 if TYPE_CHECKING:
-    from randovania.game_description.pickup.standard_pickup import (
-        StandardPickupDefinition,
-    )
+    from randovania.games.game import ProgressiveItemTuples
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
@@ -126,13 +123,7 @@ class DreadPresetDescriber(GamePresetDescriber):
 
         return template_strings
 
-    def expected_shuffled_pickup_count(self, configuration: BaseConfiguration) -> dict[StandardPickupDefinition, int]:
-        count = super().expected_shuffled_pickup_count(configuration)
-        majors = configuration.standard_pickup_configuration
-
+    def progressive_items(self) -> ProgressiveItemTuples:
         from randovania.games.dread.pickup_database import progressive_items
 
-        for progressive_item_name, non_progressive_items in progressive_items.tuples():
-            handle_progressive_expected_counts(count, majors, progressive_item_name, non_progressive_items)
-
-        return count
+        return progressive_items.tuples()

--- a/randovania/games/dread/layout/preset_describer.py
+++ b/randovania/games/dread/layout/preset_describer.py
@@ -9,7 +9,6 @@ from randovania.games.dread.layout.dread_configuration import (
 from randovania.layout.preset_describer import (
     GamePresetDescriber,
     fill_template_strings_from_tree,
-    has_shuffled_item,
     message_for_required_mains,
 )
 
@@ -61,7 +60,6 @@ class DreadPresetDescriber(GamePresetDescriber):
     def format_params(self, configuration: BaseConfiguration) -> dict[str, list[str]]:
         assert isinstance(configuration, DreadConfiguration)
 
-        standard_pickups = configuration.standard_pickup_configuration
         template_strings = super().format_params(configuration)
 
         extra_message_tree = {
@@ -75,16 +73,6 @@ class DreadPresetDescriber(GamePresetDescriber):
                     "Immediate Energy Part": configuration.immediate_energy_parts,
                 },
                 {f"{configuration.energy_per_tank} energy per Energy Tank": configuration.energy_per_tank != 100},
-            ],
-            "Item Pool": [
-                {
-                    "Progressive Beam": has_shuffled_item(standard_pickups, "Progressive Beam"),
-                    "Progressive Charge Beam": has_shuffled_item(standard_pickups, "Progressive Charge Beam"),
-                    "Progressive Missile": has_shuffled_item(standard_pickups, "Progressive Missile"),
-                    "Progressive Bomb": has_shuffled_item(standard_pickups, "Progressive Bomb"),
-                    "Progressive Suit": has_shuffled_item(standard_pickups, "Progressive Suit"),
-                    "Progressive Spin": has_shuffled_item(standard_pickups, "Progressive Spin"),
-                }
             ],
             "Gameplay": [
                 {

--- a/randovania/games/dread/pickup_database/pickup-database.json
+++ b/randovania/games/dread/pickup_database/pickup-database.json
@@ -103,7 +103,7 @@
                 "Wide"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "missing",
+            "expected_case_for_describer": "shuffled",
             "original_location": 57
         },
         "Plasma Beam": {
@@ -118,7 +118,7 @@
                 "Plasma"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "missing",
+            "expected_case_for_describer": "shuffled",
             "original_location": 115
         },
         "Wave Beam": {
@@ -133,7 +133,7 @@
                 "Wave"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "missing",
+            "expected_case_for_describer": "shuffled",
             "original_location": 143
         },
         "Progressive Beam": {
@@ -150,7 +150,7 @@
                 "Wave"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled"
+            "expected_case_for_describer": "missing"
         },
         "Charge Beam": {
             "pickup_category": "beam",
@@ -282,7 +282,7 @@
                 "Ice"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled"
+            "expected_case_for_describer": "missing"
         },
         "Storm Missile": {
             "pickup_category": "missile",
@@ -359,7 +359,7 @@
                 "Varia"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled",
+            "expected_case_for_describer": "missing",
             "original_location": 23
         },
         "Gravity Suit": {
@@ -375,7 +375,7 @@
                 "Gravity"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled",
+            "expected_case_for_describer": "missing",
             "original_location": 79,
             "description": "Gravity Suit automatically gives you Varia Suit.\nIt's recommended to use Progressive Suit instead."
         },
@@ -423,7 +423,7 @@
                 "Bomb"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled",
+            "expected_case_for_describer": "missing",
             "original_location": 58
         },
         "Cross Bomb": {
@@ -439,7 +439,7 @@
                 "Cross"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled",
+            "expected_case_for_describer": "missing",
             "original_location": 145
         },
         "Progressive Bomb": {

--- a/randovania/games/dread/pickup_database/pickup-database.json
+++ b/randovania/games/dread/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 7,
+    "schema_version": 8,
     "pickup_categories": {
         "beam": {
             "long_name": "Beams",
@@ -102,9 +102,8 @@
             "progression": [
                 "Wide"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 57
         },
         "Plasma Beam": {
@@ -118,9 +117,8 @@
             "progression": [
                 "Plasma"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 115
         },
         "Wave Beam": {
@@ -134,9 +132,8 @@
             "progression": [
                 "Wave"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 143
         },
         "Progressive Beam": {
@@ -152,9 +149,8 @@
                 "Plasma",
                 "Wave"
             ],
-            "default_shuffled_count": 3,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Charge Beam": {
             "pickup_category": "beam",
@@ -168,9 +164,8 @@
             "progression": [
                 "Charge"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 0
         },
         "Diffusion Beam": {
@@ -185,9 +180,8 @@
             "progression": [
                 "Diffusion"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 35
         },
         "Progressive Charge Beam": {
@@ -203,9 +197,8 @@
                 "Charge",
                 "Diffusion"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Grapple Beam": {
             "pickup_category": "beam",
@@ -219,9 +212,8 @@
             "progression": [
                 "Grapple"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 25
         },
         "Missiles": {
@@ -236,9 +228,8 @@
             "progression": [
                 "MissileLauncher"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "ammo": [
                 "MissileAmmo"
             ],
@@ -257,9 +248,8 @@
             "progression": [
                 "Supers"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 100
         },
         "Ice Missile": {
@@ -274,9 +264,8 @@
             "progression": [
                 "Ice"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 146
         },
         "Progressive Missile": {
@@ -292,9 +281,8 @@
                 "Supers",
                 "Ice"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Storm Missile": {
             "pickup_category": "missile",
@@ -308,9 +296,8 @@
             "progression": [
                 "Storm"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 142
         },
         "Phantom Cloak": {
@@ -323,9 +310,8 @@
             "progression": [
                 "Cloak"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 138
         },
         "Flash Shift": {
@@ -338,14 +324,13 @@
             "progression": [
                 "Flash"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
-            "original_location": 78,
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "FlashUpgrade"
             ],
-            "unlocks_ammo": true
+            "unlocks_ammo": true,
+            "original_location": 78
         },
         "Pulse Radar": {
             "pickup_category": "aeion",
@@ -357,9 +342,8 @@
             "progression": [
                 "Pulse"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 110
         },
         "Varia Suit": {
@@ -374,9 +358,8 @@
             "progression": [
                 "Varia"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 23
         },
         "Gravity Suit": {
@@ -391,9 +374,8 @@
             "progression": [
                 "Gravity"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 79,
             "description": "Gravity Suit automatically gives you Varia Suit.\nIt's recommended to use Progressive Suit instead."
         },
@@ -410,9 +392,8 @@
                 "Varia",
                 "Gravity"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Morph Ball": {
             "pickup_category": "morph_ball",
@@ -425,9 +406,8 @@
             "progression": [
                 "Morph"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 144
         },
         "Bomb": {
@@ -442,9 +422,8 @@
             "progression": [
                 "Bomb"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 58
         },
         "Cross Bomb": {
@@ -459,9 +438,8 @@
             "progression": [
                 "Cross"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 145
         },
         "Progressive Bomb": {
@@ -477,9 +455,8 @@
                 "Bomb",
                 "Cross"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Power Bomb": {
             "pickup_category": "morph_ball",
@@ -493,14 +470,13 @@
             "progression": [
                 "MainPB"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
-            "original_location": 137,
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "PBAmmo"
             ],
-            "unlocks_ammo": true
+            "unlocks_ammo": true,
+            "original_location": 137
         },
         "Slide": {
             "pickup_category": "misc",
@@ -510,9 +486,8 @@
             "progression": [
                 "Slide"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "hide_from_gui": true
         },
         "Spider Magnet": {
@@ -527,9 +502,8 @@
             "progression": [
                 "Magnet"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 139
         },
         "Speed Booster": {
@@ -544,9 +518,8 @@
             "progression": [
                 "Speed"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 147
         },
         "Spin Boost": {
@@ -561,9 +534,8 @@
             "progression": [
                 "Spin"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 104
         },
         "Space Jump": {
@@ -578,9 +550,8 @@
             "progression": [
                 "Space"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 119
         },
         "Progressive Spin": {
@@ -596,9 +567,8 @@
                 "Spin",
                 "Space"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Screw Attack": {
             "pickup_category": "misc",
@@ -611,9 +581,8 @@
             "progression": [
                 "Screw"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 27
         },
         "Energy Tank": {
@@ -628,9 +597,9 @@
             "progression": [
                 "ETank"
             ],
-            "default_shuffled_count": 8,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 8
         },
         "Energy Part": {
             "pickup_category": "energy_tank",
@@ -644,9 +613,9 @@
             "progression": [
                 "EFragment"
             ],
-            "default_shuffled_count": 16,
-            "default_starting_count": 0,
-            "preferred_location_category": "minor"
+            "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 16
         },
         "Speed Booster Upgrade": {
             "pickup_category": "misc",
@@ -658,9 +627,8 @@
             "progression": [
                 "SpeedBoostUpgrade"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "minor",
+            "expected_case_for_describer": "missing",
             "description": "Speed Booster Upgrades reduce the amount of time it takes Speed Booster to activate by 0.25 seconds (for each upgrade collected).\nThe minimum charge time is 0.25s."
         }
     },

--- a/randovania/games/prime1/pickup_database/pickup-database.json
+++ b/randovania/games/prime1/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 7,
+    "schema_version": 8,
     "pickup_categories": {
         "visor": {
             "long_name": "Visors",
@@ -111,9 +111,8 @@
             "progression": [
                 "Charge"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 23
         },
         "Power Beam": {
@@ -126,9 +125,8 @@
             "progression": [
                 "Power"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item"
         },
         "Wave Beam": {
             "pickup_category": "beam",
@@ -140,9 +138,8 @@
             "progression": [
                 "Wave"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 41
         },
         "Ice Beam": {
@@ -155,9 +152,8 @@
             "progression": [
                 "Ice"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 34
         },
         "Plasma Beam": {
@@ -170,9 +166,8 @@
             "progression": [
                 "Plasma"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 98
         },
         "Missile Launcher": {
@@ -187,9 +182,8 @@
             "progression": [
                 "MissileLauncher"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "Missile"
             ],
@@ -208,9 +202,8 @@
             "progression": [
                 "Grapple"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 75
         },
         "Combat Visor": {
@@ -223,9 +216,8 @@
             "progression": [
                 "Combat"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item"
         },
         "Scan Visor": {
             "pickup_category": "visor",
@@ -238,9 +230,8 @@
             "progression": [
                 "Scan"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item"
         },
         "Thermal Visor": {
             "pickup_category": "visor",
@@ -252,9 +243,8 @@
             "progression": [
                 "Thermal"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 50
         },
         "X-Ray Visor": {
@@ -267,9 +257,8 @@
             "progression": [
                 "X-Ray"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 71
         },
         "Space Jump Boots": {
@@ -284,9 +273,8 @@
             "progression": [
                 "SpaceJump"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 59
         },
         "Energy Tank": {
@@ -301,9 +289,9 @@
             "progression": [
                 "EnergyTank"
             ],
-            "default_shuffled_count": 14,
-            "default_starting_count": 0,
-            "preferred_location_category": "minor"
+            "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 14
         },
         "Morph Ball": {
             "pickup_category": "morph_ball",
@@ -316,9 +304,8 @@
             "progression": [
                 "MorphBall"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 5
         },
         "Morph Ball Bomb": {
@@ -333,9 +320,8 @@
             "progression": [
                 "Bombs"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 28
         },
         "Boost Ball": {
@@ -350,9 +336,8 @@
             "progression": [
                 "Boost"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 43
         },
         "Spider Ball": {
@@ -367,9 +352,8 @@
             "progression": [
                 "Spider"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 44
         },
         "Power Bomb": {
@@ -384,9 +368,8 @@
             "progression": [
                 "MainPB"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "PowerBomb"
             ],
@@ -401,9 +384,8 @@
             "progression": [
                 "PowerSuit"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "hide_from_gui": true,
             "must_be_starting": true
         },
@@ -419,9 +401,8 @@
             "progression": [
                 "VariaSuit"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 20
         },
         "Gravity Suit": {
@@ -436,9 +417,8 @@
             "progression": [
                 "GravitySuit"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 54
         },
         "Phazon Suit": {
@@ -453,9 +433,8 @@
             "progression": [
                 "PhazonSuit"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 83
         },
         "Super Missile": {
@@ -470,9 +449,8 @@
             "progression": [
                 "Supers"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 47
         },
         "Wavebuster": {
@@ -485,9 +463,8 @@
             "progression": [
                 "Wavebuster"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 13
         },
         "Ice Spreader": {
@@ -500,9 +477,8 @@
             "progression": [
                 "IceSpreader"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 95
         },
         "Flamethrower": {
@@ -515,9 +491,8 @@
             "progression": [
                 "Flamethrower"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 76
         }
     },

--- a/randovania/games/prime2/layout/preset_describer.py
+++ b/randovania/games/prime2/layout/preset_describer.py
@@ -11,15 +11,12 @@ from randovania.games.prime2.layout.echoes_configuration import (
 from randovania.layout.preset_describer import (
     GamePresetDescriber,
     fill_template_strings_from_tree,
-    handle_progressive_expected_counts,
     has_shuffled_item,
     message_for_required_mains,
 )
 
 if TYPE_CHECKING:
-    from randovania.game_description.pickup.standard_pickup import (
-        StandardPickupDefinition,
-    )
+    from randovania.games.game import ProgressiveItemTuples
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
@@ -178,13 +175,7 @@ class EchoesPresetDescriber(GamePresetDescriber):
 
         return template_strings
 
-    def expected_shuffled_pickup_count(self, configuration: BaseConfiguration) -> dict[StandardPickupDefinition, int]:
-        count = super().expected_shuffled_pickup_count(configuration)
-        majors = configuration.standard_pickup_configuration
-
+    def progressive_items(self) -> ProgressiveItemTuples:
         from randovania.games.prime2.pickup_database import progressive_items
 
-        for progressive_item_name, non_progressive_items in progressive_items.tuples():
-            handle_progressive_expected_counts(count, majors, progressive_item_name, non_progressive_items)
-
-        return count
+        return progressive_items.tuples()

--- a/randovania/games/prime2/layout/preset_describer.py
+++ b/randovania/games/prime2/layout/preset_describer.py
@@ -11,7 +11,6 @@ from randovania.games.prime2.layout.echoes_configuration import (
 from randovania.layout.preset_describer import (
     GamePresetDescriber,
     fill_template_strings_from_tree,
-    has_shuffled_item,
     message_for_required_mains,
 )
 
@@ -97,7 +96,6 @@ def create_beam_configuration_description(
 class EchoesPresetDescriber(GamePresetDescriber):
     def format_params(self, configuration: BaseConfiguration) -> dict[str, list[str]]:
         assert isinstance(configuration, EchoesConfiguration)
-        standard_pickups = configuration.standard_pickup_configuration
         pickup_database = default_database.pickup_database_for_game(configuration.game)
 
         template_strings = super().format_params(configuration)
@@ -127,8 +125,6 @@ class EchoesPresetDescriber(GamePresetDescriber):
         extra_message_tree = {
             "Item Pool": [
                 {
-                    "Progressive Suit": has_shuffled_item(standard_pickups, "Progressive Suit"),
-                    "Progressive Grapple": has_shuffled_item(standard_pickups, "Progressive Grapple"),
                     "Split beam ammo": unified_ammo.pickup_count == 0,
                 }
             ],

--- a/randovania/games/prime2/pickup_database/pickup-database.json
+++ b/randovania/games/prime2/pickup_database/pickup-database.json
@@ -594,7 +594,7 @@
                 "ScrewAttack"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled",
+            "expected_case_for_describer": "missing",
             "additional_resources": {
                 "Percent": 1
             },

--- a/randovania/games/prime2/pickup_database/pickup-database.json
+++ b/randovania/games/prime2/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 7,
+    "schema_version": 8,
     "pickup_categories": {
         "visor": {
             "long_name": "Visors",
@@ -126,9 +126,8 @@
             "progression": [
                 "Combat"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "Percent": 1
             }
@@ -144,9 +143,8 @@
             "progression": [
                 "Scan"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "Percent": 1
             }
@@ -161,9 +159,8 @@
             "progression": [
                 "DarkVisor"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -179,9 +176,8 @@
             "progression": [
                 "Echo"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -199,9 +195,8 @@
             "progression": [
                 "Varia"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "Percent": 1
             },
@@ -220,9 +215,8 @@
             "progression": [
                 "DarkSuit"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "additional_resources": {
                 "Percent": 1
             },
@@ -240,9 +234,8 @@
             "progression": [
                 "LightSuit"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "additional_resources": {
                 "Percent": 1
             },
@@ -262,9 +255,8 @@
                 "DarkSuit",
                 "LightSuit"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             }
@@ -277,9 +269,8 @@
             "progression": [
                 "DoubleDamage"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "additional_resources": {
                 "Percent": 1
             },
@@ -296,9 +287,8 @@
             "progression": [
                 "Power"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "Percent": 1
             },
@@ -316,9 +306,8 @@
             "progression": [
                 "Charge"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "Percent": 1
             }
@@ -333,9 +322,8 @@
             "progression": [
                 "Dark"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "DarkAmmo"
             ],
@@ -354,9 +342,8 @@
             "progression": [
                 "Light"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "LightAmmo"
             ],
@@ -375,9 +362,8 @@
             "progression": [
                 "Annihilator"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "DarkAmmo",
                 "LightAmmo"
@@ -395,9 +381,8 @@
             "progression": [
                 "UnlimitedBeamAmmo"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "additional_resources": {
                 "Percent": 1
             },
@@ -415,9 +400,8 @@
             "progression": [
                 "MorphBall"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "Percent": 1
             },
@@ -435,9 +419,8 @@
             "progression": [
                 "Bombs"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -455,9 +438,8 @@
             "progression": [
                 "Boost"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -475,9 +457,8 @@
             "progression": [
                 "Spider"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -493,9 +474,9 @@
                 "dread": "powerup_powerbomb"
             },
             "progression": [],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 1,
             "ammo": [
                 "PowerBomb"
             ],
@@ -518,9 +499,8 @@
             "progression": [
                 "CannonBall"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "additional_resources": {
                 "Percent": 1
             },
@@ -538,9 +518,8 @@
             "progression": [
                 "SpaceJump"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -557,9 +536,8 @@
             "progression": [
                 "Gravity"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -577,9 +555,8 @@
             "progression": [
                 "Grapple"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -596,9 +573,8 @@
             "progression": [
                 "ScrewAttack"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -617,9 +593,8 @@
                 "Grapple",
                 "ScrewAttack"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -637,9 +612,8 @@
             "progression": [
                 "MissileLauncher"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "Missile"
             ],
@@ -660,9 +634,8 @@
             "progression": [
                 "Seekers"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "Missile"
             ],
@@ -679,9 +652,8 @@
             "progression": [
                 "UnlimitedMissiles"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "additional_resources": {
                 "Percent": 1
             },
@@ -699,9 +671,8 @@
             "progression": [
                 "Supers"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -715,9 +686,8 @@
             "progression": [
                 "Sunburst"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -733,9 +703,8 @@
             "progression": [
                 "Darkburst"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -751,9 +720,8 @@
             "progression": [
                 "SonicBoom"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -769,9 +737,8 @@
             "progression": [
                 "Violet"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -787,9 +754,8 @@
             "progression": [
                 "Amber"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -805,9 +771,8 @@
             "progression": [
                 "Emerald"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -823,9 +788,8 @@
             "progression": [
                 "Cobalt"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "Percent": 1
             },
@@ -843,9 +807,9 @@
             "progression": [
                 "EnergyTank"
             ],
-            "default_shuffled_count": 14,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 14,
             "additional_resources": {
                 "Percent": 1
             },

--- a/randovania/games/prime3/layout/preset_describer.py
+++ b/randovania/games/prime3/layout/preset_describer.py
@@ -7,13 +7,12 @@ from randovania.layout.preset_describer import (
     ConditionalMessageTree,
     GamePresetDescriber,
     fill_template_strings_from_tree,
-    handle_progressive_expected_counts,
     has_shuffled_item,
     message_for_required_mains,
 )
 
 if TYPE_CHECKING:
-    from randovania.game_description.pickup.standard_pickup import StandardPickupDefinition
+    from randovania.games.game import ProgressiveItemTuples
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
@@ -48,13 +47,7 @@ class CorruptionPresetDescriber(GamePresetDescriber):
 
         return template_strings
 
-    def expected_shuffled_pickup_count(self, configuration: BaseConfiguration) -> dict[StandardPickupDefinition, int]:
-        count = super().expected_shuffled_pickup_count(configuration)
-        majors = configuration.standard_pickup_configuration
-
+    def progressive_items(self) -> ProgressiveItemTuples:
         from randovania.games.prime3.pickup_database import progressive_items
 
-        for progressive_item_name, non_progressive_items in progressive_items.tuples():
-            handle_progressive_expected_counts(count, majors, progressive_item_name, non_progressive_items)
-
-        return count
+        return progressive_items.tuples()

--- a/randovania/games/prime3/pickup_database/pickup-database.json
+++ b/randovania/games/prime3/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 7,
+    "schema_version": 8,
     "pickup_categories": {
         "visor": {
             "long_name": "Visors",
@@ -115,9 +115,8 @@
             "progression": [
                 "ChargeUpgrade"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "ItemPercentage": 1
             }
@@ -130,9 +129,8 @@
             "progression": [
                 "PowerBeam"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -147,9 +145,8 @@
             "progression": [
                 "PlasmaBeam"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -163,9 +160,8 @@
             "progression": [
                 "NovaBeam"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -180,9 +176,8 @@
                 "PlasmaBeam",
                 "NovaBeam"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             }
@@ -193,9 +188,9 @@
             "model_name": "Missile Launcher",
             "offworld_models": {},
             "progression": [],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 1,
             "ammo": [
                 "Missile"
             ],
@@ -213,9 +208,8 @@
             "progression": [
                 "IceMissile"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -229,9 +223,8 @@
             "progression": [
                 "Seekers"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -246,9 +239,8 @@
                 "IceMissile",
                 "Seekers"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             }
@@ -261,9 +253,8 @@
             "progression": [
                 "GrappleBeamPull"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -277,9 +268,8 @@
             "progression": [
                 "GrappleBeamSwing"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -293,9 +283,8 @@
             "progression": [
                 "GrappleBeamVoltage"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -309,9 +298,8 @@
             "progression": [
                 "CombatVisor"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -326,9 +314,8 @@
             "progression": [
                 "ScanVisor"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -343,9 +330,8 @@
             "progression": [
                 "CommandVisor"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             }
@@ -358,9 +344,8 @@
             "progression": [
                 "XRayVisor"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -374,9 +359,8 @@
             "progression": [
                 "DoubleJump"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             }
@@ -389,9 +373,8 @@
             "progression": [
                 "ScrewAttack"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -405,9 +388,8 @@
             "progression": [
                 "SuitType"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -421,9 +403,9 @@
             "progression": [
                 "EnergyTank"
             ],
-            "default_shuffled_count": 14,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 14,
             "additional_resources": {
                 "ItemPercentage": 1
             }
@@ -436,9 +418,8 @@
             "progression": [
                 "MorphBall"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "ItemPercentage": 1
             }
@@ -451,9 +432,8 @@
             "progression": [
                 "Bomb"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "additional_resources": {
                 "ItemPercentage": 1
             }
@@ -466,9 +446,8 @@
             "progression": [
                 "BoostBall"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -482,9 +461,8 @@
             "progression": [
                 "SpiderBall"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -498,9 +476,8 @@
             "progression": [
                 "HyperModeTank"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -514,9 +491,8 @@
             "progression": [
                 "HyperModeMissile"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -530,9 +506,8 @@
             "progression": [
                 "HyperModeBall"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -546,9 +521,8 @@
             "progression": [
                 "HyperModeGrapple"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -562,9 +536,8 @@
             "progression": [
                 "ShipGrapple"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "additional_resources": {
                 "ItemPercentage": 1
             },
@@ -576,9 +549,9 @@
             "model_name": "Ship Missile",
             "offworld_models": {},
             "progression": [],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 1,
             "ammo": [
                 "ShipMissile"
             ],

--- a/randovania/games/samus_returns/layout/preset_describer.py
+++ b/randovania/games/samus_returns/layout/preset_describer.py
@@ -7,15 +7,12 @@ from randovania.games.samus_returns.layout.msr_configuration import MSRArtifactC
 from randovania.layout.preset_describer import (
     GamePresetDescriber,
     fill_template_strings_from_tree,
-    handle_progressive_expected_counts,
     has_shuffled_item,
     message_for_required_mains,
 )
 
 if TYPE_CHECKING:
-    from randovania.game_description.pickup.standard_pickup import (
-        StandardPickupDefinition,
-    )
+    from randovania.games.game import ProgressiveItemTuples
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
@@ -137,13 +134,7 @@ class MSRPresetDescriber(GamePresetDescriber):
 
         return template_strings
 
-    def expected_shuffled_pickup_count(self, configuration: BaseConfiguration) -> dict[StandardPickupDefinition, int]:
-        count = super().expected_shuffled_pickup_count(configuration)
-        majors = configuration.standard_pickup_configuration
-
+    def progressive_items(self) -> ProgressiveItemTuples:
         from randovania.games.samus_returns.pickup_database import progressive_items
 
-        for progressive_item_name, non_progressive_items in progressive_items.tuples():
-            handle_progressive_expected_counts(count, majors, progressive_item_name, non_progressive_items)
-
-        return count
+        return progressive_items.tuples()

--- a/randovania/games/samus_returns/layout/preset_describer.py
+++ b/randovania/games/samus_returns/layout/preset_describer.py
@@ -87,11 +87,6 @@ class MSRPresetDescriber(GamePresetDescriber):
             ],
             "Item Pool": [
                 {
-                    "Progressive Beam": has_shuffled_item(standard_pickups, "Progressive Beam"),
-                    "Progressive Jump": has_shuffled_item(standard_pickups, "Progressive Jump"),
-                    "Progressive Suit": has_shuffled_item(standard_pickups, "Progressive Suit"),
-                },
-                {
                     "Energy Reserve Tank": has_shuffled_item(standard_pickups, "Energy Reserve Tank"),
                     "Aeion Reserve Tank": has_shuffled_item(standard_pickups, "Aeion Reserve Tank"),
                     "Missile Reserve Tank": has_shuffled_item(standard_pickups, "Missile Reserve Tank"),

--- a/randovania/games/samus_returns/pickup_database/pickup-database.json
+++ b/randovania/games/samus_returns/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 7,
+    "schema_version": 8,
     "pickup_categories": {
         "beam": {
             "long_name": "Beams",
@@ -117,9 +117,8 @@
             "progression": [
                 "Wave"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 46
         },
         "Spazer Beam": {
@@ -132,11 +131,10 @@
             "progression": [
                 "Spazer"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
-            "description": "Spazer Beam automatically gives you Wave Beam.\nIt's recommended to use Progressive Beam instead.",
-            "original_location": 84
+            "expected_case_for_describer": "missing",
+            "original_location": 84,
+            "description": "Spazer Beam automatically gives you Wave Beam.\nIt's recommended to use Progressive Beam instead."
         },
         "Plasma Beam": {
             "pickup_category": "beam",
@@ -148,9 +146,8 @@
             "progression": [
                 "Plasma"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 125,
             "description": "Plasma Beam automatically gives you both Wave and Spazer Beam.\nIt's recommended to use Progressive Beam instead."
         },
@@ -166,9 +163,8 @@
                 "Spazer",
                 "Plasma"
             ],
-            "default_shuffled_count": 3,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Charge Beam": {
             "pickup_category": "beam",
@@ -180,9 +176,8 @@
             "progression": [
                 "Charge"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 11
         },
         "Ice Beam": {
@@ -195,9 +190,8 @@
             "progression": [
                 "Ice"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 27
         },
         "Grapple Beam": {
@@ -208,9 +202,8 @@
             "progression": [
                 "Grapple"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 60
         },
         "Missile Launcher": {
@@ -223,9 +216,8 @@
             "progression": [
                 "MissileLauncher"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 1,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "starting_item",
             "ammo": [
                 "MissileAmmo"
             ],
@@ -241,9 +233,8 @@
             "progression": [
                 "Supers"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "SMAmmo"
             ],
@@ -258,9 +249,8 @@
             "progression": [
                 "Pulse"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "Aeion"
             ],
@@ -275,9 +265,8 @@
             "progression": [
                 "Armor"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "Aeion"
             ],
@@ -292,9 +281,8 @@
             "progression": [
                 "Burst"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "Aeion"
             ],
@@ -309,9 +297,8 @@
             "progression": [
                 "Phase"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "Aeion"
             ],
@@ -328,9 +315,8 @@
             "progression": [
                 "Varia"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 45
         },
         "Gravity Suit": {
@@ -343,11 +329,10 @@
             "progression": [
                 "Gravity"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
-            "description": "Gravity Suit automatically gives you Varia Suit.\nIt's recommended to use Progressive Suit instead.",
-            "original_location": 124
+            "expected_case_for_describer": "missing",
+            "original_location": 124,
+            "description": "Gravity Suit automatically gives you Varia Suit.\nIt's recommended to use Progressive Suit instead."
         },
         "Progressive Suit": {
             "pickup_category": "suit",
@@ -360,9 +345,8 @@
                 "Varia",
                 "Gravity"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Morph Ball": {
             "pickup_category": "morph_ball",
@@ -374,9 +358,8 @@
             "progression": [
                 "Morph"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 12
         },
         "Spider Ball": {
@@ -389,9 +372,8 @@
             "progression": [
                 "Spider"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 28
         },
         "Bomb": {
@@ -404,9 +386,8 @@
             "progression": [
                 "Bomb"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 26
         },
         "Spring Ball": {
@@ -419,9 +400,8 @@
             "progression": [
                 "Spring"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 37
         },
         "Power Bomb Launcher": {
@@ -434,9 +414,8 @@
             "progression": [
                 "MainPB"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "PBAmmo"
             ],
@@ -453,9 +432,8 @@
             "progression": [
                 "Boots"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 44
         },
         "Space Jump": {
@@ -468,9 +446,8 @@
             "progression": [
                 "Space"
             ],
-            "default_shuffled_count": 0,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "missing",
             "original_location": 99
         },
         "Progressive Jump": {
@@ -484,9 +461,8 @@
                 "Boots",
                 "Space"
             ],
-            "default_shuffled_count": 2,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled"
         },
         "Screw Attack": {
             "pickup_category": "misc",
@@ -498,9 +474,8 @@
             "progression": [
                 "Screw"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 117
         },
         "Baby Metroid": {
@@ -511,9 +486,8 @@
             "progression": [
                 "Baby"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_location": 171
         },
         "Energy Tank": {
@@ -526,9 +500,9 @@
             "progression": [
                 "ETank"
             ],
-            "default_shuffled_count": 10,
-            "default_starting_count": 0,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 10
         },
         "Energy Reserve Tank": {
             "pickup_category": "reserve_tank",
@@ -538,9 +512,8 @@
             "progression": [
                 "ERTank"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "preferred_location_category": "minor"
+            "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled"
         },
         "Aeion Reserve Tank": {
             "pickup_category": "reserve_tank",
@@ -550,9 +523,8 @@
             "progression": [
                 "ARTank"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "preferred_location_category": "minor"
+            "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled"
         },
         "Missile Reserve Tank": {
             "pickup_category": "reserve_tank",
@@ -562,9 +534,8 @@
             "progression": [
                 "MRTank"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "preferred_location_category": "minor"
+            "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled"
         }
     },
     "ammo_pickups": {

--- a/randovania/games/super_metroid/pickup_database/pickup-database.json
+++ b/randovania/games/super_metroid/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 7,
+    "schema_version": 8,
     "pickup_categories": {
         "beam": {
             "long_name": "Beams",
@@ -103,10 +103,9 @@
             "progression": [
                 "Charge"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 23,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 23
         },
         "Ice Beam": {
             "pickup_category": "beam",
@@ -119,10 +118,9 @@
             "progression": [
                 "Ice"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 50,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 50
         },
         "Wave Beam": {
             "pickup_category": "beam",
@@ -135,10 +133,9 @@
             "progression": [
                 "Wave"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 68,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 68
         },
         "Spazer Beam": {
             "pickup_category": "beam",
@@ -151,10 +148,9 @@
             "progression": [
                 "Spazer"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 42,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 42
         },
         "Plasma Beam": {
             "pickup_category": "beam",
@@ -167,10 +163,9 @@
             "progression": [
                 "Plasma"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 143,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 143
         },
         "Missile Launcher": {
             "pickup_category": "missile",
@@ -183,9 +178,9 @@
                 "dread": "powerup_icemissile"
             },
             "progression": [],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 1,
             "ammo": [
                 "Missile"
             ],
@@ -202,9 +197,9 @@
                 "dread": "powerup_supermissile"
             },
             "progression": [],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 1,
             "ammo": [
                 "Supers"
             ],
@@ -221,9 +216,9 @@
                 "dread": "powerup_powerbomb"
             },
             "progression": [],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 1,
             "ammo": [
                 "PowerBomb"
             ],
@@ -241,10 +236,9 @@
             "progression": [
                 "Grapple"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 60,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 60
         },
         "X-Ray Scope": {
             "pickup_category": "visor",
@@ -257,10 +251,9 @@
             "progression": [
                 "X-Ray"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 38,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 38
         },
         "Varia Suit": {
             "pickup_category": "suit",
@@ -275,10 +268,9 @@
             "progression": [
                 "Varia"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 48,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 48
         },
         "Gravity Suit": {
             "pickup_category": "suit",
@@ -293,10 +285,9 @@
             "progression": [
                 "Gravity"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 135,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 135
         },
         "Morph Ball": {
             "pickup_category": "morph_ball",
@@ -310,10 +301,9 @@
             "progression": [
                 "Morph"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 26,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 26
         },
         "Morph Ball Bomb": {
             "pickup_category": "morph_ball",
@@ -328,10 +318,9 @@
             "progression": [
                 "Bombs"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 7,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 7
         },
         "Spring Ball": {
             "pickup_category": "morph_ball",
@@ -344,10 +333,9 @@
             "progression": [
                 "SpringBall"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 150,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 150
         },
         "Screw Attack": {
             "pickup_category": "movement",
@@ -361,10 +349,9 @@
             "progression": [
                 "ScrewAttack"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 79,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 79
         },
         "Hi-Jump Boots": {
             "pickup_category": "movement",
@@ -379,10 +366,9 @@
             "progression": [
                 "HiJump"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 53,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 53
         },
         "Space Jump": {
             "pickup_category": "movement",
@@ -397,10 +383,9 @@
             "progression": [
                 "SpaceJump"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 154,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 154
         },
         "Speed Booster": {
             "pickup_category": "movement",
@@ -415,10 +400,9 @@
             "progression": [
                 "SpeedBooster"
             ],
-            "default_shuffled_count": 1,
-            "default_starting_count": 0,
-            "original_location": 66,
-            "preferred_location_category": "major"
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "original_location": 66
         },
         "Energy Tank": {
             "pickup_category": "energy_tank",
@@ -433,9 +417,9 @@
             "progression": [
                 "ETank"
             ],
-            "default_shuffled_count": 14,
-            "default_starting_count": 0,
-            "preferred_location_category": "minor"
+            "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 14
         },
         "Reserve Tank": {
             "pickup_category": "energy_tank",
@@ -450,9 +434,9 @@
             "progression": [
                 "Reserves"
             ],
-            "default_shuffled_count": 4,
-            "default_starting_count": 0,
-            "preferred_location_category": "minor"
+            "preferred_location_category": "minor",
+            "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 4
         }
     },
     "ammo_pickups": {

--- a/test/games/dread/layout/test_dread_describer.py
+++ b/test/games/dread/layout/test_dread_describer.py
@@ -53,7 +53,7 @@ def test_dread_format_params(has_artifacts: bool, rb_damage_mode: DreadRavenBeak
         "Item Pool": [
             "Size: 148 of 149" if has_artifacts else "Size: 145 of 149",
             "Starts with Pulse Radar",
-            "Progressive Charge Beam, Progressive Bomb, Progressive Suit, Progressive Spin",
+            "Progressive Charge Beam, Progressive Suit, Progressive Bomb, Progressive Spin",
         ],
         "Logic Settings": ["All tricks disabled"],
     }

--- a/test/games/prime2/layout/test_echoes_preset_describer.py
+++ b/test/games/prime2/layout/test_echoes_preset_describer.py
@@ -88,7 +88,14 @@ def test_echoes_format_params2(default_echoes_configuration):
             randomization_mode=RandomizationMode.MAJOR_MINOR_SPLIT,
         ),
         standard_pickup_configuration=dataclasses.replace(
-            std_pick.replace_states({std_pick.get_pickup_with_name("Scan Visor"): StandardPickupState()}),
+            std_pick.replace_states(
+                {
+                    std_pick.get_pickup_with_name("Scan Visor"): StandardPickupState(),
+                    std_pick.get_pickup_with_name("Dark Suit"): StandardPickupState(num_shuffled_pickups=1),
+                    std_pick.get_pickup_with_name("Light Suit"): StandardPickupState(num_shuffled_pickups=1),
+                    std_pick.get_pickup_with_name("Progressive Suit"): StandardPickupState(),
+                }
+            ),
             minimum_random_starting_pickups=1,
             maximum_random_starting_pickups=2,
         ),
@@ -128,7 +135,7 @@ def test_echoes_format_params2(default_echoes_configuration):
             "Minor: 61/61",
             "1 to 2 random starting items",
             "Excludes Scan Visor",
-            "Progressive Suit, Split beam ammo",
+            "Split beam ammo",
             "Sky Temple Keys at all bosses",
         ],
     }

--- a/test/games/prime2/layout/test_echoes_preset_describer.py
+++ b/test/games/prime2/layout/test_echoes_preset_describer.py
@@ -72,7 +72,8 @@ def test_echoes_format_params(default_echoes_configuration):
         "Item Pool": [
             "Size: 118 of 119",
             "Vanilla starting items",
-            "Progressive Suit, Split beam ammo",
+            "Progressive Suit",
+            "Split beam ammo",
             "Sky Temple Keys at all bosses",
         ],
     }

--- a/test/games/samus_returns/layout/test_msr_describer.py
+++ b/test/games/samus_returns/layout/test_msr_describer.py
@@ -57,7 +57,7 @@ def test_msr_format_params(artifacts):
         "Item Pool": [
             f"Size: {174+artifacts.required_artifacts} of 211",
             "Starts with Scan Pulse",
-            "Progressive Beam, Progressive Jump, Progressive Suit",
+            "Progressive Beam, Progressive Suit, Progressive Jump",
             "Energy Reserve Tank, Aeion Reserve Tank, Missile Reserve Tank",
         ],
         "Gameplay": ["Starts at Surface - East - Landing Site"],

--- a/test/generator/pickup_pool/test_pickup_creator.py
+++ b/test/generator/pickup_pool/test_pickup_creator.py
@@ -41,8 +41,6 @@ def test_create_pickup_for(echoes_resource_database, generic_pickup_category):
         model_name="SuperModel",
         offworld_models=frozendict({}),
         progression=("DarkVisor", "MorphBall", "Bombs"),
-        default_starting_count=0,
-        default_shuffled_count=1,
         ammo=("EnergyTank", "DarkAmmo"),
         must_be_starting=False,
         original_location=None,

--- a/test/gui/dialog/test_item_configuration_popup.py
+++ b/test/gui/dialog/test_item_configuration_popup.py
@@ -37,6 +37,7 @@ def test_state_change_to_starting(skip_qtbot, echoes_pickup_database, echoes_res
     set_combo_with_value(popup.state_case_combo, StandardPickupStateCase.STARTING_ITEM)
 
     # Assert
+    assert popup.case == StandardPickupStateCase.STARTING_ITEM
     assert popup.state == StandardPickupState(
         include_copy_in_original_location=False,
         num_shuffled_pickups=0,

--- a/test/layout/test_standard_pickup_state.py
+++ b/test/layout/test_standard_pickup_state.py
@@ -61,8 +61,6 @@ def standard_pickup_state(request, echoes_pickup_database, generic_pickup_catego
         model_name="Model Name",
         offworld_models=frozendict(),
         progression=(request.param.get("progression", "Power"),),
-        default_starting_count=0,
-        default_shuffled_count=1,
         ammo=request.param.get("ammo_index", ()),
         must_be_starting=True,
         original_location=None,


### PR DESCRIPTION
Fixes setting a pickup as starting effectively setting it as excluded.

I think the way this works now finally makes sense.