### PR TITLE
Dread: Add ryujinx export to linux and macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
+- Added: Linux and macOS now have the Ryujinx exporting option available.
 - Fixed: The `Hints Location` tab no longer refers to Prime 2 when describing where the hints are placed.
 - Fixed: Customizing a preset where EMMI and Bosses were turned off for DNA placement won't have the DNA slider be initially enabled.
 - Removed: The FAQ entry stating that only the English language is supported has been removed, as all languages are patched since version 7.4.0.

--- a/randovania/games/dread/exporter/game_exporter.py
+++ b/randovania/games/dread/exporter/game_exporter.py
@@ -17,6 +17,11 @@ class DreadModPlatform(Enum):
     ATMOSPHERE = "atmosphere"
 
 
+class LinuxRyujinxPath(Enum):
+    NATIVE = "native"
+    FLATPAK = "flatpak"
+
+
 @dataclasses.dataclass(frozen=True)
 class DreadGameExportParams(GameExportParams):
     input_path: Path

--- a/randovania/games/dread/exporter/options.py
+++ b/randovania/games/dread/exporter/options.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 from pathlib import Path
 
-from randovania.games.dread.exporter.game_exporter import DreadModPlatform
+from randovania.games.dread.exporter.game_exporter import DreadModPlatform, LinuxRyujinxPath
 from randovania.games.game import RandovaniaGame
 from randovania.interface_common.options import PerGameOptions, decode_if_not_none
 
@@ -12,6 +12,7 @@ from randovania.interface_common.options import PerGameOptions, decode_if_not_no
 class DreadPerGameOptions(PerGameOptions):
     input_directory: Path | None = None
     target_platform: DreadModPlatform = DreadModPlatform.RYUJINX
+    linux_ryujinx_path: LinuxRyujinxPath = LinuxRyujinxPath.FLATPAK
     output_preference: str | None = None
 
     @property
@@ -20,6 +21,7 @@ class DreadPerGameOptions(PerGameOptions):
             **super().as_json,
             "input_directory": str(self.input_directory) if self.input_directory is not None else None,
             "target_platform": self.target_platform.value,
+            "linux_ryujinx_path": self.linux_ryujinx_path.value,
             "output_preference": self.output_preference,
         }
 
@@ -31,5 +33,6 @@ class DreadPerGameOptions(PerGameOptions):
             cosmetic_patches=cosmetic_patches,
             input_directory=decode_if_not_none(value["input_directory"], Path),
             target_platform=DreadModPlatform(value["target_platform"]),
+            linux_ryujinx_path=LinuxRyujinxPath(value["linux_ryujinx_path"]),
             output_preference=value["output_preference"],
         )

--- a/randovania/games/dread/gui/dialog/game_export_dialog.py
+++ b/randovania/games/dread/gui/dialog/game_export_dialog.py
@@ -7,9 +7,9 @@ import platform
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
-from randovania.games.dread.exporter.game_exporter import DreadGameExportParams, DreadModPlatform
+from randovania.games.dread.exporter.game_exporter import DreadGameExportParams, DreadModPlatform, LinuxRyujinxPath
 from randovania.games.dread.exporter.options import DreadPerGameOptions
 from randovania.games.game import RandovaniaGame
 from randovania.gui.dialog.game_export_dialog import (
@@ -34,15 +34,12 @@ if TYPE_CHECKING:
     from randovania.interface_common.options import Options
 
 
-def get_path_to_ryujinx() -> Path:
-    if platform.system() == "Windows":
-        return Path(os.environ["APPDATA"], "Ryujinx", "mods", "contents", "010093801237c000")
-
-    raise ValueError("Unsupported platform")
+def return_linux_only_controls() -> set[str]:
+    return {"linux_flatpak_radio", "linux_native_radio"}
 
 
 def supports_ryujinx() -> bool:
-    return platform.system() in {"Windows"}
+    return platform.system() in {"Windows", "Linux", "Darwin"}
 
 
 def serialize_path(path: Path | None) -> str | None:
@@ -84,6 +81,35 @@ def romfs_validation(line: QtWidgets.QLineEdit):
 
 
 class DreadGameExportDialog(GameExportDialog, Ui_DreadGameExportDialog):
+    def get_path_to_ryujinx(self) -> Path:
+        ryujinx_path_tuple = ("Ryujinx", "mods", "contents", "010093801237c000")
+        current_system = platform.system()
+        if current_system == "Windows":
+            return Path(os.environ["APPDATA"], *ryujinx_path_tuple)
+        elif current_system == "Linux":
+            if self.linux_ryujinx_path == LinuxRyujinxPath.NATIVE:
+                base_config_path = QtCore.QStandardPaths.writableLocation(
+                    QtCore.QStandardPaths.StandardLocation.GenericConfigLocation
+                )
+            else:
+                base_config_path = str(
+                    Path(
+                        QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.HomeLocation),
+                        ".var",
+                        "app",
+                        "org.ryujinx.Ryujinx",
+                        "config",
+                    )
+                )
+            return Path(base_config_path, *ryujinx_path_tuple)
+        elif current_system == "Darwin":
+            return Path(
+                QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.GenericDataLocation),
+                *ryujinx_path_tuple,
+            )
+
+        raise ValueError("Unsupported platform")
+
     @classmethod
     def game_enum(cls):
         return RandovaniaGame.METROID_DREAD
@@ -154,10 +180,24 @@ class DreadGameExportDialog(GameExportDialog, Ui_DreadGameExportDialog):
         self.ftp_on_anonymous_check()
 
         # Output to Ryujinx
-        self.update_ryujinx_ui()
         self.tab_ryujinx.serialize_options = dict
         self.tab_ryujinx.restore_options = lambda p: None
         self.tab_ryujinx.is_valid = lambda: True
+
+        # Hide Linux Ryujinx controls on non-Linux
+        is_linux = platform.system() == "Linux"
+        for control_name in return_linux_only_controls():
+            widget: QtWidgets.QWidget = getattr(self, control_name)
+            widget.setVisible(is_linux)
+        if per_game.linux_ryujinx_path == LinuxRyujinxPath.NATIVE:
+            self.linux_native_radio.setChecked(True)
+        else:
+            self.linux_flatpak_radio.setChecked(True)
+        self.old_linux_ryujinx_path = self.get_path_to_ryujinx()
+        self.linux_native_radio.toggled.connect(self._on_update_linux_ryujinx_path)
+        self.linux_flatpak_radio.toggled.connect(self._on_update_linux_ryujinx_path)
+
+        self.update_ryujinx_ui()
 
         # Output to Custom
         self.custom_path_edit.textChanged.connect(self._on_custom_path_change)
@@ -218,6 +258,7 @@ class DreadGameExportDialog(GameExportDialog, Ui_DreadGameExportDialog):
             cosmetic_patches=per_game.cosmetic_patches,
             input_directory=self.input_file,
             target_platform=self.target_platform,
+            linux_ryujinx_path=self.linux_ryujinx_path,
             output_preference=output_preference,
         )
 
@@ -244,6 +285,11 @@ class DreadGameExportDialog(GameExportDialog, Ui_DreadGameExportDialog):
 
         self.output_tab_widget.setCurrentIndex(visible_tabs[0])
 
+    def _on_update_linux_ryujinx_path(self) -> None:
+        self.ryujinx_label.setText(self.ryujinx_label.text().replace(str(self.old_linux_ryujinx_path), "{mod_path}"))
+        self.old_linux_ryujinx_path = self.get_path_to_ryujinx()
+        self.update_ryujinx_ui()
+
     # Getters
     @property
     def input_file(self) -> Path:
@@ -259,6 +305,13 @@ class DreadGameExportDialog(GameExportDialog, Ui_DreadGameExportDialog):
             return DreadModPlatform.ATMOSPHERE
         else:
             return DreadModPlatform.RYUJINX
+
+    @property
+    def linux_ryujinx_path(self) -> LinuxRyujinxPath:
+        if self.linux_native_radio.isChecked():
+            return LinuxRyujinxPath.NATIVE
+        else:
+            return LinuxRyujinxPath.FLATPAK
 
     # Input file
 
@@ -317,7 +370,7 @@ class DreadGameExportDialog(GameExportDialog, Ui_DreadGameExportDialog):
         if supports_ryujinx():
             self.ryujinx_label.setText(
                 self.ryujinx_label.text().format(
-                    mod_path=get_path_to_ryujinx(),
+                    mod_path=self.get_path_to_ryujinx(),
                 )
             )
 
@@ -396,7 +449,7 @@ class DreadGameExportDialog(GameExportDialog, Ui_DreadGameExportDialog):
             post_export = None
 
         elif output_tab is self.tab_ryujinx:
-            output_path = get_path_to_ryujinx()
+            output_path = self.get_path_to_ryujinx()
             post_export = None
 
         elif output_tab is self.tab_ftp:

--- a/randovania/games/dread/gui/dialog/game_export_dialog.py
+++ b/randovania/games/dread/gui/dialog/game_export_dialog.py
@@ -83,31 +83,30 @@ def romfs_validation(line: QtWidgets.QLineEdit):
 class DreadGameExportDialog(GameExportDialog, Ui_DreadGameExportDialog):
     def get_path_to_ryujinx(self) -> Path:
         ryujinx_path_tuple = ("Ryujinx", "mods", "contents", "010093801237c000")
-        current_system = platform.system()
-        match current_system:
-            case "Windows":
+        match (platform.system(), self.linux_ryujinx_path):
+            case "Windows", _:
                 # TODO: double check what ryujinx actually uses for windows. I don't think it reads the Appdata env var
                 # but instead probably the value from QStandardPaths.
                 return Path(os.environ["APPDATA"], *ryujinx_path_tuple)
 
-            case "Linux":
-                if self.linux_ryujinx_path == LinuxRyujinxPath.NATIVE:
-                    base_config_path = QtCore.QStandardPaths.writableLocation(
-                        QtCore.QStandardPaths.StandardLocation.GenericConfigLocation
+            case "Linux", LinuxRyujinxPath.NATIVE:
+                base_config_path = QtCore.QStandardPaths.writableLocation(
+                    QtCore.QStandardPaths.StandardLocation.GenericConfigLocation
+                )
+                return Path(base_config_path, *ryujinx_path_tuple)
+            case "Linux", LinuxRyujinxPath.FLATPAK:
+                base_config_path = str(
+                    Path(
+                        QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.HomeLocation),
+                        ".var",
+                        "app",
+                        "org.ryujinx.Ryujinx",
+                        "config",
                     )
-                else:
-                    base_config_path = str(
-                        Path(
-                            QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.HomeLocation),
-                            ".var",
-                            "app",
-                            "org.ryujinx.Ryujinx",
-                            "config",
-                        )
-                    )
+                )
                 return Path(base_config_path, *ryujinx_path_tuple)
 
-            case "Darwin":
+            case "Darwin", _:
                 return Path(
                     QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.GenericDataLocation),
                     *ryujinx_path_tuple,

--- a/randovania/games/dread/gui/dialog/game_export_dialog.py
+++ b/randovania/games/dread/gui/dialog/game_export_dialog.py
@@ -84,29 +84,34 @@ class DreadGameExportDialog(GameExportDialog, Ui_DreadGameExportDialog):
     def get_path_to_ryujinx(self) -> Path:
         ryujinx_path_tuple = ("Ryujinx", "mods", "contents", "010093801237c000")
         current_system = platform.system()
-        if current_system == "Windows":
-            return Path(os.environ["APPDATA"], *ryujinx_path_tuple)
-        elif current_system == "Linux":
-            if self.linux_ryujinx_path == LinuxRyujinxPath.NATIVE:
-                base_config_path = QtCore.QStandardPaths.writableLocation(
-                    QtCore.QStandardPaths.StandardLocation.GenericConfigLocation
-                )
-            else:
-                base_config_path = str(
-                    Path(
-                        QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.HomeLocation),
-                        ".var",
-                        "app",
-                        "org.ryujinx.Ryujinx",
-                        "config",
+        match current_system:
+            case "Windows":
+                # TODO: double check what ryujinx actually uses for windows. I don't think it reads the Appdata env var
+                # but instead probably the value from QStandardPaths.
+                return Path(os.environ["APPDATA"], *ryujinx_path_tuple)
+
+            case "Linux":
+                if self.linux_ryujinx_path == LinuxRyujinxPath.NATIVE:
+                    base_config_path = QtCore.QStandardPaths.writableLocation(
+                        QtCore.QStandardPaths.StandardLocation.GenericConfigLocation
                     )
+                else:
+                    base_config_path = str(
+                        Path(
+                            QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.HomeLocation),
+                            ".var",
+                            "app",
+                            "org.ryujinx.Ryujinx",
+                            "config",
+                        )
+                    )
+                return Path(base_config_path, *ryujinx_path_tuple)
+
+            case "Darwin":
+                return Path(
+                    QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.GenericDataLocation),
+                    *ryujinx_path_tuple,
                 )
-            return Path(base_config_path, *ryujinx_path_tuple)
-        elif current_system == "Darwin":
-            return Path(
-                QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.GenericDataLocation),
-                *ryujinx_path_tuple,
-            )
 
         raise ValueError("Unsupported platform")
 

--- a/randovania/gui/ui_files/dread_game_export_dialog.ui
+++ b/randovania/gui/ui_files/dread_game_export_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>493</width>
-    <height>343</height>
+    <width>537</width>
+    <height>421</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -213,7 +213,31 @@
       <attribute name="title">
        <string>Ryujinx</string>
       </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <layout class="QVBoxLayout" name="horizontalLayout_2">
+       <item>
+        <layout class="QHBoxLayout" name="layout_linux_choice">
+         <item>
+          <widget class="QRadioButton" name="linux_flatpak_radio">
+           <property name="text">
+            <string>Use Flatpak Ryujinx folder</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="linux_native_radio">
+           <property name="text">
+            <string>Use native Ryujinx folder</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
        <item>
         <widget class="QLabel" name="ryujinx_label">
          <property name="text">

--- a/randovania/interface_common/persisted_options.py
+++ b/randovania/interface_common/persisted_options.py
@@ -196,6 +196,7 @@ _CONVERTER_FOR_VERSION = [
     _only_new_fields,  # added DebugConnectorBuilder's layout_uuid
     _only_new_fields,  # added Dread's music sliders
     _only_new_fields,  # added Dread's "Access Permanently Closed" alt-shield
+    _only_new_fields,  # added Dread Ryujinx export to Unix systems
 ]
 _CURRENT_OPTIONS_FILE_VERSION = migration_lib.get_version(_CONVERTER_FOR_VERSION)
 

--- a/test/games/dread/gui/test_dread_game_export_dialog.py
+++ b/test/games/dread/gui/test_dread_game_export_dialog.py
@@ -19,6 +19,7 @@ if typing.TYPE_CHECKING:
     from pathlib import Path
 
     import pytest_mock
+    from pytestqt.qtbot import QtBot
 
 
 @pytest.mark.parametrize("has_custom_path", [False, True])
@@ -344,7 +345,7 @@ def test_get_game_export_params_custom(skip_qtbot, tmp_path):
     )
 
 
-def test_linux_controls_changing(mocker: pytest_mock.MockerFixture, tmp_path: Path) -> None:
+def test_linux_controls_changing(skip_qtbot: QtBot, mocker: pytest_mock.MockerFixture, tmp_path: Path) -> None:
     # Setup
     mocker.patch("platform.system", return_value="Linux")
     options = MagicMock()

--- a/test/games/dread/gui/test_dread_game_export_dialog.py
+++ b/test/games/dread/gui/test_dread_game_export_dialog.py
@@ -176,7 +176,7 @@ def test_on_input_file_button(skip_qtbot, tmp_path, mocker):
 @pytest.mark.parametrize("mod_manager", [False, True])
 def test_get_game_export_params_sd_card(skip_qtbot, tmp_path, mocker, mod_manager):
     # Setup
-    mocker.patch("randovania.games.dread.gui.dialog.game_export_dialog.get_path_to_ryujinx")
+    mocker.patch("randovania.games.dread.gui.dialog.game_export_dialog.DreadGameExportDialog.get_path_to_ryujinx")
     mocker.patch("platform.system", return_value="Windows")
 
     mocker.patch(
@@ -227,9 +227,11 @@ def test_get_game_export_params_sd_card(skip_qtbot, tmp_path, mocker, mod_manage
 
 def test_get_game_export_params_ryujinx(skip_qtbot, tmp_path, mocker):
     # Setup
-    mocker.patch("platform.system", return_value="Windows")
     ryujinx_path = tmp_path.joinpath("ryujinx_mod")
-    mocker.patch("randovania.games.dread.gui.dialog.game_export_dialog.get_path_to_ryujinx", return_value=ryujinx_path)
+    mocker.patch(
+        "randovania.games.dread.gui.dialog.game_export_dialog.DreadGameExportDialog.get_path_to_ryujinx",
+        return_value=ryujinx_path,
+    )
 
     options = MagicMock()
     options.options_for_game.return_value = DreadPerGameOptions(


### PR DESCRIPTION
Flatpak (default):
![grafik](https://github.com/randovania/randovania/assets/38186597/0a005afa-b9ef-4e45-bb77-47ba25d47d30)

Native:
![grafik](https://github.com/randovania/randovania/assets/38186597/643ecf9c-3a24-4430-9580-af2261c9e13c)


I have not tested this on anything other than Linux

Fixes #5293 