### PR TITLE
AM2R: Fix door lock rando bug with a2 exterior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ##### Hydro Station
 
 - Changed: Shinesparking from Breeding Grounds Alpha Nest West to Breeding Grounds Overgrown Alley now requires an intermediate Shinespark.
+- Fixed: Hydro Station Exterior: It's now impossible for the Water Turbine to shuffle to a Spider Ball door or a Screw Attack door.
 
 ##### Industrial Complex
 

--- a/randovania/games/am2r/logic_database/Hydro Station.json
+++ b/randovania/games/am2r/logic_database/Hydro Station.json
@@ -1025,7 +1025,10 @@
                     },
                     "default_dock_weakness": "Hydro Station Water Turbine",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Door",
+                        "Spider Ball Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {

--- a/randovania/games/am2r/logic_database/Hydro Station.txt
+++ b/randovania/games/am2r/logic_database/Hydro Station.txt
@@ -131,7 +131,7 @@ Extra - minimap_data: [{'x': 29, 'y': 18}, {'x': 29, 'y': 19}, {'x': 29, 'y': 20
 
 > Door to Water Turbine Station; Heals? False
   * Layers: default
-  * Hydro Station Water Turbine to Water Turbine Station/Door to Hydro Station Exterior
+  * Hydro Station Water Turbine to Water Turbine Station/Door to Hydro Station Exterior; Dock Lock Rando incompatible with: Screw Attack Door, Spider Ball Door
   * Extra - instance_id: 110043
   > Horizontal Dock to Inner Save Station
       Trivial


### PR DESCRIPTION
If the Water Turbine is shuffled to any of these doors, there will be water when getting to the door from the front, thus rendering it impossible to enter them. 
The water will lower when entering them from behind, but logic doesn't guarantee this.