### PR TITLE
FUSION: clear some todo's in TRO and PYR

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -3179,68 +3179,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Zazabi Access": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "SpeedBooster",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "ScrewAttack",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "ShinesparkTrick",
-                                            "amount": 4,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "EntranceRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "Zazabi",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Arena Floor": {
                             "type": "or",
                             "data": {
@@ -5310,15 +5248,6 @@
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "ShinesparkTrick",
-                                                                                "amount": 5,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
                                                                             "type": "and",
                                                                             "data": {
                                                                                 "comment": null,
@@ -5337,7 +5266,33 @@
                                                                                         "data": {
                                                                                             "type": "tricks",
                                                                                             "name": "ShinesparkTrick",
-                                                                                            "amount": 5,
+                                                                                            "amount": 4,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "WallJump",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "ShinesparkTrick",
+                                                                                            "amount": 4,
                                                                                             "negate": false
                                                                                         }
                                                                                     }

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -5166,17 +5166,8 @@
                         "Door to Crumble City": {
                             "type": "and",
                             "data": {
-                                "comment": "TODO: Look into requirements further and possibly add SWJ trick. The requirement of space jump makes the advanced tricks in crumble city invalid in non-entrance rando.",
+                                "comment": null,
                                 "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "SpaceJump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
                                     {
                                         "type": "resource",
                                         "data": {
@@ -5184,6 +5175,32 @@
                                             "name": "ScrewAttack",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpaceJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "WallJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -9113,10 +9130,24 @@
                     "location_category": "minor",
                     "connections": {
                         "Door to Zazabi Arena": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
-                                "comment": "TODO: can you get out without any jump upgrades?",
-                                "items": []
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Climb High Jump Wall"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "WallJump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -3180,15 +3180,53 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Zazabi Access": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
-                                "comment": "TODO: is this possible with a shinespark?",
+                                "comment": null,
                                 "items": [
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": []
+                                            "type": "items",
+                                            "name": "SpeedBooster",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "ScrewAttack",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "ShinesparkTrick",
+                                            "amount": 4,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DoorLockRando",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "EntranceRando",
+                                            "amount": 1,
+                                            "negate": true
                                         }
                                     }
                                 ]
@@ -3340,6 +3378,10 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Screw Single Walljump"
                                                 }
                                             ]
                                         }
@@ -5192,12 +5234,60 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "template",
+                                                    "data": "Can Screw Single Walljump"
+                                                },
+                                                {
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "WallJump",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "SpeedBooster",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "ShinesparkTrick",
+                                                                    "amount": 5,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "EntranceRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLockRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "L1Locks",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -9145,6 +9235,32 @@
                                             "name": "WallJump",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpeedBooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "ShinesparkTrick",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -9194,6 +9194,13 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Bottom of Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -9219,51 +9226,11 @@
                     "pickup_index": 41,
                     "location_category": "minor",
                     "connections": {
-                        "Door to Zazabi Arena": {
-                            "type": "or",
+                        "Bottom of Room": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Climb High Jump Wall"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "WallJump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "SpeedBooster",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "ShinesparkTrick",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -9298,6 +9265,30 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Bottom of Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Bottom of Room": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 387.3391593841032,
+                        "y": 86.14898044111527,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
                         "Pickup (Power Bomb Tank)": {
                             "type": "or",
                             "data": {
@@ -9316,7 +9307,7 @@
                             }
                         },
                         "Pickup (Hidden Missile Tank)": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -9325,6 +9316,53 @@
                                         "data": {
                                             "type": "items",
                                             "name": "SpeedBooster",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Door to Zazabi Arena": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Climb High Jump Wall"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpeedBooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "ShinesparkTrick",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "WallJump",
                                             "amount": 1,
                                             "negate": false
                                         }

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -5250,7 +5250,7 @@
                                                                         {
                                                                             "type": "and",
                                                                             "data": {
-                                                                                "comment": null,
+                                                                                "comment": "TODO: add trick video",
                                                                                 "items": [
                                                                                     {
                                                                                         "type": "resource",
@@ -5276,7 +5276,7 @@
                                                                         {
                                                                             "type": "and",
                                                                             "data": {
-                                                                                "comment": null,
+                                                                                "comment": "TODO: add trick video",
                                                                                 "items": [
                                                                                     {
                                                                                         "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -5269,6 +5269,24 @@
                                                                                             "amount": 4,
                                                                                             "negate": false
                                                                                         }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Movement",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Knowledge",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
                                                                                     }
                                                                                 ]
                                                                             }

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -3228,6 +3228,15 @@
                                             "amount": 1,
                                             "negate": true
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Zazabi",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -3380,8 +3389,25 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Screw Single Walljump"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Screw Single Walljump"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "WallJump",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -5254,15 +5280,6 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "ShinesparkTrick",
-                                                                    "amount": 5,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
                                                                     "type": "misc",
                                                                     "name": "EntranceRando",
                                                                     "amount": 1,
@@ -5282,9 +5299,52 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "L1Locks",
+                                                                    "name": "L0Locks",
                                                                     "amount": 1,
                                                                     "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "ShinesparkTrick",
+                                                                                "amount": 5,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "L1Locks",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "ShinesparkTrick",
+                                                                                            "amount": 5,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -851,8 +851,12 @@ Extra - room_id: [26]
           Any of the following:
               Space Jump or Can Single Walljump
               All of the following:
-                  Level 0 Locks and Speed Booster and Shinespark Tricks (Expert) and Disabled Door Lock Rando and Disabled Entrance Rando
-                  Level 1 Locks or Wall Jump (Advanced)
+                  Level 0 Locks and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+                  Any of the following:
+                      # TODO: add trick video
+                      Level 1 Locks and Shinespark Tricks (Expert)
+                      # TODO: add trick video
+                      Shinespark Tricks (Expert) and Wall Jump (Advanced)
   > Event - L1 Locks
       Trivial
 

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -559,8 +559,6 @@ Extra - room_id: [18]
   * Layers: default
   * L0 Hatch to Zazabi Speedway/Door to Zazabi Arena
   * Extra - door_idx: (133,)
-  > Door to Zazabi Access
-      Screw Attack and Speed Booster and After Boss Zazabi Defeated and Shinespark Tricks (Expert) and Disabled Door Lock Rando and Disabled Entrance Rando
   > Arena Floor
       Screw Attack
 
@@ -853,10 +851,8 @@ Extra - room_id: [26]
           Any of the following:
               Space Jump or Can Single Walljump
               All of the following:
-                  Level 0 Locks and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
-                  Any of the following:
-                      Shinespark Tricks (Hypermode)
-                      Level 1 Locks and Shinespark Tricks (Hypermode)
+                  Level 0 Locks and Speed Booster and Shinespark Tricks (Expert) and Disabled Door Lock Rando and Disabled Entrance Rando
+                  Level 1 Locks or Wall Jump (Advanced)
   > Event - L1 Locks
       Trivial
 

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -854,7 +854,7 @@ Extra - room_id: [26]
                   Level 0 Locks and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
                   Any of the following:
                       # TODO: add trick video
-                      Level 1 Locks and Shinespark Tricks (Expert)
+                      Level 1 Locks and Knowledge (Advanced) and Movement (Beginner) and Shinespark Tricks (Expert)
                       # TODO: add trick video
                       Shinespark Tricks (Expert) and Wall Jump (Advanced)
   > Event - L1 Locks

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -560,7 +560,7 @@ Extra - room_id: [18]
   * L0 Hatch to Zazabi Speedway/Door to Zazabi Arena
   * Extra - door_idx: (133,)
   > Door to Zazabi Access
-      Impossible
+      Screw Attack and Speed Booster and Shinespark Tricks (Expert) and Disabled Door Lock Rando and Disabled Entrance Rando
   > Arena Floor
       Screw Attack
 
@@ -584,7 +584,9 @@ Extra - room_id: [18]
   > Door to Zazabi Access
       After Boss Zazabi Defeated and Can Climb High Jump Wall
   > Door to Zazabi Speedway
-      Screw Attack and Space Jump and After Boss Zazabi Defeated
+      All of the following:
+          Screw Attack and After Boss Zazabi Defeated
+          Space Jump or Can Single Walljump
   > Event - Zazabi
       All of the following:
           All of the following:
@@ -846,7 +848,9 @@ Extra - room_id: [26]
   > Door to Crumble City
       All of the following:
           Screw Attack
-          Space Jump or Wall Jump (Beginner)
+          Any of the following:
+              Space Jump or Can Single Walljump
+              Level 1 Locks and Speed Booster and Shinespark Tricks (Hypermode) and Disabled Door Lock Rando and Disabled Entrance Rando
   > Event - L1 Locks
       Trivial
 
@@ -1521,7 +1525,9 @@ Extra - room_id: [55]
   * Extra - blockx: 10
   * Extra - blocky: 26
   > Door to Zazabi Arena
-      Wall Jump (Beginner) or Can Climb High Jump Wall
+      Any of the following:
+          Wall Jump (Beginner) or Can Climb High Jump Wall
+          Speed Booster and Shinespark Tricks (Beginner)
 
 > Door to Zazabi Arena; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1516,6 +1516,8 @@ Extra - room_id: [55]
   * Extra - blocky: 4
   > Door to Zazabi Arena
       Trivial
+  > Bottom of Room
+      Trivial
 
 > Pickup (Hidden Missile Tank); Heals? False
   * Layers: default
@@ -1524,19 +1526,26 @@ Extra - room_id: [55]
   * Extra - room: 55
   * Extra - blockx: 10
   * Extra - blocky: 26
-  > Door to Zazabi Arena
-      Any of the following:
-          Wall Jump (Beginner) or Can Climb High Jump Wall
-          Speed Booster and Shinespark Tricks (Beginner)
+  > Bottom of Room
+      Trivial
 
 > Door to Zazabi Arena; Heals? False
   * Layers: default
   * L0 Hatch to Zazabi Arena/Door to Zazabi Speedway
   * Extra - door_idx: (134,)
+  > Bottom of Room
+      Trivial
+
+> Bottom of Room; Heals? False
+  * Layers: default
   > Pickup (Power Bomb Tank)
       Speed Booster
   > Pickup (Hidden Missile Tank)
       Speed Booster
+  > Door to Zazabi Arena
+      Any of the following:
+          Wall Jump (Beginner) or Can Climb High Jump Wall
+          Speed Booster and Shinespark Tricks (Beginner)
 
 ----------------
 Overgrown Hallway

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -560,7 +560,7 @@ Extra - room_id: [18]
   * L0 Hatch to Zazabi Speedway/Door to Zazabi Arena
   * Extra - door_idx: (133,)
   > Door to Zazabi Access
-      Screw Attack and Speed Booster and Shinespark Tricks (Expert) and Disabled Door Lock Rando and Disabled Entrance Rando
+      Screw Attack and Speed Booster and After Boss Zazabi Defeated and Shinespark Tricks (Expert) and Disabled Door Lock Rando and Disabled Entrance Rando
   > Arena Floor
       Screw Attack
 
@@ -586,7 +586,9 @@ Extra - room_id: [18]
   > Door to Zazabi Speedway
       All of the following:
           Screw Attack and After Boss Zazabi Defeated
-          Space Jump or Can Single Walljump
+          Any of the following:
+              Space Jump
+              Wall Jump (Advanced) and Can Single Walljump
   > Event - Zazabi
       All of the following:
           All of the following:
@@ -850,7 +852,11 @@ Extra - room_id: [26]
           Screw Attack
           Any of the following:
               Space Jump or Can Single Walljump
-              Level 1 Locks and Speed Booster and Shinespark Tricks (Hypermode) and Disabled Door Lock Rando and Disabled Entrance Rando
+              All of the following:
+                  Level 0 Locks and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+                  Any of the following:
+                      Shinespark Tricks (Hypermode)
+                      Level 1 Locks and Shinespark Tricks (Hypermode)
   > Event - L1 Locks
       Trivial
 

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -844,8 +844,9 @@ Extra - room_id: [26]
   > Door to Security Access (Upper)
       Space Jump
   > Door to Crumble City
-      # TODO: Look into requirements further and possibly add SWJ trick. The requirement of space jump makes the advanced tricks in crumble city invalid in non-entrance rando.
-      Screw Attack and Space Jump
+      All of the following:
+          Screw Attack
+          Space Jump or Wall Jump (Beginner)
   > Event - L1 Locks
       Trivial
 
@@ -1520,7 +1521,7 @@ Extra - room_id: [55]
   * Extra - blockx: 10
   * Extra - blocky: 26
   > Door to Zazabi Arena
-      Trivial
+      Wall Jump (Beginner) or Can Climb High Jump Wall
 
 > Door to Zazabi Arena; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -3393,7 +3393,7 @@
                         "Door to Pyrochamber": {
                             "type": "and",
                             "data": {
-                                "comment": "TODO: Possibly add singlewall jump trick difficulty with jump extend as an option if singlewall jump is kept.",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "or",
@@ -3439,6 +3439,74 @@
                                                                                 "name": "WallJump",
                                                                                 "amount": 1,
                                                                                 "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Jump Extend SWJ Method",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "JumpExtends",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Hi-Jump",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "WallJump",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "WallJump",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         }
                                                                     ]
@@ -3977,7 +4045,7 @@
                         "Door to Boiler Access": {
                             "type": "and",
                             "data": {
-                                "comment": "TODO: varia suit?",
+                                "comment": null,
                                 "items": []
                             }
                         }

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -3514,7 +3514,7 @@
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Screw Single Walljump"
+                                                                "data": "Can Kill Tough Beam-Resistant Enemy"
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -3508,13 +3508,17 @@
                                                                                     }
                                                                                 ]
                                                                             }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Kill Tough Beam-Resistant Enemy"
                                                                         }
                                                                     ]
                                                                 }
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Screw Single Walljump"
+                                                                "data": "Can Kill Tough Beam-Resistant Enemy"
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -3508,10 +3508,6 @@
                                                                                     }
                                                                                 ]
                                                                             }
-                                                                        },
-                                                                        {
-                                                                            "type": "template",
-                                                                            "data": "Can Kill Tough Beam-Resistant Enemy"
                                                                         }
                                                                     ]
                                                                 }

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -3511,6 +3511,10 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Screw Single Walljump"
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -3514,7 +3514,7 @@
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Kill Tough Beam-Resistant Enemy"
+                                                                "data": "Can Screw Single Walljump"
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -555,7 +555,7 @@ Extra - room_id: [14]
               High Jump or Wall Jump (Beginner)
           All of the following:
               # Jump Extend SWJ Method
-              Jump Extends (Advanced) and Can Single Walljump
+              Jump Extends (Advanced) and Can Kill Tough Beam-Resistant Enemy
               Any of the following:
                   Wall Jump (Advanced)
                   High Jump and Wall Jump (Intermediate)

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -555,7 +555,7 @@ Extra - room_id: [14]
               High Jump or Wall Jump (Beginner)
           All of the following:
               # Jump Extend SWJ Method
-              Jump Extends (Advanced) and Can Kill Tough Beam-Resistant Enemy
+              Jump Extends (Advanced) and Can Single Walljump
               Any of the following:
                   Wall Jump (Advanced)
                   High Jump and Wall Jump (Intermediate)

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -548,13 +548,17 @@ Extra - room_id: [14]
   * L0 Hatch to Sova Suite/Door to Pyrochamber Access
   * Extra - door_idx: (28,)
   > Door to Pyrochamber
-      All of the following:
-          # TODO: Possibly add singlewall jump trick difficulty with jump extend as an option if singlewall jump is kept.
-          Any of the following:
-              Space Jump
-              All of the following:
-                  Can Freeze Enemies
-                  High Jump or Wall Jump (Beginner)
+      Any of the following:
+          Space Jump
+          All of the following:
+              Can Freeze Enemies
+              High Jump or Wall Jump (Beginner)
+          All of the following:
+              # Jump Extend SWJ Method
+              Jump Extends (Advanced)
+              Any of the following:
+                  Wall Jump (Advanced)
+                  High Jump and Wall Jump (Intermediate)
 
 > Door to Pyrochamber; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -555,7 +555,7 @@ Extra - room_id: [14]
               High Jump or Wall Jump (Beginner)
           All of the following:
               # Jump Extend SWJ Method
-              Jump Extends (Advanced)
+              Jump Extends (Advanced) and Can Single Walljump
               Any of the following:
                   Wall Jump (Advanced)
                   High Jump and Wall Jump (Intermediate)

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -555,9 +555,9 @@ Extra - room_id: [14]
               High Jump or Wall Jump (Beginner)
           All of the following:
               # Jump Extend SWJ Method
-              Jump Extends (Advanced) and Can Single Walljump
+              Jump Extends (Advanced) and Can Kill Tough Beam-Resistant Enemy
               Any of the following:
-                  Wall Jump (Advanced)
+                  Wall Jump (Advanced) or Can Kill Tough Beam-Resistant Enemy
                   High Jump and Wall Jump (Intermediate)
 
 > Door to Pyrochamber; Heals? False

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -557,7 +557,7 @@ Extra - room_id: [14]
               # Jump Extend SWJ Method
               Jump Extends (Advanced) and Can Kill Tough Beam-Resistant Enemy
               Any of the following:
-                  Wall Jump (Advanced) or Can Kill Tough Beam-Resistant Enemy
+                  Wall Jump (Advanced)
                   High Jump and Wall Jump (Intermediate)
 
 > Door to Pyrochamber; Heals? False


### PR DESCRIPTION
Added a SWJ & Jump Extend method for Pyrochamber Access
Added SWJ for Level 1 Security Room
Added beginner wall jump requirement for getting back up to the door in Zazabi Speedway, as well as a beginner shinespark trick
Added SWJ template to Zazabi arena -> zazabi speedway
added shinespark tricks to level 1 Security Room to reach the door, and zazabi arena to cross without hi jump
Removed the TODO in Main Boiler as the room is not heated