### PR TITLE
Echoes - Add missing requirements to MSB connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: Movement (Intermediate) to get from the center platforms in Central Mining Station to the cannons using Space Jump Boots.
 - Added: Screw Attack from the cannons to get the item in Central Mining Station before the Pirate fight.
+- Added: Mining Station B - Room Center to Transit Station with Boost Ball, Bombs, BSJ (Intermediate), and Standable Terrain (Intermediate).
 - Fixed: The video link for the Expert Slope Jump in Central Mining Station now links to a working video.
 - Fixed: Mining Station B - Room Center to Transit Station now properly requires Boost Ball and Standable Terrain (Intermediate) for the No Space Jump Post-Puzzle path.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Movement (Intermediate) to get from the center platforms in Central Mining Station to the cannons using Space Jump Boots.
 - Added: Screw Attack from the cannons to get the item in Central Mining Station before the Pirate fight.
 - Fixed: The video link for the Expert Slope Jump in Central Mining Station now links to a working video.
-- Fixed: Mining Station B connection to Transit Station now properly requires Boost Ball and Standable Terrain (Intermediate).
+- Fixed: Mining Station B - Room Center to Transit Station now properly requires Boost Ball and Standable Terrain (Intermediate) for the No Space Jump Post-Puzzle path.
 
 ## [7.5.0] - 2024-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Movement (Intermediate) to get from the center platforms in Central Mining Station to the cannons using Space Jump Boots.
 - Added: Screw Attack from the cannons to get the item in Central Mining Station before the Pirate fight.
 - Fixed: The video link for the Expert Slope Jump in Central Mining Station now links to a working video.
+- Fixed: Mining Station B connection to Transit Station now properly requires Boost Ball and Standable Terrain (Intermediate).
 
 ## [7.5.0] - 2024-04-01
 

--- a/randovania/games/prime2/logic_database/Agon Wastes.json
+++ b/randovania/games/prime2/logic_database/Agon Wastes.json
@@ -2273,7 +2273,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=G6Sq--yB5UY",
+                                            "comment": "https://youtu.be/G6Sq--yB5UY",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -2402,7 +2402,7 @@
                                                                                     {
                                                                                         "type": "and",
                                                                                         "data": {
-                                                                                            "comment": null,
+                                                                                            "comment": "BSJ onto the blade and ledge then jump to door: https://youtu.be/LUCs9Pn194o",
                                                                                             "items": [
                                                                                                 {
                                                                                                     "type": "resource",
@@ -2443,7 +2443,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": null,
+                                                                    "comment": "Boost up the half pipe then reach the standable with Bombs",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",
@@ -2466,10 +2466,61 @@
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "BombJump",
-                                                                                "amount": 3,
+                                                                                "type": "items",
+                                                                                "name": "Boost",
+                                                                                "amount": 1,
                                                                                 "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "StandableTerrain",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "or",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "and",
+                                                                                        "data": {
+                                                                                            "comment": "Bomb Jump: https://youtu.be/Dlrx1e4oE6c?t=17",
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "tricks",
+                                                                                                        "name": "BombJump",
+                                                                                                        "amount": 3,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "and",
+                                                                                        "data": {
+                                                                                            "comment": "BSJ: https://youtu.be/Dlrx1e4oE6c?t=33",
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "tricks",
+                                                                                                        "name": "BSJ",
+                                                                                                        "amount": 2,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         }
                                                                     ]
@@ -2484,7 +2535,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=-Midfbv_BMU",
+                                            "comment": "https://youtu.be/-Midfbv_BMU",
                                             "items": [
                                                 {
                                                     "type": "template",
@@ -2505,7 +2556,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=aNdF-X_OUH8&list=PLevfta9o_QKWuQNXAnmBXtzW4nmU5VLyN&index=44",
+                                            "comment": "https://youtu.be/aNdF-X_OUH8",
                                             "items": [
                                                 {
                                                     "type": "resource",

--- a/randovania/games/prime2/logic_database/Agon Wastes.txt
+++ b/randovania/games/prime2/logic_database/Agon Wastes.txt
@@ -365,7 +365,7 @@ Extra - in_dark_aether: False
       Morph Ball and Power Bomb
   > Door to Transit Station
       Any of the following:
-          # https://www.youtube.com/watch?v=G6Sq--yB5UY
+          # https://youtu.be/G6Sq--yB5UY
           Morph Ball Bomb and Morph Ball and Space Jump Boots and Bomb Space Jump (Advanced)
           All of the following:
               After Mining Station B Portal Opened
@@ -375,11 +375,19 @@ Extra - in_dark_aether: False
                       Space Jump Boots
                       Any of the following:
                           Slope Jump (Intermediate) and Standable Terrain (Intermediate)
+                          # BSJ onto the blade and ledge then jump to door: https://youtu.be/LUCs9Pn194o
                           Morph Ball Bomb and Morph Ball and Bomb Space Jump (Intermediate)
-                  Morph Ball Bomb and Morph Ball and Bomb Jump (Advanced)
-          # https://www.youtube.com/watch?v=-Midfbv_BMU
+                  All of the following:
+                      # Boost up the half pipe then reach the standable with Bombs
+                      Morph Ball Bomb and Boost Ball and Morph Ball and Standable Terrain (Intermediate)
+                      Any of the following:
+                          # Bomb Jump: https://youtu.be/Dlrx1e4oE6c?t=17
+                          Bomb Jump (Advanced)
+                          # BSJ: https://youtu.be/Dlrx1e4oE6c?t=33
+                          Bomb Space Jump (Intermediate)
+          # https://youtu.be/-Midfbv_BMU
           Standable Terrain (Advanced) and Use Screw Attack (Space Jump)
-          # https://www.youtube.com/watch?v=aNdF-X_OUH8&list=PLevfta9o_QKWuQNXAnmBXtzW4nmU5VLyN&index=44
+          # https://youtu.be/aNdF-X_OUH8
           Scan Visor and Space Jump Boots and Before Mining Station B Portal Opened and Combat/Scan Dash (Expert) and Slope Jump (Expert) and Standable Terrain (Expert)
   > Door to Mine Shaft
       Any of the following:


### PR DESCRIPTION
Fixes #4806 

The connection in Mining Station B to Transit Station with just Bombs was missing Boost Ball as well as Standable Terrain. It's was probably forgotten about when the path was added.

Also shortens the video links on that one connection. I could have fixed the others but the whole DB needs fixing, so I left it.