### PR TITLE
AM2R: adjust missile-less metroid requirements without long beam

### DIFF
--- a/randovania/games/am2r/logic_database/header.json
+++ b/randovania/games/am2r/logic_database/header.json
@@ -2548,7 +2548,7 @@
                                         {
                                             "type": "and",
                                             "data": {
-                                                "comment": null,
+                                                "comment": "Charge-Only",
                                                 "items": [
                                                     {
                                                         "type": "resource",
@@ -2560,12 +2560,46 @@
                                                         }
                                                     },
                                                     {
-                                                        "type": "resource",
+                                                        "type": "or",
                                                         "data": {
-                                                            "type": "tricks",
-                                                            "name": "MissileLessMetroids",
-                                                            "amount": 1,
-                                                            "negate": false
+                                                            "comment": null,
+                                                            "items": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": "tricks",
+                                                                        "name": "MissileLessMetroids",
+                                                                        "amount": 2,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "and",
+                                                                    "data": {
+                                                                        "comment": null,
+                                                                        "items": [
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "items",
+                                                                                    "name": "Long Beam",
+                                                                                    "amount": 1,
+                                                                                    "negate": false
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "tricks",
+                                                                                    "name": "MissileLessMetroids",
+                                                                                    "amount": 1,
+                                                                                    "negate": false
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     }
                                                 ]
@@ -2637,7 +2671,7 @@
                                         {
                                             "type": "and",
                                             "data": {
-                                                "comment": null,
+                                                "comment": "Charge-Only",
                                                 "items": [
                                                     {
                                                         "type": "resource",
@@ -2649,12 +2683,46 @@
                                                         }
                                                     },
                                                     {
-                                                        "type": "resource",
+                                                        "type": "or",
                                                         "data": {
-                                                            "type": "tricks",
-                                                            "name": "MissileLessMetroids",
-                                                            "amount": 2,
-                                                            "negate": false
+                                                            "comment": null,
+                                                            "items": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": "tricks",
+                                                                        "name": "MissileLessMetroids",
+                                                                        "amount": 3,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "and",
+                                                                    "data": {
+                                                                        "comment": null,
+                                                                        "items": [
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "items",
+                                                                                    "name": "Long Beam",
+                                                                                    "amount": 1,
+                                                                                    "negate": false
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "tricks",
+                                                                                    "name": "MissileLessMetroids",
+                                                                                    "amount": 2,
+                                                                                    "negate": false
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     }
                                                 ]
@@ -2726,7 +2794,7 @@
                                         {
                                             "type": "and",
                                             "data": {
-                                                "comment": null,
+                                                "comment": "Charge-Only",
                                                 "items": [
                                                     {
                                                         "type": "resource",
@@ -2738,12 +2806,46 @@
                                                         }
                                                     },
                                                     {
-                                                        "type": "resource",
+                                                        "type": "or",
                                                         "data": {
-                                                            "type": "tricks",
-                                                            "name": "MissileLessMetroids",
-                                                            "amount": 4,
-                                                            "negate": false
+                                                            "comment": null,
+                                                            "items": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": "tricks",
+                                                                        "name": "MissileLessMetroids",
+                                                                        "amount": 5,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "and",
+                                                                    "data": {
+                                                                        "comment": null,
+                                                                        "items": [
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "items",
+                                                                                    "name": "Long Beam",
+                                                                                    "amount": 1,
+                                                                                    "negate": false
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "tricks",
+                                                                                    "name": "MissileLessMetroids",
+                                                                                    "amount": 4,
+                                                                                    "negate": false
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     }
                                                 ]
@@ -2815,7 +2917,7 @@
                                         {
                                             "type": "and",
                                             "data": {
-                                                "comment": "Not sure yet if this is even possible to do",
+                                                "comment": "Charge-Only",
                                                 "items": [
                                                     {
                                                         "type": "resource",
@@ -2840,6 +2942,15 @@
                                                         "data": {
                                                             "type": "items",
                                                             "name": "Morph Ball",
+                                                            "amount": 1,
+                                                            "negate": false
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "resource",
+                                                        "data": {
+                                                            "type": "items",
+                                                            "name": "Long Beam",
                                                             "amount": 1,
                                                             "negate": false
                                                         }
@@ -2991,7 +3102,7 @@
                                         {
                                             "type": "and",
                                             "data": {
-                                                "comment": null,
+                                                "comment": "Charge-Only",
                                                 "items": [
                                                     {
                                                         "type": "resource",
@@ -3003,12 +3114,46 @@
                                                         }
                                                     },
                                                     {
-                                                        "type": "resource",
+                                                        "type": "or",
                                                         "data": {
-                                                            "type": "tricks",
-                                                            "name": "MissileLessMetroids",
-                                                            "amount": 3,
-                                                            "negate": false
+                                                            "comment": null,
+                                                            "items": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": "tricks",
+                                                                        "name": "MissileLessMetroids",
+                                                                        "amount": 4,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "and",
+                                                                    "data": {
+                                                                        "comment": null,
+                                                                        "items": [
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "items",
+                                                                                    "name": "Long Beam",
+                                                                                    "amount": 1,
+                                                                                    "negate": false
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "tricks",
+                                                                                    "name": "MissileLessMetroids",
+                                                                                    "amount": 3,
+                                                                                    "negate": false
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     }
                                                 ]
@@ -3099,7 +3244,7 @@
                                                                 {
                                                                     "type": "and",
                                                                     "data": {
-                                                                        "comment": null,
+                                                                        "comment": "With Gravity",
                                                                         "items": [
                                                                             {
                                                                                 "type": "resource",
@@ -3111,24 +3256,92 @@
                                                                                 }
                                                                             },
                                                                             {
-                                                                                "type": "resource",
+                                                                                "type": "or",
                                                                                 "data": {
-                                                                                    "type": "tricks",
-                                                                                    "name": "MissileLessMetroids",
-                                                                                    "amount": 3,
-                                                                                    "negate": false
+                                                                                    "comment": null,
+                                                                                    "items": [
+                                                                                        {
+                                                                                            "type": "resource",
+                                                                                            "data": {
+                                                                                                "type": "tricks",
+                                                                                                "name": "MissileLessMetroids",
+                                                                                                "amount": 4,
+                                                                                                "negate": false
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "and",
+                                                                                            "data": {
+                                                                                                "comment": null,
+                                                                                                "items": [
+                                                                                                    {
+                                                                                                        "type": "resource",
+                                                                                                        "data": {
+                                                                                                            "type": "items",
+                                                                                                            "name": "Long Beam",
+                                                                                                            "amount": 1,
+                                                                                                            "negate": false
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "resource",
+                                                                                                        "data": {
+                                                                                                            "type": "tricks",
+                                                                                                            "name": "MissileLessMetroids",
+                                                                                                            "amount": 3,
+                                                                                                            "negate": false
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    ]
                                                                                 }
                                                                             }
                                                                         ]
                                                                     }
                                                                 },
                                                                 {
-                                                                    "type": "resource",
+                                                                    "type": "or",
                                                                     "data": {
-                                                                        "type": "tricks",
-                                                                        "name": "MissileLessMetroids",
-                                                                        "amount": 4,
-                                                                        "negate": false
+                                                                        "comment": "Without Gravity",
+                                                                        "items": [
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "tricks",
+                                                                                    "name": "MissileLessMetroids",
+                                                                                    "amount": 5,
+                                                                                    "negate": false
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "and",
+                                                                                "data": {
+                                                                                    "comment": null,
+                                                                                    "items": [
+                                                                                        {
+                                                                                            "type": "resource",
+                                                                                            "data": {
+                                                                                                "type": "items",
+                                                                                                "name": "Long Beam",
+                                                                                                "amount": 1,
+                                                                                                "negate": false
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "resource",
+                                                                                            "data": {
+                                                                                                "type": "tricks",
+                                                                                                "name": "MissileLessMetroids",
+                                                                                                "amount": 4,
+                                                                                                "negate": false
+                                                                                            }
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        ]
                                                                     }
                                                                 }
                                                             ]
@@ -3336,7 +3549,7 @@
                                         {
                                             "type": "and",
                                             "data": {
-                                                "comment": null,
+                                                "comment": "Charge-Only",
                                                 "items": [
                                                     {
                                                         "type": "resource",
@@ -3348,12 +3561,46 @@
                                                         }
                                                     },
                                                     {
-                                                        "type": "resource",
+                                                        "type": "or",
                                                         "data": {
-                                                            "type": "tricks",
-                                                            "name": "MissileLessMetroids",
-                                                            "amount": 3,
-                                                            "negate": false
+                                                            "comment": null,
+                                                            "items": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": "tricks",
+                                                                        "name": "MissileLessMetroids",
+                                                                        "amount": 4,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "and",
+                                                                    "data": {
+                                                                        "comment": null,
+                                                                        "items": [
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "items",
+                                                                                    "name": "Long Beam",
+                                                                                    "amount": 1,
+                                                                                    "negate": false
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "tricks",
+                                                                                    "name": "MissileLessMetroids",
+                                                                                    "amount": 3,
+                                                                                    "negate": false
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     }
                                                 ]
@@ -3549,7 +3796,7 @@
                                         {
                                             "type": "and",
                                             "data": {
-                                                "comment": null,
+                                                "comment": "Charge-Only",
                                                 "items": [
                                                     {
                                                         "type": "resource",
@@ -3561,12 +3808,46 @@
                                                         }
                                                     },
                                                     {
-                                                        "type": "resource",
+                                                        "type": "or",
                                                         "data": {
-                                                            "type": "tricks",
-                                                            "name": "MissileLessMetroids",
-                                                            "amount": 3,
-                                                            "negate": false
+                                                            "comment": null,
+                                                            "items": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": "tricks",
+                                                                        "name": "MissileLessMetroids",
+                                                                        "amount": 4,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "and",
+                                                                    "data": {
+                                                                        "comment": null,
+                                                                        "items": [
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "items",
+                                                                                    "name": "Long Beam",
+                                                                                    "amount": 1,
+                                                                                    "negate": false
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "resource",
+                                                                                "data": {
+                                                                                    "type": "tricks",
+                                                                                    "name": "MissileLessMetroids",
+                                                                                    "amount": 3,
+                                                                                    "negate": false
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     }
                                                 ]

--- a/randovania/games/am2r/logic_database/header.txt
+++ b/randovania/games/am2r/logic_database/header.txt
@@ -175,7 +175,12 @@ Templates
           Any of the following:
               # Item requirements
               Missiles ≥ 7 or Super Missiles ≥ 2
-              Charge Beam and Missile-Less Metroid Fights (Beginner)
+              All of the following:
+                  # Charge-Only
+                  Charge Beam
+                  Any of the following:
+                      Missile-Less Metroid Fights (Intermediate)
+                      Long Beam and Missile-Less Metroid Fights (Beginner)
           # Damage requirements
           Combat (Intermediate) or Normal Damage ≥ 65
 
@@ -184,7 +189,12 @@ Templates
           Any of the following:
               # Item requirements
               Missiles ≥ 7 or Super Missiles ≥ 2
-              Charge Beam and Missile-Less Metroid Fights (Intermediate)
+              All of the following:
+                  # Charge-Only
+                  Charge Beam
+                  Any of the following:
+                      Missile-Less Metroid Fights (Advanced)
+                      Long Beam and Missile-Less Metroid Fights (Intermediate)
           # Damage requirements
           Combat (Advanced) or Normal Damage ≥ 130
 
@@ -193,7 +203,12 @@ Templates
           Any of the following:
               # Item requirements
               Missiles ≥ 15 or Super Missiles ≥ 5
-              Charge Beam and Missile-Less Metroid Fights (Expert)
+              All of the following:
+                  # Charge-Only
+                  Charge Beam
+                  Any of the following:
+                      Missile-Less Metroid Fights (Hypermode)
+                      Long Beam and Missile-Less Metroid Fights (Expert)
           # Damage requirements
           Combat (Expert) or Normal Damage ≥ 199
 
@@ -201,8 +216,8 @@ Templates
       All of the following:
           Any of the following:
               Missiles ≥ 35 or Super Missiles ≥ 10
-              # Not sure yet if this is even possible to do
-              Charge Beam and Morph Ball and Missile-Less Metroid Fights (Hypermode)
+              # Charge-Only
+              Charge Beam and Long Beam and Morph Ball and Missile-Less Metroid Fights (Hypermode)
               All of the following:
                   # low% strat using refills
                   Morph Ball and Speed Booster and Combat (Hypermode)
@@ -217,7 +232,12 @@ Templates
           Any of the following:
               # Item requirements
               Missiles ≥ 15 or Super Missiles ≥ 3
-              Charge Beam and Missile-Less Metroid Fights (Advanced)
+              All of the following:
+                  # Charge-Only
+                  Charge Beam
+                  Any of the following:
+                      Missile-Less Metroid Fights (Expert)
+                      Long Beam and Missile-Less Metroid Fights (Advanced)
           # Energy requirements
           Combat (Expert) or Normal Damage ≥ 199
 
@@ -230,8 +250,16 @@ Templates
                   # Missile-Less Requirements
                   Charge Beam and Underwater Power Grip Wall
                   Any of the following:
-                      Missile-Less Metroid Fights (Expert)
-                      Gravity Suit and Missile-Less Metroid Fights (Advanced)
+                      All of the following:
+                          # With Gravity
+                          Gravity Suit
+                          Any of the following:
+                              Missile-Less Metroid Fights (Expert)
+                              Long Beam and Missile-Less Metroid Fights (Advanced)
+                      Any of the following:
+                          # Without Gravity
+                          Missile-Less Metroid Fights (Hypermode)
+                          Long Beam and Missile-Less Metroid Fights (Expert)
           All of the following:
               # Energy Requirements
               Gravity Suit or Combat (Intermediate)
@@ -247,7 +275,12 @@ Templates
               # Item requirements
               Super Missiles ≥ 6
               Missiles ≥ 30 and Combat (Intermediate)
-              Charge Beam and Missile-Less Metroid Fights (Advanced)
+              All of the following:
+                  # Charge-Only
+                  Charge Beam
+                  Any of the following:
+                      Missile-Less Metroid Fights (Expert)
+                      Long Beam and Missile-Less Metroid Fights (Advanced)
           Any of the following:
               # Energy Requirements
               Combat (Expert) or Normal Damage ≥ 299
@@ -267,7 +300,12 @@ Templates
               # Item requirements
               Super Missiles ≥ 7
               Missiles ≥ 32 and Combat (Intermediate)
-              Charge Beam and Missile-Less Metroid Fights (Advanced)
+              All of the following:
+                  # Charge-Only
+                  Charge Beam
+                  Any of the following:
+                      Missile-Less Metroid Fights (Expert)
+                      Long Beam and Missile-Less Metroid Fights (Advanced)
               All of the following:
                   # Backshots
                   Combat (Advanced)


### PR DESCRIPTION
No changelog entry, as it is part of long beam