### PR TITLE
bump yams to 1.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: Updated A-Kul's scan with the 2023 CGC Tournament winners.
 
+## [7.4.1] - 2024-03-xx
+
+### AM2R
+- Fixed: Hitting Zetas with Charge Beam works again.
+
 ## [7.4.0] - 2024-03-08
 
 - Added: A warning will be shown when trying to generate a game where more items are in the pool than the maximum amount of items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: The following Multiworld sprites were changed in order to fit more with AM2R's art style: Dread's Energy Part, Dread's Wide Beam, Echoes' Amber Translator, Echoes' Cobalt Translator, Echoes' Dark Agon Key, Echoes' Darkburst, Echoes' Dark Torvus Key, Echoes' Emerald Translator, Echoes' Ing Hive Key, Echoes' Sky Temple Key, Echoes' Super Missiles, Echoes' Violet Translator
 - Fixed: Rare crash when receiving a flashlight/blindfold in a Multiworld session.
 - Fixed: AM2R Speed Booster Upgrades now show properly instead of using the default offworld model.
-- Fixed: Hitting Zetas with Charge Beam works again.
 
 ### Cave Story
 - **Major** - Cave Story: Tweaked is now supported as an export platform and included with Randovania.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: The following Multiworld sprites were changed in order to fit more with AM2R's art style: Dread's Energy Part, Dread's Wide Beam, Echoes' Amber Translator, Echoes' Cobalt Translator, Echoes' Dark Agon Key, Echoes' Darkburst, Echoes' Dark Torvus Key, Echoes' Emerald Translator, Echoes' Ing Hive Key, Echoes' Sky Temple Key, Echoes' Super Missiles, Echoes' Violet Translator
 - Fixed: Rare crash when receiving a flashlight/blindfold in a Multiworld session.
 - Fixed: AM2R Speed Booster Upgrades now show properly instead of using the default offworld model.
+- Fixed: Hitting Zetas with Charge Beam works again.
 
 ### Cave Story
 - **Major** - Cave Story: Tweaked is now supported as an export platform and included with Randovania.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ aiohttp==3.9.3
     #   randovania (setup.py)
 aiosignal==1.3.1
     # via aiohttp
-am2r-yams==1.2.14
+am2r-yams==1.2.15
     # via randovania (setup.py)
 appdirs==1.4.4
     # via randovania (setup.py)


### PR DESCRIPTION
Fixed: Hitting Zetas with Charge Beam works again.