### PR TITLE
Database Editor: Least disruptive space-saving change to the json logic databases.

### DIFF
--- a/randovania/game_description/data_writer.py
+++ b/randovania/game_description/data_writer.py
@@ -449,12 +449,6 @@ def write_as_split_files(data: dict, base_path: Path) -> None:
     for region in regions:
         name = REGION_NAME_TO_FILE_NAME_RE.sub(r"", region["name"])
         data["regions"].append(f"{name}.json")
-        json_lib.write_path(
-            base_path.joinpath(f"{name}.json"),
-            region,
-        )
+        json_lib.write_path(base_path.joinpath(f"{name}.json"), region, compress=True)
 
-    json_lib.write_path(
-        base_path.joinpath("header.json"),
-        data,
-    )
+    json_lib.write_path(base_path.joinpath("header.json"), data, compress=True)

--- a/randovania/lib/json_lib.py
+++ b/randovania/lib/json_lib.py
@@ -32,9 +32,9 @@ def read_dict(path: Path) -> dict:
     return result
 
 
-def write_path(path: Path, data: Any) -> None:
+def write_path(path: Path, data: Any, *, compress: bool = False) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=4, separators=(",", ": ")))
+    path.write_text(json.dumps(data, indent=1 if compress else 4, separators=(",", ": ")))
 
 
 async def read_path_async(path: Path, *, raise_on_duplicate_keys: bool = False) -> dict | list:


### PR DESCRIPTION
Randovania's logic databases are written to files through the same method that all json files produced by the system are. While this is nice for making them human-readable (for spoilers, game seeds, etc.), it isn't really necessary for the logic databases to be output in the same way, for a few reasons:
 - Most (or all) review of logic is between the text files and not the json.
 - The deeply nested structures of the logic database result in a lot of indentation, which bloats the file
 - The logic editor mostly makes modifying the json directly pointless (with a few exceptions)

To avoid making a very drastic change to how to interact with the logic databases (especially in regards to git), this PR makes the simplest change that it can, which is to reduce the indentation for the logic databases to a single space per level. This still results in a significant (nearly 50% reduction) in the size of the logic database folders:

```
Size of logic_database folder per game
AM2R: 4.49 MB -> 2.42 MB
Blank: 64 KB -> 39 KB
Cave Story: 1.07 MB -> 610 KB
Dread: 7.35 MB -> 4.15 MB
Fusion: 3.45 MB -> 1.88 MB
Prime 1: 5.35 MB -> 2.60 MB
Prime 2: 7.32 MB -> 3.47 MB
Prime 3: 2.88 MB -> 1.58 MB
Samus Returns: 5.71 MB -> 3.07 MB
Super Metroid: 2.29 MB -> 1.28 MB

TOTAL: 39.97 MB -> 21.09 MB (47.2% reduction)
```

This also speeds up the time it takes the editor to save the databases by the same factor, as there is less for the database editor to have to write.

The json files could be further compressed by removing _all_ unnecessary whitespace, which would push the savings closer to 66%, but this could severely impact the review process and how to do conflict resolution on the DBs

This PR does not commit the changes to the logic DBs themselves, those are in a separate branch for the time being (https://github.com/shark20061/randovania/tree/compress-json-logic-databases-lite-resave-all)