### PR TITLE
Kago Room rework

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -7015,12 +7015,46 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Movement",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "DamageBoosts",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "NormalDamage",
+                                                                                "amount": 34,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -7038,7 +7072,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Kago Jump",
+                                            "comment": "Kago Jump TODO: add vid",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -7308,6 +7342,32 @@
                                                         "name": "Movement",
                                                         "amount": 3,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "DamageBoosts",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "NormalDamage",
+                                                                    "amount": 34,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -7003,7 +7003,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Jump over the Kaago with HJ",
                                             "items": [
                                                 {
                                                     "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -7003,7 +7003,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Jump over the Kaago with HJ",
+                                            "comment": "Jump over the Kago with HJ",
                                             "items": [
                                                 {
                                                     "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -7003,7 +7003,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "dmg expectations",
+                                            "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -7015,29 +7015,12 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "NormalDamage",
-                                                                    "amount": 34,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Movement",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -7062,7 +7045,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "WallJump",
-                                                        "amount": 4,
+                                                        "amount": 5,
                                                         "negate": false
                                                     }
                                                 },
@@ -7228,27 +7211,9 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "damage",
-                                            "name": "NormalDamage",
-                                            "amount": 34,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
                                             "type": "items",
                                             "name": "SpaceJump",
                                             "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Movement",
-                                            "amount": 2,
                                             "negate": false
                                         }
                                     },
@@ -7303,6 +7268,49 @@
                                             "name": "ScrewAttack",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Jump over the Kago",
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Hi-Jump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1134,8 +1134,12 @@ Extra - room_id: [33]
   > Beside missile tank
       Any of the following:
           Screw Attack or Space Jump or Can Freeze Enemies
-          Hi-Jump and Movement (Intermediate)
-          # Kago Jump
+          All of the following:
+              Hi-Jump
+              Any of the following:
+                  Movement (Intermediate)
+                  Damage Boosts (Beginner) and Normal Damage ≥ 34
+          # Kago Jump TODO: add vid
           Damage Boosts (Expert) and Wall Jump (Hypermode) and Normal Damage ≥ 34
           # Shinespark from entrance rooms
           Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
@@ -1160,6 +1164,7 @@ Extra - room_id: [33]
               # Jump over the Kago
               Movement (Advanced)
               Hi-Jump and Movement (Intermediate)
+              Damage Boosts (Beginner) and Normal Damage ≥ 34
   > Door to Glass Tube to Sector 1 (SRX)
       Screw Attack
 

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1135,7 +1135,7 @@ Extra - room_id: [33]
       Any of the following:
           Screw Attack or Space Jump or Can Freeze Enemies
           All of the following:
-              # Jump over the Kaago with HJ
+              # Jump over the Kago with HJ
               Hi-Jump
               Any of the following:
                   Movement (Intermediate)

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1134,12 +1134,9 @@ Extra - room_id: [33]
   > Beside missile tank
       Any of the following:
           Screw Attack or Space Jump or Can Freeze Enemies
-          All of the following:
-              # dmg expectations
-              Hi-Jump
-              Movement (Intermediate) or Normal Damage ≥ 34
+          Hi-Jump and Movement (Intermediate)
           # Kago Jump
-          Damage Boosts (Expert) and Wall Jump (Expert) and Normal Damage ≥ 34
+          Damage Boosts (Expert) and Wall Jump (Hypermode) and Normal Damage ≥ 34
           # Shinespark from entrance rooms
           Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
 
@@ -1156,9 +1153,13 @@ Extra - room_id: [33]
       Trivial
   > Door to Entrance Lobby
       Any of the following:
-          Screw Attack or Space Jump or Movement (Intermediate) or Normal Damage ≥ 34 or Can Freeze Enemies
+          Screw Attack or Space Jump or Can Freeze Enemies
           # Assumes you shinesparked in and killed the Kago
           Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
+          Any of the following:
+              # Jump over the Kago
+              Movement (Advanced)
+              Hi-Jump and Movement (Intermediate)
   > Door to Glass Tube to Sector 1 (SRX)
       Screw Attack
 

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1135,6 +1135,7 @@ Extra - room_id: [33]
       Any of the following:
           Screw Attack or Space Jump or Can Freeze Enemies
           All of the following:
+              # Jump over the Kaago with HJ
               Hi-Jump
               Any of the following:
                   Movement (Intermediate)


### PR DESCRIPTION
tanking a hit from the kago is now gated behind `Damage Boosts (Beginner)`

also tweaked the movements requirements for jumping over the kago without getting hit