### PR TITLE
Map Tracker: always show accessible nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.6.0] - 2024-05-??
 
+- Fixed: The Map view on the Map tracker will not show doors and generic nodes as being inaccessible if only resources were shown on the Text Map view.
+
 ### Resolver
 
 - Fixed: Some cases of seeds being wrongly considered as impossible.

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -438,7 +438,7 @@ class TrackerWindow(QtWidgets.QMainWindow, Ui_TrackerWindow):
                 self._area_name_to_item[(region.name, area.name)].setHidden(not area_is_visible)
 
         self.map_canvas.set_state(state)
-        self.map_canvas.set_visible_nodes({node for node in nodes_in_reach if not self._node_to_item[node].isHidden()})
+        self.map_canvas.set_visible_nodes(nodes_in_reach)
 
         # Persist the current state
         self.persist_current_state()


### PR DESCRIPTION
IDK why there supposed to be hidden in the first place. This now makes the `Map` view much more user friendly