### PR TITLE
Remove pre-placed indices from DNA locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
+- Fixed: DNA placement respects vanilla item placement settings to not assign two items to one location
+
 #### Logic Database
 
 - Added: New trick, Cross Bomb Launch.


### PR DESCRIPTION
Fix for https://discord.com/channels/914291389293027329/1220476257557545011

Bug TL;DR: E.g.: Use 11 DNA, set Phantom Cloak to vanilla. bootstrapping can decide to also place DNA on Corpius. Game cannot be generated because you can not leave Corpius. Add Door lock to it such that Sensor lock doors gets removed => Can be generated  + exported and played. but importing the rdvgame leads to an error.

(If this is OK, I add the same fix to other games).