### PR TITLE
Fusion: All areas: route recharge rooms through the recharge pad node

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -10533,7 +10533,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Operations Deck Save Room": {
+                        "Recharge Terminal": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -10572,13 +10572,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Operations Deck": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Recharge Terminal": {
                             "type": "and",
                             "data": {
@@ -10603,6 +10596,13 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
+                        "Door to Operations Deck": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Door to Operations Deck Save Room": {
                             "type": "and",
                             "data": {

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -1875,20 +1875,20 @@ Extra - room_id: [81]
   * Layers: default
   * L0 Hatch to Operations Deck/Door to Operations Deck Recharge Room
   * Extra - door_idx: (99,)
-  > Door to Operations Deck Save Room
+  > Recharge Terminal
       Trivial
 
 > Door to Operations Deck Save Room; Heals? False
   * Layers: default
   * L0 Hatch to Operations Deck Save Room/Door to Operations Deck Recharge Room
   * Extra - door_idx: (191,)
-  > Door to Operations Deck
-      Trivial
   > Recharge Terminal
       Trivial
 
 > Recharge Terminal; Heals? True
   * Layers: default
+  > Door to Operations Deck
+      Trivial
   > Door to Operations Deck Save Room
       Trivial
 

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -2187,7 +2187,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Save Room": {
+                        "Recharge Terminal": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2226,13 +2226,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Hub": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Recharge Terminal": {
                             "type": "and",
                             "data": {
@@ -2257,6 +2250,13 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
+                        "Door to Entrance Hub": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Door to Entrance Save Room": {
                             "type": "and",
                             "data": {

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -377,20 +377,20 @@ Extra - room_id: [11]
   * Layers: default
   * L0 Hatch to Entrance Hub/Door to Entrance Recharge Room
   * Extra - door_idx: (78,)
-  > Door to Entrance Save Room
+  > Recharge Terminal
       Trivial
 
 > Door to Entrance Save Room; Heals? False
   * Layers: default
   * L0 Hatch to Entrance Save Room/Door to Entrance Recharge Room
   * Extra - door_idx: (90,)
-  > Door to Entrance Hub
-      Trivial
   > Recharge Terminal
       Trivial
 
 > Recharge Terminal; Heals? True
   * Layers: default
+  > Door to Entrance Hub
+      Trivial
   > Door to Entrance Save Room
       Trivial
 

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -7098,13 +7098,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Hub": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Recharge Terminal": {
                             "type": "and",
                             "data": {
@@ -7144,7 +7137,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Save Room": {
+                        "Recharge Terminal": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7169,6 +7162,13 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Door to Entrance Save Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Entrance Hub": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1142,8 +1142,6 @@ Extra - room_id: [37]
   * Layers: default
   * L0 Hatch to Entrance Save Room/Door to Entrance Recharge Room
   * Extra - door_idx: (85,)
-  > Door to Entrance Hub
-      Trivial
   > Recharge Terminal
       Trivial
 
@@ -1151,12 +1149,14 @@ Extra - room_id: [37]
   * Layers: default
   * L0 Hatch to Entrance Hub/Door to Entrance Recharge Room
   * Extra - door_idx: (86,)
-  > Door to Entrance Save Room
+  > Recharge Terminal
       Trivial
 
 > Recharge Terminal; Heals? True
   * Layers: default
   > Door to Entrance Save Room
+      Trivial
+  > Door to Entrance Hub
       Trivial
 
 ----------------

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -5754,13 +5754,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Hub": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Recharge Terminal": {
                             "type": "and",
                             "data": {
@@ -5800,7 +5793,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Save Room": {
+                        "Recharge Terminal": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5825,6 +5818,13 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Door to Entrance Save Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Entrance Hub": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7148,13 +7148,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Data Storage": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Recharge Terminal": {
                             "type": "and",
                             "data": {
@@ -7194,7 +7187,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Data Save Room": {
+                        "Recharge Terminal": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7219,6 +7212,13 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Door to Data Save Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Data Storage": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -897,8 +897,6 @@ Extra - room_id: [26]
   * Layers: default
   * L0 Hatch to Entrance Save Room/Door to Entrance Recharge Room
   * Extra - door_idx: (51,)
-  > Door to Entrance Hub
-      Trivial
   > Recharge Terminal
       Trivial
 
@@ -906,12 +904,14 @@ Extra - room_id: [26]
   * Layers: default
   * L0 Hatch to Entrance Hub/Door to Entrance Recharge Room
   * Extra - door_idx: (52,)
-  > Door to Entrance Save Room
+  > Recharge Terminal
       Trivial
 
 > Recharge Terminal; Heals? True
   * Layers: default
   > Door to Entrance Save Room
+      Trivial
+  > Door to Entrance Hub
       Trivial
 
 ----------------
@@ -1082,8 +1082,6 @@ Extra - room_id: [31]
   * Layers: default
   * L0 Hatch to Data Save Room/Door to Data Recharge Room
   * Extra - door_idx: (65,)
-  > Door to Data Storage
-      Trivial
   > Recharge Terminal
       Trivial
 
@@ -1091,12 +1089,14 @@ Extra - room_id: [31]
   * Layers: default
   * L0 Hatch to Data Storage/Door to Data Recharge Room
   * Extra - door_idx: (66,)
-  > Door to Data Save Room
+  > Recharge Terminal
       Trivial
 
 > Recharge Terminal; Heals? True
   * Layers: default
   > Door to Data Save Room
+      Trivial
+  > Door to Data Storage
       Trivial
 
 ----------------

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -7453,13 +7453,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Hub": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Recharge Terminal": {
                             "type": "and",
                             "data": {
@@ -7499,7 +7492,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Save Room": {
+                        "Recharge Terminal": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7524,6 +7517,13 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Door to Entrance Save Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Entrance Hub": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -1137,8 +1137,6 @@ Extra - room_id: [29]
   * Layers: default
   * L0 Hatch to Entrance Save Room/Door to Entrance Recharge Room
   * Extra - door_idx: (61,)
-  > Door to Entrance Hub
-      Trivial
   > Recharge Terminal
       Trivial
 
@@ -1146,12 +1144,14 @@ Extra - room_id: [29]
   * Layers: default
   * L0 Hatch to Entrance Hub/Door to Entrance Recharge Room
   * Extra - door_idx: (99,)
-  > Door to Entrance Save Room
+  > Recharge Terminal
       Trivial
 
 > Recharge Terminal; Heals? True
   * Layers: default
   > Door to Entrance Save Room
+      Trivial
+  > Door to Entrance Hub
       Trivial
 
 ----------------

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -5515,7 +5515,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Hub": {
+                        "Recharge Terminal": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5554,13 +5554,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Save Room": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Recharge Terminal": {
                             "type": "and",
                             "data": {
@@ -5585,6 +5578,13 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
+                        "Door to Entrance Save Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Door to Entrance Hub": {
                             "type": "and",
                             "data": {

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -941,20 +941,20 @@ Extra - room_id: [32]
   * Layers: default
   * L0 Hatch to Entrance Save Room/Door to Entrance Recharge Room
   * Extra - door_idx: (72,)
-  > Door to Entrance Hub
+  > Recharge Terminal
       Trivial
 
 > Door to Entrance Hub; Heals? False
   * Layers: default
   * L0 Hatch to Entrance Hub/Door to Entrance Recharge Room
   * Extra - door_idx: (74,)
-  > Door to Entrance Save Room
-      Trivial
   > Recharge Terminal
       Trivial
 
 > Recharge Terminal; Heals? True
   * Layers: default
+  > Door to Entrance Save Room
+      Trivial
   > Door to Entrance Hub
       Trivial
 

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -6468,7 +6468,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Save Room": {
+                        "Recharge Terminal": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6507,13 +6507,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Entrance Hub": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Recharge Terminal": {
                             "type": "and",
                             "data": {
@@ -6538,6 +6531,13 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
+                        "Door to Entrance Hub": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Door to Entrance Save Room": {
                             "type": "and",
                             "data": {

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -959,20 +959,20 @@ Extra - room_id: [29]
   * Layers: default
   * L0 Hatch to Entrance Hub/Door to Entrance Recharge Room
   * Extra - door_idx: (59,)
-  > Door to Entrance Save Room
+  > Recharge Terminal
       Trivial
 
 > Door to Entrance Save Room; Heals? False
   * Layers: default
   * L0 Hatch to Entrance Save Room/Door to Entrance Recharge Room
   * Extra - door_idx: (60,)
-  > Door to Entrance Hub
-      Trivial
   > Recharge Terminal
       Trivial
 
 > Recharge Terminal; Heals? True
   * Layers: default
+  > Door to Entrance Hub
+      Trivial
   > Door to Entrance Save Room
       Trivial
 


### PR DESCRIPTION
Per request in fusion-dev channel https://discord.com/channels/914291389293027329/1215675687936196608/1216805632905052310

Route all two-way recharge rooms through the recharge node to ensure it is used for energy requirements