### PR TITLE
Fusion: Add required and placed metroids to goal

### DIFF
--- a/randovania/games/fusion/generator/pool_creator.py
+++ b/randovania/games/fusion/generator/pool_creator.py
@@ -57,7 +57,7 @@ def artifact_pool(game: GameDescription, config: FusionArtifactConfig) -> PoolRe
         raise InvalidConfiguration("More Infant Metroids than allowed!")
 
     keys: list[PickupEntry] = [create_fusion_artifact(i, game.resource_database) for i in range(20)]
-    keys_to_shuffle = keys[: config.required_artifacts]
-    starting_keys = keys[config.required_artifacts :]
+    keys_to_shuffle = keys[: config.placed_artifacts]
+    starting_keys = keys[config.placed_artifacts :]
 
     return PoolResults(keys_to_shuffle, {}, starting_keys)

--- a/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
+++ b/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
@@ -28,7 +28,8 @@ class PresetFusionGoal(PresetTab, Ui_PresetFusionGoal):
         self.restrict_placement_radiobutton.toggled.connect(self._on_restrict_placement)
         self.free_placement_radiobutton.toggled.connect(self._on_free_placement)
         signal_handling.on_checked(self.prefer_bosses_check, self._on_prefer_bosses)
-        self.metroid_slider.valueChanged.connect(self._on_metroid_slider_changed)
+        self.required_slider.valueChanged.connect(self._on_required_slider_changed)
+        self.placed_slider.valueChanged.connect(self._on_placed_slider_changed)
 
     @classmethod
     def tab_title(cls) -> str:
@@ -39,8 +40,8 @@ class PresetFusionGoal(PresetTab, Ui_PresetFusionGoal):
         return False
 
     def _update_slider_max(self) -> None:
-        self.metroid_slider.setMaximum(self.num_preferred_locations)
-        self.metroid_slider.setEnabled(self.num_preferred_locations > 0)
+        self.placed_slider.setMaximum(self.num_preferred_locations)
+        self.placed_slider.setEnabled(self.num_preferred_locations > 0)
 
     def _edit_config(self, call: Callable[[FusionArtifactConfig], FusionArtifactConfig]) -> None:
         config = self._editor.configuration
@@ -86,11 +87,21 @@ class PresetFusionGoal(PresetTab, Ui_PresetFusionGoal):
         self._edit_config(edit)
         self._update_slider_max()
 
-    def _on_metroid_slider_changed(self) -> None:
-        self.metroid_slider_label.setText(f"{self.metroid_slider.value()} Infant Metroids")
+    def _on_required_slider_changed(self) -> None:
+        self.required_slider_label.setText(f"{self.required_slider.value()} Infant Metroids")
 
         def edit(config: FusionArtifactConfig) -> FusionArtifactConfig:
-            return dataclasses.replace(config, required_artifacts=self.metroid_slider.value())
+            return dataclasses.replace(config, required_artifacts=self.required_slider.value())
+
+        self._edit_config(edit)
+
+    def _on_placed_slider_changed(self) -> None:
+        self.placed_slider_label.setText(f"{self.placed_slider.value()} Infant Metroids")
+        self.required_slider.setMaximum(self.placed_slider.value())
+        self.required_slider.setEnabled(self.placed_slider.value() > 0)
+
+        def edit(config: FusionArtifactConfig) -> FusionArtifactConfig:
+            return dataclasses.replace(config, placed_artifacts=self.placed_slider.value())
 
         self._edit_config(edit)
 
@@ -100,4 +111,5 @@ class PresetFusionGoal(PresetTab, Ui_PresetFusionGoal):
         self.free_placement_radiobutton.setChecked(artifacts.prefer_anywhere)
         self.restrict_placement_radiobutton.setChecked(not artifacts.prefer_anywhere)
         self.prefer_bosses_check.setChecked(artifacts.prefer_bosses)
-        self.metroid_slider.setValue(artifacts.required_artifacts)
+        self.required_slider.setValue(artifacts.required_artifacts)
+        self.placed_slider.setValue(artifacts.placed_artifacts)

--- a/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
+++ b/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
@@ -88,7 +88,7 @@ class PresetFusionGoal(PresetTab, Ui_PresetFusionGoal):
         self._update_slider_max()
 
     def _on_required_slider_changed(self) -> None:
-        self.required_slider_label.setText(f"{self.required_slider.value()} Infant Metroids")
+        self.required_slider_label.setText(f"{self.required_slider.value()} Metroids Required")
 
         def edit(config: FusionArtifactConfig) -> FusionArtifactConfig:
             return dataclasses.replace(config, required_artifacts=self.required_slider.value())
@@ -96,7 +96,7 @@ class PresetFusionGoal(PresetTab, Ui_PresetFusionGoal):
         self._edit_config(edit)
 
     def _on_placed_slider_changed(self) -> None:
-        self.placed_slider_label.setText(f"{self.placed_slider.value()} Infant Metroids")
+        self.placed_slider_label.setText(f"{self.placed_slider.value()} Metroids in Pool")
         self.required_slider.setMaximum(self.placed_slider.value())
         self.required_slider.setEnabled(self.placed_slider.value() > 0)
 

--- a/randovania/games/fusion/layout/fusion_configuration.py
+++ b/randovania/games/fusion/layout/fusion_configuration.py
@@ -13,12 +13,11 @@ class FusionArtifactConfig(BitPackDataclass, JsonDataclass):
     prefer_bosses: bool
     prefer_anywhere: bool
     required_artifacts: int = dataclasses.field(metadata={"min": 0, "max": 20, "precision": 1})
+    placed_artifacts: int = dataclasses.field(metadata={"min": 0, "max": 20, "precision": 1})
 
 
-# TODO
 @dataclasses.dataclass(frozen=True)
 class FusionConfiguration(BaseConfiguration):
-    # These fields aren't necessary for a new game: they're here to have example/test features
     instant_transitions: bool
     energy_per_tank: int = dataclasses.field(metadata={"min": 1, "max": 1000, "precision": 1})
     artifacts: FusionArtifactConfig
@@ -29,5 +28,15 @@ class FusionConfiguration(BaseConfiguration):
 
     def active_layers(self) -> set[str]:
         result = super().active_layers()
+
+        return result
+
+    def unsupported_features(self) -> list[str]:
+        result = super().unsupported_features()
+
+        if self.artifacts.required_artifacts > self.artifacts.placed_artifacts:
+            result.append(
+                "The amount of required Infant Metroids cannot be higher than the total amount of placed Metroids."
+            )
 
         return result

--- a/randovania/games/fusion/presets/starter_preset.rdvpreset
+++ b/randovania/games/fusion/presets/starter_preset.rdvpreset
@@ -163,7 +163,8 @@
         "artifacts": {
             "prefer_bosses": true,
             "prefer_anywhere": false,
-            "required_artifacts": 5
+            "required_artifacts": 3,
+            "placed_artifacts": 5
         }
     }
 }

--- a/randovania/gui/ui_files/preset_fusion_goal.ui
+++ b/randovania/gui/ui_files/preset_fusion_goal.ui
@@ -36,7 +36,7 @@
     <item>
      <widget class="QLabel" name="description_label">
       <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In addition to preparing for battle with the SA-X, it is now necessary to collect the escaped Infant Metroids in order to reach the Operations Room. The minimum and maximum are limited to 0 and 20 Infant Metroids.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In addition to preparing for battle with the SA-X, it is now necessary to collect the escaped Infant Metroids in order to reach the Operations Room. The minimum and maximum are limited to 0 and 20 Infant Metroids. You can choose to place more Metroids than required.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>
@@ -44,9 +44,19 @@
      </widget>
     </item>
     <item>
-     <layout class="QHBoxLayout" name="metroid_slider_layout">
+     <widget class="QLabel" name="placed_label">
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls how many Infant Metroids will be placed in the game.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="placed_slider_layout">
       <item>
-       <widget class="QSlider" name="metroid_slider">
+       <widget class="QSlider" name="placed_slider">
         <property name="maximum">
          <number>46</number>
         </property>
@@ -62,7 +72,59 @@
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="metroid_slider_label">
+       <widget class="QLabel" name="placed_slider_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>20</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>0</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="QLabel" name="required_label">
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls how many Infant Metroids are required to beat the game.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="required_slider_layout">
+      <item>
+       <widget class="QSlider" name="required_slider">
+        <property name="maximum">
+         <number>46</number>
+        </property>
+        <property name="pageStep">
+         <number>2</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="required_slider_label">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
           <horstretch>0</horstretch>

--- a/randovania/gui/ui_files/preset_fusion_goal.ui
+++ b/randovania/gui/ui_files/preset_fusion_goal.ui
@@ -81,7 +81,7 @@
         </property>
         <property name="minimumSize">
          <size>
-          <width>20</width>
+          <width>150</width>
           <height>0</height>
          </size>
         </property>
@@ -133,7 +133,7 @@
         </property>
         <property name="minimumSize">
          <size>
-          <width>20</width>
+          <width>150</width>
           <height>0</height>
          </size>
         </property>

--- a/test/games/fusion/generator/test_fusion_bootstrap.py
+++ b/test/games/fusion/generator/test_fusion_bootstrap.py
@@ -19,9 +19,9 @@ _boss_indices = [100, 106, 114, 104, 115, 107, 110, 102, 109, 108, 111]
 @pytest.mark.parametrize(
     ("artifacts", "expected"),
     [
-        (FusionArtifactConfig(True, False, 5), [102, 106, 107, 110, 114]),
-        (FusionArtifactConfig(True, False, 11), _boss_indices),
-        (FusionArtifactConfig(False, False, 0), []),
+        (FusionArtifactConfig(True, False, 5, 5), [102, 106, 107, 110, 114]),
+        (FusionArtifactConfig(True, False, 11, 11), _boss_indices),
+        (FusionArtifactConfig(False, False, 0, 0), []),
     ],
 )
 def test_assign_pool_results_predetermined(fusion_game_description, fusion_configuration, artifacts, expected):
@@ -52,9 +52,9 @@ def test_assign_pool_results_predetermined(fusion_game_description, fusion_confi
 @pytest.mark.parametrize(
     ("artifacts"),
     [
-        (FusionArtifactConfig(False, True, 0)),
-        (FusionArtifactConfig(True, True, 10)),
-        (FusionArtifactConfig(False, True, 20)),
+        (FusionArtifactConfig(False, True, 0, 0)),
+        (FusionArtifactConfig(True, True, 10, 0)),
+        (FusionArtifactConfig(False, True, 20, 20)),
     ],
 )
 def test_assign_pool_results_prefer_anywhere(fusion_game_description, fusion_configuration, artifacts):
@@ -77,7 +77,7 @@ def test_assign_pool_results_prefer_anywhere(fusion_game_description, fusion_con
     ]
 
     assert pool_results.to_place == initial_starting_place
-    assert len(shuffled_metroids) == artifacts.required_artifacts
+    assert len(shuffled_metroids) == artifacts.placed_artifacts
     assert result.starting_equipment == pool_results.starting
     assert {
         index: entry for index, entry in result.pickup_assignment.items() if "Infant Metroid" in entry.pickup.name

--- a/test/games/fusion/generator/test_fusion_pool_creator.py
+++ b/test/games/fusion/generator/test_fusion_pool_creator.py
@@ -8,32 +8,49 @@ from randovania.generator.pickup_pool import PoolResults
 from randovania.layout.exceptions import InvalidConfiguration
 
 
-@pytest.mark.parametrize("metroid_count", [0, 1, 11, 20])
-def test_fusion_pool_creator(fusion_game_description, metroid_count):
+@pytest.mark.parametrize(
+    ("required_metroids", "placed_metroids"),
+    [
+        (0, 0),
+        (1, 1),
+        (11, 11),
+        (20, 20),
+    ],
+)
+def test_fusion_pool_creator(fusion_game_description, required_metroids, placed_metroids):
     db = fusion_game_description.resource_database
     # Run
-    results = artifact_pool(fusion_game_description, FusionArtifactConfig(True, True, metroid_count))
+    results = artifact_pool(
+        fusion_game_description, FusionArtifactConfig(True, True, required_metroids, placed_metroids)
+    )
 
     # Assert
     assert results == PoolResults(
-        [create_fusion_artifact(i, db) for i in range(metroid_count)],
+        [create_fusion_artifact(i, db) for i in range(required_metroids)],
         {},
-        [create_fusion_artifact(i, db) for i in range(metroid_count, 20)],
+        [create_fusion_artifact(i, db) for i in range(required_metroids, 20)],
     )
 
 
 @pytest.mark.parametrize(
-    ("bosses", "anywhere", "artifacts"),
+    ("bosses", "anywhere", "required_metroids", "placed_metroids"),
     [
-        (False, False, 1),
-        (True, False, 12),
-        (True, True, 21),
-        (False, True, 21),
+        (False, False, 1, 1),
+        (True, False, 12, 12),
+        (True, True, 21, 21),
+        (False, True, 21, 21),
     ],
 )
-def test_fusion_artifact_pool_should_throw_on_invalid_config(fusion_game_description, bosses, anywhere, artifacts):
+def test_fusion_artifact_pool_should_throw_on_invalid_config(
+    fusion_game_description, bosses, anywhere, required_metroids, placed_metroids
+):
     # Setup
-    configuration = FusionArtifactConfig(prefer_bosses=bosses, prefer_anywhere=anywhere, required_artifacts=artifacts)
+    configuration = FusionArtifactConfig(
+        prefer_bosses=bosses,
+        prefer_anywhere=anywhere,
+        required_artifacts=required_metroids,
+        placed_artifacts=placed_metroids,
+    )
 
     # Run
     with pytest.raises(InvalidConfiguration, match="More Infant Metroids than allowed!"):

--- a/test/games/fusion/gui/preset_settings/test_preset_fusion_goal.py
+++ b/test/games/fusion/gui/preset_settings/test_preset_fusion_goal.py
@@ -35,23 +35,23 @@ def test_preferred_bosses(
     tab.on_preset_changed(preset)
     assert isinstance(editor.configuration, FusionConfiguration)
 
-    assert tab.metroid_slider.isEnabled()
-    assert tab.metroid_slider.value() > 0
-    initial_slider_value = tab.metroid_slider.value()
+    assert tab.placed_slider.isEnabled()
+    assert tab.placed_slider.value() > 0
+    initial_slider_value = tab.placed_slider.value()
 
     # Run
     tab.prefer_bosses_check.setChecked(prefer_bosses)
-    slider_value_after_first_set = tab.metroid_slider.value()
+    slider_value_after_first_set = tab.placed_slider.value()
     tab._update_slider_max()
 
     # Assert
     if not prefer_bosses:
         assert slider_value_after_first_set == 0
     # The slider value should never increase from what it was before
-    assert slider_value_after_first_set >= tab.metroid_slider.value()
+    assert slider_value_after_first_set >= tab.placed_slider.value()
     assert tab.num_preferred_locations == expected_max_slider
-    assert tab.metroid_slider.maximum() == expected_max_slider
-    assert tab.metroid_slider.isEnabled() == (expected_max_slider > 0)
+    assert tab.placed_slider.maximum() == expected_max_slider
+    assert tab.placed_slider.isEnabled() == (expected_max_slider > 0)
     assert editor.configuration.artifacts.prefer_bosses == prefer_bosses
     # If default value in configuration is smaller than the max allowed value, it shouldn't increase
     expected_artifacts = expected_max_slider
@@ -61,8 +61,8 @@ def test_preferred_bosses(
     if slider_value_after_first_set == 0:
         expected_artifacts = 0
 
-    assert editor.configuration.artifacts.required_artifacts == expected_artifacts
-    assert tab.metroid_slider.value() == expected_artifacts
+    assert editor.configuration.artifacts.placed_artifacts == expected_artifacts
+    assert tab.placed_slider.value() == expected_artifacts
 
 
 def test_restricted_placement(
@@ -82,7 +82,7 @@ def test_restricted_placement(
     assert isinstance(editor.configuration, FusionConfiguration)
     skip_qtbot.addWidget(tab)
     tab.on_preset_changed(preset)
-    artifact_count = editor.configuration.artifacts.required_artifacts
+    artifact_count = editor.configuration.artifacts.placed_artifacts
     tab.free_placement_radiobutton.setChecked(True)
 
     # Run
@@ -91,7 +91,7 @@ def test_restricted_placement(
     # Assert
     assert tab.prefer_bosses_check.isEnabled()
     assert tab.restrict_placement_radiobutton.isChecked()
-    assert editor.configuration.artifacts.required_artifacts == artifact_count
+    assert editor.configuration.artifacts.placed_artifacts == artifact_count
 
 
 def test_free_placement(
@@ -111,7 +111,7 @@ def test_free_placement(
     assert isinstance(editor.configuration, FusionConfiguration)
     skip_qtbot.addWidget(tab)
     tab.on_preset_changed(preset)
-    artifact_count = editor.configuration.artifacts.required_artifacts
+    artifact_count = editor.configuration.artifacts.placed_artifacts
     tab.restrict_placement_radiobutton.setChecked(True)
 
     # Run
@@ -120,4 +120,4 @@ def test_free_placement(
     # Assert
     assert not tab.prefer_bosses_check.isEnabled()
     assert tab.free_placement_radiobutton.isChecked()
-    assert editor.configuration.artifacts.required_artifacts == artifact_count
+    assert editor.configuration.artifacts.placed_artifacts == artifact_count

--- a/test/games/fusion/layout/test_fusion_configuration.py
+++ b/test/games/fusion/layout/test_fusion_configuration.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import dataclasses
+
+from randovania.games.fusion.layout.fusion_configuration import FusionArtifactConfig, FusionConfiguration
+from randovania.games.game import RandovaniaGame
+
+
+def test_has_unsupported_features(preset_manager):
+    preset = preset_manager.default_preset_for_game(RandovaniaGame.FUSION).get_preset()
+    assert isinstance(preset.configuration, FusionConfiguration)
+
+    configuration = preset.configuration
+
+    configuration = dataclasses.replace(
+        configuration,
+        artifacts=FusionArtifactConfig(
+            prefer_bosses=True, prefer_anywhere=False, required_artifacts=5, placed_artifacts=1
+        ),
+    )
+
+    assert configuration.unsupported_features() == [
+        "The amount of required Infant Metroids cannot be higher than the total amount of placed Metroids."
+    ]
+
+
+def test_no_unsupported_features(preset_manager):
+    preset = preset_manager.default_preset_for_game(RandovaniaGame.FUSION).get_preset()
+    assert preset.configuration.unsupported_features() == []


### PR DESCRIPTION
Add option to control number of required metroids vs placed.
UI updates so required can never be higher than placed.
![image](https://github.com/randovania/randovania/assets/125271738/f80a97d3-62a8-40bb-9137-7af79981b95f)
![image](https://github.com/randovania/randovania/assets/125271738/c1f2649b-0003-4a1d-958c-50ab5909d608)
![image](https://github.com/randovania/randovania/assets/125271738/9121886b-0cd1-400f-b0fd-aaef084d5902)
