### PR TITLE
MSR - Softlocks and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,12 +65,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid: Samus Returns
 
-- **Major** - Added: Door Lock randomizer has been added, including new door types.
+- **Major** - Added: Door Lock randomizer has been added, along with new door types.
 - **Major** - Added: Elevator randomizer has been added.
+- Changed: DNA hints now just say "DNA" instead of "Metroid DNA".
 - Fixed: If no seed was exported at a previous start of Randovania, the export window now shows the correct title ID in the output path for NTSC without having to switch to PAL and back to NTSC.
 - Fixed: Removed an incorrect start location from Area 4 Central Caves, which failed when exporting the game.
 - Fixed: Typo on the exporting dialog.
 - Fixed: Common case where a modified input RomFS was considered being unmodified.
+- Fixed: Starting at Area 3 Factory Exterior - Beam Burst Chamber & Tsumuri Station no longer spawns Samus out of bounds.
 
 #### Logic Database
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ exporters = [
     "mp2hudcolor>=1.0.10",
 
     # Metroid: Samus Returns
-    "open-samus-returns-rando>=1.3.0",
+    "open-samus-returns-rando>=1.3.1",
 
     # Super Metroid
     "SuperDuperMetroid>=1.2.0",

--- a/randovania/games/samus_returns/exporter/hint_namer.py
+++ b/randovania/games/samus_returns/exporter/hint_namer.py
@@ -80,7 +80,7 @@ class MSRHintNamer(HintNamer):
         # patch the name here instead. Fix it there at one point.
         name = resource.long_name
         if resource.short_name.startswith("Metroid DNA "):
-            name = "Metroid DNA"
+            name = "DNA"
         return fmt.format(
             name,
             determiner,

--- a/randovania/games/samus_returns/logic_database/Area 3 Factory Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 Factory Exterior.json
@@ -3712,7 +3712,7 @@
                     "extra": {
                         "actor_name": "LE_Platform_SaveStation_001",
                         "actor_type": "weightactivatedplatform",
-                        "start_point_actor_name": "ST_SaveStation001"
+                        "start_point_actor_name": "ST_SaveStation_001"
                     },
                     "valid_starting_location": true,
                     "connections": {

--- a/randovania/games/samus_returns/logic_database/Area 3 Factory Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 Factory Exterior.txt
@@ -577,7 +577,7 @@ Extra - asset_id: collision_camera_036
   * Layers: default
   * Extra - actor_name: LE_Platform_SaveStation_001
   * Extra - actor_type: weightactivatedplatform
-  * Extra - start_point_actor_name: ST_SaveStation001
+  * Extra - start_point_actor_name: ST_SaveStation_001
   > Door to Transport to Area 2
       Trivial
 

--- a/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.json
+++ b/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.json
@@ -5088,8 +5088,8 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -3056.4209407684993,
-                        "y": -2013.4645860133862,
+                        "x": -3056.42,
+                        "y": -2013.46,
                         "z": 0.0
                     },
                     "description": "",
@@ -5108,7 +5108,7 @@
                         "node": "Door to Mines Entrance"
                     },
                     "default_dock_weakness": "Access Locked",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -5240,8 +5240,8 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -3057.6119338543244,
-                        "y": -2018.1589473217828,
+                        "x": -3057.61,
+                        "y": -2018.16,
                         "z": 0.0
                     },
                     "description": "",
@@ -5260,7 +5260,7 @@
                         "node": "Door to Tsumuri Tunnel"
                     },
                     "default_dock_weakness": "Power Beam Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.json
+++ b/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.json
@@ -5092,7 +5092,7 @@
                         "y": -2013.46,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "FIXME: Door is excluded for DLR because it causes issues when trying to enter\nMines Intersection Terminal without first entering Diggernaut Excavation\nTunnels.",
                     "layers": [
                         "default"
                     ],
@@ -5244,7 +5244,7 @@
                         "y": -2018.16,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "FIXME: Door is excluded for DLR because it causes issues when trying to enter\nMines Intersection Terminal without first entering Diggernaut Excavation\nTunnels.",
                     "layers": [
                         "default"
                     ],

--- a/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.txt
+++ b/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.txt
@@ -707,7 +707,7 @@ Extra - asset_id: collision_camera_010
 
 > Door to Tsumuri Tunnel; Heals? False
   * Layers: default
-  * Access Locked to Tsumuri Tunnel/Door to Mines Entrance
+  * Access Locked to Tsumuri Tunnel/Door to Mines Entrance; Excluded from Dock Lock Rando
   * Extra - actor_name: Door011
   * Extra - actor_type: doorclosedpower
   > Door to Diggernaut Excavation Tunnels
@@ -733,7 +733,7 @@ Extra - polygon: [[-3100.0, -1465.969970703125], [-3100.0, -2224.4599609375], [4
 Extra - asset_id: collision_camera_011
 > Door to Mines Entrance; Heals? False
   * Layers: default
-  * Power Beam Door to Mines Entrance/Door to Tsumuri Tunnel
+  * Power Beam Door to Mines Entrance/Door to Tsumuri Tunnel; Excluded from Dock Lock Rando
   * Extra - actor_name: Door011
   * Extra - actor_type: doorclosedpower
   > Door to Mines Intersection Terminal

--- a/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.txt
+++ b/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.txt
@@ -708,6 +708,9 @@ Extra - asset_id: collision_camera_010
 > Door to Tsumuri Tunnel; Heals? False
   * Layers: default
   * Access Locked to Tsumuri Tunnel/Door to Mines Entrance; Excluded from Dock Lock Rando
+  * FIXME: Door is excluded for DLR because it causes issues when trying to enter
+Mines Intersection Terminal without first entering Diggernaut Excavation
+Tunnels.
   * Extra - actor_name: Door011
   * Extra - actor_type: doorclosedpower
   > Door to Diggernaut Excavation Tunnels
@@ -734,6 +737,9 @@ Extra - asset_id: collision_camera_011
 > Door to Mines Entrance; Heals? False
   * Layers: default
   * Power Beam Door to Mines Entrance/Door to Tsumuri Tunnel; Excluded from Dock Lock Rando
+  * FIXME: Door is excluded for DLR because it causes issues when trying to enter
+Mines Intersection Terminal without first entering Diggernaut Excavation
+Tunnels.
   * Extra - actor_name: Door011
   * Extra - actor_type: doorclosedpower
   > Door to Mines Intersection Terminal

--- a/requirements.txt
+++ b/requirements.txt
@@ -178,7 +178,7 @@ open-dread-rando==2.10.0
     # via randovania (setup.py)
 open-prime-rando==0.12.0
     # via randovania (setup.py)
-open-samus-returns-rando==1.3.0
+open-samus-returns-rando==1.3.1
     # via randovania (setup.py)
 packaging==24.0
     # via

--- a/test/test_files/patcher_data/samus_returns/samus_returns/door_lock/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/door_lock/world_1.json
@@ -4169,14 +4169,14 @@
                 "scenario": "s010_area1",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 5 Tower Interior - Gamma+ Arena.\n"
+            "text": "DNA is located in Area 5 Tower Interior - Gamma+ Arena.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s020_area2",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 3 Factory Interior - Gamma Arena South.\nMetroid DNA is located in Area 1 - Metroid Caverns Alpha Arena North East.\n"
+            "text": "DNA is located in Area 3 Factory Interior - Gamma Arena South.\nDNA is located in Area 1 - Metroid Caverns Alpha Arena North East.\n"
         },
         {
             "accesspoint_actor": {
@@ -4197,7 +4197,7 @@
                 "scenario": "s065_area6b",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 3 Metroid Caverns - Gamma Arena Center.\nMetroid DNA is located in Area 4 Central Caves - Gamma Arena.\nMetroid DNA is located in Area 3 Metroid Caverns - Alpha+ Arena West.\n"
+            "text": "DNA is located in Area 3 Metroid Caverns - Gamma Arena Center.\nDNA is located in Area 4 Central Caves - Gamma Arena.\nDNA is located in Area 3 Metroid Caverns - Alpha+ Arena West.\n"
         },
         {
             "accesspoint_actor": {
@@ -4211,28 +4211,28 @@
                 "scenario": "s070_area7",
                 "actor": "LE_RandoDNA_002"
             },
-            "text": "Metroid DNA is located in Area 2 Dam Exterior - Exterior Alpha+ Arena.\n"
+            "text": "DNA is located in Area 2 Dam Exterior - Exterior Alpha+ Arena.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s090_area9",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 3 Factory Exterior - Gamma Arena.\n"
+            "text": "DNA is located in Area 3 Factory Exterior - Gamma Arena.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s100_area10",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 6 - Zeta Arena.\n"
+            "text": "DNA is located in Area 6 - Zeta Arena.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s110_surfaceb",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 1 - Metroid Caverns Alpha Arena South West.\n"
+            "text": "DNA is located in Area 1 - Metroid Caverns Alpha Arena South West.\n"
         }
     ],
     "cosmetic_patches": {

--- a/test/test_files/patcher_data/samus_returns/samus_returns/start_inventory/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/start_inventory/world_1.json
@@ -4158,35 +4158,35 @@
                 "scenario": "s020_area2",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 3 Metroid Caverns - Alpha+ Arena North.\nMetroid DNA is located in Area 1 - Exterior Alpha Arena.\n"
+            "text": "DNA is located in Area 3 Metroid Caverns - Alpha+ Arena North.\nDNA is located in Area 1 - Exterior Alpha Arena.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s033_area3b",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 1 - Metroid Caverns Alpha Arena South East.\nMetroid DNA is located in Area 7 - Omega+ Arena.\nMetroid DNA is located in Area 3 Factory Interior - Gamma Arena & Transport to Metroid Caverns East.\n"
+            "text": "DNA is located in Area 1 - Metroid Caverns Alpha Arena South East.\nDNA is located in Area 7 - Omega+ Arena.\nDNA is located in Area 3 Factory Interior - Gamma Arena & Transport to Metroid Caverns East.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s050_area5",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 7 - Omega Arena North.\n"
+            "text": "DNA is located in Area 7 - Omega Arena North.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s065_area6b",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 2 Dam Entryway - Alpha+ Arena.\nMetroid DNA is located in Area 5 Tower Interior - Zeta+ Arena.\n"
+            "text": "DNA is located in Area 2 Dam Entryway - Alpha+ Arena.\nDNA is located in Area 5 Tower Interior - Zeta+ Arena.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s070_area7",
                 "actor": "LE_RandoDNA_001"
             },
-            "text": "Metroid DNA is located in Area 5 Tower Lobby - Alpha+ Arena.\n"
+            "text": "DNA is located in Area 5 Tower Lobby - Alpha+ Arena.\n"
         },
         {
             "accesspoint_actor": {
@@ -4207,7 +4207,7 @@
                 "scenario": "s100_area10",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 3 Metroid Caverns - Gamma Arena South.\n"
+            "text": "DNA is located in Area 3 Metroid Caverns - Gamma Arena South.\n"
         },
         {
             "accesspoint_actor": {

--- a/test/test_files/patcher_data/samus_returns/samus_returns/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/starter_preset/world_1.json
@@ -4169,28 +4169,28 @@
                 "scenario": "s010_area1",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 7 - Omega+ Arena.\n"
+            "text": "DNA is located in Area 7 - Omega+ Arena.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s020_area2",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 4 Central Caves - Gamma Arena.\nMetroid DNA is located in Area 2 Dam Exterior - Inner Alpha Arena.\n"
+            "text": "DNA is located in Area 4 Central Caves - Gamma Arena.\nDNA is located in Area 2 Dam Exterior - Inner Alpha Arena.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s033_area3b",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 4 Crystal Mines - Gamma Arena.\nMetroid DNA is located in Area 7 - Omega Arena South.\n"
+            "text": "DNA is located in Area 4 Crystal Mines - Gamma Arena.\nDNA is located in Area 7 - Omega Arena South.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s050_area5",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 4 Central Caves - Alpha+ Arena.\nMetroid DNA is located in Area 1 - Metroid Caverns Alpha Arena South West.\n"
+            "text": "DNA is located in Area 4 Central Caves - Alpha+ Arena.\nDNA is located in Area 1 - Metroid Caverns Alpha Arena South West.\n"
         },
         {
             "accesspoint_actor": {
@@ -4204,7 +4204,7 @@
                 "scenario": "s070_area7",
                 "actor": "LE_RandoDNA_001"
             },
-            "text": "Metroid DNA is located in Area 7 - Omega Arena North.\n"
+            "text": "DNA is located in Area 7 - Omega Arena North.\n"
         },
         {
             "accesspoint_actor": {
@@ -4218,14 +4218,14 @@
                 "scenario": "s090_area9",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 3 Factory Exterior - Gamma Arena.\n"
+            "text": "DNA is located in Area 3 Factory Exterior - Gamma Arena.\n"
         },
         {
             "accesspoint_actor": {
                 "scenario": "s100_area10",
                 "actor": "LE_RandoDNA"
             },
-            "text": "Metroid DNA is located in Area 2 Dam Interior - Gamma Arena.\n"
+            "text": "DNA is located in Area 2 Dam Interior - Gamma Arena.\n"
         },
         {
             "accesspoint_actor": {


### PR DESCRIPTION
- DNA hints now just say "DNA" instead of "Metroid DNA".
- Starting at Area 3 Factory Exterior - Beam Burst Chamber & Tsumuri Station no longer spawns Samus out of bounds.
- Bumps OSRR