### PR TITLE
Fusion: add audio options to cosmetics

### DIFF
--- a/randovania/games/fusion/gui/dialog/cosmetic_patches_dialog.py
+++ b/randovania/games/fusion/gui/dialog/cosmetic_patches_dialog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import functools
 from typing import TYPE_CHECKING
 
 from randovania.games.fusion.layout.fusion_cosmetic_patches import ColorSpace, FusionCosmeticPatches
@@ -27,6 +28,11 @@ class FusionCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_FusionCosmeticPa
         for color_space in ColorSpace:
             self.color_space_combo.addItem(color_space.long_name, color_space)
 
+        self.radio_buttons = {
+            False: self.mono_option,
+            True: self.stereo_option,
+        }
+
         self.on_new_cosmetic_patches(current)
         self.connect_signals()
 
@@ -40,11 +46,21 @@ class FusionCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_FusionCosmeticPa
         self._persist_check_field(self.tileset_palette_check, "enable_tileset_palette")
         # Combobox for Color Space
         self.color_space_combo.currentIndexChanged.connect(self._on_color_space_update)
+        # Radio buttons for Mono/Stereo
+        for stereo_default, radio_button in self.radio_buttons.items():
+            radio_button.toggled.connect(functools.partial(self._on_stereo_option_changed, stereo_default))
+        # Checkboxes for disabling Music/SFX
+        self._persist_check_field(self.disable_music_check, "disable_music")
+        self._persist_check_field(self.disable_sfx_check, "disable_sfx")
 
     def _on_color_space_update(self) -> None:
         self._cosmetic_patches = dataclasses.replace(
             self._cosmetic_patches, color_space=self.color_space_combo.currentData()
         )
+
+    def _on_stereo_option_changed(self, option: bool, value: bool) -> None:
+        if value:
+            self._cosmetic_patches = dataclasses.replace(self._cosmetic_patches, stereo_default=option)
 
     def on_new_cosmetic_patches(self, patches: FusionCosmeticPatches) -> None:
         self.suit_palette_check.setChecked(patches.enable_suit_palette)
@@ -52,6 +68,10 @@ class FusionCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_FusionCosmeticPa
         self.enemy_palette_check.setChecked(patches.enable_enemy_palette)
         self.tileset_palette_check.setChecked(patches.enable_tileset_palette)
         set_combo_with_value(self.color_space_combo, patches.color_space)
+        for stereo_default, radio_button in self.radio_buttons.items():
+            radio_button.setChecked(stereo_default == patches.stereo_default)
+        self.disable_music_check.setChecked(patches.disable_music)
+        self.disable_sfx_check.setChecked(patches.disable_sfx)
 
     @property
     def cosmetic_patches(self) -> FusionCosmeticPatches:

--- a/randovania/games/fusion/layout/fusion_cosmetic_patches.py
+++ b/randovania/games/fusion/layout/fusion_cosmetic_patches.py
@@ -28,6 +28,7 @@ enum_lib.add_long_name(
 
 @dataclasses.dataclass(frozen=True)
 class FusionCosmeticPatches(BaseCosmeticPatches):
+    # Palette Rando
     enable_suit_palette: bool = False
     suit_hue_min: int = 0
     suit_hue_max: int = 360
@@ -41,6 +42,10 @@ class FusionCosmeticPatches(BaseCosmeticPatches):
     tileset_hue_min: int = 0
     tileset_hue_max: int = 360
     color_space: ColorSpace = ColorSpace.Oklab
+    # Audio Options
+    stereo_default: bool = True
+    disable_music: bool = False
+    disable_sfx: bool = False
 
     @classmethod
     def default(cls) -> FusionCosmeticPatches:

--- a/randovania/gui/ui_files/fusion_cosmetic_patches_dialog.ui
+++ b/randovania/gui/ui_files/fusion_cosmetic_patches_dialog.ui
@@ -44,9 +44,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-200</y>
         <width>362</width>
-        <height>253</height>
+        <height>406</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -141,52 +141,68 @@
           <string>Audio Options</string>
          </property>
          <layout class="QVBoxLayout" name="audio_layout">
-         <item>
-          <widget class="QLabel" name="default_audio_label">
-           <property name="text">
-            <string>Default Audio Settings:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="stereo_layout">
-           <property name="spacing">
-            <number>6</number>
-           </property>
-           <item>
-            <widget class="QRadioButton" name="mono_option">
-             <property name="text">
-              <string>Mono</string>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="stereo_option">
-             <property name="text">
-              <string>Stereo</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="QLabel" name="audio_volume_label">
-           <property name="text">
-            <string>Audio Volume Settings:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="volume_layout">
-           <property name="spacing">
-            <number>6</number>
-           </property>
+          <item>
+           <widget class="QLabel" name="default_audio_label">
+            <property name="text">
+             <string>Default Audio Settings:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="stereo_layout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QRadioButton" name="mono_option">
+              <property name="text">
+               <string>Mono</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="stereo_option">
+              <property name="text">
+               <string>Stereo</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Minimum</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>10</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="audio_volume_label">
+            <property name="text">
+             <string>Audio Volume Settings:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="volume_layout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
             <item>
              <widget class="QCheckBox" name="disable_music_check">
               <property name="text">

--- a/randovania/gui/ui_files/fusion_cosmetic_patches_dialog.ui
+++ b/randovania/gui/ui_files/fusion_cosmetic_patches_dialog.ui
@@ -136,6 +136,77 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="audio_box">
+         <property name="title">
+          <string>Audio Options</string>
+         </property>
+         <layout class="QVBoxLayout" name="audio_layout">
+         <item>
+          <widget class="QLabel" name="custom_dna_rotation_label">
+           <property name="text">
+            <string>Default Audio Settings:</string>
+           </property>
+          </widget>
+         </item>
+          <item>
+           <layout class="QHBoxLayout" name="music_layout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QRadioButton" name="mono_option">
+              <property name="text">
+               <string>Mono</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+             </item>
+             <item>
+             <widget class="QRadioButton" name="stereo_option">
+              <property name="text">
+               <string>Stereo</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="music_layout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QCheckBox" name="disable_music_check">
+              <property name="text">
+               <string>Disable Music</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="music_layout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QCheckBox" name="disable_sfx_check">
+              <property name="text">
+               <string>Disable Sound Effects</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/randovania/gui/ui_files/fusion_cosmetic_patches_dialog.ui
+++ b/randovania/gui/ui_files/fusion_cosmetic_patches_dialog.ui
@@ -62,11 +62,11 @@
              <number>6</number>
             </property>
             <item>
-           <widget class="QCheckBox" name="suit_palette_check">
-            <property name="text">
-             <string>Randomize Suit Pallete</string>
-            </property>
-           </widget>
+             <widget class="QCheckBox" name="suit_palette_check">
+              <property name="text">
+               <string>Randomize Suit Pallete</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -76,11 +76,11 @@
              <number>6</number>
             </property>
             <item>
-           <widget class="QCheckBox" name="beam_palette_check">
-            <property name="text">
-             <string>Randomize Beam Pallete</string>
-            </property>
-           </widget>
+             <widget class="QCheckBox" name="beam_palette_check">
+              <property name="text">
+               <string>Randomize Beam Pallete</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -90,11 +90,11 @@
              <number>6</number>
             </property>
             <item>
-           <widget class="QCheckBox" name="enemy_palette_check">
-            <property name="text">
-             <string>Randomize Enemy Pallete</string>
-            </property>
-           </widget>
+             <widget class="QCheckBox" name="enemy_palette_check">
+              <property name="text">
+               <string>Randomize Enemy Pallete</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -104,11 +104,11 @@
              <number>6</number>
             </property>
             <item>
-           <widget class="QCheckBox" name="tileset_palette_check">
-            <property name="text">
-             <string>Randomize Tileset Pallete</string>
-            </property>
-           </widget>
+             <widget class="QCheckBox" name="tileset_palette_check">
+              <property name="text">
+               <string>Randomize Tileset Pallete</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -142,48 +142,55 @@
          </property>
          <layout class="QVBoxLayout" name="audio_layout">
          <item>
-          <widget class="QLabel" name="custom_dna_rotation_label">
+          <widget class="QLabel" name="default_audio_label">
            <property name="text">
             <string>Default Audio Settings:</string>
            </property>
           </widget>
          </item>
-          <item>
-           <layout class="QHBoxLayout" name="music_layout">
-            <property name="spacing">
-             <number>6</number>
-            </property>
-            <item>
-             <widget class="QRadioButton" name="mono_option">
-              <property name="text">
-               <string>Mono</string>
-              </property>
-              <property name="checked">
-               <bool>false</bool>
-              </property>
-             </widget>
-             </item>
-             <item>
-             <widget class="QRadioButton" name="stereo_option">
-              <property name="text">
-               <string>Stereo</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="music_layout">
-            <property name="spacing">
-             <number>6</number>
-            </property>
+         <item>
+          <layout class="QHBoxLayout" name="stereo_layout">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <item>
+            <widget class="QRadioButton" name="mono_option">
+             <property name="text">
+              <string>Mono</string>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="stereo_option">
+             <property name="text">
+              <string>Stereo</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QLabel" name="audio_volume_label">
+           <property name="text">
+            <string>Audio Volume Settings:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="volume_layout">
+           <property name="spacing">
+            <number>6</number>
+           </property>
             <item>
              <widget class="QCheckBox" name="disable_music_check">
               <property name="text">
-               <string>Disable Music</string>
+               <string>Mute Music</string>
               </property>
              </widget>
             </item>
@@ -197,7 +204,7 @@
             <item>
              <widget class="QCheckBox" name="disable_sfx_check">
               <property name="text">
-               <string>Disable Sound Effects</string>
+               <string>Mute Sound Effects</string>
               </property>
              </widget>
             </item>

--- a/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
+++ b/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
@@ -57,12 +57,8 @@ def test_change_music_option(skip_qtbot, music_start_value: bool, option_to_clic
 
     dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
     skip_qtbot.addWidget(dialog)
-    str_to_option_map = {
-        "stereo_option": dialog.stereo_option,
-        "mono_option": dialog.mono_option,
-    }
-    radio_button = str_to_option_map[option_to_click]
 
+    radio_button = getattr(dialog, option_to_click)
     skip_qtbot.mouseClick(radio_button, QtCore.Qt.MouseButton.LeftButton)
 
     assert dialog.cosmetic_patches == FusionCosmeticPatches(stereo_default=music_end_value)

--- a/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
+++ b/test/games/fusion/gui/test_fusion_cosmetic_patches_dialog.py
@@ -14,9 +14,11 @@ from randovania.games.fusion.layout.fusion_cosmetic_patches import ColorSpace, F
         ("enable_beam_palette", "beam_palette_check"),
         ("enable_enemy_palette", "enemy_palette_check"),
         ("enable_tileset_palette", "tileset_palette_check"),
+        ("disable_music", "disable_music_check"),
+        ("disable_sfx", "disable_sfx_check"),
     ],
 )
-def test_enable_palette(skip_qtbot, field_name: str, widget_field: str) -> None:
+def test_enable_checkboxes(skip_qtbot, field_name: str, widget_field: str) -> None:
     cosmetic_patches = FusionCosmeticPatches(**{field_name: False})  # type: ignore[arg-type]
 
     dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
@@ -41,3 +43,26 @@ def test_color_space(skip_qtbot):
     dialog.color_space_combo.setCurrentIndex(0)
     # Assert
     assert dialog.cosmetic_patches == FusionCosmeticPatches(color_space=ColorSpace.Oklab)
+
+
+@pytest.mark.parametrize(
+    ("music_start_value", "option_to_click", "music_end_value"),
+    [
+        (False, "stereo_option", True),
+        (True, "mono_option", False),
+    ],
+)
+def test_change_music_option(skip_qtbot, music_start_value: bool, option_to_click: str, music_end_value: bool) -> None:
+    cosmetic_patches = FusionCosmeticPatches(stereo_default=music_start_value)
+
+    dialog = FusionCosmeticPatchesDialog(None, cosmetic_patches)
+    skip_qtbot.addWidget(dialog)
+    str_to_option_map = {
+        "stereo_option": dialog.stereo_option,
+        "mono_option": dialog.mono_option,
+    }
+    radio_button = str_to_option_map[option_to_click]
+
+    skip_qtbot.mouseClick(radio_button, QtCore.Qt.MouseButton.LeftButton)
+
+    assert dialog.cosmetic_patches == FusionCosmeticPatches(stereo_default=music_end_value)


### PR DESCRIPTION
Adds the following audio options:
![image](https://github.com/randovania/randovania/assets/125271738/c136d9e8-fad0-4abe-bd54-f5fd2936310d)