### PR TITLE
MSR: remove export tooltip

### DIFF
--- a/randovania/gui/ui_files/msr_game_export_dialog.ui
+++ b/randovania/gui/ui_files/msr_game_export_dialog.ui
@@ -287,7 +287,7 @@
      <item>
       <widget class="QRadioButton" name="citra_radio">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Randovania only supports Citra.&lt;/p&gt;&lt;p&gt;Use other emulators at your own risk, but do not report any issues.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string/>
        </property>
        <property name="text">
         <string>Citra</string>
@@ -343,7 +343,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="version_btn_group"/>
   <buttongroup name="platform_btn_group"/>
+  <buttongroup name="version_btn_group"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
tooltip is completely unnecessary and slightly confusing.