### PR TITLE
GUI: fix 2 warnings for ui where multiple objects have the same name

### DIFF
--- a/randovania/games/fusion/gui/ui_files/fusion_cosmetic_patches_dialog.ui
+++ b/randovania/games/fusion/gui/ui_files/fusion_cosmetic_patches_dialog.ui
@@ -44,9 +44,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-200</y>
+        <y>-194</y>
         <width>362</width>
-        <height>406</height>
+        <height>390</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -174,22 +174,6 @@
              </widget>
             </item>
            </layout>
-          </item>
-          <item>
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Minimum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>10</height>
-             </size>
-            </property>
-           </spacer>
           </item>
           <item>
            <widget class="QLabel" name="audio_volume_label">

--- a/randovania/gui/ui_files/preset_patcher_energy.ui
+++ b/randovania/gui/ui_files/preset_patcher_energy.ui
@@ -43,8 +43,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>455</width>
-         <height>1264</height>
+         <width>460</width>
+         <height>1151</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -368,7 +368,7 @@
           <property name="title">
            <string>In-Game Difficulty</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_5">
+          <layout class="QGridLayout" name="gridLayout_6">
            <item row="0" column="0">
             <widget class="QLabel" name="ingame_difficulty_label">
              <property name="text">


### PR DESCRIPTION
fixes `randovania\games\fusion\gui\ui_files\fusion_cosmetic_patches_dialog.ui: Warning: The name 'verticalSpacer' (QSpacerItem) is already in use, defaulting to 'verticalSpacer1'.`

this doesn't noticeably change anything but here's a screenshot for completeness
![image](https://github.com/randovania/randovania/assets/125271738/548b4bfb-07bb-4d38-b4ee-7148013da9f9)
