### PR TITLE
Fusion: safety rename of destructible block events

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -1996,7 +1996,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "S1MissileBlock",
+                                            "name": "S1ChargeEscMissileBlock",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2102,7 +2102,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "S1MissileBlock",
+                                            "name": "S1ChargeEscMissileBlock",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2126,7 +2126,7 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "S1MissileBlock",
+                    "event_name": "S1ChargeEscMissileBlock",
                     "connections": {
                         "Door to Atmospheric Stabilizer Central": {
                             "type": "and",
@@ -8389,7 +8389,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "S1ShotBlock",
+                                            "name": "S1SaveShotBlock",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -8447,7 +8447,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "S1ShotBlock",
+                                "name": "S1SaveShotBlock",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -8495,7 +8495,7 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "S1ShotBlock",
+                    "event_name": "S1SaveShotBlock",
                     "connections": {
                         "Door to Short Shaft": {
                             "type": "and",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -5971,7 +5971,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "S2BombBlock",
+                                            "name": "S2DHubBombBlock",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -6135,7 +6135,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "S2BombBlock",
+                                            "name": "S2DHubBombBlock",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -6224,7 +6224,7 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "S2BombBlock",
+                    "event_name": "S2DHubBombBlock",
                     "connections": {
                         "Door to Data Save Room": {
                             "type": "resource",

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -468,7 +468,7 @@
                 "long_name": "Main Deck Power Bomb Geron Destroyed",
                 "extra": {}
             },
-            "S1MissileBlock": {
+            "S1ChargeEscMissileBlock": {
                 "long_name": "Sector 1 Charge Core Escape Missile Block Destroyed",
                 "extra": {}
             },
@@ -476,11 +476,11 @@
                 "long_name": "Sector 1 Yameba Corridor Missile Geron Destroyed",
                 "extra": {}
             },
-            "S1ShotBlock": {
+            "S1SaveShotBlock": {
                 "long_name": "Sector 1 Save Room East Shot Block Destroyed",
                 "extra": {}
             },
-            "S2BombBlock": {
+            "S2DHubBombBlock": {
                 "long_name": "Sector 2 Data Hub Bomb Block Destroyed",
                 "extra": {}
             }


### PR DESCRIPTION
Short names changed to avoid future confusion:
S1MissileBlock -> S1Charge
S1ShotBlock -> S1SaveShotBlock
S2BombBlock -> S2DHubBombBlock