### PR TITLE
Add field in rdvgames that overrides Patch Data Factory output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ dependencies = [
 
     # error reports
     "sentry-sdk",
+
+    # Patch GamesPatches JSON from rdvgame
+    "json-delta"
 ]
 
 [project.optional-dependencies]

--- a/randovania/exporter/patch_data_factory.py
+++ b/randovania/exporter/patch_data_factory.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from random import Random
 from typing import TYPE_CHECKING
 
+from json_delta import patch
+
 from randovania.game_description import default_database
 from randovania.layout import filtered_database
 
@@ -48,5 +50,10 @@ class PatchDataFactory:
     def game_enum(self) -> RandovaniaGame:
         raise NotImplementedError
 
-    def create_data(self) -> dict:
+    def create_game_specific_data(self) -> dict:
         raise NotImplementedError
+
+    def create_data(self) -> dict:
+        game_data = self.create_game_specific_data()
+
+        return patch(game_data, self.patches.custom_patcher_data, False)

--- a/randovania/exporter/patch_data_factory.py
+++ b/randovania/exporter/patch_data_factory.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from random import Random
 from typing import TYPE_CHECKING
 
-from json_delta import patch
+import json_delta
 
 from randovania.game_description import default_database
 from randovania.layout import filtered_database
@@ -56,4 +56,4 @@ class PatchDataFactory:
     def create_data(self) -> dict:
         game_data = self.create_game_specific_data()
 
-        return patch(game_data, self.patches.custom_patcher_data, False)
+        return json_delta.patch(game_data, self.patches.custom_patcher_data, False)

--- a/randovania/game_description/game_patches.py
+++ b/randovania/game_description/game_patches.py
@@ -55,6 +55,7 @@ class GamePatches:
     starting_equipment: StartingEquipment
     starting_location: NodeIdentifier
     hints: dict[NodeIdentifier, Hint]
+    custom_patcher_data: list
 
     cached_dock_connections_from: list[tuple[tuple[Node, Requirement], ...] | None] = dataclasses.field(
         hash=False, compare=False
@@ -90,6 +91,7 @@ class GamePatches:
             starting_location=game.starting_location,
             hints={},
             cached_dock_connections_from=[None] * len(game.region_list.all_nodes),
+            custom_patcher_data=[],
         )
 
     def assign_new_pickups(self, assignments: Iterable[PickupTargetAssociation]) -> GamePatches:

--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -404,7 +404,7 @@ class AM2RPatchDataFactory(PatchDataFactory):
 
         return spoiler
 
-    def create_data(self) -> dict:
+    def create_game_specific_data(self) -> dict:
         db = self.game
 
         useless_target = PickupTarget(

--- a/randovania/games/blank/exporter/patch_data_factory.py
+++ b/randovania/games/blank/exporter/patch_data_factory.py
@@ -8,5 +8,5 @@ class BlankPatchDataFactory(PatchDataFactory):
     def game_enum(self) -> RandovaniaGame:
         return RandovaniaGame.BLANK
 
-    def create_data(self) -> dict:
+    def create_game_specific_data(self) -> dict:
         return {}

--- a/randovania/games/cave_story/exporter/patch_data_factory.py
+++ b/randovania/games/cave_story/exporter/patch_data_factory.py
@@ -41,7 +41,7 @@ class CSPatchDataFactory(PatchDataFactory):
     def game_enum(self) -> RandovaniaGame:
         return RandovaniaGame.CAVE_STORY
 
-    def create_data(self) -> dict:
+    def create_game_specific_data(self) -> dict:
         game_description = self.game
         seed_number = self.description.get_seed_for_player(self.players_config.player_index)
         music_rng = Random(seed_number)

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -466,7 +466,7 @@ class DreadPatchDataFactory(PatchDataFactory):
             }
         ]
 
-    def create_data(self) -> dict:
+    def create_game_specific_data(self) -> dict:
         starting_location_node = self.game.region_list.node_by_identifier(self.patches.starting_location)
         starting_location = self._start_point_ref_for(starting_location_node)
         starting_items = self._calculate_starting_inventory(self.patches.starting_resources())

--- a/randovania/games/fusion/exporter/patch_data_factory.py
+++ b/randovania/games/fusion/exporter/patch_data_factory.py
@@ -9,5 +9,5 @@ class FusionPatchDataFactory(PatchDataFactory):
     def game_enum(self) -> RandovaniaGame:
         return RandovaniaGame.FUSION
 
-    def create_data(self) -> dict:
+    def create_game_specific_data(self) -> dict:
         return {}

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -618,7 +618,7 @@ class PrimePatchDataFactory(PatchDataFactory):
             "swapBeamControls": cosmetic_patches.user_preferences.swap_beam_controls,
         }
 
-    def create_data(self) -> dict:
+    def create_game_specific_data(self) -> dict:
         # Setup
         db = self.game
         namer = PrimeHintNamer(self.description.all_patches, self.players_config)

--- a/randovania/games/prime2/exporter/patch_data_factory.py
+++ b/randovania/games/prime2/exporter/patch_data_factory.py
@@ -927,21 +927,6 @@ class EchoesPatchDataFactory(PatchDataFactory):
         ]
 
 
-def generate_patcher_data(
-    description: LayoutDescription,
-    players_config: PlayersConfiguration,
-    cosmetic_patches: EchoesCosmeticPatches,
-) -> dict:
-    """
-
-    :param description:
-    :param players_config:
-    :param cosmetic_patches:
-    :return:
-    """
-    return EchoesPatchDataFactory(description, players_config, cosmetic_patches).create_game_specific_data()
-
-
 def _create_pickup_list(
     cosmetic_patches: EchoesCosmeticPatches,
     configuration: BaseConfiguration,

--- a/randovania/games/prime2/exporter/patch_data_factory.py
+++ b/randovania/games/prime2/exporter/patch_data_factory.py
@@ -639,7 +639,7 @@ class EchoesPatchDataFactory(PatchDataFactory):
             "hud_color": self.cosmetic_patches.hud_color if self.cosmetic_patches.use_hud_color else None,
         }
 
-    def create_data(self) -> dict[str, typing.Any]:
+    def create_game_specific_data(self) -> dict[str, typing.Any]:
         result: dict[str, typing.Any] = {}
         _add_header_data_to_result(self.description, result)
 
@@ -939,7 +939,7 @@ def generate_patcher_data(
     :param cosmetic_patches:
     :return:
     """
-    return EchoesPatchDataFactory(description, players_config, cosmetic_patches).create_data()
+    return EchoesPatchDataFactory(description, players_config, cosmetic_patches).create_game_specific_data()
 
 
 def _create_pickup_list(

--- a/randovania/games/prime3/exporter/patch_data_factory.py
+++ b/randovania/games/prime3/exporter/patch_data_factory.py
@@ -8,5 +8,5 @@ class CorruptionPatchDataFactory(PatchDataFactory):
     def game_enum(self) -> RandovaniaGame:
         return RandovaniaGame.METROID_PRIME_CORRUPTION
 
-    def create_data(self) -> dict:
+    def create_game_specific_data(self) -> dict:
         return {}

--- a/randovania/games/samus_returns/exporter/patch_data_factory.py
+++ b/randovania/games/samus_returns/exporter/patch_data_factory.py
@@ -410,7 +410,7 @@ class MSRPatchDataFactory(PatchDataFactory):
 
         return cosmetic_patches
 
-    def create_data(self) -> dict:
+    def create_game_specific_data(self) -> dict:
         starting_location = self._start_point_ref_for(self._node_for(self.patches.starting_location))
         starting_items = self._calculate_starting_inventory(self.patches.starting_resources())
         starting_text = self._starting_inventory_text()

--- a/randovania/games/super_metroid/exporter/patch_data_factory.py
+++ b/randovania/games/super_metroid/exporter/patch_data_factory.py
@@ -98,7 +98,7 @@ class SuperMetroidPatchDataFactory(PatchDataFactory):
     def game_enum(self) -> RandovaniaGame:
         return RandovaniaGame.SUPER_METROID
 
-    def create_data(self) -> dict:
+    def create_game_specific_data(self) -> dict:
         db = self.game
         useless_target = PickupTarget(
             pickup_creator.create_nothing_pickup(db.resource_database), self.players_config.player_index

--- a/randovania/layout/game_patches_serializer.py
+++ b/randovania/layout/game_patches_serializer.py
@@ -109,6 +109,10 @@ def serialize_single(player_index: int, num_players: int, patches: GamePatches) 
         ),
         "hints": {identifier.as_string: hint.as_json for identifier, hint in patches.hints.items()},
     }
+
+    if patches.custom_patcher_data:
+        result["custom_patcher_data"] = patches.custom_patcher_data
+
     return result
 
 

--- a/randovania/layout/game_patches_serializer.py
+++ b/randovania/layout/game_patches_serializer.py
@@ -160,6 +160,11 @@ def decode_single(
 
     initial_pickup_assignment = all_pools[player_index].assignment
 
+    if "custom_patcher_data" in game_modifications:
+        custom_patcher_data = game_modifications["custom_patcher_data"]
+    else:
+        custom_patcher_data = []
+
     # Starting Location
     starting_location = NodeIdentifier.from_string(game_modifications["starting_location"])
 
@@ -267,6 +272,7 @@ def decode_single(
         starting_equipment=starting_equipment,
         starting_location=starting_location,  # NodeIdentifier
         hints=hints,
+        custom_patcher_data=custom_patcher_data,
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -125,6 +125,8 @@ itsdangerous==2.1.2
     # via flask
 jinja2==3.1.3
     # via flask
+json-delta==2.0.2
+    # via randovania (setup.py)
 jsonschema==4.21.1
     # via
     #   open-dread-rando

--- a/test/games/test_log_file_export.py
+++ b/test/games/test_log_file_export.py
@@ -97,6 +97,7 @@ def pytest_generate_tests(metafunc: _pytest.python.Metafunc) -> None:
         "dread/dread_dread_multiworld.rdvgame",  # dread-dread multi
         "dread/elevator_rando.rdvgame",  # elevator_rando multi
         "dread/custom_start.rdvgame",  # crazy settings
+        "dread/custom_patcher_data.rdvgame",  # custom patcher data
         # Prime 1
         "prime1_crazy_seed.rdvgame",  # chaos features
         "prime1_crazy_seed_one_way_door.rdvgame",  # same as above but 1-way doors

--- a/test/test_files/log_files/dread/custom_patcher_data.rdvgame
+++ b/test/test_files/log_files/dread/custom_patcher_data.rdvgame
@@ -1,0 +1,618 @@
+{
+    "schema_version": 24,
+    "info": {
+        "randovania_version": "7.6.0.dev26-dirty",
+        "randovania_version_git": "50fc6c5e",
+        "permalink": "Deg_rCy0olD8bF4LknO-pbJw3nhyongAAPhn",
+        "has_spoiler": true,
+        "seed": 685867370,
+        "hash": "H6WCZNFC",
+        "word_hash": "Screw Sunnap Golzuna",
+        "presets": [
+            {
+                "schema_version": 75,
+                "base_preset_uuid": null,
+                "name": "Starter Preset",
+                "uuid": "407e97ed-decb-4889-8ab7-943f86ae48a4",
+                "description": "Basic preset.",
+                "game": "dread",
+                "configuration": {
+                    "trick_level": {
+                        "minimal_logic": false,
+                        "specific_levels": {}
+                    },
+                    "starting_location": [
+                        {
+                            "region": "Artaria",
+                            "area": "Intro Room",
+                            "node": "Start Point"
+                        }
+                    ],
+                    "available_locations": {
+                        "randomization_mode": "full",
+                        "excluded_indices": []
+                    },
+                    "standard_pickup_configuration": {
+                        "pickups_state": {
+                            "Wide Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Plasma Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Wave Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Progressive Beam": {},
+                            "Charge Beam": {},
+                            "Diffusion Beam": {},
+                            "Progressive Charge Beam": {
+                                "num_shuffled_pickups": 2
+                            },
+                            "Grapple Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Missiles": {
+                                "num_included_in_starting_pickups": 1,
+                                "included_ammo": [
+                                    15
+                                ]
+                            },
+                            "Super Missile": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Ice Missile": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Progressive Missile": {},
+                            "Storm Missile": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Phantom Cloak": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Flash Shift": {
+                                "num_shuffled_pickups": 1,
+                                "included_ammo": [
+                                    2
+                                ]
+                            },
+                            "Pulse Radar": {
+                                "num_included_in_starting_pickups": 1
+                            },
+                            "Varia Suit": {},
+                            "Gravity Suit": {},
+                            "Progressive Suit": {
+                                "num_shuffled_pickups": 2
+                            },
+                            "Morph Ball": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Bomb": {},
+                            "Cross Bomb": {},
+                            "Progressive Bomb": {
+                                "num_shuffled_pickups": 2
+                            },
+                            "Power Bomb": {
+                                "num_shuffled_pickups": 1,
+                                "included_ammo": [
+                                    2
+                                ]
+                            },
+                            "Slide": {
+                                "num_included_in_starting_pickups": 1
+                            },
+                            "Spider Magnet": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Speed Booster": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Spin Boost": {},
+                            "Space Jump": {},
+                            "Progressive Spin": {
+                                "num_shuffled_pickups": 2
+                            },
+                            "Screw Attack": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Energy Tank": {
+                                "num_shuffled_pickups": 8
+                            },
+                            "Energy Part": {
+                                "num_shuffled_pickups": 16
+                            },
+                            "Speed Booster Upgrade": {}
+                        },
+                        "default_pickups": {},
+                        "minimum_random_starting_pickups": 0,
+                        "maximum_random_starting_pickups": 0
+                    },
+                    "ammo_pickup_configuration": {
+                        "pickups_state": {
+                            "Missile Tank": {
+                                "ammo_count": [
+                                    2
+                                ],
+                                "pickup_count": 75,
+                                "requires_main_item": true
+                            },
+                            "Missile+ Tank": {
+                                "ammo_count": [
+                                    10
+                                ],
+                                "pickup_count": 11,
+                                "requires_main_item": true
+                            },
+                            "Power Bomb Tank": {
+                                "ammo_count": [
+                                    1
+                                ],
+                                "pickup_count": 13,
+                                "requires_main_item": true
+                            },
+                            "Flash Shift Upgrade": {
+                                "ammo_count": [
+                                    1
+                                ],
+                                "pickup_count": 0,
+                                "requires_main_item": true
+                            }
+                        }
+                    },
+                    "damage_strictness": 1.5,
+                    "pickup_model_style": "all-visible",
+                    "pickup_model_data_source": "etm",
+                    "logical_resource_action": "randomly",
+                    "first_progression_must_be_local": false,
+                    "minimum_available_locations_for_hint_placement": 5,
+                    "minimum_location_weight_for_hint_placement": 0.1,
+                    "dock_rando": {
+                        "mode": "vanilla",
+                        "types_state": {
+                            "door": {
+                                "can_change_from": [
+                                    "Access Open",
+                                    "Charge Beam Door",
+                                    "Grapple Beam Door",
+                                    "Missile Door",
+                                    "Plasma Beam Door",
+                                    "Power Beam Door",
+                                    "Sensor Lock Door",
+                                    "Super Missile Door",
+                                    "Wave Beam Door",
+                                    "Wide Beam Door"
+                                ],
+                                "can_change_to": [
+                                    "Charge Beam Door",
+                                    "Grapple Beam Door",
+                                    "Missile Door",
+                                    "Plasma Beam Door",
+                                    "Power Beam Door",
+                                    "Super Missile Door",
+                                    "Wave Beam Door",
+                                    "Wide Beam Door"
+                                ]
+                            }
+                        }
+                    },
+                    "single_set_for_pickups_that_solve": true,
+                    "staggered_multi_pickup_placement": true,
+                    "check_if_beatable_after_base_patches": false,
+                    "teleporters": {
+                        "mode": "vanilla",
+                        "excluded_teleporters": [],
+                        "excluded_targets": []
+                    },
+                    "energy_per_tank": 100,
+                    "immediate_energy_parts": true,
+                    "hanubia_shortcut_no_grapple": true,
+                    "hanubia_easier_path_to_itorash": true,
+                    "x_starts_released": false,
+                    "raven_beak_damage_table_handling": "consistent_low",
+                    "allow_highly_dangerous_logic": false,
+                    "nerf_power_bombs": true,
+                    "warp_to_start": true,
+                    "april_fools_hints": false,
+                    "artifacts": {
+                        "prefer_emmi": true,
+                        "prefer_major_bosses": true,
+                        "required_artifacts": 3
+                    },
+                    "constant_heat_damage": 20,
+                    "constant_cold_damage": 20,
+                    "constant_lava_damage": 20
+                }
+            }
+        ]
+    },
+    "game_modifications": [
+        {
+            "game": "dread",
+            "starting_equipment": {
+                "pickups": [
+                    "Missiles",
+                    "Pulse Radar",
+                    "Slide",
+                    "Metroid DNA 4",
+                    "Metroid DNA 5",
+                    "Metroid DNA 6",
+                    "Metroid DNA 7",
+                    "Metroid DNA 8",
+                    "Metroid DNA 9",
+                    "Metroid DNA 10",
+                    "Metroid DNA 11",
+                    "Metroid DNA 12"
+                ]
+            },
+            "starting_location": "Artaria/Intro Room/Start Point",
+            "dock_connections": {
+                "Artaria/Transport to Dairon/Elevator to Dairon": "Dairon/Transport to Artaria/Elevator to Artaria",
+                "Artaria/Transport to Cataris/Elevator to Cataris": "Cataris/Transport to Artaria/Elevator to Artaria",
+                "Artaria/Transport to Burenia/Elevator to Burenia": "Burenia/Transport to Artaria/Elevator to Artaria",
+                "Cataris/Transport to Artaria/Elevator to Artaria": "Artaria/Transport to Cataris/Elevator to Cataris",
+                "Cataris/Transport to Dairon/Shuttle to Dairon": "Dairon/Transport to Cataris/Shuttle to Cataris",
+                "Dairon/East Transport to Ferenia/Elevator to Ferenia": "Ferenia/East Transport to Dairon/Elevator to Dairon",
+                "Dairon/Transport to Artaria/Elevator to Artaria": "Artaria/Transport to Dairon/Elevator to Dairon",
+                "Dairon/West Transport to Ferenia/Elevator to Ferenia": "Ferenia/Transport to Dairon/Elevator to Dairon",
+                "Dairon/Transport to Cataris/Shuttle to Cataris": "Cataris/Transport to Dairon/Shuttle to Dairon",
+                "Dairon/Lower Transport to Burenia/Shuttle to Burenia": "Burenia/Lower Transport to Dairon/Shuttle to Dairon",
+                "Dairon/Upper Transport to Burenia/Shuttle to Burenia": "Burenia/Upper Transport to Dairon/Shuttle to Dairon",
+                "Dairon/Transport to Ghavoran/Elevator to Ghavoran": "Ghavoran/Transport to Dairon/Elevator to Dairon",
+                "Burenia/Upper Transport to Dairon/Shuttle to Dairon": "Dairon/Upper Transport to Burenia/Shuttle to Burenia",
+                "Burenia/Lower Transport to Dairon/Shuttle to Dairon": "Dairon/Lower Transport to Burenia/Shuttle to Burenia",
+                "Burenia/Transport to Ghavoran/Elevator to Ghavoran": "Ghavoran/Transport to Burenia/Elevator to Burenia",
+                "Burenia/Transport to Artaria/Elevator to Artaria": "Artaria/Transport to Burenia/Elevator to Burenia",
+                "Ferenia/East Transport to Dairon/Elevator to Dairon": "Dairon/East Transport to Ferenia/Elevator to Ferenia",
+                "Ferenia/Transport to Dairon/Elevator to Dairon": "Dairon/West Transport to Ferenia/Elevator to Ferenia",
+                "Ferenia/Transport to Ghavoran/Shuttle to Ghavoran": "Ghavoran/Transport to Ferenia/Shuttle to Ferenia",
+                "Ferenia/Transport to Hanubia/Elevator to Hanubia": "Hanubia/Transport to Ferenia/Elevator to Ferenia",
+                "Ghavoran/Transport to Burenia/Elevator to Burenia": "Burenia/Transport to Ghavoran/Elevator to Ghavoran",
+                "Ghavoran/Transport to Ferenia/Shuttle to Ferenia": "Ferenia/Transport to Ghavoran/Shuttle to Ghavoran",
+                "Ghavoran/Transport to Hanubia/Shuttle to Hanubia": "Hanubia/Transport to Ghavoran/Shuttle to Ghavoran",
+                "Ghavoran/Transport to Elun/Shuttle to Elun": "Elun/Transport to Ghavoran/Shuttle to Ghavoran",
+                "Ghavoran/Transport to Dairon/Elevator to Dairon": "Dairon/Transport to Ghavoran/Elevator to Ghavoran",
+                "Elun/Transport to Ghavoran/Shuttle to Ghavoran": "Ghavoran/Transport to Elun/Shuttle to Elun",
+                "Hanubia/Transport to Ferenia/Elevator to Ferenia": "Ferenia/Transport to Hanubia/Elevator to Hanubia",
+                "Hanubia/Transport to Ghavoran/Shuttle to Ghavoran": "Ghavoran/Transport to Hanubia/Shuttle to Hanubia",
+                "Hanubia/Transport to Itorash/Elevator to Itorash": "Itorash/Transport to Hanubia/Elevator to Hanubia",
+                "Itorash/Transport to Hanubia/Elevator to Hanubia": "Hanubia/Transport to Itorash/Elevator to Itorash"
+            },
+            "dock_weakness": {
+                "Hanubia/Entrance Tall Room/Door to Total Recharge Station North": {
+                    "type": "door",
+                    "name": "Power Beam Door"
+                },
+                "Hanubia/Total Recharge Station North/Door to Gold Chozo Warrior Arena": {
+                    "type": "door",
+                    "name": "Power Beam Door"
+                }
+            },
+            "configurable_nodes": {},
+            "locations": {
+                "Artaria": {
+                    "Arbitrary Enky Room/Pickup (Missile Tank)": "Missile+ Tank",
+                    "Central Unit Access/Pickup (Spider Magnet)": "Progressive Suit",
+                    "Charge Beam Access/Pickup (Missile Tank)": "Missile Tank",
+                    "Charge Beam Room/Pickup (Charge Beam)": "Progressive Spin",
+                    "Charge Tutorial/Pickup (Energy Tank)": "Spider Magnet",
+                    "Corpius Arena/Pickup (Phantom Cloak)": "Metroid DNA 3",
+                    "David Jaffe Room/Pickup (Missile Tank)": "Missile Tank",
+                    "EMMI Zone Exit North/Pickup (Missile Tank)": "Missile+ Tank",
+                    "EMMI Zone Exit Northwest/Pickup (Missile Tank)": "Missile+ Tank",
+                    "EMMI Zone First Entrance/Pickup (Missile Tank)": "Morph Ball",
+                    "EMMI Zone Hub/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "EMMI Zone Spinner/Pickup (Missile Tank)": "Storm Missile",
+                    "East Lava Missile Room/Pickup (Missile Tank)": "Energy Part",
+                    "Energy Recharge Station South/Pickup (Missile Tank)": "Energy Part",
+                    "Freezer/Pickup (Missile Tank)": "Energy Part",
+                    "Grapple Beam Room/Pickup (Grapple Beam)": "Missile Tank",
+                    "Hot Cataris Shortcut/Pickup (Missile Tank)": "Energy Part",
+                    "Invisible Corpius Room/Pickup (Missile Tank)": "Missile Tank",
+                    "Melee Tutorial Room/Pickup (Missile Tank 1)": "Missile Tank",
+                    "Melee Tutorial Room/Pickup (Missile Tank 2)": "Progressive Charge Beam",
+                    "Proto EMMI Introduction/Pickup (Missile Tank)": "Energy Part",
+                    "Screw Attack Room/Pickup (Missile Tank, Top)": "Missile Tank",
+                    "Screw Attack Room/Pickup (Missile Tank, Underwater)": "Power Bomb Tank",
+                    "Screw Attack Room/Pickup (Screw Attack)": "Missile+ Tank",
+                    "Shutter Platform Puzzle/Pickup (Energy Tank)": "Energy Part",
+                    "Speed Hallway/Pickup (Energy Part)": "Flash Shift",
+                    "Speed Hallway/Pickup (Missile+ Tank)": "Missile Tank",
+                    "Teleport to Cataris/Pickup (Missile Tank, Supers-locked)": "Wide Beam",
+                    "Teleport to Cataris/Pickup (Missile Tank, Underwater)": "Energy Part",
+                    "Thermal Device/Pickup (Missile Tank)": "Missile Tank",
+                    "Transport to Burenia/Pickup (Missile Tank)": "Missile Tank",
+                    "Varia Suit Room/Pickup (Varia Suit)": "Missile Tank",
+                    "Varia Suit Tutorial North/Pickup (Missile+ Tank)": "Missile Tank",
+                    "Waterfall/Pickup (Energy Part)": "Progressive Bomb",
+                    "Waterfall/Pickup (Missile Tank)": "Missile Tank"
+                },
+                "Burenia": {
+                    "Burenia Hub to Dairon/Pickup (Energy Part)": "Missile Tank",
+                    "Burenia Hub to Dairon/Pickup (Missile Tank)": "Energy Tank",
+                    "Drogyga Arena/Pickup (Drogyga)": "Missile Tank",
+                    "Early Gravity Speedboost Room 1/Pickup (Energy Part)": "Missile Tank",
+                    "Early Gravity Speedboost Room 1/Pickup (Missile+ Tank)": "Missile Tank",
+                    "Energy Recharge South/Pickup (Missile Tank)": "Energy Part",
+                    "Flash Shift Room/Pickup (Flash Shift)": "Wave Beam",
+                    "Gravity Suit Room/Pickup (Gravity Suit)": "Missile Tank",
+                    "Gravity Suit Room/Pickup (Power Bomb Tank)": "Energy Part",
+                    "Gravity Suit Tower/Pickup (Missile Tank)": "Ice Missile",
+                    "Gravity Suit Tower/Pickup (Missile+ Tank)": "Missile Tank",
+                    "Main Hub Tower Middle/Pickup (Missile Tank)": "Missile+ Tank",
+                    "Main Hub Tower Middle/Pickup (Missile+ Tank)": "Missile Tank",
+                    "Main Hub Tower Top/Pickup (Energy Tank)": "Power Bomb Tank",
+                    "Main Hub Tower Top/Pickup (Missile Tank)": "Missile Tank",
+                    "Storm Missile Gate Room/Pickup (Energy Tank)": "Power Bomb Tank",
+                    "Teleport to Ferenia/Pickup (Missile+ Tank)": "Missile Tank",
+                    "Transport to Artaria/Pickup (Missile Tank)": "Missile Tank",
+                    "Underneath Drogyga/Pickup (Missile Tank)": "Energy Part",
+                    "Upper Burenia Hub/Pickup (Missile Tank)": "Missile+ Tank"
+                },
+                "Cataris": {
+                    "Above Z-57 Fight/Pickup (Missile Tank)": "Energy Tank",
+                    "Above Z-57 Fight/Pickup (Z-57)": "Power Bomb Tank",
+                    "Central Unit Access/Pickup (Morph Ball)": "Grapple Beam",
+                    "Dairon Transport Access/Pickup (Missile Tank)": "Missile Tank",
+                    "Diffusion Beam Room/Pickup (Diffusion Beam)": "Missile Tank",
+                    "Diffusion Beam Room/Pickup (Power Bomb Tank)": "Missile+ Tank",
+                    "Double Obsydomithon Room/Pickup (Missile Tank)": "Power Bomb Tank",
+                    "EMMI Zone Exits West/Pickup (Missile Tank)": "Missile Tank",
+                    "EMMI Zone Hidden Missile Room/Pickup (Missile Tank)": "Missile Tank",
+                    "EMMI Zone Item Tunnel/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Kraid Arena/Pickup (Kraid)": "Missile Tank",
+                    "Kraid Eyedoor Room/Pickup (Missile Tank)": "Progressive Charge Beam",
+                    "Lava Button East Access/Pickup (Missile Tank)": "Power Bomb Tank",
+                    "Teleport to Artaria (Blue)/Pickup (Missile Tank)": "Missile Tank",
+                    "Teleport to Artaria (Blue)/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Teleport to Artaria (Red)/Pickup (Missile+ Tank)": "Missile Tank",
+                    "Teleport to Dairon/Pickup (Missile Tank)": "Super Missile",
+                    "Teleport to Ghavoran/Pickup (Missile Tank - Bottom)": "Phantom Cloak",
+                    "Teleport to Ghavoran/Pickup (Missile Tank - Top)": "Missile Tank",
+                    "Thermal Device Room North/Pickup (Energy Part)": "Missile+ Tank",
+                    "Thermal Device Room North/Pickup (Energy Tank)": "Power Bomb Tank",
+                    "Transport to Artaria/Pickup (Missile Tank)": "Energy Tank",
+                    "Underlava Puzzle Room 2/Pickup (Energy Part)": "Missile Tank",
+                    "Z-57 Heat Room East/Pickup (Missile Tank)": "Screw Attack",
+                    "Z-57 Heat Room West (Right)/Pickup (Missile Tank)": "Missile Tank"
+                },
+                "Dairon": {
+                    "Big Hub/Pickup (Missile Tank)": "Missile Tank",
+                    "Bomb Room/Pickup (Bomb)": "Missile Tank",
+                    "Bomb Room/Pickup (Missile Tank)": "Missile Tank",
+                    "Central Unit Access/Pickup (Energy Part)": "Energy Tank",
+                    "Central Unit Access/Pickup (Speed Booster)": "Metroid DNA 1",
+                    "Cross Bomb Puzzle Room/Pickup (Missile Tank)": "Energy Part",
+                    "EMMI Zone Exit North/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "EMMI Zone Exit Northwest/Pickup (Missile Tank)": "Missile Tank",
+                    "Early Grapple Access/Pickup (Energy Part)": "Power Bomb",
+                    "Early Grapple Room/Pickup (Missile Tank Speedboost)": "Missile Tank",
+                    "Early Grapple Room/Pickup (Missile Tank Tunnel)": "Energy Tank",
+                    "Energy Recharge Station West/Pickup (Energy Part)": "Missile Tank",
+                    "Freezer/Pickup (Missile Tank - Lower)": "Energy Transfer Module",
+                    "Freezer/Pickup (Missile Tank - Upper)": "Missile Tank",
+                    "Hidden Grapple Shortcut Room/Pickup (Missile Tank)": "Energy Tank",
+                    "Lake Puzzle Room/Pickup (Power Bomb Tank)": "Energy Part",
+                    "Save Station West Tunnels/Pickup (Missile Tank)": "Missile+ Tank",
+                    "Shinespark Tutorial/Pickup (Energy Tank)": "Energy Part",
+                    "Storm Missile Gate Room/Pickup (Missile+ Tank)": "Missile Tank",
+                    "Teleport to Artaria/Pickup (Missile Tank)": "Missile Tank",
+                    "Transport to Artaria/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Wide Beam Room/Pickup (Wide Beam)": "Energy Part",
+                    "Yellow EMMI Introduction/Pickup (Energy Part)": "Missile Tank"
+                },
+                "Elun": {
+                    "Ammo Recharge Station/Pickup (Energy Tank)": "Missile Tank",
+                    "Fan Room/Pickup (Missile Tank)": "Missile Tank",
+                    "Horizontal Bomb Maze/Pickup (Missile Tank)": "Missile Tank",
+                    "Plasma Beam Room/Pickup (Plasma Beam)": "Missile Tank",
+                    "Vertical Bomb Maze/Pickup (Power Bomb Tank)": "Energy Part"
+                },
+                "Ferenia": {
+                    "Cold Room (Storm Missile Gate)/Pickup (Missile Tank)": "Missile Tank",
+                    "Energy Recharge Station Secret/Pickup (Energy Part)": "Missile Tank",
+                    "Escue Arena/Pickup (Storm Missile)": "Progressive Spin",
+                    "Escue Eyedoor Room/Pickup (Missile Tank)": "Power Bomb Tank",
+                    "Fan Room/Pickup (Missile+ Tank)": "Missile Tank",
+                    "Path to Escue/Pickup (Energy Part)": "Power Bomb Tank",
+                    "Pitfall Puzzle Room/Pickup (Missile Tank)": "Energy Tank",
+                    "Purple EMMI Arena/Pickup (Wave Beam)": "Plasma Beam",
+                    "Purple EMMI Introduction/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Separate Tunnels Room/Pickup (Missile Tank - Left)": "Missile Tank",
+                    "Separate Tunnels Room/Pickup (Missile Tank - Right)": "Missile Tank",
+                    "Space Jump Room/Pickup (Missile Tank)": "Missile Tank",
+                    "Space Jump Room/Pickup (Missile+ Tank)": "Missile Tank",
+                    "Space Jump Room/Pickup (Space Jump)": "Missile Tank",
+                    "Speedboost Slopes Maze/Pickup (Energy Part)": "Missile Tank",
+                    "Total Recharge Station/Pickup (Energy Part)": "Missile Tank",
+                    "Twin Robot Arena/Pickup (Power Bomb Tank)": "Missile Tank"
+                },
+                "Ghavoran": {
+                    "Above Pulse Radar/Pickup (Missile Tank)": "Power Bomb Tank",
+                    "Central Unit Access/Pickup (Ice Missile)": "Missile+ Tank",
+                    "Cross Bomb Tutorial/Pickup (Missile Tank)": "Missile Tank",
+                    "Dairon Transport Access/Pickup (Missile Tank)": "Energy Tank",
+                    "Elun Transport Access/Pickup (Missile Tank)": "Power Bomb Tank",
+                    "Golzuna Arena/Pickup (Cross Bomb)": "Metroid DNA 2",
+                    "Golzuna Tower/Pickup (Energy Part)": "Missile Tank",
+                    "Golzuna Tower/Pickup (Missile Tank)": "Missile Tank",
+                    "Left Entrance/Pickup (Missile Tank)": "Energy Part",
+                    "Map Station Access Secret/Pickup (Missile Tank)": "Missile Tank",
+                    "Pulse Radar Room/Pickup (Pulse Radar)": "Progressive Suit",
+                    "Right Entrance/Pickup (Missile Tank)": "Power Bomb Tank",
+                    "Spin Boost Room/Pickup (Spin Boost)": "Missile Tank",
+                    "Spin Boost Tower/Pickup (Energy Part)": "Missile Tank",
+                    "Spin Boost Tower/Pickup (Energy Tank)": "Progressive Bomb",
+                    "Spin Boost Tower/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Super Missile Room Access/Pickup (Missile+ Tank)": "Missile Tank",
+                    "Super Missile Room/Pickup (Super Missile)": "Missile Tank",
+                    "Teleport to Burenia/Pickup (Missile Tank)": "Speed Booster",
+                    "Total Recharge Station North/Pickup (Missile Tank)": "Power Bomb Tank"
+                },
+                "Hanubia": {
+                    "Ferenia Shortcut/Pickup (Missile Tank)": "Missile Tank",
+                    "Orange EMMI Introduction/Pickup (Power Bomb)": "Missile Tank",
+                    "Speedboost Puzzle Room/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Total Recharge Station North/Pickup (Missile Tank)": "Missile+ Tank"
+                }
+            },
+            "hints": {
+                "Dairon/Navigation Station North/Save Station": {
+                    "hint_type": "joke",
+                    "precision": null,
+                    "target": null,
+                    "dark_temple": null
+                },
+                "Artaria/Navigation Station South/Save Station": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 139,
+                    "dark_temple": null
+                },
+                "Artaria/Navigation Station North/Save Station": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 52,
+                    "dark_temple": null
+                },
+                "Cataris/Navigation Station Northwest/Save Station": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 110,
+                    "dark_temple": null
+                },
+                "Cataris/Navigation Station Southeast/Save Station": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 34,
+                    "dark_temple": null
+                },
+                "Burenia/Navigation Station North/Save Station": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 5,
+                    "dark_temple": null
+                },
+                "Burenia/Navigation Station South/Save Station": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 142,
+                    "dark_temple": null
+                },
+                "Dairon/Navigation Station South/Save Station": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 143,
+                    "dark_temple": null
+                },
+                "Hanubia/Navigation Station/Save Station": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 93,
+                    "dark_temple": null
+                },
+                "Ferenia/Navigation Station/Save Station": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 109,
+                    "dark_temple": null
+                },
+                "Ghavoran/Navigation Station/Save Station": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 103,
+                    "dark_temple": null
+                }
+            },
+            "custom_patcher_data": [
+                [
+                    ["starting_text", 0],
+                    [
+                        "Hello world!"
+                    ]
+                ]
+            ]
+        }
+    ],
+    "item_order": [
+        "Progressive Charge Beam at Artaria/Melee Tutorial Room/Pickup (Missile Tank 2)",
+        "Progressive Spin at Artaria/Charge Beam Room/Pickup (Charge Beam)",
+        "Spider Magnet at Artaria/Charge Tutorial/Pickup (Energy Tank)",
+        "Morph Ball at Artaria/EMMI Zone First Entrance/Pickup (Missile Tank)",
+        "Progressive Suit at Artaria/Central Unit Access/Pickup (Spider Magnet) with hint at Artaria/Navigation Station South/Save Station",
+        "Screw Attack at Cataris/Z-57 Heat Room East/Pickup (Missile Tank) with hint at Artaria/Navigation Station North/Save Station",
+        "Progressive Bomb at Artaria/Waterfall/Pickup (Energy Part)",
+        "Progressive Suit at Ghavoran/Pulse Radar Room/Pickup (Pulse Radar) with hint at Cataris/Navigation Station Northwest/Save Station",
+        "Progressive Charge Beam at Cataris/Kraid Eyedoor Room/Pickup (Missile Tank) with hint at Cataris/Navigation Station Southeast/Save Station",
+        "Flash Shift at Artaria/Speed Hallway/Pickup (Energy Part)",
+        "Super Missile at Cataris/Teleport to Dairon/Pickup (Missile Tank)",
+        "Wide Beam at Artaria/Teleport to Cataris/Pickup (Missile Tank, Supers-locked)",
+        "Power Bomb at Dairon/Early Grapple Access/Pickup (Energy Part)",
+        "Grapple Beam at Cataris/Central Unit Access/Pickup (Morph Ball)",
+        "Wave Beam at Burenia/Flash Shift Room/Pickup (Flash Shift)",
+        "Storm Missile at Artaria/EMMI Zone Spinner/Pickup (Missile Tank) with hint at Burenia/Navigation Station North/Save Station",
+        "Progressive Spin at Ferenia/Escue Arena/Pickup (Storm Missile) with hint at Burenia/Navigation Station South/Save Station",
+        "Plasma Beam at Ferenia/Purple EMMI Arena/Pickup (Wave Beam) with hint at Dairon/Navigation Station South/Save Station",
+        "Ice Missile at Burenia/Gravity Suit Tower/Pickup (Missile Tank) with hint at Hanubia/Navigation Station/Save Station",
+        "Progressive Bomb at Ghavoran/Spin Boost Tower/Pickup (Energy Tank) with hint at Ferenia/Navigation Station/Save Station",
+        "Speed Booster at Ghavoran/Teleport to Burenia/Pickup (Missile Tank) with hint at Ghavoran/Navigation Station/Save Station",
+        "Phantom Cloak at Cataris/Teleport to Ghavoran/Pickup (Missile Tank - Bottom)",
+        "Energy Tank at Ghavoran/Dairon Transport Access/Pickup (Missile Tank)",
+        "Energy Tank at Ferenia/Pitfall Puzzle Room/Pickup (Missile Tank)",
+        "Energy Tank at Burenia/Burenia Hub to Dairon/Pickup (Missile Tank)",
+        "Energy Tank at Cataris/Transport to Artaria/Pickup (Missile Tank)",
+        "Energy Tank at Dairon/Central Unit Access/Pickup (Energy Part)",
+        "Missile Tank at Hanubia/Orange EMMI Introduction/Pickup (Power Bomb)",
+        "Energy Tank at Dairon/Hidden Grapple Shortcut Room/Pickup (Missile Tank)"
+    ]
+}

--- a/test/test_files/patcher_data/dread/dread/custom_patcher_data/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/custom_patcher_data/world_1.json
@@ -1,0 +1,4092 @@
+{
+    "configuration_identifier": "XXXXXXXX",
+    "starting_location": {
+        "scenario": "s010_cave",
+        "actor": "StartPoint0"
+    },
+    "starting_items": {
+        "ITEM_WEAPON_MISSILE_MAX": 15,
+        "ITEM_SONAR": 1,
+        "ITEM_FLOOR_SLIDE": 1,
+        "ITEM_RANDO_ARTIFACT_4": 1,
+        "ITEM_RANDO_ARTIFACT_5": 1,
+        "ITEM_RANDO_ARTIFACT_6": 1,
+        "ITEM_RANDO_ARTIFACT_7": 1,
+        "ITEM_RANDO_ARTIFACT_8": 1,
+        "ITEM_RANDO_ARTIFACT_9": 1,
+        "ITEM_RANDO_ARTIFACT_10": 1,
+        "ITEM_RANDO_ARTIFACT_11": 1,
+        "ITEM_RANDO_ARTIFACT_12": 1
+    },
+    "starting_text": [
+        [
+            "Hello world!"
+        ]
+    ],
+    "pickups": [
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Spin acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_DOUBLE_JUMP",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_SPACE_JUMP",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "ItemSphere_ChargeBeam"
+            },
+            "model": [
+                "powerup_doublejump",
+                "powerup_spacejump"
+            ],
+            "map_icon": {
+                "icon_id": "PROGRESSIVE_SPIN",
+                "original_actor": {
+                    "scenario": "s010_cave",
+                    "layer": "default",
+                    "actor": "powerup_chargebeam"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile+ Tank acquired.\nMissile capacity increased by 10.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 10
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank011"
+            },
+            "model": [
+                "item_missiletankplus"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletankplus"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank012"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Spider Magnet acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAGNET_GLOVE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_EnergyTank001"
+            },
+            "model": [
+                "powerup_spidermagnet"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_spidermagnet"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Morph Ball acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MORPH_BALL",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank001"
+            },
+            "model": [
+                "powerup_morphball"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_morphball"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Storm Missile acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MULTILOCKON",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank002"
+            },
+            "model": [
+                "powerup_stormmissile"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_stormmissile"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_missiletank_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank003"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank004"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank005"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank006"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank007"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank003_1"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank009"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_energytank_000"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_missiletankplus_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Bomb acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_BOMB",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_LINE_BOMB",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_energyfragment_001"
+            },
+            "model": [
+                "powerup_bomb",
+                "powerup_crossbomb"
+            ],
+            "map_icon": {
+                "icon_id": "PROGRESSIVE_BOMB"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile+ Tank acquired.\nMissile capacity increased by 10.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 10
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_missiletank_001"
+            },
+            "model": [
+                "item_missiletankplus"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletankplus"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Flash Shift acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_GHOST_AURA",
+                        "quantity": 1
+                    },
+                    {
+                        "item_id": "ITEM_UPGRADE_FLASH_SHIFT_CHAIN",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_energyfragment_000"
+            },
+            "model": [
+                "powerup_ghostaura"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_ghostaura"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_powerbombtank_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Wide Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_WIDE_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_missiletank_003"
+            },
+            "model": [
+                "powerup_widebeam"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_widebeam"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile+ Tank acquired.\nMissile capacity increased by 10.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 10
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_missiletank_004"
+            },
+            "model": [
+                "item_missiletankplus"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletankplus"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank010"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "IT_VARIA_GEN_001"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank",
+                "original_actor": {
+                    "scenario": "s010_cave",
+                    "layer": "default",
+                    "actor": "powerup_variasuit"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_missiletank_002"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "ItemSphere_GrappleBeam"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank",
+                "original_actor": {
+                    "scenario": "s010_cave",
+                    "layer": "default",
+                    "actor": "powerup_grapplebeam"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank014"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile+ Tank acquired.\nMissile capacity increased by 10.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 10
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "ItemSphere_ScrewAttack"
+            },
+            "model": [
+                "item_missiletankplus"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletankplus",
+                "original_actor": {
+                    "scenario": "s010_cave",
+                    "layer": "default",
+                    "actor": "powerup_screwattack"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank015"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "Item_MissileTank016"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_missiletankplus_001"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Charge Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_CHARGE_BEAM",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_DIFFUSION_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_missiletank_005"
+            },
+            "model": [
+                "powerup_chargebeam",
+                "powerup_diffusionbeam"
+            ],
+            "map_icon": {
+                "icon_id": "PROGRESSIVE_CHARGE"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "item_missiletank_006"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_powerbombtank_002"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Charge Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_CHARGE_BEAM",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_DIFFUSION_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_012"
+            },
+            "model": [
+                "powerup_chargebeam",
+                "powerup_diffusionbeam"
+            ],
+            "map_icon": {
+                "icon_id": "PROGRESSIVE_CHARGE"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "itemsphere_diffusionbeam"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank",
+                "original_actor": {
+                    "scenario": "s020_magma",
+                    "layer": "default",
+                    "actor": "powerup_diffusionbeam"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank"
+            },
+            "model": [
+                "item_energytank"
+            ],
+            "map_icon": {
+                "icon_id": "item_energytank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_008"
+            },
+            "model": [
+                "item_energytank"
+            ],
+            "map_icon": {
+                "icon_id": "item_energytank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_001"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_SUPER_MISSILE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_003"
+            },
+            "model": [
+                "powerup_supermissile"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_supermissile"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_004"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_005"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile+ Tank acquired.\nMissile capacity increased by 10.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 10
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_energyfragment_001"
+            },
+            "model": [
+                "item_missiletankplus"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletankplus"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_007"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_energyfragment_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_009"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_010"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_011"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_powerbombtank_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_energytank_000"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletankplus_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile+ Tank acquired.\nMissile capacity increased by 10.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 10
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_powerbombtank_001"
+            },
+            "model": [
+                "item_missiletankplus"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletankplus"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Screw Attack acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SCREW_ATTACK",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_002"
+            },
+            "model": [
+                "powerup_screwattack"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_screwattack"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Phantom Cloak acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_OPTIC_CAMOUFLAGE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_006"
+            },
+            "model": [
+                "powerup_opticcamo"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_opticcamo"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "item_missiletank_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletank_004"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletank_002"
+            },
+            "model": [
+                "item_energytank"
+            ],
+            "map_icon": {
+                "icon_id": "item_energytank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "itemsphere_widebeam"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment",
+                "original_actor": {
+                    "scenario": "s030_baselab",
+                    "layer": "default",
+                    "actor": "powerup_widebeam"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "itemsphere_bomb"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank",
+                "original_actor": {
+                    "scenario": "s030_baselab",
+                    "layer": "default",
+                    "actor": "powerup_bomb"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletank"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletank_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_powerbombtank_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletank_003"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_energyfragment_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Main Power Bomb acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB",
+                        "quantity": 1
+                    },
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_energyfragment_001"
+            },
+            "model": [
+                "powerup_powerbomb"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_powerbomb"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_powerbombtank_001"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletank_007"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletank_008"
+            },
+            "model": [
+                "itemsphere"
+            ],
+            "map_icon": {
+                "custom_icon": {
+                    "label": "NOTHING"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletankplus_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile+ Tank acquired.\nMissile capacity increased by 10.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 10
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletank_010"
+            },
+            "model": [
+                "item_missiletankplus"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletankplus"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_energyfragment_002"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_energytank"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_energyfragment_003"
+            },
+            "model": [
+                "item_energytank"
+            ],
+            "map_icon": {
+                "icon_id": "item_energytank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_powerbombtank_002"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletank_001"
+            },
+            "model": [
+                "item_energytank"
+            ],
+            "map_icon": {
+                "icon_id": "item_energytank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletank_005"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "item_missiletank_006"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletank"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Wave Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_WAVE_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "powerup_ghostaura"
+            },
+            "model": [
+                "powerup_wavebeam"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_wavebeam"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "itemsphere_gravitysuit"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank",
+                "original_actor": {
+                    "scenario": "s040_aqua",
+                    "layer": "default",
+                    "actor": "powerup_gravitysuit"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletank_000"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletank_001"
+            },
+            "model": [
+                "item_energytank"
+            ],
+            "map_icon": {
+                "icon_id": "item_energytank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_energytank_000"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletank_003"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletank_005"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_powerbombtank_000"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_energyfragment_002"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletankplus_002"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletankplus"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletankplus_001"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_energyfragment_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletankplus_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile+ Tank acquired.\nMissile capacity increased by 10.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 10
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletank_006"
+            },
+            "model": [
+                "item_missiletankplus"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletankplus"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Ice Missile acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_ICE_MISSILE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletank_004"
+            },
+            "model": [
+                "powerup_icemissile"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_icemissile"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile+ Tank acquired.\nMissile capacity increased by 10.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 10
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_missiletank_007"
+            },
+            "model": [
+                "item_missiletankplus"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletankplus"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "item_energytank"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_powerbombtank_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_missiletank_000"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_missiletank_005"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_missiletank_001"
+            },
+            "model": [
+                "item_energytank"
+            ],
+            "map_icon": {
+                "icon_id": "item_energytank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "itemsphere_supermissile"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank",
+                "original_actor": {
+                    "scenario": "s050_forest",
+                    "layer": "default",
+                    "actor": "powerup_supermissile"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_missiletank_002"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_missiletankplus_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Speed Booster acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SPEED_BOOSTER",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_missiletank_004"
+            },
+            "model": [
+                "powerup_speedbooster"
+            ],
+            "map_icon": {
+                "icon_id": "powerup_speedbooster"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "itemsphere_doublejump"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank",
+                "original_actor": {
+                    "scenario": "s050_forest",
+                    "layer": "default",
+                    "actor": "powerup_doublejump"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_energyfragment_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_missiletank_006"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_missiletank_007"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_missiletank_003"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Bomb acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_BOMB",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_LINE_BOMB",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_energytank_000"
+            },
+            "model": [
+                "powerup_bomb",
+                "powerup_crossbomb"
+            ],
+            "map_icon": {
+                "icon_id": "PROGRESSIVE_BOMB"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Suit acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_VARIA_SUIT",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_GRAVITY_SUIT",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "powerup_sonar"
+            },
+            "model": [
+                "powerup_variasuit",
+                "powerup_gravitysuit"
+            ],
+            "map_icon": {
+                "icon_id": "PROGRESSIVE_SUIT"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_missiletank_009"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_energyfragment"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "item_missiletank"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_quarantine",
+                "layer": "default",
+                "actor": "item_energytank_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_quarantine",
+                "layer": "default",
+                "actor": "itemsphere_plasmabeam_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank",
+                "original_actor": {
+                    "scenario": "s060_quarantine",
+                    "layer": "default",
+                    "actor": "powerup_plasmabeam"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Part acquired.\nEnergy capacity increased by 25.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_LIFE_SHARDS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_quarantine",
+                "layer": "default",
+                "actor": "item_powerbombtank_000"
+            },
+            "model": [
+                "item_energyfragment"
+            ],
+            "map_icon": {
+                "icon_id": "item_energyfragment"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_quarantine",
+                "layer": "default",
+                "actor": "item_missiletank_002"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_quarantine",
+                "layer": "default",
+                "actor": "item_missiletank_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "itemsphere_spacejump"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank",
+                "original_actor": {
+                    "scenario": "s070_basesanc",
+                    "layer": "default",
+                    "actor": "powerup_spacejump"
+                }
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_missiletank_001"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_missiletank_000"
+            },
+            "model": [
+                "item_energytank"
+            ],
+            "map_icon": {
+                "icon_id": "item_energytank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_missiletank_004"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_energyfragment_002"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_energyfragment_001"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_missiletank_003"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_powerbombtank_001"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_powerbombtank_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_missiletankplus_001"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_missiletank_002"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_missiletankplus_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_energyfragment_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_missiletank_005"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "item_energyfragment"
+            },
+            "model": [
+                "item_powerbombtank"
+            ],
+            "map_icon": {
+                "icon_id": "item_powerbombtank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile+ Tank acquired.\nMissile capacity increased by 10.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 10
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s080_shipyard",
+                "layer": "default",
+                "actor": "item_missiletank_000"
+            },
+            "model": [
+                "item_missiletankplus"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletankplus"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s080_shipyard",
+                "layer": "default",
+                "actor": "item_powerbombtank_000"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s080_shipyard",
+                "layer": "default",
+                "actor": "item_missiletank"
+            },
+            "model": [
+                "item_missiletank"
+            ],
+            "map_icon": {
+                "icon_id": "item_missiletank"
+            }
+        },
+        {
+            "pickup_type": "emmi",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s080_shipyard",
+                "function": "OnEmmyShipyardAbilityObtained",
+                "args": 0
+            },
+            "pickup_actordef": "actors/characters/emmyshipyard/charclasses/emmyshipyard.bmsad",
+            "pickup_string_key": "GUI_ITEM_ACQUIRED_POWER_BOMB"
+        },
+        {
+            "pickup_type": "corpius",
+            "caption": "Metroid DNA 3 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_ARTIFACT_3",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s010_cave",
+                "function": "OnCorpiusDeath_CUSTOM",
+                "args": 0
+            },
+            "pickup_actordef": "actors/characters/scorpius/charclasses/scorpius.bmsad",
+            "pickup_string_key": "GUI_ITEM_ACQUIRED_OPTICAL_CAMO"
+        },
+        {
+            "pickup_type": "emmi",
+            "caption": "Progressive Suit acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_VARIA_SUIT",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_GRAVITY_SUIT",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s010_cave",
+                "function": "OnEmmyCaveDead",
+                "args": 0
+            },
+            "pickup_actordef": "actors/characters/emmycave/charclasses/emmycave.bmsad",
+            "pickup_string_key": "GUI_ITEM_ACQUIRED_SPIDER_MAGNET"
+        },
+        {
+            "pickup_type": "cutscene",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s040_aqua",
+                "function": "OnHydrogigaDead_CUSTOM",
+                "args": 0
+            }
+        },
+        {
+            "pickup_type": "cutscene",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s020_magma",
+                "function": "OnExperimentDeath_CUSTOM",
+                "args": 0
+            }
+        },
+        {
+            "pickup_type": "corex",
+            "caption": "Progressive Spin acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_DOUBLE_JUMP",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_SPACE_JUMP",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s070_basesanc",
+                "function": "escue",
+                "args": 2
+            },
+            "pickup_actordef": "actors/characters/core_x_superquetzoa/charclasses/core_x_superquetzoa.bmsad",
+            "pickup_string_key": "GUI_ITEM_ACQUIRED_MULTI_LOCK"
+        },
+        {
+            "pickup_type": "emmi",
+            "caption": "Plasma Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_PLASMA_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s070_basesanc",
+                "function": "OnEmmySancDead",
+                "args": 0
+            },
+            "pickup_actordef": "actors/characters/emmysanc/charclasses/emmysanc.bmsad",
+            "pickup_string_key": "GUI_ITEM_ACQUIRED_WAVE_BEAM"
+        },
+        {
+            "pickup_type": "emmi",
+            "caption": "Grapple Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_GRAPPLE_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s020_magma",
+                "function": "OnEmmyMagmaDead",
+                "args": 0
+            },
+            "pickup_actordef": "actors/characters/emmymagma/charclasses/emmymagma.bmsad",
+            "pickup_string_key": "GUI_ITEM_ACQUIRED_MORPH_BALL"
+        },
+        {
+            "pickup_type": "corex",
+            "caption": "Metroid DNA 2 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_ARTIFACT_2",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s050_forest",
+                "function": "golzuna",
+                "args": 2
+            },
+            "pickup_actordef": "actors/characters/core_x/charclasses/core_x.bmsad",
+            "pickup_string_key": "GUI_ITEM_ACQUIRED_LINE_BOMB"
+        },
+        {
+            "pickup_type": "emmi",
+            "caption": "Missile+ Tank acquired.\nMissile capacity increased by 10.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 10
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s050_forest",
+                "function": "OnEmmyForestDead",
+                "args": 0
+            },
+            "pickup_actordef": "actors/characters/emmyforest/charclasses/emmyforest.bmsad",
+            "pickup_string_key": "GUI_ITEM_ACQUIRED_ICE_MISSILE"
+        },
+        {
+            "pickup_type": "emmi",
+            "caption": "Metroid DNA 1 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_ARTIFACT_1",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s030_baselab",
+                "function": "OnEmmyBaseLabDead",
+                "args": 0
+            },
+            "pickup_actordef": "actors/characters/emmylab/charclasses/emmylab.bmsad",
+            "pickup_string_key": "GUI_ITEM_ACQUIRED_SPEED_BOOSTER"
+        },
+        {
+            "pickup_type": "cutscene",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 2
+                    }
+                ]
+            ],
+            "pickup_lua_callback": {
+                "scenario": "s020_magma",
+                "function": "OnKraidDeath_CUSTOM",
+                "args": 0
+            }
+        }
+    ],
+    "elevators": [],
+    "hints": [
+        {
+            "accesspoint_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "PRP_CV_AccessPoint002"
+            },
+            "hint_id": "CAVE_2",
+            "text": "The {c1}Screw Attack{c0} can be found in {c5}Cataris{c0}."
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s010_cave",
+                "layer": "default",
+                "actor": "PRP_CV_AccessPoint001"
+            },
+            "hint_id": "CAVE_1",
+            "text": "A {c1}Progressive Suit{c0} can be found in {c5}Artaria{c0}."
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "accesspoint"
+            },
+            "hint_id": "MAGMA_1",
+            "text": "A {c1}Progressive Charge Beam{c0} can be found in {c5}Cataris{c0}."
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s020_magma",
+                "layer": "default",
+                "actor": "accesspoint_000"
+            },
+            "hint_id": "MAGMA_2",
+            "text": "A {c1}Progressive Suit{c0} can be found in {c5}Ghavoran{c0}."
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "accesspoint_000"
+            },
+            "hint_id": "LAB_1",
+            "text": "The {c1}Plasma Beam{c0} can be found in {c5}Ferenia{c0}."
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s030_baselab",
+                "layer": "default",
+                "actor": "accesspoint_001"
+            },
+            "hint_id": "LAB_2",
+            "text": "{c4}A joke hint.{c0}"
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "accesspoint_000"
+            },
+            "hint_id": "AQUA_1",
+            "text": "The {c1}Storm Missile{c0} can be found in {c5}Artaria{c0}."
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s040_aqua",
+                "layer": "default",
+                "actor": "accesspoint_001"
+            },
+            "hint_id": "AQUA_2",
+            "text": "A {c1}Progressive Spin{c0} can be found in {c5}Ferenia{c0}."
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s070_basesanc",
+                "layer": "default",
+                "actor": "accesspoint_000"
+            },
+            "hint_id": "SANC_1",
+            "text": "A {c1}Progressive Bomb{c0} can be found in {c5}Ghavoran{c0}."
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "accesspoint_000"
+            },
+            "hint_id": "FOREST_1",
+            "text": "The {c1}Speed Booster{c0} can be found in {c5}Ghavoran{c0}."
+        },
+        {
+            "accesspoint_actor": {
+                "scenario": "s080_shipyard",
+                "layer": "default",
+                "actor": "accesspoint_000"
+            },
+            "hint_id": "SHIP_1",
+            "text": "The {c1}Ice Missile{c0} can be found in {c5}Burenia{c0}."
+        }
+    ],
+    "text_patches": {
+        "GUI_COMPANY_TITLE_SCREEN": "<versions>|Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Some Words (XXXXXXXX)",
+        "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
+        "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."
+    },
+    "spoiler_log": {
+        "Wide Beam": "Artaria - Teleport to Cataris",
+        "Plasma Beam": "Ferenia - Purple EMMI Arena",
+        "Wave Beam": "Burenia - Flash Shift Room",
+        "Progressive Charge Beam": "Artaria - Melee Tutorial Room\nCataris - Kraid Eyedoor Room",
+        "Grapple Beam": "Cataris - Central Unit Access",
+        "Super Missile": "Cataris - Teleport to Dairon",
+        "Ice Missile": "Burenia - Gravity Suit Tower",
+        "Storm Missile": "Artaria - EMMI Zone Spinner",
+        "Phantom Cloak": "Cataris - Teleport to Ghavoran",
+        "Flash Shift": "Artaria - Speed Hallway",
+        "Progressive Suit": "Artaria - Central Unit Access\nGhavoran - Pulse Radar Room",
+        "Morph Ball": "Artaria - EMMI Zone First Entrance",
+        "Progressive Bomb": "Artaria - Waterfall\nGhavoran - Spin Boost Tower",
+        "Power Bomb": "Dairon - Early Grapple Access",
+        "Spider Magnet": "Artaria - Charge Tutorial",
+        "Speed Booster": "Ghavoran - Teleport to Burenia",
+        "Progressive Spin": "Artaria - Charge Beam Room\nFerenia - Escue Arena",
+        "Screw Attack": "Cataris - Z-57 Heat Room East",
+        "Metroid DNA 1": "Dairon - Central Unit Access",
+        "Metroid DNA 2": "Ghavoran - Golzuna Arena",
+        "Metroid DNA 3": "Artaria - Corpius Arena"
+    },
+    "cosmetic_patches": {
+        "config": {
+            "AIManager": {
+                "bShowBossLifebar": false,
+                "bShowEnemyLife": false,
+                "bShowEnemyDamage": false,
+                "bShowPlayerDamage": false
+            },
+            "SoundSystemATK": {
+                "fMusicVolume": 1.0,
+                "fSfxVolume": 1.0,
+                "fEnvironmentStreamsVolume": 1.0
+            }
+        },
+        "lua": {
+            "custom_init": {
+                "enable_death_counter": false,
+                "enable_room_name_display": "NEVER"
+            },
+            "camera_names_dict": {
+                "s010_cave": {
+                    "collision_camera_000": "First Tutorial",
+                    "collision_camera_000_Init": "Intro Room",
+                    "collision_camera_001": "Charge Tutorial",
+                    "collision_camera_002": "Melee Tutorial West",
+                    "collision_camera_003": "Melee Tutorial Room",
+                    "collision_camera_004": "Early Cloak Room",
+                    "collision_camera_005": "EMMI Zone First Entrance",
+                    "collision_camera_006": "White EMMI Introduction",
+                    "collision_camera_008": "Teleport to Dairon",
+                    "collision_camera_009": "EMMI Zone Exit North",
+                    "collision_camera_010": "EMMI Zone Hub",
+                    "collision_camera_011": "Teleport to Cataris",
+                    "collision_camera_012": "Save Station West",
+                    "collision_camera_013": "Charge Beam Access",
+                    "collision_camera_014": "Charge Beam Room",
+                    "collision_camera_015": "EMMI Zone Spinner",
+                    "collision_camera_016": "Proto EMMI Introduction",
+                    "collision_camera_017": "White EMMI Arena",
+                    "collision_camera_018": "EMMI Zone Entrance Hallway",
+                    "collision_camera_020": "Corpius Arena",
+                    "collision_camera_021": "David Jaffe Room",
+                    "collision_camera_022": "Thermal Door Tutorial",
+                    "collision_camera_023": "Magma Flow Vista",
+                    "collision_camera_023_B": "East Lava Missile Room",
+                    "collision_camera_024": "Hot Room Hub",
+                    "collision_camera_025": "Save Station East",
+                    "collision_camera_026": "Chain Reaction Room",
+                    "collision_camera_028": "Varia Suit Tutorial South",
+                    "collision_camera_029": "Varia Suit Tutorial North",
+                    "collision_camera_030": "Shutter Platform Puzzle",
+                    "collision_camera_031": "Varia Suit Room",
+                    "collision_camera_032": "Spider Beam Tower",
+                    "collision_camera_033": "Grapple Beam Room",
+                    "collision_camera_034": "Transport to Dairon - Superheated",
+                    "collision_camera_045": "First Tutorial Access",
+                    "collision_camera_048": "EMMI Zone Dome",
+                    "collision_camera_049": "Central Unit Access",
+                    "collision_camera_050": "Invisible Corpius Room",
+                    "collision_camera_051": "EMMI Zone Exit Northwest",
+                    "collision_camera_053": "EMMI Zone Ballspark Hallway",
+                    "collision_camera_054": "Energy Recharge Station South",
+                    "collision_camera_055": "Chain Reaction Access",
+                    "collision_camera_056": "Waterfall",
+                    "collision_camera_057": "Water Tunnel under Map",
+                    "collision_camera_058": "Map Station",
+                    "collision_camera_059": "Behind Waterfall",
+                    "collision_camera_060": "Water Reservoir",
+                    "collision_camera_061": "EMMI Zone Exit South",
+                    "collision_camera_062": "Cold Introduction",
+                    "collision_camera_063": "Save Station South",
+                    "collision_camera_064": "Proto EMMI Battle",
+                    "collision_camera_065": "Navigation Station North",
+                    "collision_camera_066": "Path to Thermal Device",
+                    "collision_camera_067": "Thermal Device",
+                    "collision_camera_068": "Navigation Station South",
+                    "collision_camera_069": "Wide Beam Block Room",
+                    "collision_camera_070": "Arbitrary Enky Room",
+                    "collision_camera_071": "EMMI First Chase End",
+                    "collision_camera_072": "Path to Corpius",
+                    "collision_camera_073": "Phantom Cloak Tutorial",
+                    "collision_camera_074": "Proto EMMI CU",
+                    "collision_camera_075": "EMMI Zone Exit Southwest",
+                    "collision_camera_076": "Save Station North",
+                    "collision_camera_077": "Transport to Cataris - Experiment Z-57",
+                    "collision_camera_078": "Hot Cataris Shortcut",
+                    "collision_camera_079": "Lower Path to Cataris",
+                    "collision_camera_080": "Transport to Burenia - Lower",
+                    "collision_camera_081": "Screw Attack Room",
+                    "collision_camera_082": "Freezer",
+                    "collision_camera_083": "Speed Booster Bonus Room",
+                    "collision_camera_085": "Shortcut to Screw Attack",
+                    "collision_camera_086": "Speed Hallway",
+                    "collision_camera_088": "Shinespark Tower to Grapple",
+                    "collision_camera_089": "Grapple Beam Tutorial",
+                    "collision_camera_090": "Central Unit",
+                    "collision_camera_091": "Red Chozo Arena"
+                },
+                "s020_magma": {
+                    "collision_camera_000": "Transport to Artaria - Thermal Device",
+                    "collision_camera_001": "Dropdown Pit",
+                    "collision_camera_002": "Navigation Station Southeast",
+                    "collision_camera_004": "Thermal Device Room South",
+                    "collision_camera_006": "Artaria Transport Access",
+                    "collision_camera_007": "Total Recharge Station South",
+                    "collision_camera_009": "Above Z-57 Fight",
+                    "collision_camera_010": "EMMI Zone Exit East",
+                    "collision_camera_012": "Lava Button East",
+                    "collision_camera_013": "Tall Magnet Walls Access",
+                    "collision_camera_014": "Moving Magnet Walls (Tall)",
+                    "collision_camera_015": "Teleport to Artaria (Blue)",
+                    "collision_camera_016": "Total Recharge Station North",
+                    "collision_camera_018": "Energy Recharge Station",
+                    "collision_camera_019": "Z-57 Heat Room West (Left)",
+                    "collision_camera_020": "Green EMMI Introduction",
+                    "collision_camera_021": "Z-57 Heat Room West (Right)",
+                    "collision_camera_022": "EMMI Zone Exit to Map Station",
+                    "collision_camera_023": "Long Mouth Statue Room",
+                    "collision_camera_024": "Above Kraid",
+                    "collision_camera_025": "Teleport to Artaria (Red)",
+                    "collision_camera_026": "Teleport to Ghavoran",
+                    "collision_camera_027": "Ghavoran Teleport Access",
+                    "collision_camera_028": "EMMI Zone Exits West",
+                    "collision_camera_029": "EMMI Zone Item Tunnel",
+                    "collision_camera_030": "Map Station",
+                    "collision_camera_031": "Moving Magnet Walls (Small)",
+                    "collision_camera_032": "EMMI Zone Tower East",
+                    "collision_camera_033": "Save Station East",
+                    "collision_camera_034": "Hall Thermal Device Room",
+                    "collision_camera_035": "EMMI Zone Tower West",
+                    "collision_camera_036": "Central Unit Access",
+                    "collision_camera_037": "Central Unit",
+                    "collision_camera_038": "Lava Button West",
+                    "collision_camera_040": "Dairon Transport Access",
+                    "collision_camera_041": "Transport to Dairon - Entrance",
+                    "collision_camera_042": "Thermal Device Room North",
+                    "collision_camera_043": "Path to Kraid Entryway",
+                    "collision_camera_044": "Diffusion Beam Room",
+                    "collision_camera_045": "Lava Button East Access",
+                    "collision_camera_046": "EMMI Zone East Tower Access",
+                    "collision_camera_048": "Double Obsydomithon Room",
+                    "collision_camera_049": "Z-57 Heat Room East",
+                    "collision_camera_051": "Teleport to Dairon",
+                    "collision_camera_052": "Green EMMI Introduction Access",
+                    "collision_camera_053": "Underlava Puzzle Room 2",
+                    "collision_camera_054": "Underlava Puzzle Room 1",
+                    "collision_camera_055": "EMMI Zone Hidden Missile Room",
+                    "collision_camera_058": "Navigation Station Northwest",
+                    "collision_camera_059": "EMMI Zone West Exit Path",
+                    "collision_camera_060": "Heated U-Turn",
+                    "collision_camera_061": "Kraid Eyedoor Room",
+                    "collision_camera_062": "Save Station West",
+                    "collision_camera_063": "Kraid Arena",
+                    "collision_camera_064": "West Teleport Access",
+                    "collision_camera_CooldownX": "Experiment Z-57 Fight?"
+                },
+                "s030_baselab": {
+                    "collision_camera_000": "Save Station East",
+                    "collision_camera_001": "Teleport to Artaria",
+                    "collision_camera_002": "Hub Access",
+                    "collision_camera_003": "Transport to Ferenia - Quiet Robe Entrance",
+                    "collision_camera_004": "Big Hub",
+                    "collision_camera_005": "EMMI Zone Exit East",
+                    "collision_camera_006": "Wide Beam Room",
+                    "collision_camera_007": "Power Switch 1",
+                    "collision_camera_008": "Teleport to Cataris",
+                    "collision_camera_009": "Total Recharge Station East",
+                    "collision_camera_010": "Early Grapple Access",
+                    "collision_camera_011": "Transport to Artaria - Grapple",
+                    "collision_camera_012": "Early Grapple Room",
+                    "collision_camera_013": "Heated Room West",
+                    "collision_camera_014": "Navigation Station South",
+                    "collision_camera_015": "Energy Recharge Station Middle",
+                    "collision_camera_016": "Shinespark Tutorial",
+                    "collision_camera_017": "EMMI Zone Exit North",
+                    "collision_camera_018": "Yellow EMMI Introduction",
+                    "collision_camera_019": "Transport to Ferenia - Quiet Robe Exit",
+                    "collision_camera_020": "Cross Bomb Puzzle Room",
+                    "collision_camera_021": "Bomb Room",
+                    "collision_camera_022": "Total Recharge Station West",
+                    "collision_camera_023": "Map Station",
+                    "collision_camera_024": "Power Switch 2",
+                    "collision_camera_025": "Freezer",
+                    "collision_camera_026": "Test Chamber Access",
+                    "collision_camera_027": "EMMI Zone Exit Northwest",
+                    "collision_camera_028": "Experiment Z-57 Test Chamber",
+                    "collision_camera_029": "EMMI Zone Exit West",
+                    "collision_camera_030": "Hidden Grapple Shortcut Room",
+                    "collision_camera_031": "Save Station West Tunnels",
+                    "collision_camera_032": "Save Station West",
+                    "collision_camera_033": "Storm Missile Gate Room",
+                    "collision_camera_034": "Ammo Recharge Station",
+                    "collision_camera_035": "Lake Puzzle Room",
+                    "collision_camera_036": "EMMI Zone Exit Southwest",
+                    "collision_camera_037": "EMMI Zone Exit South",
+                    "collision_camera_038": "Central Unit",
+                    "collision_camera_039": "Burenia Upper Transport Access",
+                    "collision_camera_040": "Central Unit Access",
+                    "collision_camera_041": "Burenia Lower Transport Access",
+                    "collision_camera_042": "Energy Recharge Station West",
+                    "collision_camera_043": "Transport to Cataris - Central Unit",
+                    "collision_camera_044": "Navigation Station North",
+                    "collision_camera_045": "Transport to Burenia - Submarine",
+                    "collision_camera_046": "Transport to Burenia - Sea Bridge",
+                    "collision_camera_047": "Transport to Ghavoran - Early Supers"
+                },
+                "s040_aqua": {
+                    "collision_camera_000": "Map Station",
+                    "collision_camera_001": "Upper Burenia Hub",
+                    "collision_camera_002": "Burenia Hub to Dairon",
+                    "collision_camera_003": "Transport to Dairon - Sea Bridge",
+                    "collision_camera_004": "Transport to Dairon - Submarine",
+                    "collision_camera_005": "Drogyga Eyedoor",
+                    "collision_camera_006": "Transport to Ghavoran - Robot",
+                    "collision_camera_007": "Underneath Drogyga",
+                    "collision_camera_008": "Teleport to Ferenia",
+                    "collision_camera_009": "Navigation Station North",
+                    "collision_camera_010": "Burenia Main Hub",
+                    "collision_camera_011": "Save Station Middle",
+                    "collision_camera_012": "Underwater Horseshoe",
+                    "collision_camera_013": "Energy Recharge South",
+                    "collision_camera_014": "Flash Shift Room",
+                    "collision_camera_015": "Teleport to Ghavoran",
+                    "collision_camera_016": "Navigation Station South",
+                    "collision_camera_017": "Transport to Artaria - Screw Attack",
+                    "collision_camera_018": "Early Gravity Speedboost Room 1",
+                    "collision_camera_019": "Early Gravity Speedboost Room 2",
+                    "collision_camera_021": "Gravity Suit Tower",
+                    "collision_camera_022": "Ammo Recharge South",
+                    "collision_camera_023": "Gravity Suit Room",
+                    "collision_camera_024": "Gravity Suit Room Access",
+                    "collision_camera_025": "Storm Missile Gate Room",
+                    "collision_camera_026": "Save Station South Access",
+                    "collision_camera_027": "Save Station South",
+                    "collision_camera_028": "Drogyga Arena",
+                    "collision_camera_029": "Drogyga Access",
+                    "collision_camera_030": "Save Station North"
+                },
+                "s070_basesanc": {
+                    "collision_camera_000": "Transport to Dairon - Grapple Block",
+                    "collision_camera_001": "Purple EMMI Introduction Access",
+                    "collision_camera_002": "Total Recharge Station",
+                    "collision_camera_003": "EMMI Zone Exit West",
+                    "collision_camera_004": "Fan Room Access",
+                    "collision_camera_005": "Quiet Robe Room",
+                    "collision_camera_006": "Fan Room",
+                    "collision_camera_007": "Teleport to Burenia (Cyan)",
+                    "collision_camera_008": "Transport to Dairon - DNA Station",
+                    "collision_camera_009": "Speedboost Slopes Maze",
+                    "collision_camera_010": "Cold Room (Small)",
+                    "collision_camera_011": "Separate Tunnels Room",
+                    "collision_camera_012": "Space Jump Room",
+                    "collision_camera_013": "Pitfall Puzzle Room",
+                    "collision_camera_014": "Transport to Ghavoran - Storm Gate",
+                    "collision_camera_015": "Space Jump Room Access",
+                    "collision_camera_016": "Navigation Station",
+                    "collision_camera_017": "Twin Robot Arena",
+                    "collision_camera_018": "Cold Room (Energy Recharge Station)",
+                    "collision_camera_019": "Energy Recharge Station (Gate)",
+                    "collision_camera_020": "Energy Recharge Station Secret",
+                    "collision_camera_021": "EMMI Zone Exit Middle",
+                    "collision_camera_022": "Map Station Access",
+                    "collision_camera_023": "Map Station",
+                    "collision_camera_024": "Storm Missile Tutorial",
+                    "collision_camera_025": "Path to Escue",
+                    "collision_camera_026": "Escue Eyedoor Room",
+                    "collision_camera_027": "Escue Arena",
+                    "collision_camera_028": "Transport to Hanubia - E.M.M.I.",
+                    "collision_camera_029": "Save Station North",
+                    "collision_camera_030": "Cold Room (Storm Missile Gate)",
+                    "collision_camera_031": "Wave Beam Tutorial",
+                    "collision_camera_032": "EMMI Zone Exit East",
+                    "collision_camera_033": "EMMI Zone Exit East Access",
+                    "collision_camera_034": "Purple EMMI Arena",
+                    "collision_camera_035": "Central Unit",
+                    "collision_camera_038": "Central Unit Access",
+                    "collision_camera_040": "Purple EMMI Introduction",
+                    "collision_camera_041": "Save Station Southeast"
+                },
+                "s050_forest": {
+                    "collision_camera_000": "Transport to Burenia - Upper",
+                    "collision_camera_001": "Right Entrance",
+                    "collision_camera_002": "Robot Fight Arena",
+                    "collision_camera_003": "Left Entrance",
+                    "collision_camera_004": "Blue EMMI Introduction",
+                    "collision_camera_005": "Navigation Station Access",
+                    "collision_camera_006": "Navigation Station",
+                    "collision_camera_007": "Flipper Room",
+                    "collision_camera_008": "Dairon Transport Access",
+                    "collision_camera_009": "Super Missile Room Access",
+                    "collision_camera_010": "Super Missile Room",
+                    "collision_camera_011": "EMMI Zone Exit Southeast",
+                    "collision_camera_012": "Map Station Access",
+                    "collision_camera_013": "Map Station",
+                    "collision_camera_014": "EMMI Zone Exit West",
+                    "collision_camera_015": "Early Ice Room",
+                    "collision_camera_016": "EMMI Zone Exit Northwest",
+                    "collision_camera_017": "Central Unit",
+                    "collision_camera_018": "EMMI Zone Middle Path",
+                    "collision_camera_019": "Central Unit Access",
+                    "collision_camera_020": "EMMI Zone Exit Northeast",
+                    "collision_camera_021": "Spin Boost Tower",
+                    "collision_camera_022": "Save Station Center",
+                    "collision_camera_023": "Chozo Warrior Arena",
+                    "collision_camera_024": "Golzuna Tower",
+                    "collision_camera_025": "Total Recharge Station North",
+                    "collision_camera_026": "Golzuna Arena",
+                    "collision_camera_027": "Transport to Ferenia - Main Gate",
+                    "collision_camera_028": "Map Station Access Secret",
+                    "collision_camera_029": "Elun Transport Access",
+                    "collision_camera_030": "Spin Boost Room",
+                    "collision_camera_031": "Energy Recharge Station",
+                    "collision_camera_032": "Pulse Radar Room",
+                    "collision_camera_033": "Cross Bomb Tutorial",
+                    "collision_camera_034": "Transport to Hanubia - Bridge",
+                    "collision_camera_035": "Spider Magnet Elevator",
+                    "collision_camera_036": "Above Golzuna",
+                    "collision_camera_037": "Transport to Elun",
+                    "collision_camera_038": "Transport to Dairon - Freezer",
+                    "collision_camera_039": "Above Pulse Radar",
+                    "collision_camera_040": "Save Station East"
+                },
+                "s060_quarantine": {
+                    "collision_camera_000": "Bridge Gate",
+                    "collision_camera_001": "Transport to Ghavoran - Flipper",
+                    "collision_camera_002": "Purple Drapes",
+                    "collision_camera_003": "Ammo Recharge Station",
+                    "collision_camera_004": "Chozo Soldier Arena",
+                    "collision_camera_005": "Gyroscope Room",
+                    "collision_camera_006": "Plasma Beam Room",
+                    "collision_camera_007": "Spider Magnet Room",
+                    "collision_camera_008": "Fan Room",
+                    "collision_camera_009": "Vertical Bomb Maze",
+                    "collision_camera_010": "Horizontal Bomb Maze",
+                    "collision_camera_011": "Exterior Bridge",
+                    "collision_camera_012": "Save Station",
+                    "collision_camera_MBL": "Bottom Morph Launcher"
+                },
+                "s080_shipyard": {
+                    "collision_camera_000": "Transport to Ferenia - Central Unit",
+                    "collision_camera_001": "Transport to Ghavoran - Golzuna",
+                    "collision_camera_002": "Ferenia Shortcut",
+                    "collision_camera_003": "Navigation Station",
+                    "collision_camera_004": "Entrance Tall Room",
+                    "collision_camera_005": "Gold Chozo Warrior Arena",
+                    "collision_camera_006": "Total Recharge Station North",
+                    "collision_camera_007": "Transport to Itorash",
+                    "collision_camera_008": "Ship Room",
+                    "collision_camera_009": "Speedboost Puzzle Room",
+                    "collision_camera_010": "Tank Room",
+                    "collision_camera_011": "EMMI Zone Exit West",
+                    "collision_camera_012": "Central Unit",
+                    "collision_camera_013": "EMMI Zone Exit East",
+                    "collision_camera_014": "Orange EMMI Introduction",
+                    "collision_camera_015": "Total Recharge Station East",
+                    "collision_camera_020": "Raven Beak X Arena",
+                    "collision_camera_016": "Escape Room 3",
+                    "collision_camera_018": "Escape Room 2",
+                    "collision_camera_019": "Escape Room 1",
+                    "collision_camera_1000": "collision_camera_1000 (H)"
+                },
+                "s090_skybase": {
+                    "collision_camera_000": "Save Station",
+                    "collision_camera_001": "Transport to Hanubia - Elite Chozo",
+                    "collision_camera_002": "Elevator to Raven Beak",
+                    "collision_camera_003": "Elevator Cutscene",
+                    "collision_camera_004": "Raven Beak Arena"
+                }
+            }
+        },
+        "shield_versions": {
+            "ice_missile": "DEFAULT",
+            "storm_missile": "DEFAULT",
+            "diffusion_beam": "DEFAULT",
+            "bomb": "DEFAULT",
+            "cross_bomb": "DEFAULT",
+            "power_bomb": "ALTERNATE",
+            "closed": "DEFAULT"
+        }
+    },
+    "energy_per_tank": 100,
+    "immediate_energy_parts": true,
+    "enable_remote_lua": true,
+    "constant_environment_damage": {
+        "heat": 20,
+        "cold": 20,
+        "lava": 20
+    },
+    "game_patches": {
+        "raven_beak_damage_table_handling": "consistent_low",
+        "remove_grapple_blocks_hanubia_shortcut": true,
+        "remove_grapple_block_path_to_itorash": true,
+        "default_x_released": false,
+        "nerf_power_bombs": true,
+        "warp_to_start": true
+    },
+    "show_shields_on_minimap": true,
+    "door_patches": [
+        {
+            "actor": {
+                "scenario": "s080_shipyard",
+                "layer": "default",
+                "actor": "doorpowerpower_005"
+            },
+            "door_type": "power_beam"
+        },
+        {
+            "actor": {
+                "scenario": "s080_shipyard",
+                "layer": "default",
+                "actor": "doorpowerpower_006"
+            },
+            "door_type": "power_beam"
+        }
+    ],
+    "tile_group_patches": [
+        {
+            "actor": {
+                "scenario": "s010_cave",
+                "layer": "breakables",
+                "actor": "breakabletilegroup_060"
+            },
+            "tiletype": "SPEEDBOOST"
+        }
+    ],
+    "new_spawn_points": [],
+    "objective": {
+        "required_artifacts": 3,
+        "hints": [
+            "{c1}Metroid DNA 1{c0} is guarded by {c2}E.M.M.I.-04SB{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c2}Golzuna{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c2}Corpius{c0}."
+        ]
+    },
+    "layout_uuid": "00000000-0000-1111-0000-000000000000"
+}


### PR DESCRIPTION
- Game specific PDFs now override `create_game_specific_data`, which is then invoked by the common PDF
- Adds a `custom_patcher_data` field to GamePatches
- Adds a package requirement for `json-delta`

Conflicts with #6250. Unsure if PDF changes conflict with others.