### PR TITLE
Update trick_details_popup.ui to allow Trick Details window to be resized freely

### DIFF
--- a/randovania/gui/ui_files/trick_details_popup.ui
+++ b/randovania/gui/ui_files/trick_details_popup.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>


### PR DESCRIPTION
Allows the Trick Details window to be resized freely instead of being height limited.

Fixes https://discord.com/channels/914291389293027329/914294217256362024/1214968506714685530