### PR TITLE
MSR - A3 Metroid Caverns Logic Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed: Metroid Caverns Hub: Dock to Metroid Caverns Save Station -> Tunnel to Metroid Caverns Save Station now has the correct grouping for the logical paths.
 
+##### Area 3 Metroid Caverns
+
+- Added: Caverns Teleporter East - Reaching the Missile now has correct requirements with High Jump Boots, requiring either a Super Jump (Advanced), Unmorph Extend (Intermediate), or Freezing the Gullugg (Intermediate).
+
 ## [8.0.0] - 2024-05-01
 
 - **Major** - Added: Metroid Samus Returns has been added with full single player support. Includes random starting locations, some toggleable patches, and more.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### Area 3 Metroid Caverns
 
-- Added: Caverns Teleporter East - Reaching the Missile now has correct requirements with High Jump Boots, requiring either a Super Jump (Advanced), Unmorph Extend (Intermediate), or Freezing the Gullugg (Intermediate).
+- Added: Caverns Teleporter East - Reaching the pickup now has correct requirements with High Jump Boots, requiring either a Super Jump (Advanced), Unmorph Extend (Intermediate), or Freezing the Gullugg (Intermediate).
 
 ## [8.0.0] - 2024-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### Area 3 Metroid Caverns
 
-- Added: Caverns Teleporter East - Reaching the pickup now has correct requirements with High Jump Boots, requiring either a Super Jump (Advanced), Unmorph Extend (Intermediate), or Freezing the Gullugg (Intermediate).
+- Added: Caverns Teleporter East - Reaching the pickup now has correct requirements with High Jump Boots, requiring either a Super Jump (Advanced), Unmorph Extend (Intermediate), or Freezing the Moheek (Intermediate).
 
 ## [8.0.0] - 2024-05-01
 

--- a/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.json
@@ -4535,7 +4535,7 @@
                                                                         {
                                                                             "type": "and",
                                                                             "data": {
-                                                                                "comment": "Freeze the Gullugg as reaches the lower corner of the platform: https://youtu.be/uM1DHyPmGiM",
+                                                                                "comment": "Freeze the Moheek as reaches the lower level of the platform: https://youtu.be/uM1DHyPmGiM",
                                                                                 "items": [
                                                                                     {
                                                                                         "type": "resource",

--- a/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.json
@@ -4449,15 +4449,6 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Boots",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
                                                         "name": "Space",
                                                         "amount": 1,
                                                         "negate": false
@@ -4483,6 +4474,100 @@
                                                                     "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Boots",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Super Jump: https://youtu.be/uM1DHyPmGiM?t=14",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "SuperJump",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Unmorph Extend: https://youtu.be/uM1DHyPmGiM?t=9",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "UnmorphExtend",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Freeze the Gullugg as reaches the lower corner of the platform: https://youtu.be/uM1DHyPmGiM",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Charge",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Ice",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "FrozenEnemy",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]

--- a/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.txt
@@ -663,8 +663,17 @@ Extra - asset_id: collision_camera_026
       All of the following:
           Morph Ball and Destroy Blob Throwers/Steel Orbs
           Any of the following:
-              High Jump Boots or Grapple Beam or Space Jump or Simple IBJ
+              Grapple Beam or Space Jump or Simple IBJ
               Spider Boost (Intermediate) and Can Spider Boost
+              All of the following:
+                  High Jump Boots
+                  Any of the following:
+                      # Super Jump: https://youtu.be/uM1DHyPmGiM?t=14
+                      Super Jump (Advanced)
+                      # Unmorph Extend: https://youtu.be/uM1DHyPmGiM?t=9
+                      Unmorph Extend (Intermediate)
+                      # Freeze the Gullugg as reaches the lower corner of the platform: https://youtu.be/uM1DHyPmGiM
+                      Charge Beam and Ice Beam and Stand on Frozen Enemy (Intermediate)
   > Above Teleporter
       Trivial
 

--- a/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.txt
@@ -672,7 +672,7 @@ Extra - asset_id: collision_camera_026
                       Super Jump (Advanced)
                       # Unmorph Extend: https://youtu.be/uM1DHyPmGiM?t=9
                       Unmorph Extend (Intermediate)
-                      # Freeze the Gullugg as reaches the lower corner of the platform: https://youtu.be/uM1DHyPmGiM
+                      # Freeze the Moheek as reaches the lower level of the platform: https://youtu.be/uM1DHyPmGiM
                       Charge Beam and Ice Beam and Stand on Frozen Enemy (Intermediate)
   > Above Teleporter
       Trivial


### PR DESCRIPTION
Adds proper logic with HJ in Caverns Teleporter East to reach the pickup