### PR TITLE
Resolver: Remove filter on interesting resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.6.0] - 2024-05-??
 
-- Nothing yet! Add changes here.
+### Resolver
+
+- Fixed: Some cases of seeds being wrongly considered as impossible.
 
 ## [7.5.1] - 2024-04-??
 

--- a/randovania/resolver/resolver.py
+++ b/randovania/resolver/resolver.py
@@ -195,12 +195,8 @@ async def _inner_advance_depth(
             rest_of_actions.append(action_tuple)
 
     actions = list(
-        reach.satisfiable_actions(
-            state,
-            logic.victory_condition(state),
-            itertools.chain(
-                major_pickup_actions, lock_actions, rest_of_actions, point_of_no_return_actions, dangerous_actions
-            ),
+        itertools.chain(
+            major_pickup_actions, lock_actions, rest_of_actions, point_of_no_return_actions, dangerous_actions
         )
     )
     logic.log_checking_satisfiable_actions(state, actions)

--- a/randovania/resolver/resolver_reach.py
+++ b/randovania/resolver/resolver_reach.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 
 from randovania.game_description.db.node import Node
 from randovania.game_description.db.resource_node import ResourceNode
-from randovania.game_description.game_description import calculate_interesting_resources
 from randovania.game_description.requirements import fast_as_set
 from randovania.game_description.requirements.base import Requirement
 from randovania.game_description.requirements.requirement_and import RequirementAnd
@@ -186,25 +185,6 @@ class ResolverReach:
                     additional_requirements.alternatives
                 )
                 self._logic.log_skip_action_missing_requirement(node, self._logic.game)
-
-    def satisfiable_actions(
-        self,
-        state: State,
-        victory_condition: Requirement,
-        actions: typing.Iterable[tuple[ResourceNode, int]],
-    ) -> Iterator[tuple[ResourceNode, int]]:
-        interesting_resources = calculate_interesting_resources(
-            self._satisfiable_requirements.union(victory_condition.as_set(state.node_context()).alternatives),
-            state.node_context(),
-            state.energy,
-        )
-
-        # print(" > satisfiable actions, with {} interesting resources".format(len(interesting_resources)))
-        for action, energy in actions:
-            for resource, amount in action.resource_gain_on_collect(state.node_context()):
-                if resource in interesting_resources:
-                    yield action, energy
-                    break
 
     def collectable_resource_nodes(self, context: NodeContext) -> Iterator[ResourceNode]:
         for node in self.nodes:


### PR DESCRIPTION
Fix issue where required items are skipped because they aren't interesting yet, and never gotten back to because we don't have a good way to indicate that we should go back for it.