### PR TITLE
Slightly optimize add_ammo_pickups

### DIFF
--- a/randovania/generator/pickup_pool/ammo_pickup.py
+++ b/randovania/generator/pickup_pool/ammo_pickup.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING
 from randovania.generator.pickup_pool.pickup_creator import create_ammo_pickup
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.layout.base.ammo_pickup_configuration import AmmoPickupConfiguration
@@ -15,13 +13,15 @@ if TYPE_CHECKING:
 def add_ammo_pickups(
     resource_database: ResourceDatabase,
     ammo_configuration: AmmoPickupConfiguration,
-) -> Iterator[PickupEntry]:
+) -> list[PickupEntry]:
     """
     Creates the necessary pickups for the given ammo_configuration.
     :param resource_database:
     :param ammo_configuration:
     :return:
     """
+    result = []
     for ammo, state in ammo_configuration.pickups_state.items():
-        for _ in range(state.pickup_count):
-            yield create_ammo_pickup(ammo, state.ammo_count, state.requires_main_item, resource_database)
+        pickup = create_ammo_pickup(ammo, state.ammo_count, state.requires_main_item, resource_database)
+        result.extend([pickup] * state.pickup_count)
+    return result

--- a/test/generator/pickup_pool/test_ammo.py
+++ b/test/generator/pickup_pool/test_ammo.py
@@ -9,14 +9,21 @@ from randovania.layout.base.ammo_pickup_configuration import AmmoPickupConfigura
 
 def test_add_ammo(echoes_resource_database, mocker):
     # Setup
+    pickup1 = MagicMock()
+    pickup2 = MagicMock()
+
     mock_create_ammo_pickup: MagicMock = mocker.patch(
-        "randovania.generator.pickup_pool.ammo_pickup.create_ammo_pickup", autospec=True
+        "randovania.generator.pickup_pool.ammo_pickup.create_ammo_pickup",
+        autospec=True,
+        side_effect=[pickup1, pickup2],
     )
 
     ammo1 = MagicMock()
     ammo2 = MagicMock()
     state1 = MagicMock()
+    state1.pickup_count = 1
     state2 = MagicMock()
+    state2.pickup_count = 2
 
     ammo_configuration = AmmoPickupConfiguration(
         {
@@ -26,12 +33,12 @@ def test_add_ammo(echoes_resource_database, mocker):
     )
 
     # Run
-    results = list(
-        randovania.generator.pickup_pool.ammo_pickup.add_ammo_pickups(echoes_resource_database, ammo_configuration)
+    results = randovania.generator.pickup_pool.ammo_pickup.add_ammo_pickups(
+        echoes_resource_database, ammo_configuration
     )
 
     # Assert
-    assert results == [mock_create_ammo_pickup.return_value, mock_create_ammo_pickup.return_value]
+    assert results == [pickup1, pickup2, pickup2]
     mock_create_ammo_pickup.assert_has_calls(
         [
             call(ammo1, state1.ammo_count, state1.requires_main_item, echoes_resource_database),


### PR DESCRIPTION
The test was working by magic before, because apparently `range(MagicMock())` is `range(0, 1)`??