### PR TITLE
Fusion: Remove open hatches from change_from list

### DIFF
--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -1984,8 +1984,7 @@
                         "L1 Hatch",
                         "L2 Hatch",
                         "L3 Hatch",
-                        "L4 Hatch",
-                        "Open Hatch"
+                        "L4 Hatch"
                     ],
                     "change_to": [
                         "L0 Hatch",

--- a/randovania/games/fusion/logic_database/header.txt
+++ b/randovania/games/fusion/logic_database/header.txt
@@ -168,7 +168,6 @@ Dock Weaknesses
           L2 Hatch
           L3 Hatch
           L4 Hatch
-          Open Hatch
       Change to:
           L0 Hatch
           L1 Hatch


### PR DESCRIPTION
Per request in fusion-dev: https://discord.com/channels/914291389293027329/1215675687936196608/1217168246080274552

Open hatches would need to use an open clipdata hatch slot to work correctly, and some open hatch rooms don't have any hatch slots unused, so it's safer to remove open hatches from the door randomization.

(Doors can still become open hatches)