### PR TITLE
MSR: fix spider boost hint

### DIFF
--- a/randovania/games/samus_returns/exporter/joke_hints.py
+++ b/randovania/games/samus_returns/exporter/joke_hints.py
@@ -4,8 +4,8 @@ JOKE_HINTS = [
     "The Chozo have Sealed this hint away.",
     "Spider Boosting can quickly cover large distances.\nTake advantage whenever possible!",
     (
-        "The Spider Boost can be used while in Spider Ball form.\nIt will launch you forward,"
-        " damaging enemies you make contact with."
+        "The Spider Boost can be used while in Spider Ball form.\n"
+        "It will launch you forward, damaging enemies you make contact with."
     ),
     "Drag pins onto the map to mark points of interest.",
     "Samus, we cannot Return this hint to you.",

--- a/randovania/games/samus_returns/exporter/joke_hints.py
+++ b/randovania/games/samus_returns/exporter/joke_hints.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 JOKE_HINTS = [
     "The Chozo have Sealed this hint away.",
     "Spider Boosting can quickly cover large distances.\nTake advantage whenever possible!",
-    "The Spider Boost can be used while in Spider Ball form.\n"
-    "It will launch you forward, damaging enemies you make contact with.",
+    (
+        "The Spider Boost can be used while in Spider Ball form.\nIt will launch you forward,"
+        "damaging enemies you make contact with."
+    ),
     "Drag pins onto the map to mark points of interest.",
     "Samus, we cannot Return this hint to you.",
     "Rumor has it, that walls are only a suggestion.",

--- a/randovania/games/samus_returns/exporter/joke_hints.py
+++ b/randovania/games/samus_returns/exporter/joke_hints.py
@@ -5,7 +5,7 @@ JOKE_HINTS = [
     "Spider Boosting can quickly cover large distances.\nTake advantage whenever possible!",
     (
         "The Spider Boost can be used while in Spider Ball form.\nIt will launch you forward,"
-        "damaging enemies you make contact with."
+        " damaging enemies you make contact with."
     ),
     "Drag pins onto the map to mark points of interest.",
     "Samus, we cannot Return this hint to you.",


### PR DESCRIPTION
Currently this causes the text to be two hints. THis PR fixes it to be one hint.