### PR TITLE
Dread: Add spawn point nodes to rooms without any

### DIFF
--- a/randovania/games/dread/logic_database/Ferenia.json
+++ b/randovania/games/dread/logic_database/Ferenia.json
@@ -13261,7 +13261,27 @@
                 ],
                 "asset_id": "collision_camera_038_A"
             },
-            "nodes": {}
+            "nodes": {
+                "Start Point": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 10750.0,
+                        "y": 5000.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "start_point_actor_name": "SP_Checkpoint_CentralUnit",
+                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
+                    },
+                    "valid_starting_location": false,
+                    "connections": {}
+                }
+            }
         },
         "Purple EMMI Introduction": {
             "default_node": "Start Point",

--- a/randovania/games/dread/logic_database/Ferenia.txt
+++ b/randovania/games/dread/logic_database/Ferenia.txt
@@ -2342,6 +2342,11 @@ Central Unit Access
 Extra - total_boundings: {'x1': 9450.0, 'x2': 11550.0, 'y1': 2600.0, 'y2': 5900.0}
 Extra - polygon: [[11550.0, 5900.0], [9450.0, 5900.0], [9450.0, 2600.0], [11550.0, 2600.0]]
 Extra - asset_id: collision_camera_038_A
+> Start Point; Heals? False
+  * Layers: default
+  * Extra - start_point_actor_name: SP_Checkpoint_CentralUnit
+  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
+
 ----------------
 Purple EMMI Introduction
 Extra - total_boundings: {'x1': -8500.0, 'x2': -4400.0, 'y1': -7402.5, 'y2': -3800.0}

--- a/randovania/games/dread/logic_database/Hanubia.json
+++ b/randovania/games/dread/logic_database/Hanubia.json
@@ -4085,8 +4085,8 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 15000.0,
-                        "y": -8000.0,
+                        "x": 14600.0,
+                        "y": -8400.0,
                         "z": 0.0
                     },
                     "description": "",

--- a/randovania/games/dread/logic_database/Hanubia.json
+++ b/randovania/games/dread/logic_database/Hanubia.json
@@ -4156,10 +4156,14 @@
                 "asset_id": "collision_camera_016"
             },
             "nodes": {
-                "This room is here for technical reasons": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 5750.0,
+                        "y": -2550.0,
+                        "z": 0.0
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4200,10 +4204,14 @@
                 "asset_id": "collision_camera_018"
             },
             "nodes": {
-                "This room is here for technical reasons": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 13050.0,
+                        "y": -3850.0,
+                        "z": 0.0
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4244,10 +4252,14 @@
                 "asset_id": "collision_camera_019"
             },
             "nodes": {
-                "This room is here for technical reasons": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 14850.0,
+                        "y": -5950.0,
+                        "z": 0.0
+                    },
                     "description": "",
                     "layers": [
                         "default"

--- a/randovania/games/dread/logic_database/Hanubia.json
+++ b/randovania/games/dread/logic_database/Hanubia.json
@@ -2022,15 +2022,22 @@
                 "asset_id": "collision_camera_008"
             },
             "nodes": {
-                "This room is here for technical reasons": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -12500.0,
+                        "y": 6900.0,
+                        "z": 0.0
+                    },
                     "description": "",
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "start_point_actor_name": "SP_Checkpoint_Endgame",
+                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
+                    },
                     "valid_starting_location": false,
                     "connections": {}
                 }
@@ -4074,15 +4081,22 @@
                 "asset_id": "collision_camera_020"
             },
             "nodes": {
-                "This room is here for technical reasons": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 15000.0,
+                        "y": -8000.0,
+                        "z": 0.0
+                    },
                     "description": "",
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "start_point_actor_name": "SP_Checkpoint_Escape",
+                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
+                    },
                     "valid_starting_location": false,
                     "connections": {}
                 }

--- a/randovania/games/dread/logic_database/Hanubia.txt
+++ b/randovania/games/dread/logic_database/Hanubia.txt
@@ -446,8 +446,10 @@ Ship Room
 Extra - total_boundings: {'x1': -19100.0, 'x2': -6400.0, 'y1': 1700.0, 'y2': 9000.0}
 Extra - polygon: [[-7600.0, 9000.0], [-19100.0, 9000.0], [-19100.0, 6400.0], [-12100.0, 5300.0], [-12100.0, 1700.0], [-6400.0, 1700.0], [-6400.0, 4300.0], [-7600.0, 4900.0]]
 Extra - asset_id: collision_camera_008
-> This room is here for technical reasons; Heals? False
+> Start Point; Heals? False
   * Layers: default
+  * Extra - start_point_actor_name: SP_Checkpoint_Endgame
+  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
 
 ----------------
 Speedboost Puzzle Room
@@ -835,8 +837,10 @@ Raven Beak X Arena
 Extra - total_boundings: {'x1': 11800.0, 'x2': 18600.0, 'y1': -8700.0, 'y2': -4500.0}
 Extra - polygon: [[18600.0, -4500.0], [15400.0, -4500.0], [15400.0, -6100.0], [11800.0, -6100.0], [11800.0, -8700.0], [18600.0, -8700.0]]
 Extra - asset_id: collision_camera_020
-> This room is here for technical reasons; Heals? False
+> Start Point; Heals? False
   * Layers: default
+  * Extra - start_point_actor_name: SP_Checkpoint_Escape
+  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
 
 ----------------
 Escape Room 3

--- a/randovania/games/dread/logic_database/Hanubia.txt
+++ b/randovania/games/dread/logic_database/Hanubia.txt
@@ -847,7 +847,7 @@ Escape Room 3
 Extra - total_boundings: {'x1': -500.0, 'x2': 6500.0, 'y1': -8600.0, 'y2': -1900.0}
 Extra - polygon: [[6500.0, -1900.0], [4400.0, -1900.0], [4400.0, -3800.0], [-500.0, -3900.0], [-500.0, -7600.0], [900.0, -7600.0], [1500.0, -7900.0], [2700.0, -7900.0], [4100.0, -8600.0], [6500.0, -8600.0]]
 Extra - asset_id: collision_camera_016
-> This room is here for technical reasons; Heals? False
+> Start Point; Heals? False
   * Layers: default
 
 ----------------
@@ -855,7 +855,7 @@ Escape Room 2
 Extra - total_boundings: {'x1': 11400.0, 'x2': 13500.0, 'y1': -5900.0, 'y2': -3300.0}
 Extra - polygon: [[13500.0, -3300.0], [11400.0, -3300.0], [11400.0, -5900.0], [13500.0, -5900.0]]
 Extra - asset_id: collision_camera_018
-> This room is here for technical reasons; Heals? False
+> Start Point; Heals? False
   * Layers: default
 
 ----------------
@@ -863,7 +863,7 @@ Escape Room 1
 Extra - total_boundings: {'x1': 13400.0, 'x2': 15500.0, 'y1': -6100.0, 'y2': -4200.0}
 Extra - polygon: [[15500.0, -4200.0], [13400.0, -4200.0], [13400.0, -6100.0], [15500.0, -6100.0]]
 Extra - asset_id: collision_camera_019
-> This room is here for technical reasons; Heals? False
+> Start Point; Heals? False
   * Layers: default
 
 ----------------


### PR DESCRIPTION
This is intended to be used for plandos only, as targets for either starting location or transport destination. Affects the following rooms:
- Ferenia - Central Unit Access (using `SP_Checkpoint_CentralUnit`)
- Hanubia - Escape Room 1
- Hanubia - Escape Room 2
- Hanubia - Escape Room 3
- Hanubia - Raven Beak X Arena (using `SP_Checkpoint_Escape`)
- Hanubia - Ship Room (using `SP_Checkpoint_Endgame`)

Note: On initial spawn, the Ship Room spawn point will disable pressing Start/Select until reloading to checkpoint, and leaving the room will cause the screen to go black until an area transition. This is a vanilla bug with this room and unavoidable to my knowledge.