### PR TITLE
Remove Door as start location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: Door Lock randomizer has been added.
 - Fixed: If no seed was exported at a previous start of Randovania, the export window now shows the correct title ID in the output path for NTSC without having to switch to PAL and back to NTSC.
+- Fixed: Removed an incorrect start location from Area 4 Central Caves, which failed when exporting the game.
 
 #### Logic Database
 

--- a/randovania/games/samus_returns/logic_database/Area 4 Central Caves.json
+++ b/randovania/games/samus_returns/logic_database/Area 4 Central Caves.json
@@ -3856,7 +3856,7 @@
                         "actor_name": "Door007",
                         "actor_type": "doorchargecharge"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 4 Central Caves",

--- a/randovania/games/samus_returns/logic_database/Area 4 Central Caves.txt
+++ b/randovania/games/samus_returns/logic_database/Area 4 Central Caves.txt
@@ -556,7 +556,7 @@ Transit Tunnel
 Extra - total_boundings: {'x1': 6500.0, 'x2': 9050.0, 'y1': -6400.0, 'y2': -3000.0}
 Extra - polygon: [[6500.0, -3000.0], [6500.0, -6400.0], [9050.0, -6400.0], [9050.0, -4500.0], [8100.0, -4500.0], [8100.0, -3000.0]]
 Extra - asset_id: collision_camera_010
-> Door to Caves Intersection Terminal; Heals? False; Spawn Point; Default Node
+> Door to Caves Intersection Terminal; Heals? False; Default Node
   * Layers: default
   * Charge Beam Door to Caves Intersection Terminal/Door to Transit Tunnel
   * Extra - actor_name: Door007


### PR DESCRIPTION
Dunno if this goes to `Logic database` section in the changelog.
Logically it is fine to start anywhere but at the same time it's just wrong to start in a door and it fails during patch time not generaton time.