### PR TITLE
Use dataclasses for NodeIdentifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ dependencies = [
     # nonblocking file IO
     "aiofiles",
 
-    # Better than dataclasses for NodeIdentifier
-    "attrs>=21.4.0",
-
     # Immutable dicts, used in many places
     "frozendict",
 

--- a/randovania/cli/commands/render_regions.py
+++ b/randovania/cli/commands/render_regions.py
@@ -95,7 +95,7 @@ def render_region_graph_logic(args):
         )
 
     def _cross_region_dock(node: DockNode):
-        return node.default_connection.region_name != node.identifier.region_name
+        return node.default_connection.region != node.identifier.region
 
     per_game_colors = {
         RandovaniaGame.METROID_PRIME_ECHOES: {

--- a/randovania/game_description/db/area_identifier.py
+++ b/randovania/game_description/db/area_identifier.py
@@ -6,18 +6,18 @@ from typing import Self
 
 @dataclass(frozen=True, order=True, slots=True)
 class AreaIdentifier:
-    region_name: str
-    area_name: str
+    region: str
+    area: str
 
     def __post_init__(self) -> None:
-        assert isinstance(self.region_name, str)
-        assert isinstance(self.area_name, str)
+        assert isinstance(self.region, str)
+        assert isinstance(self.area, str)
 
     @property
     def as_json(self) -> dict:
         return {
-            "region": self.region_name,
-            "area": self.area_name,
+            "region": self.region,
+            "area": self.area,
         }
 
     @classmethod
@@ -29,15 +29,15 @@ class AreaIdentifier:
 
     @property
     def as_tuple(self) -> tuple[str, str]:
-        return self.region_name, self.area_name
+        return self.region, self.area
 
     @property
     def as_string(self) -> str:
-        return f"{self.region_name}/{self.area_name}"
+        return f"{self.region}/{self.area}"
 
     @classmethod
     def from_string(cls, value: str) -> Self:
         return cls(*value.split("/", 1))
 
     def __repr__(self) -> str:
-        return f"region {self.region_name}/area {self.area_name}"
+        return f"region {self.region}/area {self.area}"

--- a/randovania/game_description/db/node.py
+++ b/randovania/game_description/db/node.py
@@ -62,7 +62,7 @@ class Node:
 
     @property
     def name(self) -> str:
-        return self.identifier.node_name
+        return self.identifier.node
 
     def __post_init__(self) -> None:
         if not self.layers:

--- a/randovania/game_description/db/node_identifier.py
+++ b/randovania/game_description/db/node_identifier.py
@@ -1,53 +1,51 @@
 from __future__ import annotations
 
+import dataclasses
 from typing import Self
-
-import attrs
 
 from randovania.game_description.db.area_identifier import AreaIdentifier
 
 
-@attrs.define(init=True, frozen=True, cache_hash=True, order=True, slots=True)
+@dataclasses.dataclass(frozen=True, order=True, slots=True)
 class NodeIdentifier:
-    area_identifier: AreaIdentifier
-    node_name: str
+    region: str
+    area: str
+    node: str
 
     @classmethod
     def create(cls, region: str, area: str, node: str) -> Self:
-        return cls(AreaIdentifier(region, area), node)
+        return cls(region, area, node)
+
+    @classmethod
+    def with_area(cls, area_identifier: AreaIdentifier, node_name: str) -> Self:
+        return cls(area_identifier.region, area_identifier.area, node_name)
 
     @property
     def as_json(self) -> dict:
-        result = self.area_identifier.as_json
-        result["node"] = self.node_name
-        return result
+        return {
+            "region": self.region,
+            "area": self.area,
+            "node": self.node,
+        }
 
     @classmethod
     def from_json(cls, value: dict) -> Self:
-        return cls(AreaIdentifier.from_json(value), value["node"])
+        return cls(value["region"], value["area"], value["node"])
 
     @property
     def as_string(self) -> str:
-        return f"{self.region_name}/{self.area_name}/{self.node_name}"
+        return f"{self.region}/{self.area}/{self.node}"
 
     @classmethod
     def from_string(cls, value: str) -> Self:
         return cls.create(*value.split("/", 2))
 
     def __repr__(self) -> str:
-        return f"{self.area_identifier}/node {self.node_name}"
+        return f"region {self.region}/area {self.area}/node {self.node}"
 
     @property
-    def region_name(self) -> str:
-        return self.area_identifier.region_name
-
-    @property
-    def area_name(self) -> str:
-        return self.area_identifier.area_name
-
-    @property
-    def area_location(self) -> AreaIdentifier:
-        return self.area_identifier
+    def area_identifier(self) -> AreaIdentifier:
+        return AreaIdentifier(self.region, self.area)
 
     def renamed(self, new_name: str) -> NodeIdentifier:
-        return NodeIdentifier(area_identifier=self.area_identifier, node_name=new_name)
+        return NodeIdentifier(self.region, self.area, node=new_name)

--- a/randovania/game_description/db/node_provider.py
+++ b/randovania/game_description/db/node_provider.py
@@ -24,7 +24,7 @@ class NodeProvider:
 
     def identifier_for_area(self, area: Area) -> AreaIdentifier:
         region = self.region_with_area(area)
-        return AreaIdentifier(region_name=region.name, area_name=area.name)
+        return AreaIdentifier(region=region.name, area=area.name)
 
     def region_with_name(self, name: str) -> Region:
         raise NotImplementedError
@@ -67,27 +67,27 @@ class NodeProvider:
         raise NotImplementedError
 
     def node_by_identifier(self, identifier: NodeIdentifier) -> Node:
-        area = self.area_by_area_location(identifier.area_location)
-        node = area.node_with_name(identifier.node_name)
+        area = self.area_by_area_location(identifier.area_identifier)
+        node = area.node_with_name(identifier.node)
         if node is not None:
             return node
-        raise ValueError(f"No node with name {identifier.node_name} found in {area}")
+        raise ValueError(f"No node with name {identifier.node} found in {area}")
 
     def area_by_area_location(self, location: AreaIdentifier) -> Area:
         return self.region_and_area_by_area_identifier(location)[1]
 
     def region_by_area_location(self, location: AreaIdentifier) -> Region:
-        return self.region_with_name(location.region_name)
+        return self.region_with_name(location.region)
 
     def region_and_area_by_area_identifier(self, identifier: AreaIdentifier) -> tuple[Region, Area]:
-        region = self.region_with_name(identifier.region_name)
-        area = region.area_by_name(identifier.area_name)
+        region = self.region_with_name(identifier.region)
+        area = region.area_by_name(identifier.area)
         return region, area
 
     def node_to_area_location(self, node: Node) -> AreaIdentifier:
         return AreaIdentifier(
-            region_name=self.nodes_to_region(node).name,
-            area_name=self.nodes_to_area(node).name,
+            region=self.nodes_to_region(node).name,
+            area=self.nodes_to_area(node).name,
         )
 
     def open_requirement_for(self, weakness: DockWeakness) -> Requirement:

--- a/randovania/game_description/db/region.py
+++ b/randovania/game_description/db/region.py
@@ -48,9 +48,9 @@ class Region:
         raise KeyError(f"Unknown name: {area_name}")
 
     def area_by_identifier(self, location: AreaIdentifier) -> Area:
-        if self.name != location.region_name:
-            raise ValueError(f"Attempting to use AreaIdentifier for {location.region_name} with region {self.name}")
-        return self.area_by_name(location.area_name)
+        if self.name != location.region:
+            raise ValueError(f"Attempting to use AreaIdentifier for {location.region} with region {self.name}")
+        return self.area_by_name(location.area)
 
     def correct_name(self, use_dark_name: bool) -> str:
         if use_dark_name and self.dark_name is not None:

--- a/randovania/game_description/db/region_list.py
+++ b/randovania/game_description/db/region_list.py
@@ -236,13 +236,13 @@ class RegionList(NodeProvider):
         if cache_result is not None:
             return cache_result
 
-        area = self.area_by_area_location(identifier.area_location)
-        node = area.node_with_name(identifier.node_name)
+        area = self.area_by_area_location(identifier.area_identifier)
+        node = area.node_with_name(identifier.node)
         if node is not None:
             self._identifier_to_node[identifier] = node
             return node
 
-        raise ValueError(f"No node with name {identifier.node_name} found in {area}")
+        raise ValueError(f"No node with name {identifier.node} found in {area}")
 
     def typed_node_by_identifier(self, i: NodeIdentifier, t: type[NodeType]) -> NodeType:
         result = self.node_by_identifier(i)
@@ -256,11 +256,11 @@ class RegionList(NodeProvider):
         return self.region_and_area_by_area_identifier(location)[1]
 
     def region_by_area_location(self, location: AreaIdentifier) -> Region:
-        return self.region_with_name(location.region_name)
+        return self.region_with_name(location.region)
 
     def region_and_area_by_area_identifier(self, identifier: AreaIdentifier) -> tuple[Region, Area]:
-        region = self.region_with_name(identifier.region_name)
-        area = region.area_by_name(identifier.area_name)
+        region = self.region_with_name(identifier.region)
+        area = region.area_by_name(identifier.area)
         return region, area
 
     def correct_area_identifier_name(self, identifier: AreaIdentifier) -> str:

--- a/randovania/game_description/editor.py
+++ b/randovania/game_description/editor.py
@@ -111,7 +111,7 @@ class Editor:
     def rename_area(self, current_area: Area, new_name: str) -> None:
         current_world = self.game.region_list.region_with_area(current_area)
         old_identifier = self.game.region_list.identifier_for_area(current_area)
-        new_identifier = dataclasses.replace(old_identifier, area_name=new_name)
+        new_identifier = dataclasses.replace(old_identifier, area=new_name)
 
         self.replace_references_to_area_identifier(
             old_identifier,
@@ -140,11 +140,11 @@ class Editor:
                             new_node = dataclasses.replace(
                                 node,
                                 identifier=node.identifier.renamed(
-                                    node.name.replace(old_identifier.area_name, new_identifier.area_name),
+                                    node.name.replace(old_identifier.area, new_identifier.area),
                                 ),
-                                default_connection=NodeIdentifier(
+                                default_connection=NodeIdentifier.with_area(
                                     area_identifier=new_identifier,
-                                    node_name=node.default_connection.node_name,
+                                    node_name=node.default_connection.node,
                                 ),
                             )
 
@@ -170,7 +170,7 @@ class Editor:
                             new_node = dataclasses.replace(
                                 node,
                                 identifier=node.identifier.renamed(
-                                    node.name.replace(old_identifier.area_name, new_identifier.area_name),
+                                    node.name.replace(old_identifier.area, new_identifier.area),
                                 ),
                                 default_connection=new_identifier,
                             )

--- a/randovania/game_description/integrity_check.py
+++ b/randovania/game_description/integrity_check.py
@@ -39,9 +39,9 @@ def raw_expected_dock_names(
     expected_connector = "to"
     if weakness.requirement == Requirement.impossible() and weakness.name != "Not Determined":
         expected_connector = "from"
-    target_area_str = f"{dock_type.long_name} {expected_connector} {connection.area_name}"
-    target_region_str = f"{dock_type.long_name} {expected_connector} {connection.region_name}"
-    if source_region_name != connection.region_name:
+    target_area_str = f"{dock_type.long_name} {expected_connector} {connection.area}"
+    target_region_str = f"{dock_type.long_name} {expected_connector} {connection.region}"
+    if source_region_name != connection.region:
         yield target_region_str
     yield target_area_str
 
@@ -51,7 +51,7 @@ def expected_dock_names(node: DockNode) -> Iterator[str]:
     Provides valid names for this node. The first result is the recommended name.
     """
     yield from raw_expected_dock_names(
-        node.dock_type, node.default_dock_weakness, node.default_connection.area_identifier, node.identifier.region_name
+        node.dock_type, node.default_dock_weakness, node.default_connection.area_identifier, node.identifier.region
     )
 
 

--- a/randovania/game_description/pretty_print.py
+++ b/randovania/game_description/pretty_print.py
@@ -104,7 +104,7 @@ def pretty_print_node_type(node: Node, region_list: RegionList, db: ResourceData
             other = region_list.node_by_identifier(node.default_connection)
             other_name = region_list.node_name(other)
         except IndexError as e:
-            other_name = f"(Area {node.default_connection.area_name}, index {node.default_connection.node_name}) [{e}]"
+            other_name = f"(Area {node.default_connection.area}, index {node.default_connection.node}) [{e}]"
 
         message = f"{node.default_dock_weakness.name} to {other_name}"
 

--- a/randovania/games/cave_story/exporter/patch_data_factory.py
+++ b/randovania/games/cave_story/exporter/patch_data_factory.py
@@ -283,7 +283,7 @@ class CSPatchDataFactory(PatchDataFactory):
             starting_script += f"<ML+{num_to_tsc_value(self.configuration.starting_hp + life - 3).decode('utf-8')}"
 
         # Starting Locations
-        if self.patches.starting_location.area_name in {"Start Point", "First Cave", "Hermit Gunsmith"}:
+        if self.patches.starting_location.area in {"Start Point", "First Cave", "Hermit Gunsmith"}:
             # started in first cave
             starting_script += "<FL+6200"
         else:

--- a/randovania/games/cave_story/generator/bootstrap.py
+++ b/randovania/games/cave_story/generator/bootstrap.py
@@ -74,7 +74,7 @@ class CSBootstrap(Bootstrap):
                 results.assignment[puppy_indices.pop()] = p
 
         # weapon to break blocks in first cave (do it this way to ensure a particular distribution chance)
-        if patches.starting_location.area_name in {"Start Point", "First Cave", "Hermit Gunsmith"}:
+        if patches.starting_location.area in {"Start Point", "First Cave", "Hermit Gunsmith"}:
             _sn_weapons = list(SN_WEAPONS)
 
             bubble_sn = db.get_trick("SNBubbler")
@@ -96,7 +96,7 @@ class CSBootstrap(Bootstrap):
                 results.assignment[index] = weapon
 
         # strong weapon and life capsule in camp
-        if patches.starting_location.area_name == "Camp":
+        if patches.starting_location.area == "Camp":
             strong_weapons = get_valid_pickups(STRONG_WEAPONS)
             life_capsules = get_valid_pickups(["5HP Life Capsule"])
             camp_indices = get_valid_indices(CAMP_INDICES)

--- a/randovania/games/cave_story/generator/hint_distributor.py
+++ b/randovania/games/cave_story/generator/hint_distributor.py
@@ -50,7 +50,7 @@ class CSHintDistributor(HintDistributor):
                 items_with_hint.append("Rusty Key")
             else:
                 items_with_hint.append("ID Card")
-            if patches.starting_location.area_name != "Start Point":
+            if patches.starting_location.area != "Start Point":
                 items_with_hint.append("Arthur's Key")
 
             already_hinted_indices = [hint.target for hint in patches.hints.values() if hint.target is not None]

--- a/randovania/games/cave_story/gui/preset_settings/cs_starting_area_tab.py
+++ b/randovania/games/cave_story/gui/preset_settings/cs_starting_area_tab.py
@@ -45,7 +45,7 @@ class PresetCSStartingArea(PresetStartingArea):
         save_points = [node.identifier for node in region_list.iterate_nodes() if "Save Point" in node.name]
 
         # remove because save point is locked behind a boss fight
-        save_points = [i for i in save_points if i.area_name != "Egg Observation Room?"]
+        save_points = [i for i in save_points if i.area != "Egg Observation Room?"]
 
         with self._editor as editor:
             editor.set_configuration_field(

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -91,9 +91,7 @@ def get_resources_for_details(
 
 
 def _get_destination_room_for_teleportal(connection: Node):
-    return connection.extra.get(
-        "transporter_name", f"{connection.identifier.region_name} - {connection.identifier.area_name}"
-    )
+    return connection.extra.get("transporter_name", f"{connection.identifier.region} - {connection.identifier.area}")
 
 
 class DreadPatchDataFactory(PatchDataFactory):

--- a/randovania/games/dread/gui/preset_settings/dread_teleporters_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_teleporters_tab.py
@@ -61,7 +61,7 @@ class PresetTeleportersDread(PresetTeleporterTab, Ui_PresetTeleportersDread, Nod
 
         locations = TeleporterList.nodes_list(self.game_enum)
         node_identifiers: dict[NodeIdentifier, Area] = {
-            loc: region_list.area_by_area_location(loc.area_location) for loc in locations
+            loc: region_list.area_by_area_location(loc.area_identifier) for loc in locations
         }
         checks: dict[NodeIdentifier, QtWidgets.QCheckBox] = {
             loc: self._create_check_for_source_teleporters(loc) for loc in locations

--- a/randovania/games/prime1/exporter/game_exporter.py
+++ b/randovania/games/prime1/exporter/game_exporter.py
@@ -112,7 +112,7 @@ def make_one_map(filepath: Path, level_data: dict, region: Region, dock_types_to
                 disabled_doors.add((src_name, src_dock_num))
 
             if node.extra["nonstandard"]:
-                dst_name = node.default_connection.area_identifier.area_name
+                dst_name = node.default_connection.area_identifier.area
                 room_connections.append((wrap_text(src_name), wrap_text(dst_name)))
 
     # add edges which were shuffled

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -282,8 +282,8 @@ def _serialize_dock_modifications(
                 dock_num_by_area_node[(area.name, node.name)] = index
                 is_nonstandard[(area.name, index)] = node.extra["nonstandard"]
                 default_connections_node_name[(area.name, index)] = (
-                    node.default_connection.area_name,
-                    node.default_connection.node_name,
+                    node.default_connection.area,
+                    node.default_connection.node,
                 )
 
                 if node.default_dock_weakness.name == "Permanently Locked":
@@ -292,7 +292,7 @@ def _serialize_dock_modifications(
                 if node.extra["nonstandard"]:
                     continue
                 area_dock_nums[area.name].append(index)
-                attached_areas[area.name].append(node.default_connection.area_name)
+                attached_areas[area.name].append(node.default_connection.area)
                 candidates.append((area.name, index))
             size_indices[area.name] = area.extra["size_index"]
 
@@ -685,8 +685,8 @@ class PrimePatchDataFactory(PatchDataFactory):
 
                     source_name = prime1_elevators.RANDOMPRIME_CUSTOM_NAMES[
                         (
-                            identifier.area_location.region_name,
-                            identifier.area_location.area_name,
+                            identifier.area_identifier.region,
+                            identifier.area_identifier.area,
                         )
                     ]
                     level_data[region.name]["transports"][source_name] = target

--- a/randovania/games/prime1/gui/preset_settings/prime_teleporters_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_teleporters_tab.py
@@ -76,7 +76,7 @@ class PresetTeleportersPrime1(PresetTeleporterTab, Ui_PresetTeleportersPrime1, N
 
         locations = TeleporterList.nodes_list(self.game_enum)
         node_identifiers: dict[NodeIdentifier, Area] = {
-            loc: region_list.area_by_area_location(loc.area_location) for loc in locations
+            loc: region_list.area_by_area_location(loc.area_identifier) for loc in locations
         }
         checks: dict[NodeIdentifier, QtWidgets.QCheckBox] = {
             loc: self._create_check_for_source_teleporters(loc) for loc in locations

--- a/randovania/games/prime2/exporter/patch_data_factory.py
+++ b/randovania/games/prime2/exporter/patch_data_factory.py
@@ -162,11 +162,11 @@ def _create_elevators_field(patches: GamePatches, game: GameDescription, elevato
 
     for node, connection in patches.all_dock_connections():
         if isinstance(node, DockNode) and node.dock_type == elevator_type:
-            target_area_location = connection.identifier.area_location
+            target_area_location = connection.identifier.area_identifier
             elevator_fields.append(
                 {
                     "instance_id": node.extra["teleporter_instance_id"],
-                    "origin_location": _area_identifier_to_json(game.region_list, node.identifier.area_location),
+                    "origin_location": _area_identifier_to_json(game.region_list, node.identifier.area_identifier),
                     "target_location": _area_identifier_to_json(game.region_list, target_area_location),
                     "room_name": _pretty_name_for_elevator(game.game, region_list, node, target_area_location),
                 }

--- a/randovania/games/prime2/gui/portal_details_tab.py
+++ b/randovania/games/prime2/gui/portal_details_tab.py
@@ -44,7 +44,9 @@ class PortalDetailsTab(BaseConnectionDetailsTab):
                     per_area[region.name][area.name].add(node)
 
         def name_for(target):
-            target_region, target_area = region_list.region_and_area_by_area_identifier(target.identifier.area_location)
+            target_region, target_area = region_list.region_and_area_by_area_identifier(
+                target.identifier.area_identifier
+            )
             target_name = target_area.name
             if portal_count_in_area[target_region.name][target_area.name] > 1:
                 target_name += f" - {target.name}"

--- a/randovania/games/prime2/gui/preset_settings/echoes_teleporters_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_teleporters_tab.py
@@ -95,7 +95,7 @@ class PresetTeleportersPrime2(PresetTeleporterTab, Ui_PresetTeleportersPrime2, N
 
         locations = TeleporterList.nodes_list(self.game_enum)
         node_identifiers: dict[NodeIdentifier, Area] = {
-            loc: region_list.area_by_area_location(loc.area_location) for loc in locations
+            loc: region_list.area_by_area_location(loc.area_identifier) for loc in locations
         }
         checks: dict[NodeIdentifier, QtWidgets.QCheckBox] = {
             loc: self._create_check_for_source_teleporters(loc) for loc in locations
@@ -106,7 +106,7 @@ class PresetTeleportersPrime2(PresetTeleporterTab, Ui_PresetTeleportersPrime2, N
         for location in sorted(
             locations,
             key=lambda loc: (
-                self.custom_weights.get(loc.area_location.region_name, 0),
+                self.custom_weights.get(loc.area_identifier.region, 0),
                 checks[loc].text(),
             ),
         ):

--- a/randovania/games/super_metroid/exporter/patch_data_factory.py
+++ b/randovania/games/super_metroid/exporter/patch_data_factory.py
@@ -137,7 +137,7 @@ class SuperMetroidPatchDataFactory(PatchDataFactory):
         starting_save_index = starting_area.extra["save_index"]
 
         starting_location_info = {
-            "starting_region": starting_point.region_name,
+            "starting_region": starting_point.region,
             "starting_save_station_index": starting_save_index,
         }
 

--- a/randovania/generator/filler/player_state.py
+++ b/randovania/generator/filler/player_state.py
@@ -196,11 +196,11 @@ class PlayerState:
                 teleporters.append(
                     "* {} to {}".format(
                         elevators.get_elevator_or_area_name(
-                            self.game.game, wl, wl.identifier_for_node(node).area_location, True
+                            self.game.game, wl, wl.identifier_for_node(node).area_identifier, True
                         ),
                         (
                             elevators.get_elevator_or_area_name(
-                                self.game.game, wl, wl.identifier_for_node(other).area_location, True
+                                self.game.game, wl, wl.identifier_for_node(other).area_identifier, True
                             )
                             if other is not None
                             else "<Not connected>"

--- a/randovania/generator/teleporter_distributor.py
+++ b/randovania/generator/teleporter_distributor.py
@@ -32,11 +32,11 @@ class TeleporterHelper:
 
     @property
     def region_name(self) -> str:
-        return self.teleporter.area_location.region_name
+        return self.teleporter.area_identifier.region
 
     @property
     def area_name(self) -> str:
-        return self.teleporter.area_location.area_name
+        return self.teleporter.area_identifier.area
 
     def connect_to(self, other: TeleporterHelper) -> None:
         self.destination = other.teleporter
@@ -46,7 +46,7 @@ class TeleporterHelper:
 
     @property
     def area_location(self) -> AreaIdentifier:
-        return self.teleporter.area_location
+        return self.teleporter.area_identifier
 
 
 def try_randomize_teleporters(
@@ -87,7 +87,7 @@ def try_randomize_teleporters(
                 cteleporter2 = list3[index]
                 if (
                     cteleporter2.region_name == cteleporter1.region_name
-                    or cteleporter2.area_name == cteleporter1.destination.area_name
+                    or cteleporter2.area_name == cteleporter1.destination.area
                 ):
                     cteleporter_list1.append(cteleporter2)
                     list3.remove(cteleporter2)

--- a/randovania/gui/data_editor.py
+++ b/randovania/gui/data_editor.py
@@ -475,7 +475,7 @@ class DataEditorWindow(QMainWindow, Ui_DataEditorWindow):
             msg = f"Unable to describe node: {e}"
 
         if isinstance(node, DockNode):
-            msg = f'{node.default_dock_weakness.name} to <a href="node://{node.default_connection.as_string}">{node.default_connection.node_name}</a>'
+            msg = f'{node.default_dock_weakness.name} to <a href="node://{node.default_connection.as_string}">{node.default_connection.node}</a>'
 
         self.node_name_label.setText(node.name)
         self.node_details_label.setText(msg)
@@ -708,12 +708,12 @@ class DataEditorWindow(QMainWindow, Ui_DataEditorWindow):
         dock_type, dock_weakness = self.game_description.dock_weakness_database.default_weakness
         source_name_base = next(
             integrity_check.raw_expected_dock_names(
-                dock_type, dock_weakness, target_identifier, source_identifier.region_name
+                dock_type, dock_weakness, target_identifier, source_identifier.region
             )
         )
         target_name_base = next(
             integrity_check.raw_expected_dock_names(
-                dock_type, dock_weakness, source_identifier, target_identifier.region_name
+                dock_type, dock_weakness, source_identifier, target_identifier.region
             )
         )
 
@@ -730,8 +730,12 @@ class DataEditorWindow(QMainWindow, Ui_DataEditorWindow):
             source_name = source_name_base
             target_name = target_name_base
 
-        new_node_this_area_identifier = NodeIdentifier(self.region_list.identifier_for_area(current_area), source_name)
-        new_node_other_area_identifier = NodeIdentifier(self.region_list.identifier_for_area(target_area), target_name)
+        new_node_this_area_identifier = NodeIdentifier.with_area(
+            self.region_list.identifier_for_area(current_area), source_name
+        )
+        new_node_other_area_identifier = NodeIdentifier.with_area(
+            self.region_list.identifier_for_area(target_area), target_name
+        )
 
         new_node_this_area = DockNode(
             identifier=new_node_this_area_identifier,

--- a/randovania/gui/lib/node_list_helper.py
+++ b/randovania/gui/lib/node_list_helper.py
@@ -47,7 +47,7 @@ class NodeListHelper:
                 areas_by_region[region.name].append(area)
             if identifier.area_identifier not in nodes_by_area:
                 nodes_by_area[identifier.area_identifier] = []
-            nodes_by_area[identifier.area_identifier].append(area.node_with_name(identifier.node_name))
+            nodes_by_area[identifier.area_identifier].append(area.node_with_name(identifier.node))
 
         return regions, areas_by_region, nodes_by_area
 

--- a/randovania/gui/preset_settings/preset_teleporter_tab.py
+++ b/randovania/gui/preset_settings/preset_teleporter_tab.py
@@ -107,7 +107,7 @@ class PresetTeleporterTab(PresetTab, NodeListHelper):
 
     def _create_check_for_source_teleporters(self, location: NodeIdentifier):
         name = elevators.get_elevator_or_area_name(
-            self.game_enum, self.game_description.region_list, location.area_location, True
+            self.game_enum, self.game_description.region_list, location.area_identifier, True
         )
 
         check = QtWidgets.QCheckBox(self.teleporters_source_group)

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -534,7 +534,7 @@ class TrackerWindow(QtWidgets.QMainWindow, Ui_TrackerWindow):
 
         for region_name in sorted(nodes_by_region.keys()):
             nodes = nodes_by_region[region_name]
-            nodes_locations = [region_list.identifier_for_node(node).area_location for node in nodes]
+            nodes_locations = [region_list.identifier_for_node(node).area_identifier for node in nodes]
             nodes_names = [
                 elevators.get_short_elevator_or_area_name(self.game_configuration.game, region_list, location, False)
                 for location in nodes_locations

--- a/randovania/layout/game_patches_serializer.py
+++ b/randovania/layout/game_patches_serializer.py
@@ -54,7 +54,7 @@ def _pickup_assignment_to_item_locations(
 
 
 def _find_area_with_teleporter(region_list: RegionList, teleporter: NodeIdentifier) -> Area:
-    return region_list.area_by_area_location(teleporter.area_location)
+    return region_list.area_by_area_location(teleporter.area_identifier)
 
 
 def serialize_single(player_index: int, num_players: int, patches: GamePatches) -> dict:

--- a/randovania/resolver/logic.py
+++ b/randovania/resolver/logic.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 def n(node: Node, region_list, with_region=False) -> str:
-    return region_list.node_name(node, with_region) if node is not None else "None"
+    return region_list.node(node, with_region) if node is not None else "None"
 
 
 def energy_string(state: State) -> str:

--- a/randovania/resolver/logic.py
+++ b/randovania/resolver/logic.py
@@ -9,14 +9,15 @@ from randovania.resolver.exceptions import ResolverTimeoutError
 
 if TYPE_CHECKING:
     from randovania.game_description.db.node import Node
+    from randovania.game_description.db.region_list import RegionList
     from randovania.game_description.game_description import GameDescription
     from randovania.game_description.requirements.base import Requirement
     from randovania.layout.base.base_configuration import BaseConfiguration
     from randovania.resolver.state import State
 
 
-def n(node: Node, region_list, with_region=False) -> str:
-    return region_list.node(node, with_region) if node is not None else "None"
+def n(node: Node, region_list: RegionList, with_region: bool = False) -> str:
+    return region_list.node_name(node, with_region) if node is not None else "None"
 
 
 def energy_string(state: State) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ attrs==23.2.0
     # via
     #   aiohttp
     #   jsonschema
-    #   randovania (setup.py)
     #   referencing
 bidict==0.23.1
     # via python-socketio

--- a/test/game_description/test_editor.py
+++ b/test/game_description/test_editor.py
@@ -67,7 +67,7 @@ def test_replace_node(game_editor):
     assert region_list.area_by_area_location(loc).connections[source][new_node] is req
     dock_to_landing = region_list.area_by_area_location(loc2).node_with_name("Door to Landing Site")
     assert isinstance(dock_to_landing, DockNode)
-    assert dock_to_landing.default_connection.node_name == "FooBar"
+    assert dock_to_landing.default_connection.node == "FooBar"
 
 
 def test_replace_node_unknown_node(game_editor):
@@ -100,4 +100,4 @@ def test_rename_area(game_editor):
     area_2 = region_list.area_by_area_location(loc_2)
     dock_node = area_2.node_with_name("Elevator to Temple Grounds")
     assert dock_node is not None
-    assert dock_node.default_connection.area_name == new_area_name
+    assert dock_node.default_connection.area == new_area_name

--- a/test/games/am2r/test_am2r.py
+++ b/test/games/am2r/test_am2r.py
@@ -66,8 +66,8 @@ def test_all_tricks_should_have_proper_requirements():
                 if len(set(required_resource_collection.values())) > 1:
                     database_dict[required_resources].append(
                         (
-                            f"{node.name} ({node.identifier.area_name})",
-                            f"{dest_node.name} ({dest_node.identifier.area_name})",
+                            f"{node.name} ({node.identifier.area})",
+                            f"{dest_node.name} ({dest_node.identifier.area})",
                         )
                     )
 

--- a/test/games/cave_story/generator/test_cs_bootstrap.py
+++ b/test/games/cave_story/generator/test_cs_bootstrap.py
@@ -63,10 +63,10 @@ def test_assign_pool_results(default_cs_configuration: CSConfiguration, puppies,
     first_cave_assignment = [
         target.pickup for index, target in result.pickup_assignment.items() if index in FIRST_CAVE_INDICES
     ]
-    expected_first_cave_len = 1 if starting_area.area_name == "Start Point" else 0
+    expected_first_cave_len = 1 if starting_area.area == "Start Point" else 0
 
     assert len(first_cave_assignment) == expected_first_cave_len
-    assert starting_area.area_name != "Start Point" or first_cave_assignment[0].broad_category.name in {
+    assert starting_area.area != "Start Point" or first_cave_assignment[0].broad_category.name in {
         "weapon",
         "missile_related",
     }
@@ -74,7 +74,7 @@ def test_assign_pool_results(default_cs_configuration: CSConfiguration, puppies,
     # Camp weapon/life capsule
     camp_assignment = [target.pickup for index, target in result.pickup_assignment.items() if index in CAMP_INDICES]
 
-    if starting_area.area_name != "Camp":
+    if starting_area.area != "Camp":
         assert len(camp_assignment) == 0
     else:
         expected_names = set(STRONG_WEAPONS)

--- a/test/games/fusion/test_fusion.py
+++ b/test/games/fusion/test_fusion.py
@@ -64,8 +64,8 @@ def test_all_tricks_should_have_proper_requirements():
                 if len(set(required_resource_collection.values())) > 1:
                     database_dict[required_resources].append(
                         (
-                            f"{node.name} ({node.identifier.area_name})",
-                            f"{dest_node.name} ({dest_node.identifier.area_name})",
+                            f"{node.name} ({node.identifier.area})",
+                            f"{dest_node.name} ({dest_node.identifier.area})",
                         )
                     )
 

--- a/test/generator/test_dock_weakness_distributor.py
+++ b/test/generator/test_dock_weakness_distributor.py
@@ -45,7 +45,7 @@ def test_distribute_pre_fill_weaknesses_swap(empty_patches):
         patches,
         rng,
     )
-    docks = {(n.identifier.area_name, n.name): w.name for n, w in result.all_dock_weaknesses()}
+    docks = {(n.identifier.area, n.name): w.name for n, w in result.all_dock_weaknesses()}
 
     assert docks == {
         ("Back-Only Lock Room", "Door to Starting Area"): "Explosive Door",
@@ -84,7 +84,7 @@ def test_distribute_pre_fill_weaknesses_swap_force_two_way(empty_patches):
         patches,
         rng,
     )
-    docks = {(n.identifier.area_name, n.name): w.name for n, w in result.all_dock_weaknesses()}
+    docks = {(n.identifier.area, n.name): w.name for n, w in result.all_dock_weaknesses()}
 
     assert docks == {
         ("Back-Only Lock Room", "Door to Starting Area"): "Back-Only Door",
@@ -122,8 +122,8 @@ def test_distribute_pre_fill_docks(empty_patches, monkeypatch):
         patches,
         rng,
     )
-    docks = {(n.identifier.area_name, n.name): w.name for n, w in result.all_dock_weaknesses()}
-    to_shuffle = [(n.identifier.area_name, n.name) for n in result.all_weaknesses_to_shuffle()]
+    docks = {(n.identifier.area, n.name): w.name for n, w in result.all_dock_weaknesses()}
+    to_shuffle = [(n.identifier.area, n.name) for n in result.all_weaknesses_to_shuffle()]
 
     assert docks == {
         ("Back-Only Lock Room", "Door to Starting Area"): "Normal Door",


### PR DESCRIPTION
Negligible time difference, but actually a bit faster. Means we can also not depend on `attrs` (but it's still installed as transient dependency)

```
> randovania development benchmark compare tools\benchmark-7.5.0.json .\tools\benchmark-nodeidentifier.json
                    Difference | Fixes | Failures |     Mean |    Stdev |   Median
        Blank Development Game |     0 |        0 |   -0.004 |    0.007 |   -0.003
                 Metroid Prime |     0 |        0 |    0.016 |    0.066 |    0.026
       Metroid Prime 2: Echoes |     0 |        0 |   -0.035 |    0.126 |   -0.037
   Metroid Prime 3: Corruption |     0 |        0 |   -0.058 |    0.115 |   -0.040
                 Super Metroid |     0 |        0 |   -0.031 |    0.084 |   -0.026
                 Metroid Dread |     0 |        0 |   -0.132 |    0.349 |   -0.097
        Metroid: Samus Returns |     0 |        0 |    0.049 |    0.562 |    0.015
                    Cave Story |     0 |        0 |   -0.002 |    0.099 |   -0.018
      Another Metroid 2 Remake |     0 |        0 |    0.048 |    0.158 |    0.080
                Metroid Fusion |     0 |        0 |    0.030 |    0.131 |    0.022
```