### PR TITLE
MSR: exclude a3 mc door from being wave

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.json
@@ -1194,8 +1194,8 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -11658.019323671497,
-                        "y": -6045.410628019324,
+                        "x": -11658.02,
+                        "y": -6045.41,
                         "z": 0.0
                     },
                     "description": "",
@@ -1215,7 +1215,9 @@
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Wave Beam Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,

--- a/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.json
@@ -354,7 +354,9 @@
                     },
                     "default_dock_weakness": "Access Locked",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Wave Beam Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,

--- a/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.txt
@@ -46,7 +46,7 @@ Extra - asset_id: collision_camera_006
 
 > Door to Gamma Arena South; Heals? False
   * Layers: default
-  * Access Locked to Gamma Arena South/Door to Transport to Factory Exterior North
+  * Access Locked to Gamma Arena South/Door to Transport to Factory Exterior North; Dock Lock Rando incompatible with: Wave Beam Door
   * Extra - actor_name: Door003
   * Extra - actor_type: doorclosedpower
   > Save Station

--- a/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.txt
@@ -203,7 +203,7 @@ Extra - asset_id: collision_camera_009
 
 > Door to Transport to Factory Exterior North; Heals? False
   * Layers: default
-  * Power Beam Door to Transport to Factory Exterior North/Door to Gamma Arena South
+  * Power Beam Door to Transport to Factory Exterior North/Door to Gamma Arena South; Dock Lock Rando incompatible with: Wave Beam Door
   * Extra - actor_name: Door003
   * Extra - actor_type: doorclosedpower
   > Right of Tunnels


### PR DESCRIPTION
Doesnt need changelog entry, as its part of the DLR change.