### PR TITLE
Get sentry url from configuration

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -124,6 +124,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OBFUSCATOR_SECRET: ${{ secrets.OBFUSCATOR_SECRET }}
+          SENTRY_CLIENT_URL: ${{ secrets.SENTRY_CLIENT_URL }}
           PRODUCTION: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/stable') }}
 
       - name: executable check

--- a/randovania/exporter/game_exporter.py
+++ b/randovania/exporter/game_exporter.py
@@ -1,9 +1,6 @@
 import dataclasses
 from pathlib import Path
 
-import sentry_sdk
-
-from randovania import monitoring
 from randovania.lib import status_update_lib
 
 
@@ -54,9 +51,11 @@ class GameExporter:
         progress_update: status_update_lib.ProgressUpdateCallable,
     ):
         self._before_export()
+        from randovania import monitoring
+
         try:
             with monitoring.attach_patcher_data(patch_data):
-                with sentry_sdk.start_transaction(op="task", name="export_game") as span:
+                with monitoring.start_transaction(op="task", name="export_game") as span:
                     span.set_tag("exporter", type(self).__name__)
                     self._do_export_game(patch_data, export_params, progress_update)
         finally:

--- a/randovania/interface_common/generator_frontend.py
+++ b/randovania/interface_common/generator_frontend.py
@@ -5,8 +5,7 @@ import multiprocessing
 from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING
 
-import sentry_sdk
-
+from randovania import monitoring
 from randovania.generator import generator
 from randovania.layout.base.dock_rando_configuration import DockRandoMode
 from randovania.lib.status_update_lib import ConstantPercentageCallback, ProgressUpdateCallable
@@ -37,7 +36,7 @@ def generate_layout(
     :param retries:
     :return:
     """
-    with sentry_sdk.start_transaction(op="task", name="generate_layout") as span:
+    with monitoring.start_transaction(op="task", name="generate_layout") as span:
         games = {preset.game.short_name for preset in parameters.presets}
         span.set_tag("num_worlds", parameters.world_count)
         span.set_tag("game", next(iter(games)) if len(games) == 1 else "cross-game")

--- a/randovania/monitoring/__init__.py
+++ b/randovania/monitoring/__init__.py
@@ -15,12 +15,12 @@ import randovania
 
 
 class HomeEventScrubber(sentry_sdk.scrubber.EventScrubber):
-    def scrub_dict(self, d):
+    def scrub_dict(self, d: object) -> None:
         super().scrub_dict(d)
         _filter_user_home(d)
 
 
-def _filter_data(data, str_filter: typing.Callable[[str], str]) -> typing.Any | None:
+def _filter_data(data: object, str_filter: typing.Callable[[str], str]) -> typing.Any | None:
     result = None
     if isinstance(data, dict):
         for k, v in tuple(data.items()):

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -158,6 +158,7 @@ async def main():
         "discord_client_id": client_id,
         "server_address": f"https://randovania.metroidprime.run/{server_suffix}",
         "socketio_path": f"/{server_suffix}/socket.io",
+        "sentry_urls": {"client": os.environ["SENTRY_CLIENT_URL"]},
     }
     json_lib.write_path(_ROOT_FOLDER.joinpath("randovania", "data", "configuration.json"), configuration)
 


### PR DESCRIPTION
This means sentry is only initialized in builds provided via our CI, and the official server

---

I'm not worried about these values being secret, but I do want to stop reports from people who make their own executables.