### PR TITLE
Fusion: remove export accept button

### DIFF
--- a/randovania/gui/ui_files/fusion_game_export_dialog.ui
+++ b/randovania/gui/ui_files/fusion_game_export_dialog.ui
@@ -14,13 +14,6 @@
    <string>Game Patching</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
-    <widget class="QPushButton" name="accept_button">
-     <property name="text">
-      <string>Accept</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="description_label">
      <property name="sizePolicy">
@@ -55,7 +48,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="2" column="0" colspan="2">
     <widget class="QPushButton" name="cancel_button">
      <property name="text">
       <string>Cancel</string>


### PR DESCRIPTION
The accept buttons starts exporting which errors due to not implemented.

So we just remove the accept button.