### PR TITLE
Main deck: comment and trick (video) pass

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -70,7 +70,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "Weapon Requirements",
+                                            "comment": "Weapon Requirements - TODO: more beams",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -96,7 +96,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Energy requirements",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -320,7 +320,7 @@
                         "y": 173.43,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "TODO: revise how this node gets into play",
                     "layers": [
                         "default"
                     ],
@@ -657,6 +657,13 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Other to Spitter Speedway": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -716,13 +723,34 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Power Bombs"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Skip collecting the item. Break PB blocks first, then reload the room: https://www.youtube.com/watch?v=2WbnkPhd7tk",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Power Bombs"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Bounce in Ball"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Shinespark and spam jump at the ceiling: https://www.youtube.com/watch?v=QpbgjolExgE",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -745,18 +773,9 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "misc",
-                                                        "name": "DoorLockRando",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
                                                         "type": "tricks",
                                                         "name": "ShinesparkTrick",
-                                                        "amount": 3,
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 }
@@ -839,19 +858,44 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
+                        "Pickup (Hidden Missile Tank)": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Power Bombs"
+                                    }
+                                ]
+                            }
+                        },
                         "Door to Docking Bay Shaft": {
                             "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Skip collecting the item. Break PB blocks first, then reload the room.",
                                             "items": [
                                                 {
                                                     "type": "template",
                                                     "data": "Can Use Power Bombs"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Bounce in Ball"
                                                 }
                                             ]
                                         }
@@ -859,7 +903,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Speedboost from Spitter Speedway",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -868,15 +912,6 @@
                                                         "name": "SpeedBooster",
                                                         "amount": 1,
                                                         "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "misc",
-                                                        "name": "DoorLockRando",
-                                                        "amount": 1,
-                                                        "negate": true
                                                     }
                                                 },
                                                 {
@@ -1564,8 +1599,8 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Missiles",
+                                            "type": "events",
+                                            "name": "MainDeckOperationsMissileShield",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -1615,8 +1650,8 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Missiles",
+                                            "type": "events",
+                                            "name": "MainDeckOperationsMissileShield",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -1629,6 +1664,23 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Event - Missile Shield": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Missiles",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -1738,7 +1790,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Shinespark from adjacent room: https://www.youtube.com/watch?v=GX6K70StdeY",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -1787,6 +1839,27 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Single Wall Jump",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Screw Single Walljump"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "WallJump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -1808,7 +1881,7 @@
                         "y": 400.0,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "This door is currently an event door and thus always Level-0",
                     "layers": [
                         "default"
                     ],
@@ -1913,7 +1986,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "SA-X Requirements",
+                                            "comment": "SA-X Requirements - TODO: revise these. iirc plasma isnt needed anymore.",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -1965,7 +2038,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "Core-X Requirements",
+                                            "comment": "Core-X Requirements - TODO: how many missiles?",
                                             "items": [
                                                 {
                                                     "type": "template",
@@ -2170,7 +2243,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Dodging Requirements",
+                                            "comment": "Dodging Requirements - TODO: how does screw attack help?",
                                             "items": [
                                                 {
                                                     "type": "or",
@@ -2223,6 +2296,31 @@
                                         }
                                     }
                                 ]
+                            }
+                        }
+                    }
+                },
+                "Event - Missile Shield": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 555.92,
+                        "y": 404.7,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "MainDeckOperationsMissileShield",
+                    "connections": {
+                        "Door to Operations Deck Navigation Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -2416,18 +2514,26 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Hi-Jump",
-                                                                    "amount": 1,
-                                                                    "negate": false
+                                                                    "comment": "Intended method",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Hi-Jump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": "https://discord.com/channels/119665192110915584/1205560315652349962/1210970374741823499",
+                                                                    "comment": "HJ-Less: https://www.youtube.com/watch?v=AUkhZE_5CbE",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",
@@ -2807,7 +2913,7 @@
                         "Door to Restricted Corridor": {
                             "type": "and",
                             "data": {
-                                "comment": "You can diagonally spark into the corner and WJ/SJ to item then go back down, the reqs have to be here though",
+                                "comment": "You can get into the cage and get the item without shinesparking all the way up. The reqs have to be here though",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -2819,27 +2925,51 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "ShinesparkTrick",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Knowledge",
-                                            "amount": 4,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Shinespark into the corner",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "ShinesparkTrick",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Jump mid-speedboost: https://www.youtube.com/watch?v=u3xzqtz6Gro",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Get to the item while in the cage",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -2935,7 +3065,7 @@
                         "Pickup (Power Bomb Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": "Check the connection from item to restricted corridor for way to only go halfway up",
+                                "comment": "Check the connection from item to restricted corridor for way to only go halfway up. Can be revised after remote activation nodes",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -3147,7 +3277,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=EiFFpvNaT_A",
+                                            "comment": "Shinespark and recharge in Hornoad Hallway",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -3191,22 +3321,44 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "ShinesparkTrick",
-                                                                    "amount": 5,
-                                                                    "negate": false
+                                                                    "comment": "HJ-less: https://www.youtube.com/watch?v=cjf9wNjAbEY",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "ShinesparkTrick",
+                                                                                "amount": 5,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "WallJump",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": null,
+                                                                    "comment": "With HJ: https://www.youtube.com/watch?v=lDKp1H8k7oM",
                                                                     "items": [
                                                                         {
-                                                                            "type": "template",
-                                                                            "data": "Can Climb High Jump Wall"
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Hi-Jump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
                                                                         },
                                                                         {
                                                                             "type": "resource",
@@ -3216,11 +3368,29 @@
                                                                                 "amount": 4,
                                                                                 "negate": false
                                                                             }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "WallJump",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
                                                                         }
                                                                     ]
                                                                 }
                                                             }
                                                         ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "L0Locks",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -3434,7 +3604,7 @@
                     "valid_starting_location": false,
                     "event_name": "MainDeckPBGeron",
                     "connections": {
-                        "Door to Habitation Storage": {
+                        "Door to Station Entrance": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4111,7 +4281,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Shinespark from the Navigation Station: https://www.youtube.com/watch?v=QcD2-t9UDrg",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -4127,17 +4297,8 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "ShinesparkTrick",
-                                                        "amount": 2,
+                                                        "amount": 3,
                                                         "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "misc",
-                                                        "name": "DoorLockRando",
-                                                        "amount": 1,
-                                                        "negate": true
                                                     }
                                                 },
                                                 {
@@ -4212,7 +4373,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Speedboost from other room",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -4239,6 +4400,15 @@
                                                         "name": "EntranceRando",
                                                         "amount": 1,
                                                         "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "L0Locks",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -5638,8 +5808,87 @@
                                 "comment": null,
                                 "items": [
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "MainDeckMaintainanceGeronUpper",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Upper Maintainance Geron": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
                                         "type": "template",
                                         "data": "Can Kill Geron"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Shinespark from Operations Deck: https://www.youtube.com/watch?v=Y3k5lGKTX4Y",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpeedBooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "ShinesparkTrick",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLockRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "L0Locks",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "MainDeckOperationsMissileShield",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -5723,8 +5972,87 @@
                                 "comment": null,
                                 "items": [
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "MainDeckMaintainanceGeronLower",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Lower Maintainance Geron": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
                                         "type": "template",
                                         "data": "Can Kill Geron"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Shinespark from Main Deck Entrance: https://www.youtube.com/watch?v=dWJXG-nGo6A",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpeedBooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLockRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "L0Locks",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "ShinesparkTrick",
+                                                        "amount": 5,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "WallJump",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -5768,10 +6096,77 @@
                                 "comment": null,
                                 "items": [
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "MainDeckMaintainanceGeronLower",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Lower Maintainance Geron": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
                                         "type": "template",
                                         "data": "Can Kill Geron"
                                     }
                                 ]
+                            }
+                        }
+                    }
+                },
+                "Event - Lower Maintainance Geron": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 182.4,
+                        "y": 336.35,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "MainDeckMaintainanceGeronLower",
+                    "connections": {
+                        "Door to Crew Quarters West": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Upper Maintainance Geron": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 221.09430438842202,
+                        "y": 1176.5378151260504,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "MainDeckMaintainanceGeronUpper",
+                    "connections": {
+                        "Other to Operations Deck": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -6173,7 +6568,7 @@
                         "Event - Arachnus": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "FIXME: add health requirements once these dont prevent missile start",
                                 "items": [
                                     {
                                         "type": "or",
@@ -6201,11 +6596,11 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 586.4340602284527,
-                        "y": 275.190031152648,
+                        "x": 586.43,
+                        "y": 275.19,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "FIXME: The connections to return back here technically arent trivial, but are\ncurrently assumed until a few generator issues have been figured out.",
                     "layers": [
                         "default"
                     ],
@@ -6917,8 +7312,37 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Power Bombs"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Destroy Blocks",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Power Bombs"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "PBs only requires two because one doesn't destroy all of them.",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "PowerBombs",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Bombs"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "or",
@@ -7251,6 +7675,166 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
+                        "Other to Silo Tunnel": {
+                            "type": "and",
+                            "data": {
+                                "comment": "Charge shinespark from Auxilary Power Station: https://www.youtube.com/watch?v=vVG5YNwzGjw",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "SpeedBooster",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "EntranceRando",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Open the gate. Without Charge, the shot must be precisely timed. With Charge, just let go of beam while in the transition.",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "ChargeBeam",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "WideBeam",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Get high enough to spark",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Hi-Jump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "WallJump",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Get into tunnel",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "MidAirMorph",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Jump, then shoot vine below so you can grab the ledge",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Bounce in Ball"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "Nettori",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "ShinesparkTrick",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Door to Silo Save Room": {
                             "type": "and",
                             "data": {
@@ -7364,7 +7948,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Shinespark from Save Station: https://www.youtube.com/watch?v=x7CqxW4JyJ4",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -7391,41 +7975,6 @@
                                                         "name": "EntranceRando",
                                                         "amount": 1,
                                                         "negate": true
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "misc",
-                                                        "name": "DoorLockRando",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": "Needed to break the vines",
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "WaveBeam",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "WideBeam",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
                                                     }
                                                 }
                                             ]
@@ -7571,21 +8120,29 @@
                                         "data": "Can Kill Tough Beam-Resistant Enemy"
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "Combat",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "SpaceJump",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": "Dodge Pirates: https://www.youtube.com/watch?v=QAffTKp5seU",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpaceJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -7634,7 +8191,7 @@
                         "Beside Pickup": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "Jump over the item",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -7682,21 +8239,29 @@
                                         "data": "Can Kill Tough Beam-Resistant Enemy"
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "Combat",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "SpaceJump",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": "Dodge Pirates: https://www.youtube.com/watch?v=u8_gclW4-gQ",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpaceJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -7705,7 +8270,7 @@
                         "Other to Silo Scaffolding": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "Jump over the item",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -7807,37 +8372,84 @@
                         "Beside Pickup": {
                             "type": "or",
                             "data": {
-                                "comment": null,
+                                "comment": "Get past pirates",
                                 "items": [
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Kill them",
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Kill Tough Beam-Resistant Enemy"
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "ScrewAttack",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "and",
                                                     "data": {
-                                                        "comment": "Expected dmg trickless",
+                                                        "comment": "Via normal methods. Expects you to take damage or avoid their shots.",
                                                         "items": [
                                                             {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "NormalDamage",
-                                                                    "amount": 128,
-                                                                    "negate": false
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Can Kill Tough Beam-Resistant Enemy"
                                                             },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Combat",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "NormalDamage",
+                                                                                "amount": 128,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "With Power Bombs",
+                                                        "items": [
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "Combat",
-                                                                    "amount": 2,
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Power Bombs"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "PowerBombs",
+                                                                    "amount": 4,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -7850,7 +8462,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Damage Boost through them",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -7874,47 +8486,16 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Combat",
-                                            "amount": 3,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "ScrewAttack",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Damageless: https://www.youtube.com/watch?v=zmSH3fDcCVI",
                                             "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Use Power Bombs"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "PowerBombs",
-                                                        "amount": 4,
-                                                        "negate": false
-                                                    }
-                                                },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Combat",
-                                                        "amount": 1,
+                                                        "amount": 3,
                                                         "negate": false
                                                     }
                                                 }
@@ -7976,7 +8557,7 @@
                         "Pickup (Missile Tank)": {
                             "type": "or",
                             "data": {
-                                "comment": null,
+                                "comment": "Requirements to deal with the pirates are in the connection from above",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -7998,7 +8579,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Get up",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -8019,16 +8600,71 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Get past pirates",
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Kill Tough Beam-Resistant Enemy"
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Kill them",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "ScrewAttack",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Via normal methods. Taking/avoiding damage is accounted in connection to down here",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Kill Tough Beam-Resistant Enemy"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "With Power Bombs",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Use Power Bombs"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "PowerBombs",
+                                                                                "amount": 4,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Combat",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Damage Boost through them",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -8052,12 +8688,20 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Combat",
-                                                        "amount": 3,
-                                                        "negate": false
+                                                        "comment": "Damageless: https://youtu.be/zmSH3fDcCVI?t=31",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -8134,16 +8778,33 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Get past pirates",
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Kill Tough Beam-Resistant Enemy"
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Kill them",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Kill Tough Beam-Resistant Enemy"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "ScrewAttack",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Damage Boost through them",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -8167,12 +8828,20 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Combat",
-                                                        "amount": 3,
-                                                        "negate": false
+                                                        "comment": "Pirates don't exist if coming from above was done damageless: https://www.youtube.com/watch?v=2Pfo7v_Qngg",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -8742,7 +9411,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Don't fall down the crumble block",
+                                            "comment": "Don't fall down the crumble block: https://www.youtube.com/watch?v=7T5fVhUYQ4g",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -8820,11 +9489,7 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Springball"
+                                        "data": "Can Bounce in Ball"
                                     }
                                 ]
                             }
@@ -8890,7 +9555,7 @@
                         "y": 76.81,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "TODO: does this require the reactor to be activated in order to get used?",
                     "layers": [
                         "default"
                     ],
@@ -9188,12 +9853,41 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "items",
-                                            "name": "SpaceJump",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpaceJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "SWJ",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Screw Single Walljump"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "WallJump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -9956,7 +10650,7 @@
                         "y": 410.23,
                         "z": 0.0
                     },
-                    "description": "Causes issues with door lock rando.\n\nGeneration gets stuck after giving SJ and speed and trying to reach this event.",
+                    "description": "TODO: Causes issues with door lock rando.\n\nGeneration gets stuck after giving SJ and speed and trying to reach this event.",
                     "layers": [
                         "default"
                     ],
@@ -10800,7 +11494,7 @@
                         "y": 80.0,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "This door is currently an event door and thus always Level-0",
                     "layers": [
                         "default"
                     ],
@@ -11156,7 +11850,7 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": "Yakuza",
+                                                        "comment": "Yakuza - TODO: what about plasma?",
                                                         "items": [
                                                             {
                                                                 "type": "and",
@@ -11318,7 +12012,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Core-X",
+                                                        "comment": "Core-X . TODO: should probably get adjusted",
                                                         "items": [
                                                             {
                                                                 "type": "resource",

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -2038,7 +2038,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "Core-X Requirements - TODO: how many missiles?",
+                                            "comment": "Core-X Requirements",
                                             "items": [
                                                 {
                                                     "type": "template",
@@ -2243,7 +2243,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Dodging Requirements - TODO: how does screw attack help?",
+                                            "comment": "Dodging Requirements",
                                             "items": [
                                                 {
                                                     "type": "or",
@@ -4297,7 +4297,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "ShinesparkTrick",
-                                                        "amount": 3,
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 },
@@ -5886,6 +5886,15 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -6048,6 +6057,15 @@
                                                         "type": "tricks",
                                                         "name": "WallJump",
                                                         "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -9555,7 +9573,7 @@
                         "y": 76.81,
                         "z": 0.0
                     },
-                    "description": "TODO: does this require the reactor to be activated in order to get used?",
+                    "description": "",
                     "layers": [
                         "default"
                     ],
@@ -12012,7 +12030,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Core-X . TODO: should probably get adjusted",
+                                                        "comment": "Core-X",
                                                         "items": [
                                                             {
                                                                 "type": "resource",

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -354,7 +354,7 @@ Extra - room_id: [13, 74, 85]
               Charge Beam and Plasma Beam
               Wide Beam or Combat (Advanced)
           Any of the following:
-              # Core-X Requirements - TODO: how many missiles?
+              # Core-X Requirements
               45 DMG Missiles
               Combat (Beginner) and 30 DMG Missiles
               Combat (Intermediate) and 20 DMG Missiles
@@ -367,7 +367,7 @@ Extra - room_id: [13, 74, 85]
               Combat (Advanced) and Normal Damage ≥ 400
               Combat (Expert) and Normal Damage ≥ 150
           All of the following:
-              # Dodging Requirements - TODO: how does screw attack help?
+              # Dodging Requirements
               Screw Attack or Combat (Advanced)
               Combat (Intermediate) or Can Freeze Enemies
 
@@ -698,7 +698,7 @@ Extra - room_id: [23]
       Any of the following:
           Morph Ball
           # Shinespark from the Navigation Station: https://www.youtube.com/watch?v=QcD2-t9UDrg
-          Speed Booster and Shinespark Tricks (Advanced) and Disabled Entrance Rando
+          Speed Booster and Shinespark Tricks (Intermediate) and Disabled Entrance Rando
   > Door to Quarantine Bay
       Trivial
 
@@ -997,7 +997,7 @@ Extra - room_id: [35]
       Any of the following:
           Can Kill Missile Geron
           # Shinespark from Operations Deck: https://www.youtube.com/watch?v=Y3k5lGKTX4Y
-          Level 0 Locks and Speed Booster and After Main Deck Operations Deck Missile Shield and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
+          Level 0 Locks and Speed Booster and After Main Deck Operations Deck Missile Shield and Knowledge (Beginner) and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Other to Operations Maintenance Storage; Heals? False
   * Layers: default
@@ -1016,7 +1016,7 @@ Extra - room_id: [35]
       Any of the following:
           Can Kill Missile Geron
           # Shinespark from Main Deck Entrance: https://www.youtube.com/watch?v=dWJXG-nGo6A
-          Level 0 Locks and Speed Booster and Shinespark Tricks (Hypermode) and Wall Jump (Advanced) and Disabled Door Lock Rando and Disabled Entrance Rando
+          Level 0 Locks and Speed Booster and Knowledge (Beginner) and Shinespark Tricks (Hypermode) and Wall Jump (Advanced) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Door to Crew Quarters East; Heals? False
   * Layers: default
@@ -1633,7 +1633,6 @@ Extra - room_id: [58]
 
 > Save Station; Heals? False; Spawn Point
   * Layers: default
-  * TODO: does this require the reactor to be activated in order to get used?
   * Extra - X: 10
   * Extra - Y: 10
   > Door to Central Reactor Core
@@ -2109,7 +2108,7 @@ Extra - room_id: [86]
                   Missiles ≥ 55 and Combat (Intermediate) and 20 DMG Missiles
                   Missiles ≥ 110 and Combat (Expert) and 10 DMG Missiles
               All of the following:
-                  # Core-X . TODO: should probably get adjusted
+                  # Core-X
                   Missiles
                   Any of the following:
                       30 DMG Missiles

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -11,9 +11,10 @@ Extra - room_id: [0, 63]
   > Event - Omega Metroid
       All of the following:
           After Navigation Controls Activated
-          # Weapon Requirements
+          # Weapon Requirements - TODO: more beams
           Wide Beam or Combat (Intermediate)
           Any of the following:
+              # Energy requirements
               Combat (Hypermode) or Normal Damage ≥ 1000
               Combat (Beginner) and Normal Damage ≥ 800
               Combat (Intermediate) and Normal Damage ≥ 600
@@ -44,6 +45,7 @@ Extra - room_id: [0, 63]
 > Event - L0; Heals? False
   * Layers: default
   * Event Level 0 Locks Released
+  * TODO: revise how this node gets into play
   > Ship
       Trivial
 
@@ -114,6 +116,8 @@ Extra - room_id: [7]
   * Extra - blocky: 14
   > Door to Docking Bay Shaft
       Trivial
+  > Other to Spitter Speedway
+      Trivial
 
 > Door to Docking Bay Shaft; Heals? False
   * Layers: default
@@ -125,8 +129,10 @@ Extra - room_id: [7]
       Trivial
   > Other to Spitter Speedway
       Any of the following:
-          Can Use Power Bombs
-          Speed Booster and Shinespark Tricks (Advanced) and Disabled Door Lock Rando and Disabled Entrance Rando
+          # Skip collecting the item. Break PB blocks first, then reload the room: https://www.youtube.com/watch?v=2WbnkPhd7tk
+          Disabled Entrance Rando and Can Bounce in Ball and Can Use Power Bombs
+          # Shinespark and spam jump at the ceiling: https://www.youtube.com/watch?v=QpbgjolExgE
+          Speed Booster and Shinespark Tricks (Intermediate) and Disabled Entrance Rando
 
 > Door to Central Hub; Heals? False
   * Layers: default
@@ -139,10 +145,14 @@ Extra - room_id: [7]
   * Layers: default
   * Open Passage to Spitter Speedway/Other to Station Entrance
   * Extra - door_idx: (108,)
+  > Pickup (Hidden Missile Tank)
+      Can Use Power Bombs
   > Door to Docking Bay Shaft
       Any of the following:
-          Can Use Power Bombs
-          Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+          # Skip collecting the item. Break PB blocks first, then reload the room.
+          Disabled Entrance Rando and Can Bounce in Ball and Can Use Power Bombs
+          # Speedboost from Spitter Speedway
+          Speed Booster and Disabled Entrance Rando
 
 ----------------
 Main Deck Recharge Room
@@ -279,16 +289,18 @@ Extra - room_id: [13, 74, 85]
   * Open Passage to Operations Maintenance Shaft/Other to Operations Deck
   * Extra - door_idx: (22, 175)
   > Door to Operations Deck Navigation Room
-      Missiles
+      After Main Deck Operations Deck Missile Shield
 
 > Door to Operations Deck Navigation Room; Heals? False
   * Layers: default
   * L0 Hatch to Operations Deck Navigation Room/Door to Operations Deck
   * Extra - door_idx: (27, 172)
   > Other to Operations Maintenance Shaft
-      Missiles
+      After Main Deck Operations Deck Missile Shield
   > Door to Elevator to Crew Quarters
       Trivial
+  > Event - Missile Shield
+      Missiles
 
 > Door to Operations Deck Recharge Room; Heals? False
   * Layers: default
@@ -310,11 +322,15 @@ Extra - room_id: [13, 74, 85]
           All Infants Collected
           Any of the following:
               Can Climb High Jump Wall
+              # Shinespark from adjacent room: https://www.youtube.com/watch?v=GX6K70StdeY
               Level 0 Locks and Speed Booster and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
+              # Single Wall Jump
+              Wall Jump (Beginner) and Can Single Walljump
 
 > Door to Operations Room; Heals? False
   * Layers: default
   * L0 Hatch to Operations Room/Door to Operations Deck
+  * This door is currently an event door and thus always Level-0
   * Extra - door_idx: (193, 146)
   > Before Operations Room
       Trivial
@@ -334,11 +350,11 @@ Extra - room_id: [13, 74, 85]
   > Event - SA-X
       All of the following:
           All of the following:
-              # SA-X Requirements
+              # SA-X Requirements - TODO: revise these. iirc plasma isnt needed anymore.
               Charge Beam and Plasma Beam
               Wide Beam or Combat (Advanced)
           Any of the following:
-              # Core-X Requirements
+              # Core-X Requirements - TODO: how many missiles?
               45 DMG Missiles
               Combat (Beginner) and 30 DMG Missiles
               Combat (Intermediate) and 20 DMG Missiles
@@ -351,9 +367,15 @@ Extra - room_id: [13, 74, 85]
               Combat (Advanced) and Normal Damage ≥ 400
               Combat (Expert) and Normal Damage ≥ 150
           All of the following:
-              # Dodging Requirements
+              # Dodging Requirements - TODO: how does screw attack help?
               Screw Attack or Combat (Advanced)
               Combat (Intermediate) or Can Freeze Enemies
+
+> Event - Missile Shield; Heals? False
+  * Layers: default
+  * Event Main Deck Operations Deck Missile Shield
+  > Door to Operations Deck Navigation Room
+      Trivial
 
 ----------------
 Maintenance Corridor
@@ -389,8 +411,9 @@ Extra - room_id: [15]
           All of the following:
               Can Freeze Enemies
               Any of the following:
+                  # Intended method
                   Hi-Jump
-                  # https://discord.com/channels/119665192110915584/1205560315652349962/1210970374741823499
+                  # HJ-Less: https://www.youtube.com/watch?v=AUkhZE_5CbE
                   Movement (Intermediate) and Wall Jump (Intermediate)
 
 > Door to Habitation Deck (Lower); Heals? False
@@ -462,8 +485,14 @@ Extra - room_id: [17, 77]
       Speed Booster
   > Door to Restricted Corridor
       All of the following:
-          # You can diagonally spark into the corner and WJ/SJ to item then go back down, the reqs have to be here though
-          Speed Booster and Knowledge (Expert) and Shinespark Tricks (Intermediate)
+          # You can get into the cage and get the item without shinesparking all the way up. The reqs have to be here though
+          Speed Booster
+          Any of the following:
+              # Shinespark into the corner
+              Shinespark Tricks (Intermediate)
+              # Jump mid-speedboost: https://www.youtube.com/watch?v=u3xzqtz6Gro
+              Movement (Intermediate)
+          # Get to the item while in the cage
           Space Jump or Wall Jump (Intermediate)
 
 > Door to Restricted Navigation Room; Heals? False
@@ -477,7 +506,7 @@ Extra - room_id: [17, 77]
   * Extra - door_idx: (34, 183)
   > Pickup (Power Bomb Tank)
       All of the following:
-          # Check the connection from item to restricted corridor for way to only go halfway up
+          # Check the connection from item to restricted corridor for way to only go halfway up. Can be revised after remote activation nodes
           Speed Booster
           # This can safely not have Door Lock Rando check
           Disabled Entrance Rando
@@ -514,11 +543,13 @@ Extra - room_id: [18]
       Any of the following:
           Can Kill PB Geron
           All of the following:
-              # https://www.youtube.com/watch?v=EiFFpvNaT_A
-              Speed Booster and Knowledge (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
+              # Shinespark and recharge in Hornoad Hallway
+              Level 0 Locks and Speed Booster and Knowledge (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
               Any of the following:
-                  Shinespark Tricks (Hypermode)
-                  Shinespark Tricks (Expert) and Can Climb High Jump Wall
+                  # HJ-less: https://www.youtube.com/watch?v=cjf9wNjAbEY
+                  Shinespark Tricks (Hypermode) and Wall Jump (Advanced)
+                  # With HJ: https://www.youtube.com/watch?v=lDKp1H8k7oM
+                  Hi-Jump and Shinespark Tricks (Expert) and Wall Jump (Intermediate)
 
 > Door to Hornoad Hallway; Heals? False
   * Layers: default
@@ -553,7 +584,7 @@ Extra - room_id: [18]
 > Event - Central Hub PB Geron; Heals? False
   * Layers: default
   * Event Main Deck Power Bomb Geron Destroyed
-  > Door to Habitation Storage
+  > Door to Station Entrance
       Trivial
 
 ----------------
@@ -666,7 +697,8 @@ Extra - room_id: [23]
   > Door to Main Elevator Access
       Any of the following:
           Morph Ball
-          Speed Booster and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
+          # Shinespark from the Navigation Station: https://www.youtube.com/watch?v=QcD2-t9UDrg
+          Speed Booster and Shinespark Tricks (Advanced) and Disabled Entrance Rando
   > Door to Quarantine Bay
       Trivial
 
@@ -677,7 +709,8 @@ Extra - room_id: [23]
   > Door to Western Hub
       Any of the following:
           Morph Ball
-          Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+          # Speedboost from other room
+          Level 0 Locks and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Door to Quarantine Bay; Heals? False
   * Layers: default
@@ -959,7 +992,12 @@ Extra - room_id: [35]
   * Open Passage to Operations Deck/Other to Operations Maintenance Shaft
   * Extra - door_idx: (79,)
   > Other to Crew Quarters East
-      Can Kill Missile Geron
+      After Main Deck Operations Deck Maintenance Shaft Upper Missile Geron
+  > Event - Upper Maintainance Geron
+      Any of the following:
+          Can Kill Missile Geron
+          # Shinespark from Operations Deck: https://www.youtube.com/watch?v=Y3k5lGKTX4Y
+          Level 0 Locks and Speed Booster and After Main Deck Operations Deck Missile Shield and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Other to Operations Maintenance Storage; Heals? False
   * Layers: default
@@ -973,14 +1011,33 @@ Extra - room_id: [35]
   * L0 Hatch to Crew Quarters West/Door to Operations Maintenance Shaft
   * Extra - door_idx: (81,)
   > Door to Crew Quarters East
-      Can Kill Missile Geron
+      After Main Deck Operations Deck Maintenance Shaft Lower Missile Geron
+  > Event - Lower Maintainance Geron
+      Any of the following:
+          Can Kill Missile Geron
+          # Shinespark from Main Deck Entrance: https://www.youtube.com/watch?v=dWJXG-nGo6A
+          Level 0 Locks and Speed Booster and Shinespark Tricks (Hypermode) and Wall Jump (Advanced) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Door to Crew Quarters East; Heals? False
   * Layers: default
   * L0 Hatch to Crew Quarters East/Door to Operations Maintenance Shaft
   * Extra - door_idx: (82,)
   > Door to Crew Quarters West
+      After Main Deck Operations Deck Maintenance Shaft Lower Missile Geron
+  > Event - Lower Maintainance Geron
       Can Kill Missile Geron
+
+> Event - Lower Maintainance Geron; Heals? False
+  * Layers: default
+  * Event Main Deck Operations Deck Maintenance Shaft Lower Missile Geron
+  > Door to Crew Quarters West
+      Trivial
+
+> Event - Upper Maintainance Geron; Heals? False
+  * Layers: default
+  * Event Main Deck Operations Deck Maintenance Shaft Upper Missile Geron
+  > Other to Operations Deck
+      Trivial
 
 ----------------
 Crew Quarters Save Room
@@ -1060,11 +1117,15 @@ Extra - room_id: [38]
   > Other to Maintenance Corridor
       Morph Ball
   > Event - Arachnus
-      # Core-X Requirements
-      Missiles
+      All of the following:
+          # FIXME: add health requirements once these dont prevent missile start
+          # Core-X Requirements
+          Missiles
 
 > Beside Door; Heals? False
   * Layers: default
+  * FIXME: The connections to return back here technically arent trivial, but are
+currently assumed until a few generator issues have been figured out.
   > Pickup (Energy Tank)
       Trivial
   > Door to Crew Quarters East
@@ -1211,7 +1272,12 @@ Extra - room_id: [47]
   * Extra - door_idx: (107,)
   > Pickup (Hidden Power Bomb Tank)
       All of the following:
-          Can Bounce in Ball and Can Use Power Bombs
+          Can Bounce in Ball
+          All of the following:
+              # Destroy Blocks
+              Can Use Power Bombs
+              # PBs only requires two because one doesn't destroy all of them.
+              Power Bombs ≥ 2 or Can Use Bombs
           Wall Jump (Beginner) or Can Climb High Jump Wall
 
 ----------------
@@ -1265,6 +1331,21 @@ Extra - room_id: [49, 59]
   * Layers: default
   * Open Hatch to Silo Checkpoint/Door to Central Reactor Core
   * Extra - door_idx: (124, 137)
+  > Other to Silo Tunnel
+      All of the following:
+          # Charge shinespark from Auxilary Power Station: https://www.youtube.com/watch?v=vVG5YNwzGjw
+          Speed Booster and Shinespark Tricks (Advanced) and Disabled Entrance Rando
+          Any of the following:
+              # Open the gate. Without Charge, the shot must be precisely timed. With Charge, just let go of beam while in the transition.
+              Charge Beam or Movement (Advanced)
+              Wide Beam and Movement (Intermediate)
+          # Get high enough to spark
+          Hi-Jump or Wall Jump (Intermediate)
+          Any of the following:
+              # Get into tunnel
+              After Boss Nettori Defeated or Mid-Air Morph (Advanced) or Can Bounce in Ball
+              # Jump, then shoot vine below so you can grab the ledge
+              Movement (Intermediate)
   > Door to Silo Save Room
       Trivial
 
@@ -1282,10 +1363,8 @@ Extra - room_id: [49, 59]
   > Door to Silo Entry
       Any of the following:
           Space Jump
-          All of the following:
-              Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
-              # Needed to break the vines
-              Wave Beam or Wide Beam
+          # Shinespark from Save Station: https://www.youtube.com/watch?v=x7CqxW4JyJ4
+          Speed Booster and Shinespark Tricks (Beginner) and Disabled Entrance Rando
   > Door to Scaffolding Access
       Wall Jump (Beginner) or Can Climb High Jump Wall
   > Door to Silo Checkpoint
@@ -1314,7 +1393,10 @@ Extra - room_id: [50]
   * Open Hatch to Central Reactor Core/Door to Scaffolding Access
   * Extra - door_idx: (114,)
   > Beside Pickup
-      Space Jump or Combat (Intermediate) or Can Kill Tough Beam-Resistant Enemy
+      Any of the following:
+          Can Kill Tough Beam-Resistant Enemy
+          # Dodge Pirates: https://www.youtube.com/watch?v=QAffTKp5seU
+          Space Jump or Combat (Intermediate)
 
 > Other to Silo Scaffolding; Heals? False
   * Layers: default
@@ -1323,6 +1405,7 @@ Extra - room_id: [50]
   > Pickup (Energy Tank)
       Trivial
   > Beside Pickup
+      # Jump over the item
       Movement (Intermediate)
 
 > Beside Pickup; Heals? False
@@ -1330,8 +1413,12 @@ Extra - room_id: [50]
   > Pickup (Energy Tank)
       Trivial
   > Door to Central Reactor Core
-      Space Jump or Combat (Intermediate) or Can Kill Tough Beam-Resistant Enemy
+      Any of the following:
+          Can Kill Tough Beam-Resistant Enemy
+          # Dodge Pirates: https://www.youtube.com/watch?v=u8_gclW4-gQ
+          Space Jump and Combat (Intermediate)
   > Other to Silo Scaffolding
+      # Jump over the item
       Movement (Intermediate)
 
 ----------------
@@ -1354,13 +1441,20 @@ Extra - room_id: [51]
   * Extra - door_idx: (116,)
   > Beside Pickup
       Any of the following:
-          Screw Attack or Combat (Advanced)
-          All of the following:
-              Can Kill Tough Beam-Resistant Enemy
-              # Expected dmg trickless
-              Combat (Intermediate) or Normal Damage ≥ 128
+          # Get past pirates
+          Any of the following:
+              # Kill them
+              Screw Attack
+              All of the following:
+                  # Via normal methods. Expects you to take damage or avoid their shots.
+                  Can Kill Tough Beam-Resistant Enemy
+                  Combat (Intermediate) or Normal Damage ≥ 128
+              # With Power Bombs
+              Power Bombs ≥ 4 and Combat (Beginner) and Can Use Power Bombs
+          # Damage Boost through them
           Damage Boosts (Intermediate) and Normal Damage ≥ 195
-          Power Bombs ≥ 4 and Combat (Beginner) and Can Use Power Bombs
+          # Damageless: https://www.youtube.com/watch?v=zmSH3fDcCVI
+          Combat (Advanced)
 
 > Door to Yakuza Arena; Heals? False
   * Layers: default
@@ -1370,13 +1464,25 @@ Extra - room_id: [51]
 > Beside Pickup; Heals? False
   * Layers: default
   > Pickup (Missile Tank)
+      # Requirements to deal with the pirates are in the connection from above
       Morph Ball
   > Other to Scaffolding Access
       All of the following:
+          # Get up
           Wall Jump (Advanced) or Can Climb High Jump Wall
           Any of the following:
-              Combat (Advanced) or Can Kill Tough Beam-Resistant Enemy
+              # Get past pirates
+              Any of the following:
+                  # Kill them
+                  Screw Attack
+                  # Via normal methods. Taking/avoiding damage is accounted in connection to down here
+                  Can Kill Tough Beam-Resistant Enemy
+                  # With Power Bombs
+                  Power Bombs ≥ 4 and Combat (Beginner) and Can Use Power Bombs
+              # Damage Boost through them
               Damage Boosts (Intermediate) and Normal Damage ≥ 195
+              # Damageless: https://youtu.be/zmSH3fDcCVI?t=31
+              Combat (Advanced)
   > Door to Yakuza Arena
       All of the following:
           Morph Ball and Can Kill Eye Door
@@ -1385,8 +1491,13 @@ Extra - room_id: [51]
               Wave Beam or Can Use Any Bombs
               Diffusion Missile Data and Missiles
           Any of the following:
-              Combat (Advanced) or Can Kill Tough Beam-Resistant Enemy
+              # Get past pirates
+              # Kill them
+              Screw Attack or Can Kill Tough Beam-Resistant Enemy
+              # Damage Boost through them
               Damage Boosts (Intermediate) and Normal Damage ≥ 95
+              # Pirates don't exist if coming from above was done damageless: https://www.youtube.com/watch?v=2Pfo7v_Qngg
+              Combat (Advanced)
 
 ----------------
 Silo Checkpoint
@@ -1498,7 +1609,7 @@ Extra - room_id: [57]
       Any of the following:
           Can Use Any Bombs
           All of the following:
-              # Don't fall down the crumble block
+              # Don't fall down the crumble block: https://www.youtube.com/watch?v=7T5fVhUYQ4g
               Movement (Beginner)
               Wall Jump (Beginner) or Can Climb High Jump Wall
 
@@ -1507,7 +1618,7 @@ Extra - room_id: [57]
   * L2 Hatch to Central Hub/Door to Habitation Storage
   * Extra - door_idx: (131,)
   > Pickup (Power Bomb Tank)
-      Can Use Bombs or Can Use Springball
+      Can Bounce in Ball
 
 ----------------
 Silo Save Room
@@ -1522,6 +1633,7 @@ Extra - room_id: [58]
 
 > Save Station; Heals? False; Spawn Point
   * Layers: default
+  * TODO: does this require the reactor to be activated in order to get used?
   * Extra - X: 10
   * Extra - Y: 10
   > Door to Central Reactor Core
@@ -1579,7 +1691,12 @@ Extra - room_id: [62]
   * L4 Hatch to Restricted Save Room/Door to Restricted Entrance
   * Extra - door_idx: (144,)
   > Other to Checkpoint to Restricted Zone
-      Screw Attack and Space Jump
+      All of the following:
+          Screw Attack
+          Any of the following:
+              Space Jump
+              # SWJ
+              Wall Jump (Beginner) and Can Single Walljump
 
 ----------------
 Restricted Save Room
@@ -1732,7 +1849,7 @@ Extra - room_id: [69]
 
 > Save the Animals; Heals? False
   * Layers: default
-  * Causes issues with door lock rando.
+  * TODO: Causes issues with door lock rando.
 
 Generation gets stuck after giving SJ and speed and trying to reach this event.
   > Other to Habitation Ventilation (Upper)
@@ -1907,6 +2024,7 @@ Extra - room_id: [82]
 > Door to Operations Deck; Heals? False
   * Layers: default
   * L0 Hatch to Operations Deck/Door to Operations Room
+  * This door is currently an event door and thus always Level-0
   * Extra - door_idx: (194,)
   > Event - Flight Controls
       Trivial
@@ -1982,7 +2100,7 @@ Extra - room_id: [86]
           All of the following:
               # Weapon Requirements
               Any of the following:
-                  # Yakuza
+                  # Yakuza - TODO: what about plasma?
                   All of the following:
                       Charge Beam
                       Wide Beam or Combat (Beginner)
@@ -1991,7 +2109,7 @@ Extra - room_id: [86]
                   Missiles ≥ 55 and Combat (Intermediate) and 20 DMG Missiles
                   Missiles ≥ 110 and Combat (Expert) and 10 DMG Missiles
               All of the following:
-                  # Core-X
+                  # Core-X . TODO: should probably get adjusted
                   Missiles
                   Any of the following:
                       30 DMG Missiles

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -487,6 +487,18 @@
             "S2ZigZagBombBlocks": {
                 "long_name": "Sector 2 Zoro Zig-Zag Bomb Blocks Broken",
                 "extra": {}
+            },
+            "MainDeckMaintainanceGeronLower": {
+                "long_name": "Main Deck Operations Deck Maintenance Shaft Lower Missile Geron",
+                "extra": {}
+            },
+            "MainDeckMaintainanceGeronUpper": {
+                "long_name": "Main Deck Operations Deck Maintenance Shaft Upper Missile Geron",
+                "extra": {}
+            },
+            "MainDeckOperationsMissileShield": {
+                "long_name": "Main Deck Operations Deck Missile Shield",
+                "extra": {}
             }
         },
         "tricks": {
@@ -974,7 +986,7 @@
                             {
                                 "type": "or",
                                 "data": {
-                                    "comment": null,
+                                    "comment": "TODO: missile gerons actually take only 3 missiles? is this for the s1 cube gerons instead?",
                                     "items": [
                                         {
                                             "type": "resource",
@@ -2183,6 +2195,11 @@
         "Knowledge": [
             1,
             2,
+            3
+        ],
+        "MidAirMorph": [
+            1,
+            2,
             3,
             4
         ],
@@ -2203,12 +2220,6 @@
             1,
             2,
             3
-        ],
-        "MidAirMorph": [
-            1,
-            2,
-            3,
-            4
         ],
         "JBJ": [
             3,

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -986,7 +986,7 @@
                             {
                                 "type": "or",
                                 "data": {
-                                    "comment": "TODO: missile gerons actually take only 3 missiles? is this for the s1 cube gerons instead?",
+                                    "comment": null,
                                     "items": [
                                         {
                                             "type": "resource",

--- a/randovania/games/fusion/logic_database/header.txt
+++ b/randovania/games/fusion/logic_database/header.txt
@@ -41,6 +41,7 @@ Templates
 * Can Kill Missile Geron:
       Any of the following:
           Any of the following:
+              # TODO: missile gerons actually take only 3 missiles? is this for the s1 cube gerons instead?
               Missiles ≥ 6
               Missiles ≥ 3 and 10 DMG Missiles
               Missiles ≥ 2 and 20 DMG Missiles

--- a/randovania/games/fusion/logic_database/header.txt
+++ b/randovania/games/fusion/logic_database/header.txt
@@ -41,7 +41,6 @@ Templates
 * Can Kill Missile Geron:
       Any of the following:
           Any of the following:
-              # TODO: missile gerons actually take only 3 missiles? is this for the s1 cube gerons instead?
               Missiles ≥ 6
               Missiles ≥ 3 and 10 DMG Missiles
               Missiles ≥ 2 and 20 DMG Missiles


### PR DESCRIPTION
- Adds TODO's and FIXME's to things that are worth remembering to change/revise later
- Adds more comments
- Adds a lot of trick videos
- Adds events for the operations deck missile shield, and maintenance shaft gerons
- Adds a lot of shinespark tricks

As well as a lot of other Main Deck clean up.
Note, that for open transitions, or hatches, I removed `Disabled Door Lock Rando`, because no doors can be placed there. In a future PR, I plan to add "shuffle open hatches" misc resource, so that shinesparks aren't always completely out of logic when Door Lock Rando is enabled.