### PR TITLE
Allow 'Open Map' cosmetic option for Prime to be enabled with Random Elevators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.2.0] - 2024-07-??
 
 ### Metroid Prime
-- Changed: Open Map can be used with Elevator Randomization (Unvisited rooms do not reveal their name. Unvisisted Elevators do not reveal their destination.)
+- Changed: Open Map can be used with Elevator Randomization (Unvisited rooms do not reveal their name. Unvisited Elevators do not reveal their destination.)
 
 ## [8.1.0] - 2024-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.2.0] - 2024-07-??
 
-- Nothing yet! Add changes here.
+### Metroid Prime
+- Changed: Open Map can be used with Elevator Randomization (Unvisited rooms do not reveal their name. Unvisisted Elevators do not reveal their destination.)
 
 ## [8.1.0] - 2024-06-04
 

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -813,7 +813,7 @@ class PrimePatchDataFactory(PatchDataFactory):
         else:
             starting_memo = None
 
-        if self.cosmetic_patches.open_map and self.configuration.teleporters.is_vanilla:
+        if self.cosmetic_patches.open_map:
             map_default_state = "Always"
         else:
             map_default_state = "MapStationOrVisit"


### PR DESCRIPTION
The reasoning for disabling the 'Open Map' cosmetic for Prime 1 for Elevator Randomizer was that players supposedly could just look at the room name to see the Elevator destination.  
However, in Prime 1, room names don't appear for not-visited rooms, even after using a Map Station .  
Unless there are plans for a patch that shows room names for not-visited rooms, players should be allowed to use Open Map regardless of whether elevators are randomized or not.  

* Visited Room (Name is revealed)
  * ![image](https://github.com/randovania/randovania/assets/15365192/56755439-9510-45ca-a8b3-b9577c448bcd)
* Not-visited Room (Name is not revealed)
  * ![image](https://github.com/randovania/randovania/assets/15365192/be60c83b-3417-4f6b-b056-f92fa37a3b82)