### PR TITLE
Properly introduce PickupIndex age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.2.0] - 2024-07-??
+
+- Changed: Ammo pickups now have a smaller impact in generator.
+
 ## [8.1.0] - 2024-06-??
 
 - Changed: In Item Pool tab, improved the presentation for configuring ammo.

--- a/randovania/game_description/pickup/pickup_entry.py
+++ b/randovania/game_description/pickup/pickup_entry.py
@@ -67,6 +67,7 @@ class PickupGeneratorParams:
     probability_offset: float = 0.0
     probability_multiplier: float = 1.0
     required_progression: int = 0
+    index_age_impact: float = 1.0  # by how much the PickupIndex's age is incremented when this pickup is placed
 
 
 @dataclass(frozen=True)

--- a/randovania/game_description/pickup/standard_pickup.py
+++ b/randovania/game_description/pickup/standard_pickup.py
@@ -36,6 +36,7 @@ class StandardPickupDefinition(JsonDataclass, DataclassPostInitTypeCheck):
     hide_from_gui: bool = dataclasses.field(default=False, metadata=EXCLUDE_DEFAULT)
     must_be_starting: bool = dataclasses.field(default=False, metadata=EXCLUDE_DEFAULT)
     original_location: PickupIndex | None = dataclasses.field(default=None, metadata=EXCLUDE_DEFAULT)
+    index_age_impact: float = dataclasses.field(default=1.0, metadata=EXCLUDE_DEFAULT)
     probability_offset: float = dataclasses.field(default=0.0, metadata=EXCLUDE_DEFAULT)
     probability_multiplier: float = dataclasses.field(default=1.0, metadata=EXCLUDE_DEFAULT)
     description: str | None = dataclasses.field(default=None, metadata=EXCLUDE_DEFAULT)

--- a/randovania/generator/filler/player_state.py
+++ b/randovania/generator/filler/player_state.py
@@ -40,7 +40,7 @@ class PlayerState:
     game: GameDescription
     pickups_left: list[PickupEntry]
     configuration: FillerConfiguration
-    pickup_index_considered_count: collections.defaultdict[PickupIndex, int]
+    pickup_index_age: collections.defaultdict[PickupIndex, float]
     hint_seen_count: collections.defaultdict[NodeIdentifier, int]
     hint_initial_pickups: dict[NodeIdentifier, frozenset[PickupIndex]]
     event_seen_count: dict[ResourceInfo, int]
@@ -65,7 +65,7 @@ class PlayerState:
         self.pickups_left = pickups_left
         self.configuration = configuration
 
-        self.pickup_index_considered_count = collections.defaultdict(int)
+        self.pickup_index_age = collections.defaultdict(float)
         self.hint_seen_count = collections.defaultdict(int)
         self.event_seen_count = collections.defaultdict(int)
         self.hint_initial_pickups = {}
@@ -102,8 +102,8 @@ class PlayerState:
 
     def _log_new_pickup_index(self) -> None:
         for index in self.reach.state.collected_pickup_indices:
-            if index not in self.pickup_index_considered_count:
-                self.pickup_index_considered_count[index] = 0
+            if index not in self.pickup_index_age:
+                self.pickup_index_age[index] = 0.0
                 filler_logging.print_new_pickup_index(self.index, self.game, index)
 
     def _calculate_potential_actions(self) -> None:

--- a/randovania/generator/filler/retcon.py
+++ b/randovania/generator/filler/retcon.py
@@ -39,16 +39,24 @@ _VICTORY_WEIGHT = 1000
 def _calculate_uncollected_index_weights(
     uncollected_indices: Set[PickupIndex],
     assigned_indices: Set[PickupIndex],
-    considered_counts: Mapping[PickupIndex, int],
+    index_age: Mapping[PickupIndex, float],
     indices_groups: list[set[PickupIndex]],
 ) -> dict[PickupIndex, float]:
+    """
+    Calculates a weight
+    :param uncollected_indices
+    :param assigned_indices
+    :param index_age: the higher the age for an index, the smaller it's weight
+    :param indices_groups: indices separated in distinct groups.
+    In practice, one group for each region respecting preset exclusions
+    """
     result = {}
 
     for indices in indices_groups:
         weight_from_collected_indices = math.sqrt(len(indices) / ((1 + len(assigned_indices & indices)) ** 2))
 
         for index in sorted(uncollected_indices & indices):
-            weight_from_considered_count = min(10, considered_counts[index] + 1) ** -2
+            weight_from_considered_count = min(10.0, index_age[index] + 1.0) ** -2
             result[index] = weight_from_collected_indices * weight_from_considered_count
             # print(f"## {index} : {weight_from_collected_indices} ___ {weight_from_considered_count}")
 
@@ -175,12 +183,15 @@ def select_weighted_action(rng: Random, weighted_actions: Mapping[Action, float]
         return rng.choice(list(weighted_actions.keys()))
 
 
-def increment_considered_count(locations_weighted: WeightedLocations) -> None:
+def increment_index_age(locations_weighted: WeightedLocations, increment: float) -> None:
+    """
+    Increments the pickup index's age for every already collected index.
+    """
     for player, location, _ in locations_weighted.all_items():
-        was_present = location in player.pickup_index_considered_count
-        player.pickup_index_considered_count[location] += 1
+        was_present = location in player.pickup_index_age
+        player.pickup_index_age[location] += increment
         if not was_present:
-            # if it wasn't present, thenwe get to log!
+            # if it wasn't present, then we get to log!
             filler_logging.print_new_pickup_index(player.index, player.game, location)
 
 
@@ -346,7 +357,7 @@ def _assign_pickup_somewhere(
         index_owner_state, pickup_index = usable_locations.select_location(rng)
         index_owner_state.assign_pickup(pickup_index, PickupTarget(action, current_player.index))
 
-        increment_considered_count(all_locations)
+        increment_index_age(all_locations, action.generator_params.index_age_impact)
         all_locations.remove(index_owner_state, pickup_index)
 
         # Place a hint for the new item
@@ -409,7 +420,7 @@ def _calculate_all_pickup_indices_weight(player_states: list[PlayerState]) -> We
         pickup_index_weights = _calculate_uncollected_index_weights(
             player_state.all_indices & UncollectedState.from_reach(player_state.reach).indices,
             set(player_state.reach.state.patches.pickup_assignment),
-            player_state.pickup_index_considered_count,
+            player_state.pickup_index_age,
             player_state.indices_groups,
         )
         for pickup_index, weight in pickup_index_weights.items():

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -63,6 +63,7 @@ def create_standard_pickup(
             preferred_location_category=pickup.preferred_location_category,
             probability_offset=pickup.probability_offset,
             probability_multiplier=pickup.probability_multiplier * state.priority,
+            index_age_impact=pickup.index_age_impact,
         ),
     )
 
@@ -100,6 +101,7 @@ def create_ammo_pickup(
         generator_params=PickupGeneratorParams(
             preferred_location_category=ammo.preferred_location_category,
             probability_multiplier=2,
+            index_age_impact=0.25,
         ),
     )
 

--- a/test/generator/pickup_pool/test_pickup_creator.py
+++ b/test/generator/pickup_pool/test_pickup_creator.py
@@ -231,6 +231,7 @@ def test_create_ammo_expansion(requires_main_item: bool, echoes_pickup_database,
             preferred_location_category=LocationCategory.MINOR,
             probability_offset=0.0,
             probability_multiplier=2.0,
+            index_age_impact=0.25,
         ),
     )
 


### PR DESCRIPTION
Pickups have an impact in the age when they're assigned. The weight of an index depends on it's age, not the considered count.

Fixes #4496 