### PR TITLE
Fusion: DLR gui and db updates

### DIFF
--- a/randovania/games/fusion/generator/bootstrap.py
+++ b/randovania/games/fusion/generator/bootstrap.py
@@ -13,8 +13,10 @@ if TYPE_CHECKING:
 
     from randovania.game_description.game_description import GameDescription
     from randovania.game_description.game_patches import GamePatches
+    from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.games.fusion.layout.fusion_configuration import FusionArtifactConfig
     from randovania.generator.pickup_pool import PoolResults
+    from randovania.layout.base.base_configuration import BaseConfiguration
 
 
 def all_metroid_locations(game: GameDescription, config: FusionArtifactConfig) -> list[PickupNode]:
@@ -30,6 +32,14 @@ def all_metroid_locations(game: GameDescription, config: FusionArtifactConfig) -
 
 
 class FusionBootstrap(MetroidBootstrap):
+    def _get_enabled_misc_resources(
+        self, configuration: BaseConfiguration, resource_database: ResourceDatabase
+    ) -> set[str]:
+        enabled_resources = set()
+        if configuration.dock_rando.is_enabled():
+            enabled_resources.add("DoorLockRando")
+        return enabled_resources
+
     def assign_pool_results(self, rng: Random, patches: GamePatches, pool_results: PoolResults) -> GamePatches:
         assert isinstance(patches.configuration, FusionConfiguration)
         config = patches.configuration.artifacts

--- a/randovania/games/fusion/gui/preset_settings/__init__.py
+++ b/randovania/games/fusion/gui/preset_settings/__init__.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 def preset_tabs(editor: PresetEditor, window_manager: WindowManager) -> list[type[PresetTab]]:
     from randovania.games.fusion.gui.preset_settings.fusion_goal_tab import PresetFusionGoal
     from randovania.games.fusion.gui.preset_settings.fusion_patches_tab import PresetFusionPatches
+    from randovania.gui.preset_settings.dock_rando_tab import PresetDockRando
     from randovania.gui.preset_settings.generation_tab import PresetGeneration
     from randovania.gui.preset_settings.location_pool_tab import PresetLocationPool
     from randovania.gui.preset_settings.metroid_item_pool_tab import MetroidPresetItemPool
@@ -27,6 +28,6 @@ def preset_tabs(editor: PresetEditor, window_manager: WindowManager) -> list[typ
         MetroidPresetItemPool,
         PresetPatcherEnergy,
         PresetStartingArea,
-        # PresetDockRando, TODO: implementation to come later
+        PresetDockRando,
         PresetFusionPatches,
     ]

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -9690,15 +9690,13 @@
                         "Other to Habitation Ventilation (Upper)": {
                             "type": "or",
                             "data": {
-                                "comment": null,
+                                "comment": "Animals causes issues in generation with DLR, removed as an event for now",
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "events",
-                                            "name": "Animals",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": []
                                         }
                                     }
                                 ]
@@ -9783,17 +9781,15 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Habitation Deck Entrance (Upper)": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "Animals causes issues in generation with DLR, removed as an event for now",
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "events",
-                                            "name": "Animals",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": []
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -9773,7 +9773,7 @@
                                 ]
                             }
                         },
-                        "Event - Save the Animals": {
+                        "Save the Animals": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9782,21 +9782,20 @@
                         }
                     }
                 },
-                "Event - Save the Animals": {
-                    "node_type": "event",
+                "Save the Animals": {
+                    "node_type": "generic",
                     "heal": false,
                     "coordinates": {
                         "x": 312.28,
                         "y": 410.23,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "Causes issues with door lock rando.\n\nGeneration gets stuck after giving SJ and speed and trying to reach this event.",
                     "layers": [
                         "default"
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "Animals",
                     "connections": {
                         "Other to Habitation Ventilation (Upper)": {
                             "type": "and",

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -10249,15 +10249,6 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
                                             "name": "EntranceRando",
                                             "amount": 1,
                                             "negate": true

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -1662,7 +1662,8 @@
                     "extra": {
                         "door_idx": [
                             141,
-                            174
+                            174,
+                            204
                         ]
                     },
                     "valid_starting_location": false,

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -2894,7 +2894,7 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Pickup (Power Bomb Tank)": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": "Check the connection from item to restricted corridor for way to only go halfway up",
                                 "items": [
@@ -2906,14 +2906,31 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "This can safely not have Door Lock Rando check",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
                         },
                         "Door to Restricted Navigation Room": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -2922,6 +2939,15 @@
                                             "name": "SpeedBooster",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "EntranceRando",
+                                            "amount": 1,
+                                            "negate": true
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -1708,7 +1708,7 @@ Extra - room_id: [69]
   > Door to Habitation Deck Entrance (Middle)
       Trivial
   > Other to Habitation Ventilation (Upper)
-      After Animals Released
+      Impossible
   > Above Pickup
       Trivial
 
@@ -1724,7 +1724,7 @@ Extra - room_id: [69]
   * Open Passage to Habitation Ventilation/Other to Habitation Deck (Upper)
   * Extra - door_idx: (163,)
   > Door to Habitation Deck Entrance (Upper)
-      After Animals Released
+      Trivial
   > Save the Animals
       Trivial
 

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -1721,12 +1721,14 @@ Extra - room_id: [69]
   * Extra - door_idx: (163,)
   > Door to Habitation Deck Entrance (Upper)
       After Animals Released
-  > Event - Save the Animals
+  > Save the Animals
       Trivial
 
-> Event - Save the Animals; Heals? False
+> Save the Animals; Heals? False
   * Layers: default
-  * Event Animals Released
+  * Causes issues with door lock rando.
+
+Generation gets stuck after giving SJ and speed and trying to reach this event.
   > Other to Habitation Ventilation (Upper)
       Trivial
 

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -298,7 +298,7 @@ Extra - room_id: [13, 74, 85]
 > Door to Elevator to Crew Quarters; Heals? False
   * Layers: default
   * L0 Hatch to Elevator to Crew Quarters/Door to Operations Deck
-  * Extra - door_idx: (141, 174)
+  * Extra - door_idx: (141, 174, 204)
   > Door to Operations Deck Navigation Room
       Trivial
   > Door to Operations Deck Recharge Room

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -1822,7 +1822,7 @@ Extra - room_id: [73]
   * Open Passage to Elevator to Sector Hub/Other to Main Elevator Cache
   * Extra - door_idx: (170,)
   > Pickup (Missile Tank)
-      Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+      Speed Booster and Disabled Entrance Rando
 
 ----------------
 Elevator to Habitation Deck

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -474,10 +474,14 @@ Extra - room_id: [17, 77]
   * L4 Hatch to Restricted Corridor/Door to Restricted Airlock
   * Extra - door_idx: (34, 183)
   > Pickup (Power Bomb Tank)
-      # Check the connection from item to restricted corridor for way to only go halfway up
-      Speed Booster
+      All of the following:
+          # Check the connection from item to restricted corridor for way to only go halfway up
+          Speed Booster
+          # This can safely not have Door Lock Rando check
+          Disabled Entrance Rando
   > Door to Restricted Navigation Room
-      Speed Booster
+      # This can safely not have Door Lock Rando check
+      Speed Booster and Disabled Entrance Rando
 
 ----------------
 Central Hub

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -10012,6 +10012,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "L0Locks",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -1562,7 +1562,7 @@ Extra - room_id: [47]
   * Extra - door_idx: (101,)
   > Pickup (Hidden Power Bomb Tank)
       All of the following:
-          Morph Ball and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando and Can Bounce in Ball
+          Level 0 Locks and Morph Ball and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando and Can Bounce in Ball
           # A way to execute the Shinespark
           Gravity Suit or Shinespark Tricks (Expert)
           Any of the following:

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -2527,7 +2527,8 @@
                     ],
                     "extra": {
                         "door_idx": [
-                            31
+                            31,
+                            68
                         ]
                     },
                     "valid_starting_location": false,
@@ -2571,7 +2572,8 @@
                     ],
                     "extra": {
                         "door_idx": [
-                            113
+                            113,
+                            31
                         ]
                     },
                     "valid_starting_location": false,

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -433,14 +433,14 @@ Extra - room_id: [13, 46]
 > Door to Reo Room; Heals? False
   * Layers: default
   * L0 Hatch to Reo Room/Door to Central Shaft
-  * Extra - door_idx: (31,)
+  * Extra - door_idx: (31, 68)
   > Beside Drop
       Can Use Any Bombs
 
 > Door to Ripper Tower; Heals? False
   * Layers: default
-  * Open Hatch to Ripper Tower/Door to Central Shaft
-  * Extra - door_idx: (113,)
+  * Open Hatch to Ripper Roost/Door to Central Shaft
+  * Extra - door_idx: (113, 31)
   > Beside Drop
       Morph Ball
 

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -439,7 +439,7 @@ Extra - room_id: [13, 46]
 
 > Door to Ripper Tower; Heals? False
   * Layers: default
-  * Open Hatch to Ripper Roost/Door to Central Shaft
+  * Open Hatch to Ripper Tower/Door to Central Shaft
   * Extra - door_idx: (113, 31)
   > Beside Drop
       Morph Ball

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -645,15 +645,6 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
                                             "name": "EntranceRando",
                                             "amount": 1,
                                             "negate": true

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -7157,7 +7157,7 @@
                         "Door to Red Tower": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -7166,15 +7166,6 @@
                                             "name": "SpeedBooster",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
                                         }
                                     },
                                     {
@@ -8018,7 +8009,7 @@
                         "Pickup (Power Bomb Tank in Shaft)": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -8045,15 +8036,6 @@
                                             "name": "ScrewAttack",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
                                         }
                                     },
                                     {

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -123,7 +123,7 @@ Extra - room_id: [3]
   * Open Hatch to Entrance Hub/Door to Security Access
   * Extra - door_idx: (8,)
   > Behind Wall
-      Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+      Speed Booster and Disabled Entrance Rando
 
 > Door to Level 2 Security Room; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -1079,7 +1079,8 @@ Extra - room_id: [30]
   * Open Passage to Checkpoint Shaft/Other to Namihe's Abode
   * Extra - door_idx: (62,)
   > Door to Red Tower
-      Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+      # This can safely not have Door Lock Rando check
+      Speed Booster and Disabled Entrance Rando
 
 ----------------
 Data Recharge Room
@@ -1241,7 +1242,8 @@ Extra - room_id: [35]
   * Extra - door_idx: (79,)
   > Pickup (Power Bomb Tank in Shaft)
       All of the following:
-          Gravity Suit and Screw Attack and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+          # This can safely not have Door Lock Rando check
+          Gravity Suit and Screw Attack and Speed Booster and Disabled Entrance Rando
           Any of the following:
               Varia Suit
               Damage Runs (Intermediate) and Lava Damage ≥ 75

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -8924,6 +8924,15 @@
                                                                                             "amount": 1,
                                                                                             "negate": false
                                                                                         }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "L0Locks",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
                                                                                     }
                                                                                 ]
                                                                             }
@@ -10226,7 +10235,7 @@
                         "Pickup (Power Bomb Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -1687,15 +1687,6 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
                                             "name": "EntranceRando",
                                             "amount": 1,
                                             "negate": true
@@ -5272,15 +5263,6 @@
                                         "data": {
                                             "type": "misc",
                                             "name": "EntranceRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -10262,15 +10244,6 @@
                                             "name": "SpeedBooster",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
                                         }
                                     },
                                     {

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -1351,7 +1351,7 @@ Extra - room_id: [35]
                   Any of the following:
                       Space Jump
                       # Shinespark
-                      Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
+                      Level 0 Locks and Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Door to Connection to Sector 2 (TRO); Heals? False
   * Layers: default
@@ -1533,6 +1533,7 @@ Extra - room_id: [38]
   * Open Passage to Aquarium Speedway/Other to Aquarium Storage
   * Extra - door_idx: (94,)
   > Pickup (Power Bomb Tank)
+      # This can safely not have Door Lock Rando check
       Gravity Suit and Speed Booster and Disabled Entrance Rando
   > After Kago
       All of the following:

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -241,7 +241,7 @@ Extra - room_id: [6]
   * Extra - door_idx: (18,)
   > Room Center
       All of the following:
-          Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+          Speed Booster and Disabled Entrance Rando
           Any of the following:
               After Sector 4 Water Level Lowered
               # TODO: damage vlues
@@ -786,7 +786,7 @@ Extra - room_id: [20]
   * Extra - door_idx: (59,)
   > Door to Skultera Sanctuary
       All of the following:
-          Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+          Speed Booster and Disabled Entrance Rando
           Any of the following:
               After Sector 4 Water Level Lowered
               # TODO: damage requirements
@@ -1533,7 +1533,7 @@ Extra - room_id: [38]
   * Open Passage to Aquarium Speedway/Other to Aquarium Storage
   * Extra - door_idx: (94,)
   > Pickup (Power Bomb Tank)
-      Gravity Suit and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+      Gravity Suit and Speed Booster and Disabled Entrance Rando
   > After Kago
       All of the following:
           High Jump and Morph Ball and Knowledge (Beginner)

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -869,15 +869,6 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
                                             "name": "EntranceRando",
                                             "amount": 1,
                                             "negate": true
@@ -1069,6 +1060,27 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Needed for charging in previous room",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Kill PB Geron"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "L0Locks",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -1731,7 +1743,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "TODO: High Jump should also be efficient to climb the room. Test before adding additional option requirement.",
+                                            "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -1745,6 +1757,10 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Can Use Any Bombs"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Climb High Jump Wall"
                                                 }
                                             ]
                                         }
@@ -4908,7 +4924,7 @@
                         "Door to Nightmare Hub West": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -4975,7 +4991,7 @@
                         "Door to Nightmare Arena": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -6975,7 +6991,7 @@
                         "Door to Arctic Containment": {
                             "type": "and",
                             "data": {
-                                "comment": "Need to charge spark in other room",
+                                "comment": "Need to charge spark in other room, This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -6989,15 +7005,6 @@
                                     {
                                         "type": "template",
                                         "data": "Can Freeze Enemies"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
                                     },
                                     {
                                         "type": "resource",
@@ -8183,7 +8190,7 @@
                         "Pickup (Power Bomb Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -8201,59 +8208,6 @@
                                             "name": "SpeedBooster",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "EntranceRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Area Transition to Sector 4 (AQA)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "SpeedBooster",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "GravitySuit",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
                                         }
                                     },
                                     {
@@ -8271,35 +8225,73 @@
                                             "comment": "Some way to kill the pirates",
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ChargeBeam",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Can Kill Tough Beam-Resistant Enemy"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Missiles",
-                                                        "amount": 10,
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 4,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Area Transition to Sector 4 (AQA)": {
+                            "type": "and",
+                            "data": {
+                                "comment": "This can safely not have Door Lock Rando check",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "SpeedBooster",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "GravitySuit",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "EntranceRando",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Some way to kill the pirates",
+                                            "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Use Power Bombs"
+                                                    "data": "Can Kill Tough Beam-Resistant Enemy"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -8342,7 +8334,7 @@
                         "Door to Zebesian Waters": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -8360,15 +8352,6 @@
                                             "name": "SpeedBooster",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
                                         }
                                     },
                                     {

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -854,7 +854,7 @@
                         "Pickup (Power Bomb Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -1446,7 +1446,8 @@
                     ],
                     "extra": {
                         "door_idx": [
-                            53
+                            53,
+                            27
                         ]
                     },
                     "valid_starting_location": false,

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -4936,15 +4936,6 @@
                                             "amount": 1,
                                             "negate": true
                                         }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
                                     }
                                 ]
                             }
@@ -5009,15 +5000,6 @@
                                         "data": {
                                             "type": "misc",
                                             "name": "EntranceRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
                                             "amount": 1,
                                             "negate": true
                                         }

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -161,6 +161,7 @@ Extra - room_id: [4]
   * L0 Hatch to Nightmare Training Grounds/Door to Aerie
   * Extra - door_idx: (10,)
   > Pickup (Power Bomb Tank)
+      # This can safely not have Door Lock Rando check
       Speed Booster and Disabled Entrance Rando
   > Pickup (Missile Tank)
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -161,7 +161,7 @@ Extra - room_id: [4]
   * L0 Hatch to Nightmare Training Grounds/Door to Aerie
   * Extra - door_idx: (10,)
   > Pickup (Power Bomb Tank)
-      Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+      Speed Booster and Disabled Entrance Rando
   > Pickup (Missile Tank)
       Trivial
 
@@ -189,9 +189,11 @@ Extra - room_id: [7, 15]
       Varia Suit
   > Door to Artic Underside
       All of the following:
-          Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+          Level 0 Locks and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
           # Damage Run
           Varia Suit
+          # Needed for charging in previous room
+          Can Kill PB Geron
 
 > Door to Waver Ward; Heals? False
   * Layers: default
@@ -285,8 +287,7 @@ Extra - room_id: [9]
       All of the following:
           # TODO:  damage reqs
           Varia Suit
-          # TODO: High Jump should also be efficient to climb the room. Test before adding additional option requirement.
-          Wall Jump (Beginner) or Can Use Any Bombs
+          Wall Jump (Beginner) or Can Climb High Jump Wall or Can Use Any Bombs
 
 ----------------
 Level 3 Security Room
@@ -831,6 +832,7 @@ Extra - room_id: [27]
   * L0 Hatch to Nightmare Arena/Door to Nightmare Access
   * Extra - door_idx: (59,)
   > Door to Nightmare Hub West
+      # This can safely not have Door Lock Rando check
       Gravity Suit and Speed Booster and Disabled Entrance Rando
 
 > Door to Nightmare Hub West; Heals? False
@@ -838,6 +840,7 @@ Extra - room_id: [27]
   * L0 Hatch to Nightmare Hub West/Door to Nightmare Access
   * Extra - door_idx: (60,)
   > Door to Nightmare Arena
+      # This can safely not have Door Lock Rando check
       Gravity Suit and Speed Booster and Disabled Entrance Rando
 
 ----------------
@@ -1198,8 +1201,8 @@ Extra - room_id: [42]
   * L0 Hatch to Kago Speedway/Door to Artic Underside
   * Extra - door_idx: (101,)
   > Door to Arctic Containment
-      # Need to charge spark in other room
-      Speed Booster and Varia Suit and Disabled Door Lock Rando and Disabled Entrance Rando and Can Freeze Enemies
+      # Need to charge spark in other room, This can safely not have Door Lock Rando check
+      Speed Booster and Varia Suit and Disabled Entrance Rando and Can Freeze Enemies
 
 ----------------
 Groznyj Grad
@@ -1373,19 +1376,25 @@ Extra - room_id: [50]
   * L0 Hatch to Zebesian Waters/Door to Flooded Airlock to Sector 4 (AQA)
   * Extra - door_idx: (115,)
   > Pickup (Power Bomb Tank)
-      Gravity Suit and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+      All of the following:
+          # This can safely not have Door Lock Rando check
+          Gravity Suit and Speed Booster and Disabled Entrance Rando
+          # Some way to kill the pirates
+          Combat (Expert) or Can Kill Tough Beam-Resistant Enemy
   > Area Transition to Sector 4 (AQA)
       All of the following:
-          Gravity Suit and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+          # This can safely not have Door Lock Rando check
+          Gravity Suit and Speed Booster and Disabled Entrance Rando
           # Some way to kill the pirates
-          Charge Beam or Missiles ≥ 10 or Screw Attack or Can Use Power Bombs
+          Combat (Expert) or Can Kill Tough Beam-Resistant Enemy
 
 > Area Transition to Sector 4 (AQA); Heals? False
   * Layers: default
   * Open Passage to Cargo Hold to Sector 5 (ARC)/Area Transition to Sector 5 (ARC)
   * Extra - door_idx: (123,)
   > Door to Zebesian Waters
-      Gravity Suit and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+      # This can safely not have Door Lock Rando check
+      Gravity Suit and Speed Booster and Disabled Entrance Rando
 
 ----------------
 Transformation Trial

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -240,7 +240,7 @@ Extra - room_id: [7, 15]
 > Door to Crow's Nest; Heals? False
   * Layers: default
   * L3 Hatch to Crow's Nest/Door to Arctic Containment
-  * Extra - door_idx: (53,)
+  * Extra - door_idx: (53, 27)
   > Door to Nightmare Training Grounds
       # TODO: damage run
       Varia Suit

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -831,14 +831,14 @@ Extra - room_id: [27]
   * L0 Hatch to Nightmare Arena/Door to Nightmare Access
   * Extra - door_idx: (59,)
   > Door to Nightmare Hub West
-      Gravity Suit and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+      Gravity Suit and Speed Booster and Disabled Entrance Rando
 
 > Door to Nightmare Hub West; Heals? False
   * Layers: default
   * L0 Hatch to Nightmare Hub West/Door to Nightmare Access
   * Extra - door_idx: (60,)
   > Door to Nightmare Arena
-      Gravity Suit and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+      Gravity Suit and Speed Booster and Disabled Entrance Rando
 
 ----------------
 Flooded Access

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -1513,6 +1513,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "L0Locks",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -1654,7 +1663,7 @@
                         "Door to Forbidden Entrance": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -2587,7 +2596,7 @@
                         "Door to Menu Corridor": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "This can safely not have Door Lock Rando check",
                                 "items": [
                                     {
                                         "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -2567,7 +2567,8 @@
                     ],
                     "extra": {
                         "door_idx": [
-                            17
+                            17,
+                            72
                         ]
                     },
                     "valid_starting_location": false,
@@ -2625,7 +2626,8 @@
                     ],
                     "extra": {
                         "door_idx": [
-                            18
+                            18,
+                            73
                         ]
                     },
                     "valid_starting_location": false,
@@ -2664,7 +2666,8 @@
                     ],
                     "extra": {
                         "door_idx": [
-                            46
+                            46,
+                            74
                         ]
                     },
                     "valid_starting_location": false,

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -215,7 +215,7 @@ Extra - room_id: [5]
       Trivial
   > Door to Pillar Puzzle
       All of the following:
-          Screw Attack and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+          Level 0 Locks and Screw Attack and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
           Any of the following:
               # Ice X logic
               Varia Suit
@@ -250,6 +250,7 @@ Extra - room_id: [5]
   * Extra - door_idx: (85,)
   > Door to Forbidden Entrance
       All of the following:
+          # This can safely not have Door Lock Rando check
           Speed Booster and Disabled Entrance Rando
           Wave Beam or Can Use Bombs
 
@@ -363,6 +364,7 @@ Extra - room_id: [9]
   * L0 Hatch to Nocturnal Playground/Door to Clogged Cavern
   * Extra - door_idx: (17, 72)
   > Door to Menu Corridor
+      # This can safely not have Door Lock Rando check
       Speed Booster and Disabled Entrance Rando
 
 > Door to Shell Access; Heals? False

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -361,21 +361,21 @@ Extra - room_id: [9]
 > Door to Nocturnal Playground; Heals? False
   * Layers: default
   * L0 Hatch to Nocturnal Playground/Door to Clogged Cavern
-  * Extra - door_idx: (17,)
+  * Extra - door_idx: (17, 72)
   > Door to Menu Corridor
       Speed Booster and Disabled Entrance Rando
 
 > Door to Shell Access; Heals? False
   * Layers: default
   * L0 Hatch to Shell Access/Door to Clogged Cavern
-  * Extra - door_idx: (18,)
+  * Extra - door_idx: (18, 73)
   > Door to Menu Corridor
       Trivial
 
 > Door to Menu Corridor; Heals? False
   * Layers: default
   * L0 Hatch to Menu Corridor/Door to Clogged Cavern
-  * Extra - door_idx: (46,)
+  * Extra - door_idx: (46, 74)
   > Door to Nocturnal Playground
       Speed Booster and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
   > Door to Shell Access

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -1885,6 +1885,17 @@
                         },
                         "lock": null
                     },
+                    "Locked Hatch": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "lock": null
+                    },
                     "L0 Hatch": {
                         "extra": {},
                         "requirement": {
@@ -1953,7 +1964,7 @@
                 },
                 "dock_rando": {
                     "unlocked": "Open Hatch",
-                    "locked": "Open Hatch",
+                    "locked": "Locked Hatch",
                     "change_from": [
                         "L0 Hatch",
                         "L1 Hatch",

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -1968,6 +1968,7 @@
                         "L2 Hatch",
                         "L3 Hatch",
                         "L4 Hatch",
+                        "Locked Hatch",
                         "Open Hatch"
                     ]
                 }

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -412,10 +412,6 @@
                 "long_name": "Sector 4 Water Level Lowered",
                 "extra": {}
             },
-            "Animals": {
-                "long_name": "Animals Released",
-                "extra": {}
-            },
             "Wide X": {
                 "long_name": "Boss Wide Core-X Defeated",
                 "extra": {}

--- a/randovania/games/fusion/logic_database/header.txt
+++ b/randovania/games/fusion/logic_database/header.txt
@@ -117,6 +117,12 @@ Dock Weaknesses
       No lock
 
 
+  * Locked Hatch
+      Open:
+          Impossible
+      No lock
+
+
   * L0 Hatch
       Open:
           Level 0 Locks
@@ -144,13 +150,6 @@ Dock Weaknesses
   * L4 Hatch
       Open:
           Level 4 Locks
-      No lock
-
-
-  * Locked Hatch
-      Extra - type: Locked
-      Open:
-          Impossible
       No lock
 
   > Dock Rando:

--- a/randovania/games/fusion/logic_database/header.txt
+++ b/randovania/games/fusion/logic_database/header.txt
@@ -146,9 +146,16 @@ Dock Weaknesses
           Level 4 Locks
       No lock
 
+
+  * Locked Hatch
+      Extra - type: Locked
+      Open:
+          Impossible
+      No lock
+
   > Dock Rando:
       Unlocked: Open Hatch
-      Locked: Open Hatch
+      Locked: Locked Hatch
       Change from:
           L0 Hatch
           L1 Hatch
@@ -162,6 +169,7 @@ Dock Weaknesses
           L2 Hatch
           L3 Hatch
           L4 Hatch
+          Locked Hatch
           Open Hatch
 
 


### PR DESCRIPTION
add DLR tab
add locked hatches
fix missing/incorrect room ids
remove many unnecessary `not DLR` checks and add some hatch requirements where it is necessary
fix some minor template usage in zebesians waters and security shaft west in s5
