### PR TITLE
Only upload binaries to GH release

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -563,7 +563,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: packages/**
+          file: packages/Randovania * *
           file_glob: true
           tag: ${{ github.ref }}
           overwrite: true


### PR DESCRIPTION
(Hopefully) Fixes #6603 
Should hopefully, be fine, at least documentation has put `target/release/my*` as an example for the glob, so I'm assuming this works too.