### PR TITLE
CS: Clean up last cave

### DIFF
--- a/randovania/games/cave_story/logic_database/Last Cave.json
+++ b/randovania/games/cave_story/logic_database/Last Cave.json
@@ -38,8 +38,42 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Balcony (Pre-Bosses)": {
-                            "type": "template",
-                            "data": "Has Weapon"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Has Weapon"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 5,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -70,8 +104,42 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Plantation": {
-                            "type": "template",
-                            "data": "Has Weapon"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Has Weapon"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 5,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 }
@@ -149,31 +217,28 @@
                     "valid_starting_location": false,
                     "event_name": "eventRedDemon",
                     "connections": {
-                        "Door to Plantation": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "booster2",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
                         "Pickup (Red Demon Boss)": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "booster2",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         },
-                        "Door to Balcony (Pre-Bosses)": {
-                            "type": "resource",
+                        "Before Red Demon": {
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "booster2",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "booster2",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -182,8 +247,8 @@
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
-                        "x": 1176.39,
-                        "y": 791.88,
+                        "x": 1175.431331953071,
+                        "y": 825.7318959567835,
                         "z": 0.0
                     },
                     "description": "",
@@ -197,22 +262,21 @@
                     "pickup_index": 29,
                     "location_category": "minor",
                     "connections": {
-                        "Door to Plantation": {
-                            "type": "resource",
+                        "Before Red Demon": {
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "booster2",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Door to Balcony (Pre-Bosses)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "booster2",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "booster2",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -270,8 +334,8 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 1212.183319100484,
-                        "y": 802.6112534396052,
+                        "x": 1225.6919159467886,
+                        "y": 885.1307679493586,
                         "z": 0.0
                     },
                     "description": "",
@@ -282,12 +346,29 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Door to Plantation": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "eventRedDemon",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "eventRedDemon",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "booster2",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Event - Red Demon": {
@@ -296,74 +377,186 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Kill Bosses"
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Item requirements",
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "template",
+                                                    "data": "Can Kill Bosses"
+                                                },
+                                                {
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "BossMissiles",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "comment": "Kill with Supers",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "BossMissiles",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "supers",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missile",
+                                                                    "amount": 8,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "supers",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "missile",
-                                                        "amount": 8,
-                                                        "negate": false
+                                                        "comment": "Kill with Missiles",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "BossMissiles",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missiles",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missile",
+                                                                    "amount": 18,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Energy requirements",
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 28,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
                                                         "type": "tricks",
-                                                        "name": "BossMissiles",
-                                                        "amount": 3,
+                                                        "name": "Combat",
+                                                        "amount": 4,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "missiles",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 22,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "missile",
-                                                        "amount": 18,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 16,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 8,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -373,12 +566,29 @@
                             }
                         },
                         "Door to Balcony (Pre-Bosses)": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "eventRedDemon",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "eventRedDemon",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "booster2",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -776,7 +986,15 @@
                                                                                                                             "type": "and",
                                                                                                                             "data": {
                                                                                                                                 "comment": "TODO - 100% requirements",
-                                                                                                                                "items": []
+                                                                                                                                "items": [
+                                                                                                                                    {
+                                                                                                                                        "type": "and",
+                                                                                                                                        "data": {
+                                                                                                                                            "comment": null,
+                                                                                                                                            "items": []
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
                                                                                                                             }
                                                                                                                         }
                                                                                                                     ]
@@ -960,7 +1178,7 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Event - Misery": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -1033,6 +1251,111 @@
                                                         "name": "missile",
                                                         "amount": 31,
                                                         "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Item requirements",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Kill Bosses"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Kill with Supers",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "BossMissiles",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "supers",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missile",
+                                                                    "amount": 13,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Kill with Missiles",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "BossMissiles",
+                                                                    "amount": 4,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missiles",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missile",
+                                                                    "amount": 31,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Health requirements",
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "TODO: health",
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": []
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -1168,79 +1491,110 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Event - Doctor": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Kill Bosses"
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Item requirements",
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "template",
+                                                    "data": "Can Kill Bosses"
+                                                },
+                                                {
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "BossMissiles",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "comment": "Kill with Supers",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "BossMissiles",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "supers",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missile",
+                                                                    "amount": 16,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "missiles",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "missile",
-                                                        "amount": 36,
-                                                        "negate": false
+                                                        "comment": "Kill with Missiles",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "BossMissiles",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missiles",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missile",
+                                                                    "amount": 36,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Health requirements",
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "BossMissiles",
-                                                        "amount": 3,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "supers",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "missile",
-                                                        "amount": 16,
-                                                        "negate": false
+                                                        "comment": "TODO: energy",
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": []
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -1349,79 +1703,110 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Event - Undead Core": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Kill Bosses"
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Item requirements",
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "template",
+                                                    "data": "Can Kill Bosses"
+                                                },
+                                                {
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "BossMissiles",
-                                                        "amount": 3,
-                                                        "negate": false
+                                                        "comment": "Kill with Supers",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "BossMissiles",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "supers",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missile",
+                                                                    "amount": 18,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "supers",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "missile",
-                                                        "amount": 18,
-                                                        "negate": false
+                                                        "comment": "Kill with Missiles",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "BossMissiles",
+                                                                    "amount": 4,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missiles",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "missile",
+                                                                    "amount": 42,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "TODO: Energy requirements",
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "BossMissiles",
-                                                        "amount": 4,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "missiles",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "missile",
-                                                        "amount": 42,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": []
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -2565,35 +2950,47 @@
                                 "comment": null,
                                 "items": [
                                     {
+                                        "type": "template",
+                                        "data": "Has Flight"
+                                    },
+                                    {
                                         "type": "or",
                                         "data": {
-                                            "comment": "No Missile tricks because holy moly 3808 HP absolutely dwarfs every other boss in the game lol",
+                                            "comment": "Item requirements",
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Kill Bosses"
-                                                },
-                                                {
-                                                    "type": "and",
+                                                    "type": "or",
                                                     "data": {
-                                                        "comment": "Shoot with Curly's Nemesis",
+                                                        "comment": "No Missile tricks because holy moly 3808 HP absolutely dwarfs every other boss in the game lol",
                                                         "items": [
                                                             {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "pacifist",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Can Kill Bosses"
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "events",
-                                                                    "name": "eventCurly3",
-                                                                    "amount": 1,
-                                                                    "negate": false
+                                                                    "comment": "Shoot with Curly's Nemesis",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "pacifist",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "events",
+                                                                                "name": "eventCurly3",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -2603,13 +3000,9 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Has Flight"
-                                    },
-                                    {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Triggering Ballos",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -2636,6 +3029,21 @@
                                                         "name": "hundo",
                                                         "amount": 1,
                                                         "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "TODO: Energy requirements",
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": []
                                                     }
                                                 }
                                             ]

--- a/randovania/games/cave_story/logic_database/Last Cave.txt
+++ b/randovania/games/cave_story/logic_database/Last Cave.txt
@@ -6,13 +6,17 @@ Extra - in_dark_aether: False
   * Layers: default
   * Door to Plantation/Door to Final Cave
   > Door to Balcony (Pre-Bosses)
-      Has Weapon
+      All of the following:
+          Has Weapon
+          Combat (Beginner) or Normal Damage ≥ 5
 
 > Door to Balcony (Pre-Bosses); Heals? False
   * Layers: default
   * Door to Balcony (Pre-Bosses)/Door to Final Cave
   > Door to Plantation
-      Has Weapon
+      All of the following:
+          Has Weapon
+          Combat (Beginner) or Normal Damage ≥ 5
 
 ----------------
 Last Cave (Hidden)
@@ -27,20 +31,16 @@ Extra - in_dark_aether: False
 > Event - Red Demon; Heals? False
   * Layers: default
   * Event Defeated Red Demon
-  > Door to Plantation
-      Booster 2.0
   > Pickup (Red Demon Boss)
-      Booster 2.0
-  > Door to Balcony (Pre-Bosses)
+      Trivial
+  > Before Red Demon
       Booster 2.0
 
 > Pickup (Red Demon Boss); Heals? False
   * Layers: default
   * Pickup 29; Category? Minor
   * Extra - event: 0300
-  > Door to Plantation
-      Booster 2.0
-  > Door to Balcony (Pre-Bosses)
+  > Before Red Demon
       Booster 2.0
 
 > Door to Balcony (Pre-Bosses); Heals? False
@@ -52,14 +52,23 @@ Extra - in_dark_aether: False
 > Before Red Demon; Heals? False
   * Layers: default
   > Door to Plantation
-      After Defeated Red Demon
+      Booster 2.0 and After Defeated Red Demon
   > Event - Red Demon
       Any of the following:
-          Can Kill Bosses
-          Missiles ≥ 8 and Super Missile Launcher and Kill Bosses with Missiles (Intermediate)
-          Missiles ≥ 18 and Missile Launcher and Kill Bosses with Missiles (Advanced)
+          Any of the following:
+              # Item requirements
+              Can Kill Bosses
+              # Kill with Supers
+              Missiles ≥ 8 and Super Missile Launcher and Kill Bosses with Missiles (Intermediate)
+              # Kill with Missiles
+              Missiles ≥ 18 and Missile Launcher and Kill Bosses with Missiles (Advanced)
+          Any of the following:
+              # Energy requirements
+              Combat (Beginner) or Combat (Expert) or Normal Damage ≥ 22 or Normal Damage ≥ 28
+              Combat (Intermediate) and Normal Damage ≥ 16
+              Combat (Advanced) and Normal Damage ≥ 8
   > Door to Balcony (Pre-Bosses)
-      After Defeated Red Demon
+      Booster 2.0 and After Defeated Red Demon
 
 ----------------
 Balcony (Pre-Bosses)
@@ -146,10 +155,18 @@ Extra - in_dark_aether: False
   * Layers: default
   * Entrance to Balcony (Pre-Bosses)/Exit to Throne Room
   > Event - Misery
-      Any of the following:
-          Can Kill Bosses
-          Missiles ≥ 13 and Super Missile Launcher and Kill Bosses with Missiles (Advanced)
-          Missiles ≥ 31 and Missile Launcher and Kill Bosses with Missiles (Expert)
+      All of the following:
+          Missiles ≥ 13 and Missiles ≥ 31 and Missile Launcher and Super Missile Launcher and Kill Bosses with Missiles (Advanced) and Kill Bosses with Missiles (Expert) and Can Kill Bosses
+          Any of the following:
+              # Item requirements
+              Can Kill Bosses
+              # Kill with Supers
+              Missiles ≥ 13 and Super Missile Launcher and Kill Bosses with Missiles (Advanced)
+              # Kill with Missiles
+              Missiles ≥ 31 and Missile Launcher and Kill Bosses with Missiles (Expert)
+          Any of the following:
+              # Health requirements
+              Trivial
 
 > Exit to Balcony (Post-Bosses); Heals? False
   * Layers: default
@@ -175,10 +192,17 @@ Extra - in_dark_aether: False
   * Layers: default
   * H/V Trigger to Throne Room/H/V Trigger to The King's Table
   > Event - Doctor
-      Any of the following:
-          Can Kill Bosses
-          Missiles ≥ 36 and Missile Launcher and Kill Bosses with Missiles (Intermediate)
-          Missiles ≥ 16 and Super Missile Launcher and Kill Bosses with Missiles (Advanced)
+      All of the following:
+          Any of the following:
+              # Item requirements
+              Can Kill Bosses
+              # Kill with Supers
+              Missiles ≥ 16 and Super Missile Launcher and Kill Bosses with Missiles (Advanced)
+              # Kill with Missiles
+              Missiles ≥ 36 and Missile Launcher and Kill Bosses with Missiles (Intermediate)
+          Any of the following:
+              # Health requirements
+              Trivial
 
 > H/V Trigger to Black Space; Heals? False
   * Layers: default
@@ -200,10 +224,17 @@ Extra - in_dark_aether: False
   * Layers: default
   * H/V Trigger to The King's Table/H/V Trigger to Black Space
   > Event - Undead Core
-      Any of the following:
-          Can Kill Bosses
-          Missiles ≥ 18 and Super Missile Launcher and Kill Bosses with Missiles (Advanced)
-          Missiles ≥ 42 and Missile Launcher and Kill Bosses with Missiles (Expert)
+      All of the following:
+          Any of the following:
+              # Item requirements
+              Can Kill Bosses
+              # Kill with Supers
+              Missiles ≥ 18 and Super Missile Launcher and Kill Bosses with Missiles (Advanced)
+              # Kill with Missiles
+              Missiles ≥ 42 and Missile Launcher and Kill Bosses with Missiles (Expert)
+          Any of the following:
+              # TODO: Energy requirements
+              Trivial
 
 ----------------
 Balcony (Post-Bosses)
@@ -393,10 +424,13 @@ Extra - in_dark_aether: False
       All of the following:
           Has Flight
           Any of the following:
-              # No Missile tricks because holy moly 3808 HP absolutely dwarfs every other boss in the game lol
-              Can Kill Bosses
-              # Shoot with Curly's Nemesis
-              After Picked up Curly (Hell) and Pacifist Strats (Beginner)
+              # Item requirements
+              Any of the following:
+                  # No Missile tricks because holy moly 3808 HP absolutely dwarfs every other boss in the game lol
+                  Can Kill Bosses
+                  # Shoot with Curly's Nemesis
+                  After Picked up Curly (Hell) and Pacifist Strats (Beginner)
+          # Triggering Ballos
           Enabled All Bosses or Enabled Best Ending or Enabled 100%
 
 > Event - Best Ending; Heals? False


### PR DESCRIPTION
Draft until next release
I really would like to have health requirements for final bosses, but they're difficult to figure out properly, because you dont have any opportunity to full heal after misery/doctor/undead core and heavy press/ballos.

That said, I'm pretty sure the only thing where something like that might matter would be entrance rando. So could maybe theoreticaly only have the health reqs on undead core + ballos. 