### PR TITLE
MSR - Add A2 Entryway custom door to PostAlpha group

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 2 Dam Entryway.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 Dam Entryway.json
@@ -2014,7 +2014,8 @@
                     "extra": {
                         "actor_name": "RandoDoor_001",
                         "actor_type": "doorpowerpower",
-                        "tile_index": 91
+                        "tile_index": 91,
+                        "append_entity_group": "PostAlpha_002"
                     },
                     "valid_starting_location": false,
                     "dock_type": "door",
@@ -2655,7 +2656,8 @@
                     "extra": {
                         "actor_name": "RandoDoor_001",
                         "actor_type": "doorpowerpower",
-                        "tile_index": 92
+                        "tile_index": 92,
+                        "append_entity_group": "PostAlpha_002"
                     },
                     "valid_starting_location": false,
                     "dock_type": "door",

--- a/randovania/games/samus_returns/logic_database/Area 2 Dam Entryway.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 Dam Entryway.txt
@@ -329,6 +329,7 @@ Extra - asset_id: collision_camera_005
   * Extra - actor_name: RandoDoor_001
   * Extra - actor_type: doorpowerpower
   * Extra - tile_index: 91
+  * Extra - append_entity_group: PostAlpha_002
   > Door to Lightning Armor & Transport to Dam Exterior East (Top)
       Any of the following:
           After Area 2 (Dam Entryway) - Transport to Dam Exterior Unlock Door
@@ -412,6 +413,7 @@ Extra - asset_id: collision_camera_007
   * Extra - actor_name: RandoDoor_001
   * Extra - actor_type: doorpowerpower
   * Extra - tile_index: 92
+  * Extra - append_entity_group: PostAlpha_002
   > Inside Arena
       Morph Ball and Shoot Any Missile
   > Outside Arena

--- a/test/test_files/patcher_data/samus_returns/samus_returns/door_lock_access_open/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/door_lock_access_open/world_1.json
@@ -4837,6 +4837,7 @@
                 92
             ],
             "entity_groups": [
+                "PostAlpha_002",
                 "collision_camera_005",
                 "collision_camera_007"
             ]


### PR DESCRIPTION
Fixes the door not appearing after the Alpha is dead