### PR TITLE
Fix #5520

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.5.1] - 2024-04-??
 
+- Changed: The output after verifying the installation has been made less misleading.
 - Nothing yet. Space reserved in case needed.
 
 ## [7.5.0] - 2024-04-01

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -818,13 +818,13 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
         if bad_files or extra_files:
             errors = []
             if bad_files:
-                errors.append(f"- {len(bad_files)} files are incorrect")
+                errors.append(f"* {len(bad_files)} files are incorrect")
 
             if missing_files:
-                errors.append(f"- {len(missing_files)} files are missing")
+                errors.append(f"* {len(missing_files)} files are missing")
 
             if extra_files:
-                errors.append(f"- {len(extra_files)} files are unexpected")
+                errors.append(f"* {len(extra_files)} files are unexpected")
 
             for m in bad_files:
                 logging.warning("Bad file: %s", m)


### PR DESCRIPTION
Since the popup is using a QMessageBox, we can't tell it to interpret the text content as markdown; QT always uses plain text for it.

I could alternatively also use `•` for it. But A) dunno if qt likes fancy unicode characters and b) since the message box is displayed natively on all OS, i'm not sure whether all OSes like fancy unicode characters.