### PR TITLE
Fusion: explicitly use freezing template as well for screw shaft

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -3347,6 +3347,10 @@
                                                                                             "amount": 5,
                                                                                             "negate": false
                                                                                         }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Can Freeze Enemies"
                                                                                     }
                                                                                 ]
                                                                             }

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -563,7 +563,7 @@ Extra - room_id: [16]
                               Ice Beam
                               Ice Missile Data and Missiles
                       # https://youtu.be/o91JwaZoFTg
-                      Diffusion Missile Data and Missiles ≥ 5 and Stand On Frozen Enemies (Hypermode)
+                      Diffusion Missile Data and Missiles ≥ 5 and Stand On Frozen Enemies (Hypermode) and Can Freeze Enemies
 
 > Door to Moto Manor; Heals? False
   * Layers: default


### PR DESCRIPTION
Rationale behind this one, is that if something causes enemies to not be freezable here, that we can more easily disable it.
This doesn't have any logical consequences for now.