### PR TITLE
Reach top of bubble lair shinespark cave from shinespark cave west with only a morph glide and walljumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Beam Doors are no longer mismatched with the door they are attached to, which would prevent certain doors from being opened.
 - Fixed: Crash when defeating the Larva Metroids in reverse.
 
+### AM2R
+
+#### Logic Database
+
+##### The Depths
+
+- Added: Bubble Lair Shinespark Cave: Expert Walljump and Intermediate Morph Glide option to climb the room as well as a video demonstration.
+
+
 ## [8.1.1] - 2024-06-08
 
 ### Metroid Prime

--- a/randovania/games/am2r/logic_database/The Depths.json
+++ b/randovania/games/am2r/logic_database/The Depths.json
@@ -4208,7 +4208,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Climb the right side and glide to the left https://youtu.be/Gq5wq0yHvCY",
+                                            "comment": "Climb the right side and glide to the left: https://youtu.be/Gq5wq0yHvCY",
                                             "items": [
                                                 {
                                                     "type": "template",

--- a/randovania/games/am2r/logic_database/The Depths.json
+++ b/randovania/games/am2r/logic_database/The Depths.json
@@ -4208,6 +4208,44 @@
                                     {
                                         "type": "and",
                                         "data": {
+                                            "comment": "Climb the right side and glide to the left https://youtu.be/Gq5wq0yHvCY",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Walljump"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "MorphGlide",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
                                             "comment": "IBJ",
                                             "items": [
                                                 {

--- a/randovania/games/am2r/logic_database/The Depths.txt
+++ b/randovania/games/am2r/logic_database/The Depths.txt
@@ -693,7 +693,7 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
       Any of the following:
           Space Jump or Can Use Spider Ball
           Hi-Jump Boots and Walljump (Beginner) and Can Walljump
-          # Climb the right side and glide to the left https://youtu.be/Gq5wq0yHvCY
+          # Climb the right side and glide to the left: https://youtu.be/Gq5wq0yHvCY
           Morph Glide (Intermediate) and Walljump (Expert) and Can Walljump
           # IBJ
           Infinite Bomb Jumping (Advanced) and Can IBJ and Can Use Bombs

--- a/randovania/games/am2r/logic_database/The Depths.txt
+++ b/randovania/games/am2r/logic_database/The Depths.txt
@@ -693,6 +693,8 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
       Any of the following:
           Space Jump or Can Use Spider Ball
           Hi-Jump Boots and Walljump (Beginner) and Can Walljump
+          # Climb the right side and glide to the left https://youtu.be/Gq5wq0yHvCY
+          Morph Glide (Intermediate) and Walljump (Expert) and Can Walljump
           # IBJ
           Infinite Bomb Jumping (Advanced) and Can IBJ and Can Use Bombs
 


### PR DESCRIPTION
On top of everything already in the database you can also reach bubble lair hub from shinespark cave west with just a glide and some expert walljumps as demonstrated here:

https://youtu.be/Gq5wq0yHvCY
(link I attached to the database)

![shinesparkcavetop](https://github.com/randovania/randovania/assets/172552024/8239fbb7-08a7-4329-8da9-03fa1a61b74a)