### PR TITLE
Sentry: add more tags

### DIFF
--- a/randovania/games/cave_story/exporter/game_exporter.py
+++ b/randovania/games/cave_story/exporter/game_exporter.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from caver import patcher as caver_patcher
 from caver.patcher import CSPlatform
 
+from randovania import monitoring
 from randovania.exporter.game_exporter import GameExporter, GameExportParams
 from randovania.games.game import RandovaniaGame
 from randovania.lib import json_lib, status_update_lib
@@ -60,6 +61,7 @@ class CSGameExporter(GameExporter):
             new_patch["mychar"] = str(RandovaniaGame.CAVE_STORY.data_path.joinpath(patch_data["mychar"]))
 
         new_patch["platform"] = export_params.platform.value
+        monitoring.set_tag("cs_platform", new_patch["platform"])
         try:
             caver_patcher.patch_files(new_patch, export_params.output_path, export_params.platform, progress_update)
         finally:

--- a/randovania/games/dread/exporter/game_exporter.py
+++ b/randovania/games/dread/exporter/game_exporter.py
@@ -74,6 +74,7 @@ class DreadGameExporter(GameExporter):
         patch_data["mod_compatibility"] = export_params.target_platform.value
         patch_data["mod_category"] = "romfs" if export_params.use_exlaunch else "pkg"
         monitoring.set_tag("dread_mod_category", patch_data["mod_category"])
+        monitoring.set_tag("dread_target_platform", patch_data["mod_compatibility"])
 
         from open_dread_rando.version import version as open_dread_rando_version
 

--- a/randovania/games/prime1/exporter/game_exporter.py
+++ b/randovania/games/prime1/exporter/game_exporter.py
@@ -179,6 +179,8 @@ class PrimeGameExporter(GameExporter):
         export_params.cache_path.mkdir(parents=True, exist_ok=True)
         cache_dir = os.fspath(export_params.cache_path)
 
+        monitoring.set_tag("prime_output_format", output_file.suffix)
+
         import py_randomprime
         from open_prime_rando.dol_patching import all_prime_dol_patches
         from ppc_asm import assembler

--- a/randovania/games/samus_returns/exporter/game_exporter.py
+++ b/randovania/games/samus_returns/exporter/game_exporter.py
@@ -70,6 +70,9 @@ class MSRGameExporter(GameExporter):
         assert isinstance(export_params, MSRGameExportParams)
         export_params.output_path.mkdir(parents=True, exist_ok=True)
 
+        monitoring.set_tag("msr_target_platform", export_params.target_platform.value)
+        monitoring.set_tag("msr_target_version", export_params.target_version.value)
+
         from open_samus_returns_rando.version import version as open_samus_returns_rando_version
 
         text_patches = patch_data["text_patches"]

--- a/randovania/interface_common/generator_frontend.py
+++ b/randovania/interface_common/generator_frontend.py
@@ -40,11 +40,16 @@ def generate_layout(
         games = {preset.game.short_name for preset in parameters.presets}
         span.set_tag("num_worlds", parameters.world_count)
         span.set_tag("game", next(iter(games)) if len(games) == 1 else "cross-game")
+        span.set_tag("amount_of_games", len(games))
+        span.set_tag("unique_games", sorted(set(games)))
         span.set_tag("attempts", retries if retries is not None else generator.DEFAULT_ATTEMPTS)
         span.set_tag("validate_after", options.advanced_validate_seed_after)
         span.set_tag(
             "dock_rando",
             any(preset.configuration.dock_rando.mode == DockRandoMode.DOCKS for preset in parameters.presets),
+        )
+        span.set_tag(
+            "minimal_logic", any(preset.configuration.trick_level.minimal_logic for preset in parameters.presets)
         )
 
         extra_args = {

--- a/randovania/monitoring/__init__.py
+++ b/randovania/monitoring/__init__.py
@@ -134,6 +134,7 @@ def client_init() -> None:
     _init(False, "client", exclude_server_name=True)
 
     sentry_sdk.set_tag("frozen", randovania.is_frozen())
+    sentry_sdk.set_tag("cpu.architecture", platform.machine())
 
     # Ignore the "packet queue is empty, aborting" message
     # It causes a disconnect, but we smoothly reconnect in that case.


### PR DESCRIPTION
I don't think this needs a changelog entry
tldr: 
- track how long it takes to open a game page
- track noteworthy settings for exporters
- track the CPU arch. 
- track a few more generation settings