### PR TITLE
MSR - Rebalance hints to accommodate new seal

### DIFF
--- a/randovania/games/samus_returns/exporter/patch_data_factory.py
+++ b/randovania/games/samus_returns/exporter/patch_data_factory.py
@@ -254,11 +254,12 @@ class MSRPatchDataFactory(PatchDataFactory):
             ("s020_area2", "LE_RandoDNA", 4, 9),
             ("s033_area3b", "LE_RandoDNA", 9, 15),
             ("s050_area5", "LE_RandoDNA", 15, 19),
-            ("s065_area6b", "LE_RandoDNA", 19, 25),
-            ("s070_area7", "LE_RandoDNA_001", 25, 28),
-            ("s070_area7", "LE_RandoDNA_002", 28, 31),
-            ("s090_area9", "LE_RandoDNA", 31, 34),
-            ("s100_area10", "LE_RandoDNA", 34, 39),
+            ("s065_area6b", "LE_RandoDNA", 19, 24),
+            ("s070_area7", "LE_RandoDNA_001", 24, 27),
+            ("s070_area7", "LE_RandoDNA_002", 27, 30),
+            ("s090_area9", "LE_RandoDNA", 30, 33),
+            ("s100_area10", "LE_RandoDNA", 33, 38),
+            ("s110_surfaceb", "LE_RandoDNA", 38, 39),
         ]
 
         for scenario, actor, start, end in actor_to_amount_map:

--- a/test/test_files/patcher_data/samus_returns/start_inventory.json
+++ b/test/test_files/patcher_data/samus_returns/start_inventory.json
@@ -4032,10 +4032,10 @@
     },
     "text_patches": {
         "GUI_MSG_NEW_GAME_CONFIRMATION_FUSION": "Words Hash ($$$$$)",
+        "GUI_MSG_NEW_GAME_CONFIRMATION_HARD": "Words Hash ($$$$$)",
         "GUI_MSG_NEW_GAME_CONFIRMATION_NORMAL": "Words Hash ($$$$$)",
         "GUI_MSG_NEW_FILE_CREATION": "Words Hash ($$$$$)",
         "GUI_MSG_NEW_GAME_CONFIRMATION": "Words Hash ($$$$$)",
-        "GUI_MSG_NEW_GAME_CONFIRMATION_HARD": "Words Hash ($$$$$)",
         "GUI_SAMUS_DATA_TITLE": "<version>",
         "GUI_CUTSCENE_OPENING_1": "Welcome to the Metroid: Samus Returns Randomizer!|Here are some useful tips to help you on your journey.",
         "GUI_CUTSCENE_OPENING_2": "All of the hazardous liquid has been drained. You can thus freely explore the planet.|Metroids now also drop items.",
@@ -4207,6 +4207,13 @@
                 "actor": "LE_RandoDNA"
             },
             "text": "Metroid DNA is located in Area 3 - Metroid Caverns - Gamma Arena South.\n"
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s110_surfaceb",
+                "actor": "LE_RandoDNA"
+            },
+            "text": "The Chozo have Sealed this hint away.\n"
         }
     ],
     "cosmetic_patches": {

--- a/test/test_files/patcher_data/samus_returns/starter_preset.json
+++ b/test/test_files/patcher_data/samus_returns/starter_preset.json
@@ -4044,10 +4044,10 @@
     },
     "text_patches": {
         "GUI_MSG_NEW_GAME_CONFIRMATION_FUSION": "Words Hash ($$$$$)",
+        "GUI_MSG_NEW_GAME_CONFIRMATION_HARD": "Words Hash ($$$$$)",
         "GUI_MSG_NEW_GAME_CONFIRMATION_NORMAL": "Words Hash ($$$$$)",
         "GUI_MSG_NEW_FILE_CREATION": "Words Hash ($$$$$)",
         "GUI_MSG_NEW_GAME_CONFIRMATION": "Words Hash ($$$$$)",
-        "GUI_MSG_NEW_GAME_CONFIRMATION_HARD": "Words Hash ($$$$$)",
         "GUI_SAMUS_DATA_TITLE": "<version>",
         "GUI_CUTSCENE_OPENING_1": "Welcome to the Metroid: Samus Returns Randomizer!|Here are some useful tips to help you on your journey.",
         "GUI_CUTSCENE_OPENING_2": "All of the hazardous liquid has been drained. You can thus freely explore the planet.|Metroids now also drop items.",
@@ -4217,11 +4217,18 @@
                 "scenario": "s090_area9",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 3 - Factory Exterior - Gamma Arena.\nMetroid DNA is located in Area 2 - Dam Interior - Gamma Arena.\n"
+            "text": "Metroid DNA is located in Area 3 - Factory Exterior - Gamma Arena.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s100_area10",
+                "actor": "LE_RandoDNA"
+            },
+            "text": "Metroid DNA is located in Area 2 - Dam Interior - Gamma Arena.\n"
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s110_surfaceb",
                 "actor": "LE_RandoDNA"
             },
             "text": "See you next mission!\n"


### PR DESCRIPTION
The custom seal in Surface - West now functions properly, so adding it into the DNA mix. This brings the total hint seals to 20: 10 Item, 10 DNA.

I made it hint 1 DNA since it can be accessed early on with the Baby. So now the DNA amounts are the following:

Surface (East/West): 1
Area 1: 4
Area 2: 5
Area 3: 6
Area 4: 4
Area 5: 5 (from 6)
Area 6: 3, 3
Area 7: 3
Area 8: 5

Alternatively, I can remove one from Area 4 and put it back on Area 5.

Merge after OSRR is updated.