### PR TITLE
Fusion: S6: Fix logic from top crumble block in xbox access becoming a bomb block

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -4407,7 +4407,12 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Break Single Bomb Blocks"
+                                    }
+                                ]
                             }
                         }
                     }

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -633,7 +633,7 @@ Extra - room_id: [16]
   > Door to X-B.O.X. Garage (Upper)
       Screw Attack and After Boss X-B.O.X. Defeated
   > Arena
-      Trivial
+      Can Break Single Bomb Blocks
 
 > Arena; Heals? False
   * Layers: default


### PR DESCRIPTION
Per request in fusion-dev: https://discord.com/channels/914291389293027329/1215675687936196608/1217936379497943190

In entrance randomizer, this room can become a trap if the player unknowingly falls through the crumble blocks without the ability to fight the X-controlled Security Robot (aka XBOX).

To avoid this trap, two changes were made to the entrance in the top left:
 - The door stays unlocked
 - The first crumble block is now a bomb block

The logic therefore needs an update here as the player must break a bomb block now.