### PR TITLE
Add "Export All Presets" feature for multiworld sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: When generating for a multiworld, certain error messages now mention the name of relevant world.
 - Added: When generating for a multiworld, all mentions of a world now use the world's name.
+- Added: "Export all presets" option under multiworld session Advanced Options.
 - Changed: Significantly improved the performance of uploading a game to multiworld session, as well as downloading the spoiler.
 - Changed: The Receiver/Provider world selector in the History tab is now sorted.
 

--- a/randovania/gui/lib/common_qt_lib.py
+++ b/randovania/gui/lib/common_qt_lib.py
@@ -177,6 +177,16 @@ def prompt_user_for_preset_file(window: QtWidgets.QWidget, new_file: bool, name:
     )
 
 
+def prompt_user_for_preset_folder(window: QtWidgets.QWidget) -> None | Path:
+    """
+    Shows a QFileDialog asking the user for a directory in which to save multiple Randovania preset files
+    :param parent:
+    :return: A string if the user selected a directory, None otherwise
+    """
+
+    return _prompt_user_for_directory(window, caption="Select a directory in which to place preset files")
+
+
 def set_default_window_icon(window: QtWidgets.QWidget):
     """
     Sets the window icon for the given widget to the default icon

--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -205,10 +205,12 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         self.rename_session_action = QtGui.QAction("Change title", self.advanced_options_menu)
         self.change_password_action = QtGui.QAction("Change password", self.advanced_options_menu)
         self.duplicate_session_action = QtGui.QAction("Duplicate session", self.advanced_options_menu)
+        self.export_all_presets_action = QtGui.QAction("Export all presets", self.advanced_options_menu)
 
         self.advanced_options_menu.addAction(self.rename_session_action)
         self.advanced_options_menu.addAction(self.change_password_action)
         self.advanced_options_menu.addAction(self.duplicate_session_action)
+        self.advanced_options_menu.addAction(self.export_all_presets_action)
         self.advanced_options_tool.setMenu(self.advanced_options_menu)
 
         # Generate Game Menu
@@ -252,6 +254,7 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         self.rename_session_action.triggered.connect(self.rename_session)
         self.change_password_action.triggered.connect(self.change_password)
         self.duplicate_session_action.triggered.connect(self.duplicate_session)
+        self.export_all_presets_action.triggered.connect(self.export_all_presets)
         self.copy_permalink_button.clicked.connect(self.copy_permalink)
         self.view_game_details_button.clicked.connect(self.view_game_details)
         self.everyone_can_claim_check.clicked.connect(self._on_everyone_can_claim_check)
@@ -577,6 +580,31 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         )
         if new_name is not None:
             await self.game_session_api.duplicate_session(new_name)
+
+    def export_all_presets(self):
+        path = common_qt_lib.prompt_user_for_preset_folder(self)
+
+        if path is None:
+            return
+
+        world_owners = {world_uid: user for user in self._session.users.values() for world_uid in user.worlds.keys()}
+        world_count = len(self._session.worlds)
+        extension = VersionedPreset.file_extension()
+
+        for i, world in enumerate(self._session.worlds):
+            world_num = i + 1
+            owner_name = world_owners[world.id].name if world.id in world_owners else "Unclaimed"
+            preset = world.preset
+            filename = (
+                string_lib.sanitize_for_path(f"World{world_num}-{preset.game.short_name}-{owner_name}-{world.name}")
+                + f".{extension}"
+            )
+            filepath = path / filename
+            preset.save_to_file(filepath)
+
+            self.update_progress(f"Completed: {world_num} of {world_count} presets", world_num * 100 / world_count)
+
+        self.update_progress(f"Successfully exported {world_count} presets", 100)
 
     async def clear_generated_game(self):
         if self._last_actions.actions:

--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -594,9 +594,11 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         for i, world in enumerate(self._session.worlds):
             world_num = i + 1
             owner_name = world_owners[world.id].name if world.id in world_owners else "Unclaimed"
+            owner_name = owner_name.replace("-", "_")
+            world_name = world.name.replace("-", "_")
             preset = world.preset
             filename = (
-                string_lib.sanitize_for_path(f"World{world_num}-{preset.game.short_name}-{owner_name}-{world.name}")
+                string_lib.sanitize_for_path(f"World{world_num}-{preset.game.short_name}-{owner_name}-{world_name}")
                 + f".{extension}"
             )
             filepath = path / filename

--- a/test/gui/test_multiplayer_session_window.py
+++ b/test/gui/test_multiplayer_session_window.py
@@ -19,6 +19,7 @@ from randovania.gui.multiplayer_session_window import MultiplayerSessionWindow
 from randovania.layout.generator_parameters import GeneratorParameters
 from randovania.layout.permalink import Permalink
 from randovania.layout.versioned_preset import VersionedPreset
+from randovania.lib import string_lib
 from randovania.lib.container_lib import zip2
 from randovania.network_common.game_connection_status import GameConnectionStatus
 from randovania.network_common.multiplayer_session import (
@@ -361,6 +362,42 @@ async def test_change_password_title_or_duplicate(window: MultiplayerSessionWind
         api_method.assert_awaited_once_with("magoo")
     else:
         api_method.assert_not_awaited()
+
+
+@pytest.mark.parametrize("accept", [False, True])
+def test_export_all_presets(
+    window: MultiplayerSessionWindow, mocker: MockerFixture, sample_session: MultiplayerSessionEntry, accept, tmp_path
+):
+    # Setup
+    window._session = sample_session
+    fake_export_path = tmp_path.joinpath("exported_presets")
+    fake_export_path.mkdir(parents=True, exist_ok=True)
+
+    prompt_user_for_preset_folder = mocker.patch(
+        "randovania.gui.lib.common_qt_lib.prompt_user_for_preset_folder",
+        return_value=fake_export_path if accept else None,
+    )
+
+    world_names = [world.name for world in sample_session.worlds]
+    games = [world.preset.game.short_name for world in sample_session.worlds]
+    owner_names = [sample_session.users_list[0].name, "Unclaimed", "Unclaimed"]
+    extension = VersionedPreset.file_extension()
+    export_filenames = [
+        string_lib.sanitize_for_path(f"World{i + 1}-{game}-{owner_name}-{world_name}") + f".{extension}"
+        for i, game, owner_name, world_name in zip(range(len(world_names)), games, owner_names, world_names)
+    ]
+
+    # Run
+    window.export_all_presets()
+
+    # Assert
+    prompt_user_for_preset_folder.assert_called()
+
+    if accept:
+        for filename in export_filenames:
+            assert fake_export_path.joinpath(filename).is_file()
+    else:
+        assert len(list(fake_export_path.iterdir())) == 0
 
 
 @pytest.fixture()

--- a/test/gui/test_multiplayer_session_window.py
+++ b/test/gui/test_multiplayer_session_window.py
@@ -378,9 +378,9 @@ def test_export_all_presets(
         return_value=fake_export_path if accept else None,
     )
 
-    world_names = [world.name for world in sample_session.worlds]
+    world_names = [world.name.replace("-", "_") for world in sample_session.worlds]
     games = [world.preset.game.short_name for world in sample_session.worlds]
-    owner_names = [sample_session.users_list[0].name, "Unclaimed", "Unclaimed"]
+    owner_names = [sample_session.users_list[0].name.replace("-", "_"), "Unclaimed", "Unclaimed"]
     extension = VersionedPreset.file_extension()
     export_filenames = [
         string_lib.sanitize_for_path(f"World{i + 1}-{game}-{owner_name}-{world_name}") + f".{extension}"


### PR DESCRIPTION
This adds a button (hidden behind "Show Experimental Settings") to the Multiworld Session window to export the preset of every world in the session to a folder. This is extremely helpful for troubleshooting large multis that are having generation problems, or to verify that all users are using settings that abide by whatever session rules were established by the host.

I'm not sure if "Show Experimental Settings" is necessarily the correct choice for toggling the visibility, but I didn't think it made sense for it to show up for all users by default.