### PR TITLE
Display destination on Ghavoran Flipper transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid Dread
 
 - Added: Progressive pickups can now be configured to be placed vanilla.
+- Fixed: The transport in Ghavoran - Flipper now shows the destination on the minimap icon.
 
 ### Metroid Prime 2: Echoes
 

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from randovania.exporter import item_names
@@ -512,6 +513,14 @@ class DreadPatchDataFactory(PatchDataFactory):
                 or node.dock_type.extra.get("is_teleportal", False)
             )
         ]
+
+        # special-case the Ghavoran Flipper train to update the map correctly
+        flipper_list = [t for t in teleporters if t["teleporter"]["actor"] == "wagontrain_quarantine_with_cutscene_000"]
+        if flipper_list:
+            other_train = deepcopy(flipper_list[0])
+            other_train["teleporter"]["actor"] = "wagontrain_quarantine_000"
+            teleporters.append(other_train)
+
         return {
             "configuration_identifier": self.description.shareable_hash,
             "starting_location": starting_location,

--- a/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
@@ -3874,6 +3874,18 @@
                 "actor": "wagontrain_baselab_000_platform"
             },
             "connection_name": "Burenia - Sea Bridge"
+        },
+        {
+            "teleporter": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "wagontrain_quarantine_000"
+            },
+            "destination": {
+                "scenario": "s030_baselab",
+                "actor": "elevator_forest_000_platform"
+            },
+            "connection_name": "Dairon - Freezer"
         }
     ],
     "hints": [

--- a/test/test_files/patcher_data/dread/dread/elevator_rando/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/elevator_rando/world_1.json
@@ -3919,6 +3919,18 @@
                 "actor": "wagontrain_aqua_001_platform"
             },
             "connection_name": "Dairon - Submarine"
+        },
+        {
+            "teleporter": {
+                "scenario": "s050_forest",
+                "layer": "default",
+                "actor": "wagontrain_quarantine_000"
+            },
+            "destination": {
+                "scenario": "s010_cave",
+                "actor": "elevator_baselab_000_platform"
+            },
+            "connection_name": "Artaria - Grapple"
         }
     ],
     "hints": [


### PR DESCRIPTION
- adds a special case to Dread's PDF to apply the same patches to both train actors in the Ghavoran - Flipper transport
- fixes #6325

![image](https://github.com/randovania/randovania/assets/25016775/fec763c5-7f36-4ccd-afa4-0cf1b87348d2)
