### PR TITLE
Fusion: S2: Data Hub: Create event for bomb block

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -5989,8 +5989,20 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Power Bombs"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Power Bombs"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Bounce in Ball"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",
@@ -6014,6 +6026,10 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Bounce in Ball"
                                                 }
                                             ]
                                         }

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -5972,74 +5972,78 @@
                                         "data": "Can Bounce in Ball"
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "S2BombBlock",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Bomb Block": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Power Bombs"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "ScrewAttack",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Use Power Bombs"
+                                                    "data": "Can Use Bombs"
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "or",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "JBJ requires using bomb explosions to gain a small bit of height so that a bomb can be placed high enough to break the block, without using spring ball. TODO - video of this",
                                                         "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "ScrewAttack",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Knowledge",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "MorphBallBombData",
-                                                                    "amount": 1,
+                                                                    "name": "JBJ",
+                                                                    "amount": 3,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "or",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "template",
-                                                                            "data": "Can Use Springball"
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "JBJ",
-                                                                                "amount": 3,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Can Use Springball"
                                                             }
                                                         ]
                                                     }
@@ -6116,71 +6120,114 @@
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "S2BombBlock",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Bomb Block": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Break Single Bomb Blocks"
+                                    },
+                                    {
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Break Single Bomb Blocks"
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpeedBooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "SpeedBooster",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Knowledge",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Movement",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "misc",
-                                                                    "name": "EntranceRando",
-                                                                    "amount": 1,
-                                                                    "negate": true
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "misc",
-                                                                    "name": "DoorLockRando",
-                                                                    "amount": 1,
-                                                                    "negate": true
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLockRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
                                                     }
                                                 }
                                             ]
                                         }
                                     }
                                 ]
+                            }
+                        }
+                    }
+                },
+                "Event - Bomb Block": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 70.71,
+                        "y": 230.48,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "S2BombBlock",
+                    "connections": {
+                        "Door to Data Save Room": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "MorphBall",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Door to Data Hub Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -993,8 +993,8 @@ Extra - room_id: [31, 7]
       After Sector 2 Data Hub Bomb Block Destroyed and Can Bounce in Ball
   > Event - Bomb Block
       Any of the following:
-          Can Use Power Bombs
-          Screw Attack and Knowledge (Beginner)
+          Can Bounce in Ball and Can Use Power Bombs
+          Screw Attack and Knowledge (Beginner) and Can Bounce in Ball
           All of the following:
               Can Use Bombs
               # JBJ requires using bomb explosions to gain a small bit of height so that a bomb can be placed high enough to break the block, without using spring ball. TODO - video of this

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -990,14 +990,15 @@ Extra - room_id: [31, 7]
   > Door to Zoro Zig-Zag
       Trivial
   > Door to Data Hub Access
-      All of the following:
-          Can Bounce in Ball
-          Any of the following:
-              Can Use Power Bombs
-              Screw Attack and Knowledge (Beginner)
-              All of the following:
-                  Morph Ball Bomb Data
-                  Jump Bombjump (Advanced) or Can Use Springball
+      After Sector 2 Data Hub Bomb Block Destroyed and Can Bounce in Ball
+  > Event - Bomb Block
+      Any of the following:
+          Can Use Power Bombs
+          Screw Attack and Knowledge (Beginner)
+          All of the following:
+              Can Use Bombs
+              # JBJ requires using bomb explosions to gain a small bit of height so that a bomb can be placed high enough to break the block, without using spring ball. TODO - video of this
+              Jump Bombjump (Advanced) or Can Use Springball
 
 > Door to Data Hub Access; Heals? False
   * Layers: default
@@ -1008,11 +1009,19 @@ Extra - room_id: [31, 7]
   > Door to Data Room
       Trivial
   > Door to Data Save Room
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Can Break Single Bomb Blocks
-              Speed Booster and Knowledge (Intermediate) and Movement (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
+      Morph Ball and After Sector 2 Data Hub Bomb Block Destroyed
+  > Event - Bomb Block
+      Any of the following:
+          Can Break Single Bomb Blocks
+          Speed Booster and Knowledge (Intermediate) and Movement (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
+
+> Event - Bomb Block; Heals? False
+  * Layers: default
+  * Event Sector 2 Data Hub Bomb Block Destroyed
+  > Door to Data Save Room
+      Morph Ball
+  > Door to Data Hub Access
+      Trivial
 
 ----------------
 Eastern Shaft

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -479,6 +479,10 @@
             "S1ShotBlock": {
                 "long_name": "Sector 1 Save Room East Shot Block Destroyed",
                 "extra": {}
+            },
+            "S2BombBlock": {
+                "long_name": "Sector 2 Data Hub Bomb Block Destroyed",
+                "extra": {}
             }
         },
         "tricks": {


### PR DESCRIPTION
Per request in fusion-dev: https://discord.com/channels/914291389293027329/1215675687936196608/1216880163917271111

The bomb block in Data Hub is permanently gone once destroyed, so this should be reflected in logic as an event.