### PR TITLE
Improve Cave Story documentation

### DIFF
--- a/randovania/games/cave_story/logic_database/Grasstown.json
+++ b/randovania/games/cave_story/logic_database/Grasstown.json
@@ -167,6 +167,138 @@
                                     }
                                 ]
                             }
+                        },
+                        "Above Chaco's House": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "eventFans",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Has Flight"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Chaco Skip - https://www.youtube.com/watch?v=Zamb3TjF60M",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "IframeReset",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Reset Iframes"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "3 hit method",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Dboost",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 6,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "2 hit method",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Dboost",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 4,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Hard Mode method",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Dboost",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Has Weapon"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -623,185 +755,6 @@
                                 ]
                             }
                         },
-                        "Area Centre": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Has Flight"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "eventFans",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": "Chaco Skip - https://www.youtube.com/watch?v=Zamb3TjF60M",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "IframeReset",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Dboost",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Damage",
-                                                                                "amount": 6,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Dboost",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Damage",
-                                                                                "amount": 4,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Dboost",
-                                                                                "amount": 3,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Damage",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "template",
-                                                                            "data": "Has Weapon"
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Reset Iframes"
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Has Weapon"
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "pacifist",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Damage",
-                                                                                "amount": 5,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "pacifist",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Teleporter to Arthur's House": {
                             "type": "and",
                             "data": {
@@ -987,226 +940,6 @@
                                 "negate": false
                             }
                         },
-                        "Area Centre": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": "Get up to the central area",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "eventFans",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Has Flight"
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Remove Points of No Return"
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "events",
-                                                                    "name": "eventFireplace",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": "Reverse Chaco Skip",
-                                                        "items": [
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": "TAS Jump",
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "GravHop",
-                                                                                "amount": 5,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": "https://www.youtube.com/watch?v=WiA3lsW5gec",
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Dboost",
-                                                                                "amount": 3,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Damage",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": "https://www.youtube.com/watch?v=rmtwHNrxU5Q",
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Dboost",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Damage",
-                                                                                "amount": 3,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": "Get past the Mannan",
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Has Weapon"
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "pacifist",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "or",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "and",
-                                                                            "data": {
-                                                                                "comment": null,
-                                                                                "items": [
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "Dboost",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "damage",
-                                                                                            "name": "Damage",
-                                                                                            "amount": 3,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    }
-                                                                                ]
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "template",
-                                                                            "data": "Has Flight"
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "pacifist",
-                                                                    "amount": 3,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "GravHop",
-                                                                    "amount": 3,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Event - Saved Kazuma": {
                             "type": "resource",
                             "data": {
@@ -1239,15 +972,134 @@
                                     }
                                 ]
                             }
+                        },
+                        "Beyond First Mannan": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "eventFans",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Has Flight"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "eventFireplace",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Remove Points of No Return"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Reverse Chaco Skip",
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "https://www.youtube.com/watch?v=rmtwHNrxU5Q",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Dboost",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "https://www.youtube.com/watch?v=WiA3lsW5gec",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Dboost",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "TAS Jump (TODO: vid)",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "GravHop",
+                                                                    "amount": 5,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
-                "Area Centre": {
+                "Above Chaco's House": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 2293.3333333333335,
-                        "y": 249.77777777777777,
+                        "x": 2008.0,
+                        "y": 222.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -1264,19 +1116,27 @@
                                 "items": []
                             }
                         },
-                        "East Side": {
+                        "Beyond First Mannan": {
                             "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Has Weapon"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Kill Mannan",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Has Weapon"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Walk through Mannan",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -1288,41 +1148,21 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Has Flight"
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Damage",
-                                                                                "amount": 3,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Dboost",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "tricks",
+                                                        "name": "Dboost",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 3,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -1331,7 +1171,28 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Fly over Mannan",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "pacifist",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Has Flight"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Jump over Mannan (TODO: vid)",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -1558,7 +1419,7 @@
                     "valid_starting_location": false,
                     "event_name": "eventFireplace",
                     "connections": {
-                        "Area Centre": {
+                        "Above Chaco's House": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1721,6 +1582,132 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        }
+                    }
+                },
+                "Beyond First Mannan": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 2801.50295222759,
+                        "y": 247.72517444981213,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
+                        "East Side": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Above Chaco's House": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Kill Mannan",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Has Weapon"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Walk through Mannan",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "pacifist",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Dboost",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Fly over Mannan",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "pacifist",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Has Flight"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Jump over Mannan (TODO: vid)",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "pacifist",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "GravHop",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/randovania/games/cave_story/logic_database/Grasstown.txt
+++ b/randovania/games/cave_story/logic_database/Grasstown.txt
@@ -29,6 +29,19 @@ Extra - starting_script: <TRA0006:0098:0004:0018
       Any of the following:
           Pacifist Strats (Intermediate) or Has Weapon
           Pacifist Strats (Beginner) and Has Flight
+  > Above Chaco's House
+      Any of the following:
+          After Activated Fans or Has Flight
+          All of the following:
+              # Chaco Skip - https://www.youtube.com/watch?v=Zamb3TjF60M
+              Invincibility Frame Reset (Beginner) and Reset Iframes
+              Any of the following:
+                  # 3 hit method
+                  Damage Boosting (Beginner) and Normal Damage ≥ 6
+                  # 2 hit method
+                  Damage Boosting (Intermediate) and Normal Damage ≥ 4
+                  # Hard Mode method
+                  Damage Boosting (Advanced) and Normal Damage ≥ 2 and Has Weapon
 
 > Entrance from Chaco's House; Heals? False
   * Layers: default
@@ -111,19 +124,6 @@ Extra - starting_script: <TRA0006:0098:0004:0018
       Any of the following:
           Pacifist Strats (Intermediate) or Has Weapon
           Pacifist Strats (Beginner) and Has Flight
-  > Area Centre
-      Any of the following:
-          After Activated Fans or Has Flight
-          All of the following:
-              # Chaco Skip - https://www.youtube.com/watch?v=Zamb3TjF60M
-              Invincibility Frame Reset (Beginner) and Reset Iframes
-              Any of the following:
-                  Damage Boosting (Beginner) and Normal Damage ≥ 6
-                  Damage Boosting (Intermediate) and Normal Damage ≥ 4
-                  Damage Boosting (Advanced) and Normal Damage ≥ 2 and Has Weapon
-              Any of the following:
-                  Pacifist Strats (Intermediate) or Has Weapon
-                  Pacifist Strats (Beginner) and Normal Damage ≥ 5
   > Teleporter to Arthur's House
       Trivial
   > Pickup (Kulala)
@@ -156,48 +156,38 @@ Extra - starting_script: <TRA0006:0098:0004:0018
       Trivial
   > Pickup (Kazuma Chest)
       Rusty Key
-  > Area Centre
-      All of the following:
-          Any of the following:
-              # Get up to the central area
-              After Activated Fans or Has Flight
-              After Entered Grasstown from Fireplace and Remove Points of No Return
-              Any of the following:
-                  # Reverse Chaco Skip
-                  # TAS Jump
-                  Gravity Hopping (Hypermode)
-                  # https://www.youtube.com/watch?v=WiA3lsW5gec
-                  Damage Boosting (Advanced) and Normal Damage ≥ 2
-                  # https://www.youtube.com/watch?v=rmtwHNrxU5Q
-                  Damage Boosting (Intermediate) and Normal Damage ≥ 3
-          Any of the following:
-              # Get past the Mannan
-              Has Weapon
-              All of the following:
-                  Pacifist Strats (Intermediate)
-                  Any of the following:
-                      Has Flight
-                      Damage Boosting (Beginner) and Normal Damage ≥ 3
-              Gravity Hopping (Advanced) and Pacifist Strats (Advanced)
   > Event - Saved Kazuma
       Explosive
   > Event - Level MG (East)
       Machine Gun
   > Near Hint
       Trivial
+  > Beyond First Mannan
+      Any of the following:
+          After Activated Fans or Has Flight
+          After Entered Grasstown from Fireplace and Remove Points of No Return
+          Any of the following:
+              # Reverse Chaco Skip
+              # https://www.youtube.com/watch?v=rmtwHNrxU5Q
+              Damage Boosting (Intermediate) and Normal Damage ≥ 3
+              # https://www.youtube.com/watch?v=WiA3lsW5gec
+              Damage Boosting (Advanced) and Normal Damage ≥ 2
+              # TAS Jump (TODO: vid)
+              Gravity Hopping (Hypermode)
 
-> Area Centre; Heals? False
+> Above Chaco's House; Heals? False
   * Layers: default
   > Door to Chaco's House
       Trivial
-  > East Side
+  > Beyond First Mannan
       Any of the following:
+          # Kill Mannan
           Has Weapon
-          All of the following:
-              Pacifist Strats (Intermediate)
-              Any of the following:
-                  Has Flight
-                  Damage Boosting (Beginner) and Normal Damage ≥ 3
+          # Walk through Mannan
+          Damage Boosting (Beginner) and Pacifist Strats (Intermediate) and Normal Damage ≥ 3
+          # Fly over Mannan
+          Pacifist Strats (Intermediate) and Has Flight
+          # Jump over Mannan (TODO: vid)
           Gravity Hopping (Advanced) and Pacifist Strats (Advanced)
 
 > Event - Saved Kazuma; Heals? False
@@ -244,7 +234,7 @@ Extra - starting_script: <TRA0006:0098:0004:0018
 > Event - Entered Grasstown from Chaco Fireplace; Heals? False
   * Layers: default
   * Event Entered Grasstown from Fireplace
-  > Area Centre
+  > Above Chaco's House
       Trivial
 
 > Event - Level MG (West); Heals? False
@@ -276,6 +266,21 @@ Extra - starting_script: <TRA0006:0098:0004:0018
       Trivial
   > Save Point
       Trivial
+
+> Beyond First Mannan; Heals? False
+  * Layers: default
+  > East Side
+      Trivial
+  > Above Chaco's House
+      Any of the following:
+          # Kill Mannan
+          Has Weapon
+          # Walk through Mannan
+          Damage Boosting (Beginner) and Pacifist Strats (Intermediate) and Normal Damage ≥ 3
+          # Fly over Mannan
+          Pacifist Strats (Intermediate) and Has Flight
+          # Jump over Mannan (TODO: vid)
+          Gravity Hopping (Advanced) and Pacifist Strats (Advanced)
 
 ----------------
 Santa's House

--- a/randovania/games/cave_story/logic_database/Last Cave.json
+++ b/randovania/games/cave_story/logic_database/Last Cave.json
@@ -2099,128 +2099,11 @@
                     "pickup_index": 31,
                     "location_category": "minor",
                     "connections": {
-                        "H/V Trigger to Sacred Grounds - B2": {
+                        "After Spike Pit": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Has Flight"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Has Weapon"
-                                    }
-                                ]
-                            }
-                        },
-                        "Event - Heavy Press": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Kill Bosses"
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": "Shoot with Curly's Nemesis",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "pacifist",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "eventCurly3",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "BossMissiles",
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "supers",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "missile",
-                                                        "amount": 18,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "BossMissiles",
-                                                        "amount": 3,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "missiles",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "missile",
-                                                        "amount": 41,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -2453,8 +2336,112 @@
                             }
                         },
                         "Event - Heavy Press": {
-                            "type": "template",
-                            "data": "Can Kill Bosses"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Kill Bosses"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Shoot with Curly's Nemesis",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "eventCurly3",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "pacifist",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "missile",
+                                                        "amount": 18,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "supers",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "BossMissiles",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "missile",
+                                                        "amount": 41,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "missiles",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "BossMissiles",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 }

--- a/randovania/games/cave_story/logic_database/Last Cave.json
+++ b/randovania/games/cave_story/logic_database/Last Cave.json
@@ -2028,64 +2028,14 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Pickup (Hell B3 Chest)": {
+                        "After Spike Pit": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Has Flight"
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Dboost",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Damage",
-                                                                    "amount": 10,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
                                     {
                                         "type": "template",
                                         "data": "Has Weapon"
-                                    }
-                                ]
-                            }
-                        },
-                        "Event - Heavy Press": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Kill Bosses"
                                     },
                                     {
                                         "type": "or",
@@ -2099,7 +2049,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Damage boost off of spikes",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -2324,6 +2274,187 @@
                                 "comment": null,
                                 "items": []
                             }
+                        }
+                    }
+                },
+                "After Spike Pit": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 458.38483355724736,
+                        "y": 80.86858735134595,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
+                        "H/V Trigger to Sacred Grounds - B2": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Has Weapon"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Has Flight"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Damage boost off of spikes",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Dboost",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 10,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Pickup (Hell B3 Chest)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Break Blocks"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "SNBubbler",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "bubbler",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "SNMissiles",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "missiles",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "supers",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missile",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Has Flight"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Heavy Press": {
+                            "type": "template",
+                            "data": "Can Kill Bosses"
                         }
                     }
                 }

--- a/randovania/games/cave_story/logic_database/Last Cave.txt
+++ b/randovania/games/cave_story/logic_database/Last Cave.txt
@@ -327,15 +327,8 @@ Extra - in_dark_aether: False
   * Layers: default
   * Pickup 31; Category? Minor
   * Extra - event: 0400
-  > H/V Trigger to Sacred Grounds - B2
-      Has Flight and Has Weapon
-  > Event - Heavy Press
-      Any of the following:
-          Can Kill Bosses
-          # Shoot with Curly's Nemesis
-          After Picked up Curly (Hell) and Pacifist Strats (Beginner)
-          Missiles ≥ 18 and Super Missile Launcher and Kill Bosses with Missiles (Intermediate)
-          Missiles ≥ 41 and Missile Launcher and Kill Bosses with Missiles (Advanced)
+  > After Spike Pit
+      Trivial
 
 > Exit to Passage?; Heals? False
   * Layers: default
@@ -366,7 +359,12 @@ Extra - in_dark_aether: False
                   Missiles and Break blocks with Missiles (Beginner)
                   Missile Launcher or Super Missile Launcher
   > Event - Heavy Press
-      Can Kill Bosses
+      Any of the following:
+          Can Kill Bosses
+          # Shoot with Curly's Nemesis
+          After Picked up Curly (Hell) and Pacifist Strats (Beginner)
+          Missiles ≥ 18 and Super Missile Launcher and Kill Bosses with Missiles (Intermediate)
+          Missiles ≥ 41 and Missile Launcher and Kill Bosses with Missiles (Advanced)
 
 ----------------
 Corridor

--- a/randovania/games/cave_story/logic_database/Last Cave.txt
+++ b/randovania/games/cave_story/logic_database/Last Cave.txt
@@ -315,17 +315,12 @@ Extra - in_dark_aether: False
 > H/V Trigger to Sacred Grounds - B2; Heals? False
   * Layers: default
   * H/V Trigger to Sacred Grounds - B2/H/V Trigger to Sacred Grounds - B3
-  > Pickup (Hell B3 Chest)
+  > After Spike Pit
       All of the following:
           Has Weapon
           Any of the following:
               Has Flight
-              Damage Boosting (Beginner) and Normal Damage ≥ 10
-  > Event - Heavy Press
-      All of the following:
-          Can Kill Bosses
-          Any of the following:
-              Has Flight
+              # Damage boost off of spikes
               Damage Boosting (Beginner) and Normal Damage ≥ 10
 
 > Pickup (Hell B3 Chest); Heals? False
@@ -351,6 +346,27 @@ Extra - in_dark_aether: False
   * Event Defeated Heavy Press
   > Exit to Passage?
       Trivial
+
+> After Spike Pit; Heals? False
+  * Layers: default
+  > H/V Trigger to Sacred Grounds - B2
+      All of the following:
+          Has Weapon
+          Any of the following:
+              Has Flight
+              # Damage boost off of spikes
+              Damage Boosting (Beginner) and Normal Damage ≥ 10
+  > Pickup (Hell B3 Chest)
+      All of the following:
+          Has Flight
+          Any of the following:
+              Can Break Blocks
+              Bubbler and Break blocks with Bubbler (Beginner)
+              All of the following:
+                  Missiles and Break blocks with Missiles (Beginner)
+                  Missile Launcher or Super Missile Launcher
+  > Event - Heavy Press
+      Can Kill Bosses
 
 ----------------
 Corridor

--- a/randovania/games/cave_story/logic_database/Plantation.json
+++ b/randovania/games/cave_story/logic_database/Plantation.json
@@ -785,7 +785,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "https://youtu.be/StXuozoLRe4",
                                             "items": [
                                                 {
                                                     "type": "resource",

--- a/randovania/games/cave_story/logic_database/Plantation.txt
+++ b/randovania/games/cave_story/logic_database/Plantation.txt
@@ -147,6 +147,7 @@ Extra - starting_script: <TRA0056:0090:0118:0083
           # Rocket Skip
           # https://www.youtube.com/watch?v=qWp-qmW6xb0
           Booster 2.0 and Machine Gun and Damage Boosting (Expert) and Normal Damage ≥ 2
+          # https://youtu.be/StXuozoLRe4
           Booster 2.0 and Damage Boosting (Hypermode)
 
 > Door to Final Cave; Heals? False

--- a/randovania/games/cave_story/logic_database/Ruined Egg Corridor.json
+++ b/randovania/games/cave_story/logic_database/Ruined Egg Corridor.json
@@ -134,22 +134,21 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Has Weapon"
-                                    },
-                                    {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "pacifist",
-                                            "amount": 3,
-                                            "negate": false
+                                            "comment": "Kill dragon",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Has Weapon"
+                                                }
+                                            ]
                                         }
                                     },
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Walk through the dragon",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -175,6 +174,23 @@
                                                         "type": "tricks",
                                                         "name": "Dboost",
                                                         "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Jump over dragon",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "pacifist",
+                                                        "amount": 3,
                                                         "negate": false
                                                     }
                                                 }
@@ -287,13 +303,21 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Has Weapon"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Kill dragon",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Has Weapon"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Fly over dragon",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -1710,16 +1734,24 @@
                         "Room Top": {
                             "type": "or",
                             "data": {
-                                "comment": null,
+                                "comment": "https://youtu.be/-hZwtVL18l0",
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Has Weapon"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Kill enemies",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Has Weapon"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Fly over problematic Hoppies",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -1740,7 +1772,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Tank a hit on a Hoppy",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -1766,7 +1798,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://youtu.be/-hZwtVL18l0",
+                                            "comment": "Damageless",
                                             "items": [
                                                 {
                                                     "type": "resource",

--- a/randovania/games/cave_story/logic_database/Ruined Egg Corridor.txt
+++ b/randovania/games/cave_story/logic_database/Ruined Egg Corridor.txt
@@ -21,8 +21,12 @@ Extra - starting_script: <TRA0049:0099:0007:0006
       Trivial
   > Pickup (Dragon Chest)
       Any of the following:
-          Pacifist Strats (Advanced) or Has Weapon
+          # Kill dragon
+          Has Weapon
+          # Walk through the dragon
           Damage Boosting (Beginner) and Pacifist Strats (Intermediate) and Normal Damage ≥ 10
+          # Jump over dragon
+          Pacifist Strats (Advanced)
   > Event - Used Egg Corridor? Teleporter
       Trivial
   > Event - Level MG (West)
@@ -41,7 +45,9 @@ Extra - starting_script: <TRA0049:0099:0007:0006
   * Layers: default
   > Door to Egg Observation Room? (East)
       Any of the following:
+          # Kill dragon
           Has Weapon
+          # Fly over dragon
           Pacifist Strats (Beginner) and Has Flight
           # Damage boost off the dragon
           Damage Boosting (Beginner) and Pacifist Strats (Advanced) and Normal Damage ≥ 10
@@ -277,10 +283,14 @@ Extra - starting_script: <TRA0053:0092:0165:0004
       Trivial
   > Room Top
       Any of the following:
-          Has Weapon
-          Pacifist Strats (Intermediate) and Has Flight
-          Pacifist Strats (Advanced) and Normal Damage ≥ 5
           # https://youtu.be/-hZwtVL18l0
+          # Kill enemies
+          Has Weapon
+          # Fly over problematic Hoppies
+          Pacifist Strats (Intermediate) and Has Flight
+          # Tank a hit on a Hoppy
+          Pacifist Strats (Advanced) and Normal Damage ≥ 5
+          # Damageless
           Pacifist Strats (Expert)
   > Door to Clock Room
       Trivial

--- a/randovania/games/cave_story/logic_database/Sand Zone.json
+++ b/randovania/games/cave_story/logic_database/Sand Zone.json
@@ -1867,7 +1867,7 @@
                                                                                     {
                                                                                         "type": "and",
                                                                                         "data": {
-                                                                                            "comment": null,
+                                                                                            "comment": "Level 3 Missiles are mandatory, and all 3 need to hit for every shot",
                                                                                             "items": [
                                                                                                 {
                                                                                                     "type": "resource",

--- a/randovania/games/cave_story/logic_database/Sand Zone.txt
+++ b/randovania/games/cave_story/logic_database/Sand Zone.txt
@@ -195,6 +195,7 @@ Extra - starting_script: <TRA0010:0099:0036:0033
                       Missile Launcher
                       Any of the following:
                           Missiles ≥ 50 and Kill Bosses with Missiles (Advanced)
+                          # Level 3 Missiles are mandatory, and all 3 need to hit for every shot
                           Missiles ≥ 25 and Kill Bosses with Missiles (Hypermode)
                   All of the following:
                       # Kill with Super Missiles

--- a/randovania/games/cave_story/logic_database/header.json
+++ b/randovania/games/cave_story/logic_database/header.json
@@ -713,7 +713,7 @@
             "BossMissiles": {
                 "long_name": "Kill Bosses with Missiles",
                 "description": "Some bosses have anti-missile behavior which can be circumvented in certain situations.",
-                "require_documentation_above": 0,
+                "require_documentation_above": 4,
                 "extra": {}
             },
             "GravHop": {


### PR DESCRIPTION
This increases documentation from 55% to 87%, if I've done my math correctly. Of the remaining undocumented tricks, one is a very easy damage boost, a handful are gravity hops (which I'll want vids with input display for), and the rest are pacifist strats that need videos showing a successful attempt