### PR TITLE
Add Metroid Goal to Fusion

### DIFF
--- a/randovania/games/fusion/generator/bootstrap.py
+++ b/randovania/games/fusion/generator/bootstrap.py
@@ -21,9 +21,9 @@ def all_metroid_locations(game: GameDescription, config: FusionArtifactConfig) -
     locations = []
     for node in game.region_list.all_nodes:
         if isinstance(node, PickupNode):
-            name = node.pickup_index
+            index = node.pickup_index.index
             # Pickups guarded by bosses
-            if config.prefer_bosses and str(name) in _boss_items:
+            if config.prefer_bosses and index in _boss_indices:
                 locations.append(node)
 
     return locations
@@ -56,16 +56,4 @@ class FusionBootstrap(MetroidBootstrap):
         return super().assign_pool_results(rng, patches, pool_results)
 
 
-_boss_items = [
-    "PickupIndex 100",
-    "PickupIndex 106",
-    "PickupIndex 114",
-    "PickupIndex 104",
-    "PickupIndex 115",
-    "PickupIndex 107",
-    "PickupIndex 110",
-    "PickupIndex 102",
-    "PickupIndex 109",
-    "PickupIndex 108",
-    "PickupIndex 111",
-]
+_boss_indices = [100, 106, 114, 104, 115, 107, 110, 102, 109, 108, 111]

--- a/randovania/games/fusion/generator/bootstrap.py
+++ b/randovania/games/fusion/generator/bootstrap.py
@@ -1,8 +1,71 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from randovania.game_description.db.pickup_node import PickupNode
+from randovania.games.fusion.generator.pool_creator import INFANT_METROID_CATEGORY
+from randovania.games.fusion.layout import FusionConfiguration
+from randovania.layout.exceptions import InvalidConfiguration
 from randovania.resolver.bootstrap import MetroidBootstrap
+
+if TYPE_CHECKING:
+    from random import Random
+
+    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_patches import GamePatches
+    from randovania.games.fusion.layout.fusion_configuration import FusionArtifactConfig
+    from randovania.generator.pickup_pool import PoolResults
+
+
+def all_metroid_locations(game: GameDescription, config: FusionArtifactConfig):
+    locations = []
+    for node in game.region_list.all_nodes:
+        if isinstance(node, PickupNode):
+            name = node.pickup_index
+            # Pickups guarded by bosses
+            if config.prefer_bosses and str(name) in _boss_items:
+                locations.append(node)
+
+    return locations
 
 
 class FusionBootstrap(MetroidBootstrap):
-    pass
-    # TODO
+    def assign_pool_results(self, rng: Random, patches: GamePatches, pool_results: PoolResults) -> GamePatches:
+        assert isinstance(patches.configuration, FusionConfiguration)
+        config = patches.configuration.artifacts
+
+        if config.prefer_anywhere:
+            return super().assign_pool_results(rng, patches, pool_results)
+
+        locations = all_metroid_locations(patches.game, config)
+        rng.shuffle(locations)
+
+        metroid_to_assign = [
+            pickup for pickup in list(pool_results.to_place) if pickup.pickup_category is INFANT_METROID_CATEGORY
+        ]
+
+        if len(metroid_to_assign) > len(locations):
+            raise InvalidConfiguration(
+                f"Has {len(metroid_to_assign)} Infant Metroids in the pool, but only {len(locations)} valid locations."
+            )
+
+        for metroid, location in zip(metroid_to_assign, locations, strict=False):
+            pool_results.to_place.remove(metroid)
+            pool_results.assignment[location.pickup_index] = metroid
+
+        return super().assign_pool_results(rng, patches, pool_results)
+
+
+_boss_items = [
+    "PickupIndex 100",
+    "PickupIndex 106",
+    "PickupIndex 114",
+    "PickupIndex 104",
+    "PickupIndex 115",
+    "PickupIndex 107",
+    "PickupIndex 110",
+    "PickupIndex 102",
+    "PickupIndex 109",
+    "PickupIndex 108",
+    "PickupIndex 111",
+]

--- a/randovania/games/fusion/generator/bootstrap.py
+++ b/randovania/games/fusion/generator/bootstrap.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from randovania.generator.pickup_pool import PoolResults
 
 
-def all_metroid_locations(game: GameDescription, config: FusionArtifactConfig):
+def all_metroid_locations(game: GameDescription, config: FusionArtifactConfig) -> list[PickupNode]:
     locations = []
     for node in game.region_list.all_nodes:
         if isinstance(node, PickupNode):

--- a/randovania/games/fusion/generator/pool_creator.py
+++ b/randovania/games/fusion/generator/pool_creator.py
@@ -2,14 +2,62 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from randovania.games.fusion.layout.fusion_configuration import FusionConfiguration
+from randovania.game_description.pickup import pickup_category
+from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
+from randovania.game_description.resources.location_category import LocationCategory
+from randovania.games.fusion.layout.fusion_configuration import FusionArtifactConfig, FusionConfiguration
+from randovania.generator.pickup_pool import PoolResults
+from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
     from randovania.game_description.game_description import GameDescription
-    from randovania.generator.pickup_pool import PoolResults
+    from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.layout.base.base_configuration import BaseConfiguration
+
+INFANT_METROID_CATEGORY = pickup_category.PickupCategory(
+    name="InfantMetroid",
+    long_name="Infant Metroid",
+    hint_details=("some ", "Infant Metroid"),
+    hinted_as_major=False,
+    is_key=True,
+)
+
+
+def create_fusion_artifact(
+    artifact_number: int,
+    resource_database: ResourceDatabase,
+) -> PickupEntry:
+    return PickupEntry(
+        name=f"Infant Metroid {artifact_number + 1}",
+        progression=((resource_database.get_item(f"Infant Metroid {artifact_number + 1}"), 1),),
+        model=PickupModel(game=resource_database.game_enum, name="InfantMetroid"),
+        pickup_category=INFANT_METROID_CATEGORY,
+        broad_category=pickup_category.GENERIC_KEY_CATEGORY,
+        generator_params=PickupGeneratorParams(
+            preferred_location_category=LocationCategory.MAJOR,
+            probability_offset=0.25,
+        ),
+    )
 
 
 def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
     assert isinstance(configuration, FusionConfiguration)
-    # TODO
+
+    results.extend_with(artifact_pool(game, configuration.artifacts))
+
+
+def artifact_pool(game: GameDescription, config: FusionArtifactConfig) -> PoolResults:
+    # Check whether we have valid artifact requirements in configuration
+    max_artifacts = 0
+    if config.prefer_anywhere:
+        max_artifacts = 20
+    elif config.prefer_bosses:
+        max_artifacts = 11
+    if config.required_artifacts > max_artifacts:
+        raise InvalidConfiguration("More Infant Metroids than allowed!")
+
+    keys: list[PickupEntry] = [create_fusion_artifact(i, game.resource_database) for i in range(20)]
+    keys_to_shuffle = keys[: config.required_artifacts]
+    starting_keys = keys[config.required_artifacts :]
+
+    return PoolResults(keys_to_shuffle, {}, starting_keys)

--- a/randovania/games/fusion/gui/preset_settings/__init__.py
+++ b/randovania/games/fusion/gui/preset_settings/__init__.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 
 def preset_tabs(editor: PresetEditor, window_manager: WindowManager) -> list[type[PresetTab]]:
+    from randovania.games.fusion.gui.preset_settings.fusion_goal_tab import PresetFusionGoal
     from randovania.games.fusion.gui.preset_settings.fusion_patches_tab import PresetFusionPatches
     from randovania.gui.preset_settings.generation_tab import PresetGeneration
     from randovania.gui.preset_settings.location_pool_tab import PresetLocationPool
@@ -21,6 +22,7 @@ def preset_tabs(editor: PresetEditor, window_manager: WindowManager) -> list[typ
     return [
         PresetTrickLevel,
         PresetGeneration,
+        PresetFusionGoal,
         PresetLocationPool,
         MetroidPresetItemPool,
         PresetPatcherEnergy,

--- a/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
+++ b/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
@@ -38,11 +38,11 @@ class PresetFusionGoal(PresetTab, Ui_PresetFusionGoal):
     def uses_patches_tab(cls) -> bool:
         return False
 
-    def _update_slider_max(self):
+    def _update_slider_max(self) -> None:
         self.metroid_slider.setMaximum(self.num_preferred_locations)
         self.metroid_slider.setEnabled(self.num_preferred_locations > 0)
 
-    def _edit_config(self, call: Callable[[FusionArtifactConfig], FusionArtifactConfig]):
+    def _edit_config(self, call: Callable[[FusionArtifactConfig], FusionArtifactConfig]) -> None:
         config = self._editor.configuration
         assert isinstance(config, FusionConfiguration)
 
@@ -79,22 +79,22 @@ class PresetFusionGoal(PresetTab, Ui_PresetFusionGoal):
         self._edit_config(edit)
         self._update_slider_max()
 
-    def _on_prefer_bosses(self, value: bool):
-        def edit(config: FusionArtifactConfig):
+    def _on_prefer_bosses(self, value: bool) -> None:
+        def edit(config: FusionArtifactConfig) -> FusionArtifactConfig:
             return dataclasses.replace(config, prefer_bosses=value)
 
         self._edit_config(edit)
         self._update_slider_max()
 
-    def _on_metroid_slider_changed(self):
+    def _on_metroid_slider_changed(self) -> None:
         self.metroid_slider_label.setText(f"{self.metroid_slider.value()} Infant Metroids")
 
-        def edit(config: FusionArtifactConfig):
+        def edit(config: FusionArtifactConfig) -> FusionArtifactConfig:
             return dataclasses.replace(config, required_artifacts=self.metroid_slider.value())
 
         self._edit_config(edit)
 
-    def on_preset_changed(self, preset: Preset):
+    def on_preset_changed(self, preset: Preset) -> None:
         assert isinstance(preset.configuration, FusionConfiguration)
         artifacts = preset.configuration.artifacts
         self.free_placement_radiobutton.setChecked(artifacts.prefer_anywhere)

--- a/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
+++ b/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from PySide6 import QtCore
+
+from randovania.games.fusion.layout.fusion_configuration import FusionArtifactConfig, FusionConfiguration
+from randovania.gui.generated.preset_fusion_goal_ui import Ui_PresetFusionGoal
+from randovania.gui.lib import signal_handling
+from randovania.gui.preset_settings.preset_tab import PresetTab
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from randovania.game_description.game_description import GameDescription
+    from randovania.gui.lib.window_manager import WindowManager
+    from randovania.interface_common.preset_editor import PresetEditor
+    from randovania.layout.preset import Preset
+
+
+class PresetFusionGoal(PresetTab, Ui_PresetFusionGoal):
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
+        self.setupUi(self)
+
+        self.goal_layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
+        self.restrict_placement_radiobutton.toggled.connect(self._on_restrict_placement)
+        self.free_placement_radiobutton.toggled.connect(self._on_free_placement)
+        signal_handling.on_checked(self.prefer_bosses_check, self._on_prefer_bosses)
+        self.metroid_slider.valueChanged.connect(self._on_metroid_slider_changed)
+
+    @classmethod
+    def tab_title(cls) -> str:
+        return "Goal"
+
+    @classmethod
+    def uses_patches_tab(cls) -> bool:
+        return False
+
+    def _update_slider_max(self):
+        self.metroid_slider.setMaximum(self.num_preferred_locations)
+        self.metroid_slider.setEnabled(self.num_preferred_locations > 0)
+
+    def _edit_config(self, call: Callable[[FusionArtifactConfig], FusionArtifactConfig]):
+        config = self._editor.configuration
+        assert isinstance(config, FusionConfiguration)
+
+        with self._editor as editor:
+            editor.set_configuration_field("artifacts", call(config.artifacts))
+
+    @property
+    def num_preferred_locations(self) -> int:
+        if self.free_placement_radiobutton.isChecked():
+            return 20
+        if self.prefer_bosses_check.isChecked():
+            return 11
+        return 0
+
+    def _on_restrict_placement(self, value: bool) -> None:
+        if not value:
+            return
+        self.prefer_bosses_check.setEnabled(True)
+
+        def edit(config: FusionArtifactConfig) -> FusionArtifactConfig:
+            return dataclasses.replace(config, prefer_anywhere=False)
+
+        self._edit_config(edit)
+        self._update_slider_max()
+
+    def _on_free_placement(self, value: bool) -> None:
+        if not value:
+            return
+        self.prefer_bosses_check.setEnabled(False)
+
+        def edit(config: FusionArtifactConfig) -> FusionArtifactConfig:
+            return dataclasses.replace(config, prefer_anywhere=True)
+
+        self._edit_config(edit)
+        self._update_slider_max()
+
+    def _on_prefer_bosses(self, value: bool):
+        def edit(config: FusionArtifactConfig):
+            return dataclasses.replace(config, prefer_bosses=value)
+
+        self._edit_config(edit)
+        self._update_slider_max()
+
+    def _on_metroid_slider_changed(self):
+        self.metroid_slider_label.setText(f"{self.metroid_slider.value()} Infant Metroids")
+
+        def edit(config: FusionArtifactConfig):
+            return dataclasses.replace(config, required_artifacts=self.metroid_slider.value())
+
+        self._edit_config(edit)
+
+    def on_preset_changed(self, preset: Preset):
+        assert isinstance(preset.configuration, FusionConfiguration)
+        artifacts = preset.configuration.artifacts
+        self.free_placement_radiobutton.setChecked(artifacts.prefer_anywhere)
+        self.restrict_placement_radiobutton.setChecked(not artifacts.prefer_anywhere)
+        self.prefer_bosses_check.setChecked(artifacts.prefer_bosses)
+        self.metroid_slider.setValue(artifacts.required_artifacts)

--- a/randovania/games/fusion/layout/fusion_configuration.py
+++ b/randovania/games/fusion/layout/fusion_configuration.py
@@ -2,8 +2,17 @@ from __future__ import annotations
 
 import dataclasses
 
+from randovania.bitpacking.bitpacking import BitPackDataclass
+from randovania.bitpacking.json_dataclass import JsonDataclass
 from randovania.games.game import RandovaniaGame
 from randovania.layout.base.base_configuration import BaseConfiguration
+
+
+@dataclasses.dataclass(frozen=True)
+class FusionArtifactConfig(BitPackDataclass, JsonDataclass):
+    prefer_bosses: bool
+    prefer_anywhere: bool
+    required_artifacts: int = dataclasses.field(metadata={"min": 0, "max": 20, "precision": 1})
 
 
 # TODO
@@ -12,6 +21,7 @@ class FusionConfiguration(BaseConfiguration):
     # These fields aren't necessary for a new game: they're here to have example/test features
     include_extra_pickups: bool
     energy_per_tank: int = dataclasses.field(metadata={"min": 1, "max": 1000, "precision": 1})
+    artifacts: FusionArtifactConfig
 
     @classmethod
     def game_enum(cls) -> RandovaniaGame:

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -1693,13 +1693,78 @@
                             }
                         },
                         "Before Operations Room": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Climb High Jump Wall"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "SpeedBooster",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "ShinesparkTrick",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLockRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "EntranceRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "L0Locks",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
                                         "type": "template",
-                                        "data": "Can Climb High Jump Wall"
+                                        "data": "All Infants Collected"
                                     }
                                 ]
                             }

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -304,7 +304,11 @@ Extra - room_id: [13, 74, 85]
   > Door to Operations Deck Recharge Room
       Trivial
   > Before Operations Room
-      Can Climb High Jump Wall
+      All of the following:
+          All Infants Collected
+          Any of the following:
+              Can Climb High Jump Wall
+              Level 0 Locks and Speed Booster and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Door to Operations Room; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -815,6 +815,10 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Freeze Enemies"
                                                 }
                                             ]
                                         }

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -143,7 +143,7 @@ Extra - room_id: [3]
       Any of the following:
           Wall Jump (Beginner) or Can Climb High Jump Wall
           Speed Booster and Shinespark Tricks (Beginner)
-          After Level 2 Locks Released and Stand On Frozen Enemies (Beginner)
+          After Level 2 Locks Released and Stand On Frozen Enemies (Beginner) and Can Freeze Enemies
   > Door to Entrance Hub
       Speed Booster
   > Door to Level 2 Security Room

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -205,6 +205,146 @@
                 "extra": {
                     "item": "Level4"
                 }
+            },
+            "Infant Metroid 1": {
+                "long_name": "Infant Metroid 1",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 2": {
+                "long_name": "Infant Metroid 2",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 3": {
+                "long_name": "Infant Metroid 3",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 4": {
+                "long_name": "Infant Metroid 4",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 5": {
+                "long_name": "Infant Metroid 5",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 6": {
+                "long_name": "Infant Metroid 6",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 7": {
+                "long_name": "Infant Metroid 7",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 8": {
+                "long_name": "Infant Metroid 8",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 9": {
+                "long_name": "Infant Metroid 9",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 10": {
+                "long_name": "Infant Metroid 10",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 11": {
+                "long_name": "Infant Metroid 11",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 12": {
+                "long_name": "Infant Metroid 12",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 13": {
+                "long_name": "Infant Metroid 13",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 14": {
+                "long_name": "Infant Metroid 14",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 15": {
+                "long_name": "Infant Metroid 15",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 16": {
+                "long_name": "Infant Metroid 16",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 17": {
+                "long_name": "Infant Metroid 17",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 18": {
+                "long_name": "Infant Metroid 18",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 19": {
+                "long_name": "Infant Metroid 19",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
+            },
+            "Infant Metroid 20": {
+                "long_name": "Infant Metroid 20",
+                "max_capacity": 1,
+                "extra": {
+                    "item": "InfantMetroid"
+                }
             }
         },
         "events": {
@@ -1513,6 +1653,197 @@
                             {
                                 "type": "template",
                                 "data": "Can Use Power Bombs"
+                            }
+                        ]
+                    }
+                }
+            },
+            "All Infants Collected": {
+                "display_name": "All Infants Collected",
+                "requirement": {
+                    "type": "and",
+                    "data": {
+                        "comment": null,
+                        "items": [
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 1",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 2",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 3",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 4",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 5",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 6",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 7",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 8",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 9",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 10",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 11",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 12",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 13",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 14",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 15",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 16",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 17",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 18",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 19",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Infant Metroid 20",
+                                    "amount": 1,
+                                    "negate": false
+                                }
                             }
                         ]
                     }

--- a/randovania/games/fusion/logic_database/header.txt
+++ b/randovania/games/fusion/logic_database/header.txt
@@ -104,6 +104,9 @@ Templates
           Missiles ≥ 10 or Screw Attack or Can Use Power Bombs
           Charge Beam and Have Any Beam Upgrade
 
+* All Infants Collected:
+      Infant Metroid 1 and Infant Metroid 10 and Infant Metroid 11 and Infant Metroid 12 and Infant Metroid 13 and Infant Metroid 14 and Infant Metroid 15 and Infant Metroid 16 and Infant Metroid 17 and Infant Metroid 18 and Infant Metroid 19 and Infant Metroid 2 and Infant Metroid 20 and Infant Metroid 3 and Infant Metroid 4 and Infant Metroid 5 and Infant Metroid 6 and Infant Metroid 7 and Infant Metroid 8 and Infant Metroid 9
+
 ====================
 Dock Weaknesses
 

--- a/randovania/games/fusion/presets/starter_preset.rdvpreset
+++ b/randovania/games/fusion/presets/starter_preset.rdvpreset
@@ -120,7 +120,7 @@
                     "ammo_count": [
                         2
                     ],
-                    "pickup_count": 30,
+                    "pickup_count": 25,
                     "requires_main_item": true
                 }
             }
@@ -159,6 +159,11 @@
         "staggered_multi_pickup_placement": true,
         "check_if_beatable_after_base_patches": false,
         "include_extra_pickups": false,
-        "energy_per_tank": 100
+        "energy_per_tank": 100,
+        "artifacts": {
+            "prefer_bosses": true,
+            "prefer_anywhere": false,
+            "required_artifacts": 5
+        }
     }
 }

--- a/randovania/gui/ui_files/preset_fusion_goal.ui
+++ b/randovania/gui/ui_files/preset_fusion_goal.ui
@@ -106,7 +106,7 @@
          <item>
           <widget class="QLabel" name="restrict_placement_label">
            <property name="text">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option limits where Infant Metroids will be placed. There can only be as many Infant Metroids shuffled as there are preferred locations enabled. Prefer Bosses adds 11 locations. These are: Arachnus, Yakuza, Charge Core-X, Zazabi, Nettori, Wide Core-X, Serris, Nightmare, Varia Core-X, X-B.O.X., and Ridley.&lt;/p&gt;&lt;p&gt;In Multiworlds, Metroids are guaranteed to be in your World.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option limits where Infant Metroids will be placed. There can only be as many Infant Metroids shuffled as there are preferred locations enabled.&lt;/p&gt;&lt;p&gt;In Multiworlds, Metroids are guaranteed to be in your World.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -116,7 +116,7 @@
          <item>
           <widget class="QCheckBox" name="prefer_bosses_check">
            <property name="text">
-            <string>Prefer Bosses (Arachnus, Charge Core-X, Zazabi, etc)</string>
+            <string>Prefer Bosses. Adds 11 locations (Arachnus, Yakuza, Charge Core-X, Zazabi, Nettori, Wide Core-X, Serris, Nightmare, Varia Core-X, X-B.O.X., and Ridley)</string>
            </property>
           </widget>
          </item>

--- a/randovania/gui/ui_files/preset_fusion_goal.ui
+++ b/randovania/gui/ui_files/preset_fusion_goal.ui
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PresetFusionGoal</class>
+ <widget class="QMainWindow" name="PresetFusionGoal">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1196</width>
+    <height>344</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Goal</string>
+  </property>
+  <widget class="QWidget" name="centralWidget">
+   <property name="maximumSize">
+    <size>
+     <width>16777215</width>
+     <height>16777215</height>
+    </size>
+   </property>
+   <layout class="QVBoxLayout" name="goal_layout">
+    <property name="leftMargin">
+     <number>4</number>
+    </property>
+    <property name="topMargin">
+     <number>8</number>
+    </property>
+    <property name="rightMargin">
+     <number>4</number>
+    </property>
+    <property name="bottomMargin">
+     <number>8</number>
+    </property>
+    <item>
+     <widget class="QLabel" name="description_label">
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In addition to preparing for battle with the SA-X, it is now necessary to collect the escaped Infant Metroids in order to reach the Operations Room. The minimum and maximum are limited to 0 and 20 Infant Metroids.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="metroid_slider_layout">
+      <item>
+       <widget class="QSlider" name="metroid_slider">
+        <property name="maximum">
+         <number>46</number>
+        </property>
+        <property name="pageStep">
+         <number>2</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="metroid_slider_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>20</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>0</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="placement_group">
+      <property name="title">
+       <string>Placement</string>
+      </property>
+      <layout class="QVBoxLayout" name="placement_layout">
+       <item>
+        <widget class="QRadioButton" name="restrict_placement_radiobutton">
+         <property name="text">
+          <string>Restricted Placement</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="leftMargin">
+          <number>20</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="restrict_placement_label">
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option limits where Infant Metroids will be placed. There can only be as many Infant Metroids shuffled as there are preferred locations enabled. Prefer Bosses adds 11 locations. These are: Arachnus, Yakuza, Charge Core-X, Zazabi, Nettori, Wide Core-X, Serris, Nightmare, Varia Core-X, X-B.O.X., and Ridley.&lt;/p&gt;&lt;p&gt;In Multiworlds, Metroids are guaranteed to be in your World.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="prefer_bosses_check">
+           <property name="text">
+            <string>Prefer Bosses (Arachnus, Charge Core-X, Zazabi, etc)</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="free_placement_radiobutton">
+         <property name="text">
+          <string>Free Placement</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="leftMargin">
+          <number>20</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="free_placement_label">
+           <property name="text">
+            <string>Enables Infant Metroids to be placed anywhere. For Multiworlds, this means even other Worlds.</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <spacer name="spacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -205,6 +205,11 @@ def msr_game_description() -> GameDescription:
 
 
 @pytest.fixture(scope="session")
+def fusion_game_description() -> GameDescription:
+    return default_database.game_description_for(RandovaniaGame.FUSION)
+
+
+@pytest.fixture(scope="session")
 def randomizer_data() -> dict:
     return decode_randomizer_data()
 

--- a/test/games/fusion/conftest.py
+++ b/test/games/fusion/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import pytest
+
+from randovania.games.fusion.layout import FusionConfiguration
+from randovania.games.game import RandovaniaGame
+
+
+@pytest.fixture()
+def fusion_configuration(preset_manager) -> FusionConfiguration:
+    configuration = preset_manager.default_preset_for_game(RandovaniaGame.FUSION).get_preset().configuration
+    assert isinstance(configuration, FusionConfiguration)
+    return configuration

--- a/test/games/fusion/generator/test_fusion_bootstrap.py
+++ b/test/games/fusion/generator/test_fusion_bootstrap.py
@@ -19,7 +19,7 @@ _boss_indices = [100, 106, 114, 104, 115, 107, 110, 102, 109, 108, 111]
 @pytest.mark.parametrize(
     ("artifacts", "expected"),
     [
-        (FusionArtifactConfig(True, False, 5), [100, 110, 109, 108, 111]),
+        (FusionArtifactConfig(True, False, 5), [102, 106, 107, 110, 114]),
         (FusionArtifactConfig(True, False, 11), _boss_indices),
         (FusionArtifactConfig(False, False, 0), []),
     ],
@@ -43,7 +43,9 @@ def test_assign_pool_results_predetermined(fusion_game_description, fusion_confi
     ]
 
     assert result.starting_equipment == pool_results.starting
-    assert set(result.pickup_assignment.keys()) == {PickupIndex(i) for i in expected}
+    assert {index for index, entry in result.pickup_assignment.items() if "Infant Metroid" in entry.pickup.name} == {
+        PickupIndex(i) for i in expected
+    }
     assert shuffled_metroids == []
 
 
@@ -77,4 +79,6 @@ def test_assign_pool_results_prefer_anywhere(fusion_game_description, fusion_con
     assert pool_results.to_place == initial_starting_place
     assert len(shuffled_metroids) == artifacts.required_artifacts
     assert result.starting_equipment == pool_results.starting
-    assert result.pickup_assignment == {}
+    assert {
+        index: entry for index, entry in result.pickup_assignment.items() if "Infant Metroid" in entry.pickup.name
+    } == {}

--- a/test/games/fusion/generator/test_fusion_bootstrap.py
+++ b/test/games/fusion/generator/test_fusion_bootstrap.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import dataclasses
+from copy import copy
+from random import Random
+
+import pytest
+
+from randovania.game_description.game_patches import GamePatches
+from randovania.game_description.resources.pickup_index import PickupIndex
+from randovania.games.fusion.generator import FusionBootstrap
+from randovania.games.fusion.generator.pool_creator import INFANT_METROID_CATEGORY
+from randovania.games.fusion.layout.fusion_configuration import FusionArtifactConfig
+from randovania.generator.pickup_pool import pool_creator
+
+_boss_indices = [100, 106, 114, 104, 115, 107, 110, 102, 109, 108, 111]
+
+
+@pytest.mark.parametrize(
+    ("artifacts", "expected"),
+    [
+        (FusionArtifactConfig(True, False, 5), [100, 110, 109, 108, 111]),
+        (FusionArtifactConfig(True, False, 11), _boss_indices),
+        (FusionArtifactConfig(False, False, 0), []),
+    ],
+)
+def test_assign_pool_results_predetermined(fusion_game_description, fusion_configuration, artifacts, expected):
+    patches = GamePatches.create_from_game(
+        fusion_game_description, 0, dataclasses.replace(fusion_configuration, artifacts=artifacts)
+    )
+    pool_results = pool_creator.calculate_pool_results(patches.configuration, patches.game)
+
+    # Run
+    result = FusionBootstrap().assign_pool_results(
+        Random(8000),
+        patches,
+        pool_results,
+    )
+
+    # Assert
+    shuffled_metroids = [
+        pickup for pickup in pool_results.to_place if pickup.pickup_category == INFANT_METROID_CATEGORY
+    ]
+
+    assert result.starting_equipment == pool_results.starting
+    assert set(result.pickup_assignment.keys()) == {PickupIndex(i) for i in expected}
+    assert shuffled_metroids == []
+
+
+@pytest.mark.parametrize(
+    ("artifacts"),
+    [
+        (FusionArtifactConfig(False, True, 0)),
+        (FusionArtifactConfig(True, True, 10)),
+        (FusionArtifactConfig(False, True, 20)),
+    ],
+)
+def test_assign_pool_results_prefer_anywhere(fusion_game_description, fusion_configuration, artifacts):
+    patches = GamePatches.create_from_game(
+        fusion_game_description, 0, dataclasses.replace(fusion_configuration, artifacts=artifacts)
+    )
+    pool_results = pool_creator.calculate_pool_results(patches.configuration, patches.game)
+    initial_starting_place = copy(pool_results.to_place)
+
+    # Run
+    result = FusionBootstrap().assign_pool_results(
+        Random(8000),
+        patches,
+        pool_results,
+    )
+
+    # Assert
+    shuffled_metroids = [
+        pickup for pickup in pool_results.to_place if pickup.pickup_category == INFANT_METROID_CATEGORY
+    ]
+
+    assert pool_results.to_place == initial_starting_place
+    assert len(shuffled_metroids) == artifacts.required_artifacts
+    assert result.starting_equipment == pool_results.starting
+    assert result.pickup_assignment == {}

--- a/test/games/fusion/generator/test_fusion_pool_creator.py
+++ b/test/games/fusion/generator/test_fusion_pool_creator.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from randovania.games.fusion.generator.pool_creator import artifact_pool, create_fusion_artifact
+from randovania.games.fusion.layout.fusion_configuration import FusionArtifactConfig
+from randovania.generator.pickup_pool import PoolResults
+from randovania.layout.exceptions import InvalidConfiguration
+
+
+@pytest.mark.parametrize("metroid_count", [0, 1, 11, 20])
+def test_fusion_pool_creator(fusion_game_description, metroid_count):
+    db = fusion_game_description.resource_database
+    # Run
+    results = artifact_pool(fusion_game_description, FusionArtifactConfig(True, True, metroid_count))
+
+    # Assert
+    assert results == PoolResults(
+        [create_fusion_artifact(i, db) for i in range(metroid_count)],
+        {},
+        [create_fusion_artifact(i, db) for i in range(metroid_count, 20)],
+    )
+
+
+@pytest.mark.parametrize(
+    ("bosses", "anywhere", "artifacts"),
+    [
+        (False, False, 1),
+        (True, False, 12),
+        (True, True, 21),
+        (False, True, 21),
+    ],
+)
+def test_fusion_artifact_pool_should_throw_on_invalid_config(fusion_game_description, bosses, anywhere, artifacts):
+    # Setup
+    configuration = FusionArtifactConfig(prefer_bosses=bosses, prefer_anywhere=anywhere, required_artifacts=artifacts)
+
+    # Run
+    with pytest.raises(InvalidConfiguration, match="More Infant Metroids than allowed!"):
+        artifact_pool(fusion_game_description, configuration)

--- a/test/games/fusion/gui/preset_settings/test_preset_fusion_goal.py
+++ b/test/games/fusion/gui/preset_settings/test_preset_fusion_goal.py
@@ -33,6 +33,7 @@ def test_preferred_bosses(
     tab = PresetFusionGoal(editor := PresetEditor(preset, options), fusion_game_description, MagicMock())
     skip_qtbot.addWidget(tab)
     tab.on_preset_changed(preset)
+    assert isinstance(editor.configuration, FusionConfiguration)
 
     assert tab.metroid_slider.isEnabled()
     assert tab.metroid_slider.value() > 0

--- a/test/games/fusion/gui/preset_settings/test_preset_fusion_goal.py
+++ b/test/games/fusion/gui/preset_settings/test_preset_fusion_goal.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from randovania.games.fusion.gui.preset_settings.fusion_goal_tab import PresetFusionGoal
+from randovania.games.fusion.layout.fusion_configuration import FusionConfiguration
+from randovania.interface_common.preset_editor import PresetEditor
+
+
+@pytest.mark.parametrize(
+    ("prefer_bosses", "expected_max_slider"),
+    [(False, 0), (True, 11)],
+)
+def test_preferred_bosses(
+    skip_qtbot,
+    fusion_game_description,
+    preset_manager,
+    prefer_bosses: bool,
+    expected_max_slider: int,
+):
+    # Setup
+    game = fusion_game_description.game
+    base = preset_manager.default_preset_for_game(game).get_preset()
+    preset = dataclasses.replace(base, uuid=uuid.UUID("bb84005f-b0f1-4e7e-8057-f4275ff4b2a3"))
+    base_configuration = preset.configuration
+    options = MagicMock()
+    assert isinstance(base_configuration, FusionConfiguration)
+
+    tab = PresetFusionGoal(editor := PresetEditor(preset, options), fusion_game_description, MagicMock())
+    skip_qtbot.addWidget(tab)
+    tab.on_preset_changed(preset)
+
+    assert tab.metroid_slider.isEnabled()
+    assert tab.metroid_slider.value() > 0
+    initial_slider_value = tab.metroid_slider.value()
+
+    # Run
+    tab.prefer_bosses_check.setChecked(prefer_bosses)
+    slider_value_after_first_set = tab.metroid_slider.value()
+    tab._update_slider_max()
+
+    # Assert
+    if not prefer_bosses:
+        assert slider_value_after_first_set == 0
+    # The slider value should never increase from what it was before
+    assert slider_value_after_first_set >= tab.metroid_slider.value()
+    assert tab.num_preferred_locations == expected_max_slider
+    assert tab.metroid_slider.maximum() == expected_max_slider
+    assert tab.metroid_slider.isEnabled() == (expected_max_slider > 0)
+    assert editor.configuration.artifacts.prefer_bosses == prefer_bosses
+    # If default value in configuration is smaller than the max allowed value, it shouldn't increase
+    expected_artifacts = expected_max_slider
+    if initial_slider_value < expected_max_slider:
+        expected_artifacts = initial_slider_value
+    # Also, if the previous slider value is already 0, then that should be the final result
+    if slider_value_after_first_set == 0:
+        expected_artifacts = 0
+
+    assert editor.configuration.artifacts.required_artifacts == expected_artifacts
+    assert tab.metroid_slider.value() == expected_artifacts
+
+
+def test_restricted_placement(
+    skip_qtbot,
+    fusion_game_description,
+    preset_manager,
+):
+    # Setup
+    game = fusion_game_description.game
+    base = preset_manager.default_preset_for_game(game).get_preset()
+    preset = dataclasses.replace(base, uuid=uuid.UUID("bb84005f-b0f1-4e7e-8057-f4275ff4b2a3"))
+    base_configuration = preset.configuration
+    options = MagicMock()
+    assert isinstance(base_configuration, FusionConfiguration)
+
+    tab = PresetFusionGoal(editor := PresetEditor(preset, options), fusion_game_description, MagicMock())
+    assert isinstance(editor.configuration, FusionConfiguration)
+    skip_qtbot.addWidget(tab)
+    tab.on_preset_changed(preset)
+    artifact_count = editor.configuration.artifacts.required_artifacts
+    tab.free_placement_radiobutton.setChecked(True)
+
+    # Run
+    tab.restrict_placement_radiobutton.setChecked(True)
+
+    # Assert
+    assert tab.prefer_bosses_check.isEnabled()
+    assert tab.restrict_placement_radiobutton.isChecked()
+    assert editor.configuration.artifacts.required_artifacts == artifact_count
+
+
+def test_free_placement(
+    skip_qtbot,
+    fusion_game_description,
+    preset_manager,
+):
+    # Setup
+    game = fusion_game_description.game
+    base = preset_manager.default_preset_for_game(game).get_preset()
+    preset = dataclasses.replace(base, uuid=uuid.UUID("bb84005f-b0f1-4e7e-8057-f4275ff4b2a3"))
+    base_configuration = preset.configuration
+    options = MagicMock()
+    assert isinstance(base_configuration, FusionConfiguration)
+
+    tab = PresetFusionGoal(editor := PresetEditor(preset, options), fusion_game_description, MagicMock())
+    assert isinstance(editor.configuration, FusionConfiguration)
+    skip_qtbot.addWidget(tab)
+    tab.on_preset_changed(preset)
+    artifact_count = editor.configuration.artifacts.required_artifacts
+    tab.restrict_placement_radiobutton.setChecked(True)
+
+    # Run
+    tab.free_placement_radiobutton.setChecked(True)
+
+    # Assert
+    assert not tab.prefer_bosses_check.isEnabled()
+    assert tab.free_placement_radiobutton.isChecked()
+    assert editor.configuration.artifacts.required_artifacts == artifact_count

--- a/test/games/fusion/test_fusion.py
+++ b/test/games/fusion/test_fusion.py
@@ -40,7 +40,7 @@ def test_all_tricks_should_have_proper_requirements():
     rl = game.region_list
     db = game.resource_database
     expected_dict: dict[Any, Any] = {}
-    database_dict = {}
+    database_dict: dict[Any, Any] = {}
     for i in range(len(resource_list)):
         database_dict[resource_list[i]] = []
         expected_dict[resource_list[i]] = []

--- a/test/games/fusion/test_fusion.py
+++ b/test/games/fusion/test_fusion.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from randovania.game_description import default_database
+from randovania.game_description.requirements.requirement_template import RequirementTemplate
+from randovania.game_description.requirements.resource_requirement import ResourceRequirement
+from randovania.games.game import RandovaniaGame
+
+resource_list = [
+    # Tricks
+    ("Jump Bombjump", "Can Use Bombs"),
+    ("Mid-Air Morph", "Morph Ball"),
+    ("Shinesparking Tricks", "SpeedBooster"),
+    ("Stand On Frozen Enemies", "Can Freeze Enemies"),
+    # Items
+    ("Morph Ball Bomb Data", "Morph Ball"),
+    ("Power Bomb Data", "Morph Ball"),
+]
+
+
+def does_requirement_contain_resource(requirement, resource, db):
+    if isinstance(requirement, RequirementTemplate):
+        if requirement.template_name == resource:
+            return True
+        template_req = requirement.template_requirement(db)
+        return does_requirement_contain_resource(template_req, resource, db)
+    if isinstance(requirement, ResourceRequirement):
+        if requirement.pretty_text == resource:
+            return True
+        return False
+    for subreq in requirement.items:
+        if does_requirement_contain_resource(subreq, resource, db):
+            return True
+    return False
+
+
+def test_all_tricks_should_have_proper_requirements():
+    game = default_database.game_description_for(RandovaniaGame.FUSION)
+    rl = game.region_list
+    db = game.resource_database
+    expected_dict = {}
+    database_dict = {}
+    for i in range(len(resource_list)):
+        database_dict[resource_list[i]] = []
+        expected_dict[resource_list[i]] = []
+
+    for node in rl.all_nodes:
+        for dest_node, requirements in rl.area_connections_from(node):
+            for required_resources in resource_list:
+                size = len(required_resources)
+                required_resource_collection = {}
+                for i in range(size):
+                    required_resource_collection[i] = False
+
+                for i in range(size):
+                    required_resource_collection[i] = does_requirement_contain_resource(
+                        requirements, required_resources[i], db
+                    )
+                    if not required_resource_collection[i]:
+                        break
+
+                if len(set(required_resource_collection.values())) > 1:
+                    database_dict[required_resources].append(
+                        (
+                            f"{node.name} ({node.identifier.area_name})",
+                            f"{dest_node.name} ({dest_node.identifier.area_name})",
+                        )
+                    )
+
+    assert database_dict == expected_dict

--- a/test/games/fusion/test_fusion.py
+++ b/test/games/fusion/test_fusion.py
@@ -46,6 +46,7 @@ def test_all_tricks_should_have_proper_requirements():
         expected_dict[resource_list[i]] = []
 
     for node in rl.all_nodes:
+        assert node is not None
         for dest_node, requirements in rl.area_connections_from(node):
             for required_resources in resource_list:
                 size = len(required_resources)

--- a/test/games/fusion/test_fusion.py
+++ b/test/games/fusion/test_fusion.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from randovania.game_description import default_database
 from randovania.game_description.requirements.requirement_template import RequirementTemplate
 from randovania.game_description.requirements.resource_requirement import ResourceRequirement
@@ -37,7 +39,7 @@ def test_all_tricks_should_have_proper_requirements():
     game = default_database.game_description_for(RandovaniaGame.FUSION)
     rl = game.region_list
     db = game.resource_database
-    expected_dict = {}
+    expected_dict: dict[Any, Any] = {}
     database_dict = {}
     for i in range(len(resource_list)):
         database_dict[resource_list[i]] = []


### PR DESCRIPTION
Adds the goal of collecting infant/baby metroids. Configurable on bosses or anywhere. Add associated tests.

Also adds basic testing for DB.