### PR TITLE
Fusion: Add palette randomizer

### DIFF
--- a/randovania/games/fusion/game_data.py
+++ b/randovania/games/fusion/game_data.py
@@ -13,9 +13,9 @@ if typing.TYPE_CHECKING:
 
 
 def _options() -> type[PerGameOptions]:
-    from randovania.interface_common.options import PerGameOptions
+    from randovania.games.fusion.exporter.options import FusionPerGameOptions
 
-    return PerGameOptions
+    return FusionPerGameOptions
 
 
 def _gui() -> game.GameGui:

--- a/randovania/games/fusion/gui/dialog/cosmetic_patches_dialog.py
+++ b/randovania/games/fusion/gui/dialog/cosmetic_patches_dialog.py
@@ -33,7 +33,13 @@ class FusionCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_FusionCosmeticPa
     def connect_signals(self) -> None:
         super().connect_signals()
 
-        self._persist_check_field(self.suit_palette_check, "enabled")
+        # Checkboxes for enabling Pallete Rando
+        self._persist_check_field(self.suit_palette_check, "enable_suit_palette")
+        self._persist_check_field(self.beam_palette_check, "enable_beam_palette")
+        self._persist_check_field(self.enemy_palette_check, "enable_enemy_palette")
+        self._persist_check_field(self.tileset_palette_check, "enable_tileset_palette")
+
+        # Combobox for Color Space
         self.color_space_combo.currentIndexChanged.connect(self._on_color_space_update)
 
     def _on_color_space_update(self) -> None:
@@ -42,10 +48,10 @@ class FusionCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_FusionCosmeticPa
         )
 
     def on_new_cosmetic_patches(self, patches: FusionCosmeticPatches) -> None:
-        self.suit_palette_check.setChecked(patches.suit_shuffle.enabled)
-        self.beam_palette_check.setChecked(patches.beam_shuffle.enabled)
-        self.enemy_palette_check.setChecked(patches.enemy_shuffle.enabled)
-        self.tileset_palette_check.setChecked(patches.tileset_shuffle.enabled)
+        self.suit_palette_check.setChecked(patches.enable_suit_palette)
+        self.beam_palette_check.setChecked(patches.enable_beam_palette)
+        self.enemy_palette_check.setChecked(patches.enable_enemy_palette)
+        self.tileset_palette_check.setChecked(patches.enable_tileset_palette)
         set_combo_with_value(self.color_space_combo, patches.color_space)
 
     @property

--- a/randovania/games/fusion/gui/dialog/cosmetic_patches_dialog.py
+++ b/randovania/games/fusion/gui/dialog/cosmetic_patches_dialog.py
@@ -1,38 +1,52 @@
 from __future__ import annotations
 
+import dataclasses
 from typing import TYPE_CHECKING
 
-from randovania.games.fusion.layout.fusion_cosmetic_patches import FusionCosmeticPatches
+from randovania.games.fusion.layout.fusion_cosmetic_patches import ColorSpace, FusionCosmeticPatches
 from randovania.gui.dialog.base_cosmetic_patches_dialog import BaseCosmeticPatchesDialog
 from randovania.gui.generated.fusion_cosmetic_patches_dialog_ui import Ui_FusionCosmeticPatchesDialog
+from randovania.gui.lib.signal_handling import set_combo_with_value
 
 if TYPE_CHECKING:
-    from PySide6 import QtWidgets
+    from PySide6.QtWidgets import QWidget
 
     from randovania.layout.base.cosmetic_patches import BaseCosmeticPatches
 
 
-# TODO
 class FusionCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_FusionCosmeticPatchesDialog):
     _cosmetic_patches: FusionCosmeticPatches
 
-    def __init__(self, parent: QtWidgets.QWidget | None, current: BaseCosmeticPatches):
+    def __init__(self, parent: QWidget | None, current: BaseCosmeticPatches):
         super().__init__(parent)
         self.setupUi(self)
 
         assert isinstance(current, FusionCosmeticPatches)
         self._cosmetic_patches = current
 
+        for color_space in ColorSpace:
+            self.color_space_combo.addItem(color_space.long_name, color_space)
+
         self.on_new_cosmetic_patches(current)
         self.connect_signals()
 
     def connect_signals(self) -> None:
         super().connect_signals()
-        # More signals here!
+
+        self._persist_check_field(self.suit_palette_check, "enabled")
+        self.color_space_combo.currentIndexChanged.connect(self._on_color_space_update)
+
+    def _on_color_space_update(self) -> None:
+        self._cosmetic_patches = dataclasses.replace(
+            self._cosmetic_patches, color_space=self.color_space_combo.currentData()
+        )
 
     def on_new_cosmetic_patches(self, patches: FusionCosmeticPatches) -> None:
-        # Update fields with the new values
-        pass
+        self.suit_palette_check.setChecked(patches.suit_shuffle.enabled)
+        self.beam_palette_check.setChecked(patches.beam_shuffle.enabled)
+        self.enemy_palette_check.setChecked(patches.enemy_shuffle.enabled)
+        self.tileset_palette_check.setChecked(patches.tileset_shuffle.enabled)
+        set_combo_with_value(self.color_space_combo, patches.color_space)
 
     @property
     def cosmetic_patches(self) -> FusionCosmeticPatches:

--- a/randovania/games/fusion/gui/dialog/cosmetic_patches_dialog.py
+++ b/randovania/games/fusion/gui/dialog/cosmetic_patches_dialog.py
@@ -38,7 +38,6 @@ class FusionCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_FusionCosmeticPa
         self._persist_check_field(self.beam_palette_check, "enable_beam_palette")
         self._persist_check_field(self.enemy_palette_check, "enable_enemy_palette")
         self._persist_check_field(self.tileset_palette_check, "enable_tileset_palette")
-
         # Combobox for Color Space
         self.color_space_combo.currentIndexChanged.connect(self._on_color_space_update)
 

--- a/randovania/games/fusion/layout/fusion_cosmetic_patches.py
+++ b/randovania/games/fusion/layout/fusion_cosmetic_patches.py
@@ -1,14 +1,53 @@
 from __future__ import annotations
 
 import dataclasses
+from enum import Enum
 
+from randovania.bitpacking.json_dataclass import JsonDataclass
 from randovania.games.game import RandovaniaGame
 from randovania.layout.base.cosmetic_patches import BaseCosmeticPatches
+from randovania.lib import enum_lib
 
 
-# TODO
+class ColorSpace(Enum):
+    """Types of Color Spaces used by the palette shuffler"""
+
+    long_name: str
+
+    Oklab = "Oklab"
+    HSV = "HSV"
+
+
+enum_lib.add_long_name(
+    ColorSpace,
+    {
+        ColorSpace.Oklab: "Oklab",
+        ColorSpace.HSV: "HSV",
+    },
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class PaletteShuffle(JsonDataclass):
+    enabled: bool
+    hue_min: int = dataclasses.field(metadata={"min": 0, "max": 360, "precision": 1})
+    hue_max: int = dataclasses.field(metadata={"min": 0, "max": 360, "precision": 1})
+
+
 @dataclasses.dataclass(frozen=True)
 class FusionCosmeticPatches(BaseCosmeticPatches):
+    suit_shuffle: PaletteShuffle = PaletteShuffle(False, 0, 360)
+    beam_shuffle: PaletteShuffle = PaletteShuffle(False, 0, 360)
+    enemy_shuffle: PaletteShuffle = PaletteShuffle(False, 0, 360)
+    tileset_shuffle: PaletteShuffle = PaletteShuffle(False, 0, 360)
+
+    symmetric: bool = False
+    color_space: ColorSpace = ColorSpace.Oklab
+
+    @classmethod
+    def default(cls) -> FusionCosmeticPatches:
+        return cls()
+
     @classmethod
     def game(cls) -> RandovaniaGame:
         return RandovaniaGame.FUSION

--- a/randovania/games/fusion/layout/fusion_cosmetic_patches.py
+++ b/randovania/games/fusion/layout/fusion_cosmetic_patches.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import dataclasses
 from enum import Enum
 
-from randovania.bitpacking.json_dataclass import JsonDataclass
 from randovania.games.game import RandovaniaGame
 from randovania.layout.base.cosmetic_patches import BaseCosmeticPatches
 from randovania.lib import enum_lib
@@ -28,20 +27,11 @@ enum_lib.add_long_name(
 
 
 @dataclasses.dataclass(frozen=True)
-class PaletteShuffle(JsonDataclass):
-    enabled: bool
-    hue_min: int = dataclasses.field(metadata={"min": 0, "max": 360, "precision": 1})
-    hue_max: int = dataclasses.field(metadata={"min": 0, "max": 360, "precision": 1})
-
-
-@dataclasses.dataclass(frozen=True)
 class FusionCosmeticPatches(BaseCosmeticPatches):
-    suit_shuffle: PaletteShuffle = PaletteShuffle(False, 0, 360)
-    beam_shuffle: PaletteShuffle = PaletteShuffle(False, 0, 360)
-    enemy_shuffle: PaletteShuffle = PaletteShuffle(False, 0, 360)
-    tileset_shuffle: PaletteShuffle = PaletteShuffle(False, 0, 360)
-
-    symmetric: bool = False
+    enable_suit_palette: bool = False
+    enable_beam_palette: bool = False
+    enable_enemy_palette: bool = False
+    enable_tileset_palette: bool = False
     color_space: ColorSpace = ColorSpace.Oklab
 
     @classmethod

--- a/randovania/games/fusion/layout/fusion_cosmetic_patches.py
+++ b/randovania/games/fusion/layout/fusion_cosmetic_patches.py
@@ -9,7 +9,7 @@ from randovania.lib import enum_lib
 
 
 class ColorSpace(Enum):
-    """Types of Color Spaces used by the palette shuffler"""
+    """Types of Color Spaces used by the palette randomizer"""
 
     long_name: str
 
@@ -29,9 +29,17 @@ enum_lib.add_long_name(
 @dataclasses.dataclass(frozen=True)
 class FusionCosmeticPatches(BaseCosmeticPatches):
     enable_suit_palette: bool = False
+    suit_hue_min: int = 0
+    suit_hue_max: int = 360
     enable_beam_palette: bool = False
+    beam_hue_min: int = 0
+    beam_hue_max: int = 360
     enable_enemy_palette: bool = False
+    enemy_hue_min: int = 0
+    enemy_hue_max: int = 360
     enable_tileset_palette: bool = False
+    tileset_hue_min: int = 0
+    tileset_hue_max: int = 360
     color_space: ColorSpace = ColorSpace.Oklab
 
     @classmethod

--- a/randovania/gui/ui_files/fusion_cosmetic_patches_dialog.ui
+++ b/randovania/gui/ui_files/fusion_cosmetic_patches_dialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>FusionCosmeticPatchesDialog</class>
- <widget class="QDialog" name="BlankCosmeticPatchesDialog">
+ <widget class="QDialog" name="FusionCosmeticPatchesDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -45,11 +45,96 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>376</width>
-        <height>195</height>
+        <width>362</width>
+        <height>253</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QGroupBox" name="palette_box">
+         <property name="title">
+          <string>Palette Shuffle</string>
+         </property>
+         <layout class="QVBoxLayout" name="palette_layout">
+          <item>
+           <layout class="QHBoxLayout" name="suit_color_layout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+           <widget class="QCheckBox" name="suit_palette_check">
+            <property name="text">
+             <string>Randomize Suit Pallete</string>
+            </property>
+           </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="beam_color_layout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+           <widget class="QCheckBox" name="beam_palette_check">
+            <property name="text">
+             <string>Randomize Beam Pallete</string>
+            </property>
+           </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="enemy_color_layout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+           <widget class="QCheckBox" name="enemy_palette_check">
+            <property name="text">
+             <string>Randomize Enemy Pallete</string>
+            </property>
+           </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="tileset_color_layout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+           <widget class="QCheckBox" name="tileset_palette_check">
+            <property name="text">
+             <string>Randomize Tileset Pallete</string>
+            </property>
+           </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="color_space_layout">
+            <item row="0" column="1">
+             <widget class="QComboBox" name="color_space_combo"/>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="color_space_label">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Color Space</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">

--- a/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
+++ b/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
@@ -17,14 +17,14 @@ from randovania.games.fusion.layout.fusion_cosmetic_patches import ColorSpace, F
     ],
 )
 def test_enable_palette(skip_qtbot, field_name: str, widget_field: str) -> None:
-    cosmetic_patches = FusionCosmeticPatches(**{field_name: False})
+    cosmetic_patches = FusionCosmeticPatches(**{field_name: False})  # type: ignore[arg-type]
 
     dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
     skip_qtbot.addWidget(dialog)
     # Run
     skip_qtbot.mouseClick(getattr(dialog, widget_field), QtCore.Qt.MouseButton.LeftButton)
     # Assert
-    assert dialog.cosmetic_patches == FusionCosmeticPatches(**{field_name: True})
+    assert dialog.cosmetic_patches == FusionCosmeticPatches(**{field_name: True})  # type: ignore[arg-type]
 
 
 def test_color_space(skip_qtbot):

--- a/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
+++ b/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
@@ -55,11 +55,12 @@ def test_color_space(skip_qtbot):
 
     dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
     skip_qtbot.addWidget(dialog)
-
-    skip_qtbot.keyClicks(dialog.color_space_combo, "HSV")
-
+    # Run
+    dialog.color_space_combo.setCurrentIndex(1)
+    # Assert
     assert dialog.cosmetic_patches == FusionCosmeticPatches(color_space=ColorSpace.HSV)
 
-    skip_qtbot.keyClicks(dialog.color_space_combo, "Oklab")
-
+    # Run
+    dialog.color_space_combo.setCurrentIndex(0)
+    # Assert
     assert dialog.cosmetic_patches == FusionCosmeticPatches(color_space=ColorSpace.Oklab)

--- a/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
+++ b/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
@@ -1,53 +1,30 @@
 from __future__ import annotations
 
+import pytest
 from PySide6 import QtCore
 
 from randovania.games.fusion.gui.dialog.cosmetic_patches_dialog import FusionCosmeticPatchesDialog
 from randovania.games.fusion.layout.fusion_cosmetic_patches import ColorSpace, FusionCosmeticPatches
 
 
-def test_suit_palette(skip_qtbot):
-    cosmetic_patches = FusionCosmeticPatches(enable_suit_palette=False)
+@pytest.mark.parametrize(
+    ("field_name", "widget_field"),
+    [
+        ("enable_suit_palette", "suit_palette_check"),
+        ("enable_beam_palette", "beam_palette_check"),
+        ("enable_enemy_palette", "enemy_palette_check"),
+        ("enable_tileset_palette", "tileset_palette_check"),
+    ],
+)
+def test_enable_palette(skip_qtbot, field_name: str, widget_field: str) -> None:
+    cosmetic_patches = FusionCosmeticPatches(**{field_name: False})
 
     dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
     skip_qtbot.addWidget(dialog)
-
-    skip_qtbot.mouseClick(dialog.suit_palette_check, QtCore.Qt.MouseButton.LeftButton)
-
-    assert dialog.cosmetic_patches == FusionCosmeticPatches(enable_suit_palette=True)
-
-
-def test_beam_palette(skip_qtbot):
-    cosmetic_patches = FusionCosmeticPatches(enable_beam_palette=False)
-
-    dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
-    skip_qtbot.addWidget(dialog)
-
-    skip_qtbot.mouseClick(dialog.beam_palette_check, QtCore.Qt.MouseButton.LeftButton)
-
-    assert dialog.cosmetic_patches == FusionCosmeticPatches(enable_beam_palette=True)
-
-
-def test_enemy_palette(skip_qtbot):
-    cosmetic_patches = FusionCosmeticPatches(enable_enemy_palette=False)
-
-    dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
-    skip_qtbot.addWidget(dialog)
-
-    skip_qtbot.mouseClick(dialog.enemy_palette_check, QtCore.Qt.MouseButton.LeftButton)
-
-    assert dialog.cosmetic_patches == FusionCosmeticPatches(enable_enemy_palette=True)
-
-
-def test_tileset_palette(skip_qtbot):
-    cosmetic_patches = FusionCosmeticPatches(enable_tileset_palette=False)
-
-    dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
-    skip_qtbot.addWidget(dialog)
-
-    skip_qtbot.mouseClick(dialog.tileset_palette_check, QtCore.Qt.MouseButton.LeftButton)
-
-    assert dialog.cosmetic_patches == FusionCosmeticPatches(enable_tileset_palette=True)
+    # Run
+    skip_qtbot.mouseClick(getattr(dialog, widget_field), QtCore.Qt.MouseButton.LeftButton)
+    # Assert
+    assert dialog.cosmetic_patches == FusionCosmeticPatches(**{field_name: True})
 
 
 def test_color_space(skip_qtbot):

--- a/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
+++ b/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from PySide6 import QtCore
+
+from randovania.games.fusion.gui.dialog.cosmetic_patches_dialog import FusionCosmeticPatchesDialog
+from randovania.games.fusion.layout.fusion_cosmetic_patches import ColorSpace, FusionCosmeticPatches
+
+
+def test_suit_palette(skip_qtbot):
+    cosmetic_patches = FusionCosmeticPatches(enable_suit_palette=False)
+
+    dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
+    skip_qtbot.addWidget(dialog)
+
+    skip_qtbot.mouseClick(dialog.suit_palette_check, QtCore.Qt.MouseButton.LeftButton)
+
+    assert dialog.cosmetic_patches == FusionCosmeticPatches(enable_suit_palette=True)
+
+
+def test_beam_palette(skip_qtbot):
+    cosmetic_patches = FusionCosmeticPatches(enable_beam_palette=False)
+
+    dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
+    skip_qtbot.addWidget(dialog)
+
+    skip_qtbot.mouseClick(dialog.beam_palette_check, QtCore.Qt.MouseButton.LeftButton)
+
+    assert dialog.cosmetic_patches == FusionCosmeticPatches(enable_beam_palette=True)
+
+
+def test_enemy_palette(skip_qtbot):
+    cosmetic_patches = FusionCosmeticPatches(enable_enemy_palette=False)
+
+    dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
+    skip_qtbot.addWidget(dialog)
+
+    skip_qtbot.mouseClick(dialog.enemy_palette_check, QtCore.Qt.MouseButton.LeftButton)
+
+    assert dialog.cosmetic_patches == FusionCosmeticPatches(enable_enemy_palette=True)
+
+
+def test_tileset_palette(skip_qtbot):
+    cosmetic_patches = FusionCosmeticPatches(enable_tileset_palette=False)
+
+    dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
+    skip_qtbot.addWidget(dialog)
+
+    skip_qtbot.mouseClick(dialog.tileset_palette_check, QtCore.Qt.MouseButton.LeftButton)
+
+    assert dialog.cosmetic_patches == FusionCosmeticPatches(enable_tileset_palette=True)
+
+
+def test_color_space(skip_qtbot):
+    cosmetic_patches = FusionCosmeticPatches(color_space=ColorSpace.Oklab)
+
+    dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
+    skip_qtbot.addWidget(dialog)
+
+    skip_qtbot.keyClicks(dialog.color_space_combo, "HSV")
+
+    assert dialog.cosmetic_patches == FusionCosmeticPatches(color_space=ColorSpace.HSV)
+
+    skip_qtbot.keyClicks(dialog.color_space_combo, "Oklab")
+
+    assert dialog.cosmetic_patches == FusionCosmeticPatches(color_space=ColorSpace.Oklab)


### PR DESCRIPTION
Adds basic palette randomizer options to cosmetics.
![image](https://github.com/randovania/randovania/assets/125271738/6401e2b8-1b42-449b-a0b3-2f65815095dd)
Room for future growth with hue_min, hue_max, symmetric options but is beyond the scope of this PR.