### PR TITLE
Prime 1: add nerf_oob option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Prime
 
+- Added: Added an option to nerf out of bounds movement.
 - Fixed: Typo on the Quality of Life preset tab.
 
 #### Logic Database

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -991,6 +991,7 @@ class PrimePatchDataFactory(PatchDataFactory):
                 },
                 "requiredArtifactCount": (12 - self.configuration.artifact_target.value)
                 + self.configuration.artifact_required.value,
+                "patchWallcrawling": self.configuration.nerf_oob,
             },
             "tweaks": ctwk_config,
             "levelData": level_data,

--- a/randovania/games/prime1/gui/preset_settings/prime_patches_chaos.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_patches_chaos.py
@@ -41,6 +41,7 @@ class PresetPrimeChaos(PresetTab, Ui_PresetPrimeChaos):
             self._add_persist_option(getattr(self, f"{f}_check"), f)
         signal_handling.on_checked(self.small_samus_check, self._on_small_samus_changed)
         signal_handling.on_checked(self.large_samus_check, self._on_large_samus_changed)
+        signal_handling.on_checked(self.nerf_oob_check, self._on_nerf_oob_changed)
         self.superheated_slider.valueChanged.connect(self._on_slider_changed)
         self.submerged_slider.valueChanged.connect(self._on_slider_changed)
 
@@ -74,6 +75,10 @@ class PresetPrimeChaos(PresetTab, Ui_PresetPrimeChaos):
             editor.set_configuration_field("large_samus", value)
             if value:
                 editor.set_configuration_field("small_samus", False)
+
+    def _on_nerf_oob_changed(self, value: bool):
+        with self._editor as editor:
+            editor.set_configuration_field("nerf_oob", value)
 
     def _on_room_rando_changed(self, value: RoomRandoMode):
         with self._editor as editor:

--- a/randovania/games/prime1/gui/ui_files/preset_prime_chaos.ui
+++ b/randovania/games/prime1/gui/ui_files/preset_prime_chaos.ui
@@ -43,8 +43,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>487</width>
-         <height>1190</height>
+         <width>482</width>
+         <height>1440</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="scroll_layout">
@@ -118,6 +118,32 @@
             <widget class="QLabel" name="legacy_mode_label">
              <property name="text">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check this box to skip various patches, resulting in gameplay as close to the vanilla experience as possible. This includes:&lt;/p&gt;&lt;p&gt;Fixed crashes, Fixed softlocks, Fast item acquisition, Better pickup scans, Undo non-NTSC sequence break patches, Varia-only heat protection and &amp;quot;General&amp;quot; QoL&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="nerf_oob_group">
+          <property name="title">
+           <string>Out of Bounds</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <widget class="QCheckBox" name="nerf_oob_check">
+             <property name="text">
+              <string>Nerf Out of Bounds</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check this box to nerf out of bounds movement. It currently achieves this by reducing the size for room transitions drastically.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>

--- a/randovania/games/prime1/layout/prime_configuration.py
+++ b/randovania/games/prime1/layout/prime_configuration.py
@@ -123,6 +123,8 @@ class PrimeConfiguration(BaseConfiguration):
 
     enemy_attributes: EnemyAttributeRandomizer | None
 
+    nerf_oob: bool
+
     @classmethod
     def game_enum(cls) -> RandovaniaGame:
         return RandovaniaGame.METROID_PRIME

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1161,6 +1161,13 @@ def _migrate_v84(preset: dict) -> dict:
     return preset
 
 
+def _migrate_v85(preset: dict) -> dict:
+    if preset["game"] == "prime1":
+        preset["configuration"]["nerf_oob"] = False
+
+    return preset
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -1246,6 +1253,7 @@ _MIGRATIONS = [
     _migrate_v82,
     _migrate_v83,
     _migrate_v84,
+    _migrate_v85,
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/test/test_files/log_files/prime1_crazy_seed.rdvgame
+++ b/test/test_files/log_files/prime1_crazy_seed.rdvgame
@@ -10,7 +10,7 @@
         "word_hash": "Zoomer Puffer Chozo",
         "presets": [
             {
-                "schema_version": 40,
+                "schema_version": 86,
                 "base_preset_uuid": null,
                 "name": "TestPreset",
                 "uuid": "43c530a6-2e63-4de9-bac2-eab217d1693d",
@@ -43,1061 +43,1302 @@
                     },
                     "starting_location": [
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Antechamber"
+                            "region": "Chozo Ruins",
+                            "area": "Antechamber",
+                            "node": "Door to Reflecting Pool"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Arboretum"
+                            "region": "Chozo Ruins",
+                            "area": "Arboretum",
+                            "node": "Door to Arboretum Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Arboretum Access"
+                            "region": "Chozo Ruins",
+                            "area": "Arboretum Access",
+                            "node": "Door to Ruined Fountain"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Burn Dome"
+                            "region": "Chozo Ruins",
+                            "area": "Burn Dome",
+                            "node": "Door to Burn Dome Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Burn Dome Access"
+                            "region": "Chozo Ruins",
+                            "area": "Burn Dome Access",
+                            "node": "Spawn Point"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Crossway"
+                            "region": "Chozo Ruins",
+                            "area": "Crossway",
+                            "node": "Door to Crossway Access West"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Crossway Access South"
+                            "region": "Chozo Ruins",
+                            "area": "Crossway Access South",
+                            "node": "Door to Crossway"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Crossway Access West"
+                            "region": "Chozo Ruins",
+                            "area": "Crossway Access West",
+                            "node": "Door to Crossway"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Dynamo"
+                            "region": "Chozo Ruins",
+                            "area": "Dynamo",
+                            "node": "Door to Dynamo Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Dynamo Access"
+                            "region": "Chozo Ruins",
+                            "area": "Dynamo Access",
+                            "node": "Door to Dynamo"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "East Atrium"
+                            "region": "Chozo Ruins",
+                            "area": "East Atrium",
+                            "node": "Door to Gathering Hall"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "East Furnace Access"
+                            "region": "Chozo Ruins",
+                            "area": "East Furnace Access",
+                            "node": "Door to Hall of the Elders"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Elder Hall Access"
+                            "region": "Chozo Ruins",
+                            "area": "Elder Hall Access",
+                            "node": "Door to Hall of the Elders"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Energy Core"
+                            "region": "Chozo Ruins",
+                            "area": "Energy Core",
+                            "node": "Door to Energy Core Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Energy Core Access"
+                            "region": "Chozo Ruins",
+                            "area": "Energy Core Access",
+                            "node": "Door to Energy Core"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Eyon Tunnel"
+                            "region": "Chozo Ruins",
+                            "area": "Eyon Tunnel",
+                            "node": "Door to Nursery Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Furnace"
+                            "region": "Chozo Ruins",
+                            "area": "Gathering Hall",
+                            "node": "Door to Save Station 2"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Gathering Hall"
+                            "region": "Chozo Ruins",
+                            "area": "Gathering Hall Access",
+                            "node": "Door to Arboretum"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Gathering Hall Access"
+                            "region": "Chozo Ruins",
+                            "area": "Hall of the Elders",
+                            "node": "Door to Elder Hall Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Hall of the Elders"
+                            "region": "Chozo Ruins",
+                            "area": "Hive Totem",
+                            "node": "Door to Totem Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Hive Totem"
+                            "region": "Chozo Ruins",
+                            "area": "Magma Pool",
+                            "node": "Door to Meditation Fountain"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Magma Pool"
+                            "region": "Chozo Ruins",
+                            "area": "Main Plaza",
+                            "node": "Door to Ruins Entrance"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Main Plaza"
+                            "region": "Chozo Ruins",
+                            "area": "Map Station",
+                            "node": "Door to Ruined Gallery"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Map Station"
+                            "region": "Chozo Ruins",
+                            "area": "Meditation Fountain",
+                            "node": "Door to Ruined Fountain"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Meditation Fountain"
+                            "region": "Chozo Ruins",
+                            "area": "North Atrium",
+                            "node": "Door to Ruined Nursery"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "North Atrium"
+                            "region": "Chozo Ruins",
+                            "area": "Nursery Access",
+                            "node": "Door to Eyon Tunnel"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Nursery Access"
+                            "region": "Chozo Ruins",
+                            "area": "Piston Tunnel",
+                            "node": "Morph Ball Door to Training Chamber"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Piston Tunnel"
+                            "region": "Chozo Ruins",
+                            "area": "Plaza Access",
+                            "node": "Door to Vault"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Plaza Access"
+                            "region": "Chozo Ruins",
+                            "area": "Reflecting Pool",
+                            "node": "Door to Reflecting Pool Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Reflecting Pool"
+                            "region": "Chozo Ruins",
+                            "area": "Reflecting Pool Access",
+                            "node": "Door to Reflecting Pool"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Reflecting Pool Access"
+                            "region": "Chozo Ruins",
+                            "area": "Ruined Fountain",
+                            "node": "Door to Ruined Fountain Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Ruined Fountain"
+                            "region": "Chozo Ruins",
+                            "area": "Ruined Fountain Access",
+                            "node": "Door to Ruined Fountain"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Ruined Fountain Access"
+                            "region": "Chozo Ruins",
+                            "area": "Ruined Gallery",
+                            "node": "Door to Totem Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Ruined Gallery"
+                            "region": "Chozo Ruins",
+                            "area": "Ruined Nursery",
+                            "node": "Door to Eyon Tunnel"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Ruined Nursery"
+                            "region": "Chozo Ruins",
+                            "area": "Ruined Shrine",
+                            "node": "Door to Ruined Shrine Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Ruined Shrine"
+                            "region": "Chozo Ruins",
+                            "area": "Ruined Shrine Access",
+                            "node": "Door to Ruined Shrine"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Ruined Shrine Access"
+                            "region": "Chozo Ruins",
+                            "area": "Ruins Entrance",
+                            "node": "Door to Transport to Tallon Overworld North"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Ruins Entrance"
+                            "region": "Chozo Ruins",
+                            "area": "Save Station 1",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Save Station 1"
+                            "region": "Chozo Ruins",
+                            "area": "Save Station 2",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Save Station 2"
+                            "region": "Chozo Ruins",
+                            "area": "Save Station 3",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Save Station 3"
+                            "region": "Chozo Ruins",
+                            "area": "Sun Tower",
+                            "node": "Door to Sun Tower Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Sun Tower"
+                            "region": "Chozo Ruins",
+                            "area": "Sun Tower Access",
+                            "node": "Door to Sun Tower"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Sun Tower Access"
+                            "region": "Chozo Ruins",
+                            "area": "Sunchamber",
+                            "node": "Before Fight (Front)"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Sunchamber"
+                            "region": "Chozo Ruins",
+                            "area": "Sunchamber Access",
+                            "node": "Door to Sunchamber Lobby"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Sunchamber Access"
+                            "region": "Chozo Ruins",
+                            "area": "Sunchamber Lobby",
+                            "node": "Door to Sunchamber Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Sunchamber Lobby"
+                            "region": "Chozo Ruins",
+                            "area": "Totem Access",
+                            "node": "Door to Ruined Gallery"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Totem Access"
+                            "region": "Chozo Ruins",
+                            "area": "Tower Chamber",
+                            "node": "Door to Tower of Light"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Tower Chamber"
+                            "region": "Chozo Ruins",
+                            "area": "Tower of Light",
+                            "node": "Door to Tower of Light Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Tower of Light"
+                            "region": "Chozo Ruins",
+                            "area": "Tower of Light Access",
+                            "node": "Door to Ruined Shrine"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Tower of Light Access"
+                            "region": "Chozo Ruins",
+                            "area": "Training Chamber",
+                            "node": "Door to Training Chamber Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Training Chamber"
+                            "region": "Chozo Ruins",
+                            "area": "Training Chamber Access",
+                            "node": "Door to Magma Pool"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Training Chamber Access"
+                            "region": "Chozo Ruins",
+                            "area": "Transport Access North",
+                            "node": "Door to Hive Totem"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Transport Access North"
+                            "region": "Chozo Ruins",
+                            "area": "Transport Access South",
+                            "node": "Door to Reflecting Pool"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Transport Access South"
+                            "region": "Chozo Ruins",
+                            "area": "Transport to Magmoor Caverns North",
+                            "node": "Teleporter to Magmoor Caverns"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Transport to Magmoor Caverns North"
+                            "region": "Chozo Ruins",
+                            "area": "Transport to Tallon Overworld East",
+                            "node": "Teleporter to Tallon Overworld"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Transport to Tallon Overworld East"
+                            "region": "Chozo Ruins",
+                            "area": "Transport to Tallon Overworld North",
+                            "node": "Teleporter to Tallon Overworld"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Transport to Tallon Overworld North"
+                            "region": "Chozo Ruins",
+                            "area": "Transport to Tallon Overworld South",
+                            "node": "Teleporter to Tallon Overworld"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Transport to Tallon Overworld South"
+                            "region": "Chozo Ruins",
+                            "area": "Vault",
+                            "node": "Door to Plaza Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Vault"
+                            "region": "Chozo Ruins",
+                            "area": "Vault Access",
+                            "node": "Door to Vault"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Vault Access"
+                            "region": "Chozo Ruins",
+                            "area": "Watery Hall",
+                            "node": "Door to Watery Hall Access"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Watery Hall"
+                            "region": "Chozo Ruins",
+                            "area": "Watery Hall Access",
+                            "node": "Door to Gathering Hall"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "Watery Hall Access"
+                            "region": "Chozo Ruins",
+                            "area": "West Furnace Access",
+                            "node": "Door to Furnace"
                         },
                         {
-                            "world_name": "Chozo Ruins",
-                            "area_name": "West Furnace Access"
+                            "region": "Frigate Orpheon",
+                            "area": "Air Lock",
+                            "node": "Door to Exterior Docking Hangar"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Air Lock"
+                            "region": "Frigate Orpheon",
+                            "area": "Biohazard Containment",
+                            "node": "Door to Deck Beta Transit Hall"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Biohazard Containment"
+                            "region": "Frigate Orpheon",
+                            "area": "Biotech Research Area 1",
+                            "node": "Door to Deck Beta Conduit Hall"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Biotech Research Area 1"
+                            "region": "Frigate Orpheon",
+                            "area": "Biotech Research Area 2",
+                            "node": "Door from Main Ventilation Shaft Section F"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Biotech Research Area 2"
+                            "region": "Frigate Orpheon",
+                            "area": "Cargo Freight Lift to Deck Gamma",
+                            "node": "Door to Deck Beta Transit Hall"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Cargo Freight Lift to Deck Gamma"
+                            "region": "Frigate Orpheon",
+                            "area": "Connection Elevator to Deck Alpha",
+                            "node": "Door from Biotech Research Area 2"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Connection Elevator to Deck Alpha"
+                            "region": "Frigate Orpheon",
+                            "area": "Connection Elevator to Deck Beta",
+                            "node": "Door to Map Facility"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Connection Elevator to Deck Beta"
+                            "region": "Frigate Orpheon",
+                            "area": "Connection Elevator to Deck Beta (2)",
+                            "node": "Door from Deck Gamma Monitor Hall"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Connection Elevator to Deck Beta (2)"
+                            "region": "Frigate Orpheon",
+                            "area": "Deck Alpha Access Hall",
+                            "node": "Door to Air Lock"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Deck Alpha Access Hall"
+                            "region": "Frigate Orpheon",
+                            "area": "Deck Alpha Mech Shaft",
+                            "node": "Dock from Connection Elevator to Deck Alpha"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Deck Alpha Mech Shaft"
+                            "region": "Frigate Orpheon",
+                            "area": "Deck Alpha Umbilical Hall",
+                            "node": "Door to Emergency Evacuation Area"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Deck Alpha Umbilical Hall"
+                            "region": "Frigate Orpheon",
+                            "area": "Deck Beta Conduit Hall",
+                            "node": "Door to Connection Elevator to Deck Beta"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Deck Beta Conduit Hall"
+                            "region": "Frigate Orpheon",
+                            "area": "Deck Beta Security Hall",
+                            "node": "Door to Biotech Research Area 1"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Deck Beta Security Hall"
+                            "region": "Frigate Orpheon",
+                            "area": "Deck Beta Transit Hall",
+                            "node": "Door to Biohazard Containment"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Deck Beta Transit Hall"
+                            "region": "Frigate Orpheon",
+                            "area": "Deck Gamma Monitor Hall",
+                            "node": "Door from Reactor Core"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Deck Gamma Monitor Hall"
+                            "region": "Frigate Orpheon",
+                            "area": "Emergency Evacuation Area",
+                            "node": "Door to Deck Alpha Access Hall"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Emergency Evacuation Area"
+                            "region": "Frigate Orpheon",
+                            "area": "Exterior Docking Hangar",
+                            "node": "Ship Save"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Exterior Docking Hangar"
+                            "region": "Frigate Orpheon",
+                            "area": "Main Ventilation Shaft Section A",
+                            "node": "Door from Cargo Freight Lift to Deck Gamma"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Main Ventilation Shaft Section A"
+                            "region": "Frigate Orpheon",
+                            "area": "Main Ventilation Shaft Section B",
+                            "node": "Door from Main Ventilation Shaft Section A"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Main Ventilation Shaft Section B"
+                            "region": "Frigate Orpheon",
+                            "area": "Main Ventilation Shaft Section C",
+                            "node": "Door from Main Ventilation Shaft Section B"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Main Ventilation Shaft Section C"
+                            "region": "Frigate Orpheon",
+                            "area": "Main Ventilation Shaft Section D",
+                            "node": "Door from Main Ventilation Shaft Section C"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Main Ventilation Shaft Section D"
+                            "region": "Frigate Orpheon",
+                            "area": "Main Ventilation Shaft Section E",
+                            "node": "Door from Main Ventilation Shaft Section D"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Main Ventilation Shaft Section E"
+                            "region": "Frigate Orpheon",
+                            "area": "Main Ventilation Shaft Section F",
+                            "node": "Door from Main Ventilation Shaft Section E"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Main Ventilation Shaft Section F"
+                            "region": "Frigate Orpheon",
+                            "area": "Map Facility",
+                            "node": "Door to Deck Alpha Umbilical Hall"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Map Facility"
+                            "region": "Frigate Orpheon",
+                            "area": "Reactor Core",
+                            "node": "Door from Reactor Core Entrance"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Reactor Core"
+                            "region": "Frigate Orpheon",
+                            "area": "Reactor Core Entrance",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Reactor Core Entrance"
+                            "region": "Frigate Orpheon",
+                            "area": "Subventilation Shaft Section A",
+                            "node": "Door from Biotech Research Area 1"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Subventilation Shaft Section A"
+                            "region": "Frigate Orpheon",
+                            "area": "Subventilation Shaft Section B",
+                            "node": "Door from Subventilation Shaft Section A"
                         },
                         {
-                            "world_name": "Frigate Orpheon",
-                            "area_name": "Subventilation Shaft Section B"
+                            "region": "Magmoor Caverns",
+                            "area": "Burning Trail",
+                            "node": "Door to Transport to Chozo Ruins North"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Burning Trail"
+                            "region": "Magmoor Caverns",
+                            "area": "Fiery Shores",
+                            "node": "Door to Shore Tunnel"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Fiery Shores"
+                            "region": "Magmoor Caverns",
+                            "area": "Geothermal Core",
+                            "node": "Door to South Core Tunnel"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Geothermal Core"
+                            "region": "Magmoor Caverns",
+                            "area": "Lake Tunnel",
+                            "node": "Door to Burning Trail"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Lake Tunnel"
+                            "region": "Magmoor Caverns",
+                            "area": "Lava Lake",
+                            "node": "Door to Lake Tunnel"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Lava Lake"
+                            "region": "Magmoor Caverns",
+                            "area": "Magmoor Workstation",
+                            "node": "Door to Transport Tunnel C"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Magmoor Workstation"
+                            "region": "Magmoor Caverns",
+                            "area": "Monitor Station",
+                            "node": "Door to Monitor Tunnel"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Monitor Station"
+                            "region": "Magmoor Caverns",
+                            "area": "Monitor Tunnel",
+                            "node": "Door to Monitor Station"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Monitor Tunnel"
+                            "region": "Magmoor Caverns",
+                            "area": "North Core Tunnel",
+                            "node": "Door to Twin Fires"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "North Core Tunnel"
+                            "region": "Magmoor Caverns",
+                            "area": "Pit Tunnel",
+                            "node": "Door to Lava Lake"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Pit Tunnel"
+                            "region": "Magmoor Caverns",
+                            "area": "Plasma Processing",
+                            "node": "Door to Geothermal Core"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Plasma Processing"
+                            "region": "Magmoor Caverns",
+                            "area": "Save Station Magmoor A",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Save Station Magmoor A"
+                            "region": "Magmoor Caverns",
+                            "area": "Save Station Magmoor B",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Save Station Magmoor B"
+                            "region": "Magmoor Caverns",
+                            "area": "Shore Tunnel",
+                            "node": "Door to Monitor Station"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Shore Tunnel"
+                            "region": "Magmoor Caverns",
+                            "area": "South Core Tunnel",
+                            "node": "Door to Geothermal Core"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "South Core Tunnel"
+                            "region": "Magmoor Caverns",
+                            "area": "Storage Cavern",
+                            "node": "Door to Triclops Pit"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Storage Cavern"
+                            "region": "Magmoor Caverns",
+                            "area": "Transport Tunnel A",
+                            "node": "Door to Transport to Phendrana Drifts North"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Transport Tunnel A"
+                            "region": "Magmoor Caverns",
+                            "area": "Transport Tunnel B",
+                            "node": "Door to Fiery Shores"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Transport Tunnel B"
+                            "region": "Magmoor Caverns",
+                            "area": "Transport Tunnel C",
+                            "node": "Door to Magmoor Workstation"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Transport Tunnel C"
+                            "region": "Magmoor Caverns",
+                            "area": "Transport to Chozo Ruins North",
+                            "node": "Teleporter to Chozo Ruins"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Transport to Chozo Ruins North"
+                            "region": "Magmoor Caverns",
+                            "area": "Transport to Phazon Mines West",
+                            "node": "Teleporter to Phazon Mines"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Transport to Phazon Mines West"
+                            "region": "Magmoor Caverns",
+                            "area": "Transport to Phendrana Drifts North",
+                            "node": "Teleporter to Phendrana Drifts"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Transport to Phendrana Drifts North"
+                            "region": "Magmoor Caverns",
+                            "area": "Transport to Phendrana Drifts South",
+                            "node": "Teleporter to Phendrana Drifts"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Transport to Phendrana Drifts South"
+                            "region": "Magmoor Caverns",
+                            "area": "Transport to Tallon Overworld West",
+                            "node": "Teleporter to Tallon Overworld"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Transport to Tallon Overworld West"
+                            "region": "Magmoor Caverns",
+                            "area": "Triclops Pit",
+                            "node": "Door to Monitor Tunnel"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Triclops Pit"
+                            "region": "Magmoor Caverns",
+                            "area": "Twin Fires",
+                            "node": "Door to Twin Fires Tunnel"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Twin Fires"
+                            "region": "Magmoor Caverns",
+                            "area": "Twin Fires Tunnel",
+                            "node": "Door to Twin Fires"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Twin Fires Tunnel"
+                            "region": "Magmoor Caverns",
+                            "area": "Warrior Shrine",
+                            "node": "Door to Monitor Station"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Warrior Shrine"
+                            "region": "Magmoor Caverns",
+                            "area": "Workstation Tunnel",
+                            "node": "Door to Magmoor Workstation"
                         },
                         {
-                            "world_name": "Magmoor Caverns",
-                            "area_name": "Workstation Tunnel"
+                            "region": "Phazon Mines",
+                            "area": "Central Dynamo",
+                            "node": "Door to Dynamo Access"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Central Dynamo"
+                            "region": "Phazon Mines",
+                            "area": "Dynamo Access",
+                            "node": "Door to Central Dynamo"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Dynamo Access"
+                            "region": "Phazon Mines",
+                            "area": "Elevator A",
+                            "node": "Door to Elevator Access A"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Elevator A"
+                            "region": "Phazon Mines",
+                            "area": "Elevator Access A",
+                            "node": "Door to Ore Processing"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Elevator Access A"
+                            "region": "Phazon Mines",
+                            "area": "Elevator Access B",
+                            "node": "Door to Metroid Quarantine A"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Elevator Access B"
+                            "region": "Phazon Mines",
+                            "area": "Elevator B",
+                            "node": "Door to Elevator Access B"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Elevator B"
+                            "region": "Phazon Mines",
+                            "area": "Elite Control",
+                            "node": "Door to Elite Control Access"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Elite Control"
+                            "region": "Phazon Mines",
+                            "area": "Elite Control Access",
+                            "node": "Door to Elevator A"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Elite Control Access"
+                            "region": "Phazon Mines",
+                            "area": "Elite Quarters",
+                            "node": "Door to Elite Quarters Access"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Elite Quarters"
+                            "region": "Phazon Mines",
+                            "area": "Elite Quarters Access",
+                            "node": "Door to Metroid Quarantine B"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Elite Quarters Access"
+                            "region": "Phazon Mines",
+                            "area": "Elite Research",
+                            "node": "Door to Security Access B"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Elite Research"
+                            "region": "Phazon Mines",
+                            "area": "Fungal Hall A",
+                            "node": "Door to Fungal Hall Access"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Fungal Hall A"
+                            "region": "Phazon Mines",
+                            "area": "Fungal Hall Access",
+                            "node": "Door to Elevator B"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Fungal Hall Access"
+                            "region": "Phazon Mines",
+                            "area": "Fungal Hall B",
+                            "node": "Door to Phazon Mining Tunnel"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Fungal Hall B"
+                            "region": "Phazon Mines",
+                            "area": "Main Quarry",
+                            "node": "Door to Quarry Access"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Main Quarry"
+                            "region": "Phazon Mines",
+                            "area": "Maintenance Tunnel",
+                            "node": "Door to Elite Control"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Maintenance Tunnel"
+                            "region": "Phazon Mines",
+                            "area": "Map Station Mines",
+                            "node": "Door to Omega Research"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Map Station Mines"
+                            "region": "Phazon Mines",
+                            "area": "Metroid Quarantine A",
+                            "node": "Door to Quarantine Access A"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Metroid Quarantine A"
+                            "region": "Phazon Mines",
+                            "area": "Metroid Quarantine B",
+                            "node": "Door to Quarantine Access B"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Metroid Quarantine B"
+                            "region": "Phazon Mines",
+                            "area": "Missile Station Mines",
+                            "node": "Door to Fungal Hall B"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Mine Security Station"
+                            "region": "Phazon Mines",
+                            "area": "Omega Research",
+                            "node": "Door to Ventilation Shaft"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Missile Station Mines"
+                            "region": "Phazon Mines",
+                            "area": "Ore Processing",
+                            "node": "Door to Elevator Access A"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Omega Research"
+                            "region": "Phazon Mines",
+                            "area": "Phazon Mining Tunnel",
+                            "node": "Door to Fungal Hall A"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Ore Processing"
+                            "region": "Phazon Mines",
+                            "area": "Phazon Processing Center",
+                            "node": "Door to Maintenance Tunnel"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Phazon Mining Tunnel"
+                            "region": "Phazon Mines",
+                            "area": "Processing Center Access",
+                            "node": "Door to Elite Quarters"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Phazon Processing Center"
+                            "region": "Phazon Mines",
+                            "area": "Quarantine Access A",
+                            "node": "Door to Central Dynamo"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Processing Center Access"
+                            "region": "Phazon Mines",
+                            "area": "Quarantine Access B",
+                            "node": "Door to Fungal Hall B"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Quarantine Access A"
+                            "region": "Phazon Mines",
+                            "area": "Quarry Access",
+                            "node": "Door to Transport to Tallon Overworld South"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Quarantine Access B"
+                            "region": "Phazon Mines",
+                            "area": "Research Access",
+                            "node": "Door to Ore Processing"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Quarry Access"
+                            "region": "Phazon Mines",
+                            "area": "Save Station Mines B",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Research Access"
+                            "region": "Phazon Mines",
+                            "area": "Save Station Mines C",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Save Station Mines B"
+                            "region": "Phazon Mines",
+                            "area": "Security Access A",
+                            "node": "Door to Main Quarry"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Save Station Mines C"
+                            "region": "Phazon Mines",
+                            "area": "Security Access B",
+                            "node": "Door to Mine Security Station"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Security Access A"
+                            "region": "Phazon Mines",
+                            "area": "Storage Depot A",
+                            "node": "Door to Mine Security Station"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Security Access B"
+                            "region": "Phazon Mines",
+                            "area": "Storage Depot B",
+                            "node": "Door to Ore Processing"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Storage Depot A"
+                            "region": "Phazon Mines",
+                            "area": "Transport Access",
+                            "node": "Door to Phazon Processing Center"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Storage Depot B"
+                            "region": "Phazon Mines",
+                            "area": "Transport to Magmoor Caverns South",
+                            "node": "Teleporter to Magmoor Caverns"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Transport Access"
+                            "region": "Phazon Mines",
+                            "area": "Transport to Tallon Overworld South",
+                            "node": "Teleporter to Tallon Overworld"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Transport to Magmoor Caverns South"
+                            "region": "Phazon Mines",
+                            "area": "Ventilation Shaft",
+                            "node": "Door to Elite Control"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Transport to Tallon Overworld South"
+                            "region": "Phazon Mines",
+                            "area": "Waste Disposal",
+                            "node": "Door to Ore Processing"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Ventilation Shaft"
+                            "region": "Phendrana Drifts",
+                            "area": "Aether Lab Entryway",
+                            "node": "Door to East Tower"
                         },
                         {
-                            "world_name": "Phazon Mines",
-                            "area_name": "Waste Disposal"
+                            "region": "Phendrana Drifts",
+                            "area": "Canyon Entryway",
+                            "node": "Door to Ice Ruins West"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Aether Lab Entryway"
+                            "region": "Phendrana Drifts",
+                            "area": "Chamber Access",
+                            "node": "Door to Hunter Cave"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Canyon Entryway"
+                            "region": "Phendrana Drifts",
+                            "area": "Chapel Tunnel",
+                            "node": "Door to Chapel of the Elders"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Chamber Access"
+                            "region": "Phendrana Drifts",
+                            "area": "Chapel of the Elders",
+                            "node": "Door to Chapel Tunnel"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Chapel Tunnel"
+                            "region": "Phendrana Drifts",
+                            "area": "Chozo Ice Temple",
+                            "node": "Door to Temple Entryway"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Chapel of the Elders"
+                            "region": "Phendrana Drifts",
+                            "area": "Courtyard Entryway",
+                            "node": "Door to Ruined Courtyard"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Chozo Ice Temple"
+                            "region": "Phendrana Drifts",
+                            "area": "East Tower",
+                            "node": "Door to Control Tower"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Control Tower"
+                            "region": "Phendrana Drifts",
+                            "area": "Frost Cave",
+                            "node": "Door to Frost Cave Access"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Courtyard Entryway"
+                            "region": "Phendrana Drifts",
+                            "area": "Frost Cave Access",
+                            "node": "Door to Frozen Pike"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "East Tower"
+                            "region": "Phendrana Drifts",
+                            "area": "Frozen Pike",
+                            "node": "Door to Pike Access"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Frost Cave"
+                            "region": "Phendrana Drifts",
+                            "area": "Gravity Chamber",
+                            "node": "Door to Lake Tunnel"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Frost Cave Access"
+                            "region": "Phendrana Drifts",
+                            "area": "Hunter Cave",
+                            "node": "Door to Lower Edge Tunnel"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Frozen Pike"
+                            "region": "Phendrana Drifts",
+                            "area": "Hunter Cave Access",
+                            "node": "Door to Frozen Pike"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Gravity Chamber"
+                            "region": "Phendrana Drifts",
+                            "area": "Hydra Lab Entryway",
+                            "node": "Door to Research Entrance"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Hunter Cave"
+                            "region": "Phendrana Drifts",
+                            "area": "Ice Ruins Access",
+                            "node": "Door to Phendrana Shorelines"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Hunter Cave Access"
+                            "region": "Phendrana Drifts",
+                            "area": "Ice Ruins East",
+                            "node": "Door to Ice Ruins Access"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Hydra Lab Entryway"
+                            "region": "Phendrana Drifts",
+                            "area": "Ice Ruins West",
+                            "node": "Door to Ruins Entryway"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Ice Ruins Access"
+                            "region": "Phendrana Drifts",
+                            "area": "Lake Tunnel",
+                            "node": "Door to Hunter Cave"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Ice Ruins East"
+                            "region": "Phendrana Drifts",
+                            "area": "Lower Edge Tunnel",
+                            "node": "Door to Phendrana's Edge"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Ice Ruins West"
+                            "region": "Phendrana Drifts",
+                            "area": "Map Station",
+                            "node": "Door to Research Entrance"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Lake Tunnel"
+                            "region": "Phendrana Drifts",
+                            "area": "North Quarantine Tunnel",
+                            "node": "Door to Quarantine Access"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Lower Edge Tunnel"
+                            "region": "Phendrana Drifts",
+                            "area": "Observatory",
+                            "node": "Door to Observatory Access"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Map Station"
+                            "region": "Phendrana Drifts",
+                            "area": "Observatory Access",
+                            "node": "Door to Research Lab Hydra"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "North Quarantine Tunnel"
+                            "region": "Phendrana Drifts",
+                            "area": "Phendrana Canyon",
+                            "node": "Door to Canyon Entryway"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Observatory"
+                            "region": "Phendrana Drifts",
+                            "area": "Phendrana Shorelines",
+                            "node": "Door to Shoreline Entrance"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Observatory Access"
+                            "region": "Phendrana Drifts",
+                            "area": "Phendrana's Edge",
+                            "node": "Door to Upper Edge Tunnel"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Phendrana Canyon"
+                            "region": "Phendrana Drifts",
+                            "area": "Pike Access",
+                            "node": "Door to Research Core"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Phendrana Shorelines"
+                            "region": "Phendrana Drifts",
+                            "area": "Plaza Walkway",
+                            "node": "Door to Ice Ruins East"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Phendrana's Edge"
+                            "region": "Phendrana Drifts",
+                            "area": "Quarantine Access",
+                            "node": "Door to Ruined Courtyard"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Pike Access"
+                            "region": "Phendrana Drifts",
+                            "area": "Quarantine Cave",
+                            "node": "Door to North Quarantine Tunnel"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Plaza Walkway"
+                            "region": "Phendrana Drifts",
+                            "area": "Quarantine Monitor",
+                            "node": "Morph Ball Door to Quarantine Cave"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Quarantine Access"
+                            "region": "Phendrana Drifts",
+                            "area": "Research Core",
+                            "node": "Door to Research Core Access"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Quarantine Cave"
+                            "region": "Phendrana Drifts",
+                            "area": "Research Core Access",
+                            "node": "Door to Research Core"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Quarantine Monitor"
+                            "region": "Phendrana Drifts",
+                            "area": "Research Entrance",
+                            "node": "Door to Specimen Storage"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Research Core"
+                            "region": "Phendrana Drifts",
+                            "area": "Research Lab Aether",
+                            "node": "Door to Aether Lab Entryway"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Research Core Access"
+                            "region": "Phendrana Drifts",
+                            "area": "Research Lab Hydra",
+                            "node": "Door to Hydra Lab Entryway"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Research Entrance"
+                            "region": "Phendrana Drifts",
+                            "area": "Ruined Courtyard",
+                            "node": "Door to Quarantine Access"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Research Lab Aether"
+                            "region": "Phendrana Drifts",
+                            "area": "Ruins Entryway",
+                            "node": "Door to Phendrana Shorelines"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Research Lab Hydra"
+                            "region": "Phendrana Drifts",
+                            "area": "Save Station A",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Ruined Courtyard"
+                            "region": "Phendrana Drifts",
+                            "area": "Save Station B",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Ruins Entryway"
+                            "region": "Phendrana Drifts",
+                            "area": "Save Station C",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Save Station A"
+                            "region": "Phendrana Drifts",
+                            "area": "Save Station D",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Save Station B"
+                            "region": "Phendrana Drifts",
+                            "area": "Security Cave",
+                            "node": "Morph Ball Door to Phendrana's Edge"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Save Station C"
+                            "region": "Phendrana Drifts",
+                            "area": "Shoreline Entrance",
+                            "node": "Door to Transport to Magmoor Caverns West"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Save Station D"
+                            "region": "Phendrana Drifts",
+                            "area": "South Quarantine Tunnel",
+                            "node": "Door to Transport to Magmoor Caverns South"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Security Cave"
+                            "region": "Phendrana Drifts",
+                            "area": "Specimen Storage",
+                            "node": "Door to Ruined Courtyard"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Shoreline Entrance"
+                            "region": "Phendrana Drifts",
+                            "area": "Storage Cave",
+                            "node": "Door to Phendrana's Edge"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "South Quarantine Tunnel"
+                            "region": "Phendrana Drifts",
+                            "area": "Temple Entryway",
+                            "node": "Door to Phendrana Shorelines"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Specimen Storage"
+                            "region": "Phendrana Drifts",
+                            "area": "Transport Access",
+                            "node": "Door to Frozen Pike"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Storage Cave"
+                            "region": "Phendrana Drifts",
+                            "area": "Transport to Magmoor Caverns South",
+                            "node": "Teleporter to Magmoor Caverns"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Temple Entryway"
+                            "region": "Phendrana Drifts",
+                            "area": "Transport to Magmoor Caverns West",
+                            "node": "Teleporter to Magmoor Caverns"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Transport Access"
+                            "region": "Phendrana Drifts",
+                            "area": "Upper Edge Tunnel",
+                            "node": "Door to Phendrana's Edge"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Transport to Magmoor Caverns South"
+                            "region": "Phendrana Drifts",
+                            "area": "West Tower",
+                            "node": "Door to West Tower Entrance"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Transport to Magmoor Caverns West"
+                            "region": "Phendrana Drifts",
+                            "area": "West Tower Entrance",
+                            "node": "Door to West Tower"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "Upper Edge Tunnel"
+                            "region": "Tallon Overworld",
+                            "area": "Alcove",
+                            "node": "Door to Landing Site"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "West Tower"
+                            "region": "Tallon Overworld",
+                            "area": "Arbor Chamber",
+                            "node": "Door to Root Cave"
                         },
                         {
-                            "world_name": "Phendrana Drifts",
-                            "area_name": "West Tower Entrance"
+                            "region": "Tallon Overworld",
+                            "area": "Artifact Temple",
+                            "node": "Door to Temple Lobby"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Alcove"
+                            "region": "Tallon Overworld",
+                            "area": "Biohazard Containment",
+                            "node": "Door to Deck Beta Transit Hall"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Arbor Chamber"
+                            "region": "Tallon Overworld",
+                            "area": "Biotech Research Area 1",
+                            "node": "Door to Deck Beta Security Hall"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Artifact Temple"
+                            "region": "Tallon Overworld",
+                            "area": "Canyon Cavern",
+                            "node": "Door to Tallon Canyon"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Biohazard Containment"
+                            "region": "Tallon Overworld",
+                            "area": "Cargo Freight Lift to Deck Gamma",
+                            "node": "Door to Reactor Access"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Biotech Research Area 1"
+                            "region": "Tallon Overworld",
+                            "area": "Connection Elevator to Deck Beta",
+                            "node": "Door to Deck Beta Conduit Hall"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Canyon Cavern"
+                            "region": "Tallon Overworld",
+                            "area": "Deck Beta Conduit Hall",
+                            "node": "Door to Connection Elevator to Deck Beta"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Cargo Freight Lift to Deck Gamma"
+                            "region": "Tallon Overworld",
+                            "area": "Deck Beta Security Hall",
+                            "node": "Door to Biohazard Containment"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Connection Elevator to Deck Beta"
+                            "region": "Tallon Overworld",
+                            "area": "Deck Beta Transit Hall",
+                            "node": "Door to Cargo Freight Lift to Deck Gamma"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Deck Beta Conduit Hall"
+                            "region": "Tallon Overworld",
+                            "area": "Frigate Access Tunnel",
+                            "node": "Door to Main Ventilation Shaft Section C"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Deck Beta Security Hall"
+                            "region": "Tallon Overworld",
+                            "area": "Frigate Crash Site",
+                            "node": "Door to Waterfall Cavern"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Deck Beta Transit Hall"
+                            "region": "Tallon Overworld",
+                            "area": "Great Tree Chamber",
+                            "node": "Door to Great Tree Hall"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Frigate Access Tunnel"
+                            "region": "Tallon Overworld",
+                            "area": "Great Tree Hall",
+                            "node": "Door to Transport Tunnel E"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Frigate Crash Site"
+                            "region": "Tallon Overworld",
+                            "area": "Gully",
+                            "node": "Door to Tallon Canyon"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Great Tree Chamber"
+                            "region": "Tallon Overworld",
+                            "area": "Hydro Access Tunnel",
+                            "node": "Door to Connection Elevator to Deck Beta"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Great Tree Hall"
+                            "region": "Tallon Overworld",
+                            "area": "Landing Site",
+                            "node": "Ship"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Gully"
+                            "region": "Tallon Overworld",
+                            "area": "Life Grove",
+                            "node": "Morph Ball Door to Life Grove Tunnel"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Hydro Access Tunnel"
+                            "region": "Tallon Overworld",
+                            "area": "Life Grove Tunnel",
+                            "node": "Door to Great Tree Hall"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Landing Site"
+                            "region": "Tallon Overworld",
+                            "area": "Main Ventilation Shaft Section A",
+                            "node": "Door to Main Ventilation Shaft Section B"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Life Grove"
+                            "region": "Tallon Overworld",
+                            "area": "Main Ventilation Shaft Section B",
+                            "node": "Door to Main Ventilation Shaft Section C"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Life Grove Tunnel"
+                            "region": "Tallon Overworld",
+                            "area": "Main Ventilation Shaft Section C",
+                            "node": "Door to Frigate Access Tunnel"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Main Ventilation Shaft Section A"
+                            "region": "Tallon Overworld",
+                            "area": "Reactor Access",
+                            "node": "Door to Reactor Core"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Main Ventilation Shaft Section B"
+                            "region": "Tallon Overworld",
+                            "area": "Reactor Core",
+                            "node": "Door to Main Ventilation Shaft Section A"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Main Ventilation Shaft Section C"
+                            "region": "Tallon Overworld",
+                            "area": "Root Cave",
+                            "node": "Door to Transport Tunnel B"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Overgrown Cavern"
+                            "region": "Tallon Overworld",
+                            "area": "Root Tunnel",
+                            "node": "Door to Root Cave"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Reactor Access"
+                            "region": "Tallon Overworld",
+                            "area": "Savestation",
+                            "node": "Save Station"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Reactor Core"
+                            "region": "Tallon Overworld",
+                            "area": "Tallon Canyon",
+                            "node": "Door to Canyon Cavern"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Root Cave"
+                            "region": "Tallon Overworld",
+                            "area": "Temple Hall",
+                            "node": "Door to Temple Security Station"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Root Tunnel"
+                            "region": "Tallon Overworld",
+                            "area": "Temple Lobby",
+                            "node": "Door to Artifact Temple"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Savestation"
+                            "region": "Tallon Overworld",
+                            "area": "Temple Security Station",
+                            "node": "Door to Temple Hall"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Tallon Canyon"
+                            "region": "Tallon Overworld",
+                            "area": "Transport Tunnel A",
+                            "node": "Door to Transport to Chozo Ruins West"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Temple Hall"
+                            "region": "Tallon Overworld",
+                            "area": "Transport Tunnel B",
+                            "node": "Door to Transport to Magmoor Caverns East"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Temple Lobby"
+                            "region": "Tallon Overworld",
+                            "area": "Transport Tunnel C",
+                            "node": "Door to Overgrown Cavern"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Temple Security Station"
+                            "region": "Tallon Overworld",
+                            "area": "Transport Tunnel D",
+                            "node": "Door to Transport to Chozo Ruins South"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Transport Tunnel A"
+                            "region": "Tallon Overworld",
+                            "area": "Transport Tunnel E",
+                            "node": "Door to Transport to Phazon Mines East"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Transport Tunnel B"
+                            "region": "Tallon Overworld",
+                            "area": "Transport to Chozo Ruins East",
+                            "node": "Teleporter to Chozo Ruins"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Transport Tunnel C"
+                            "region": "Tallon Overworld",
+                            "area": "Transport to Chozo Ruins South",
+                            "node": "Teleporter to Chozo Ruins"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Transport Tunnel D"
+                            "region": "Tallon Overworld",
+                            "area": "Transport to Chozo Ruins West",
+                            "node": "Teleporter to Chozo Ruins"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Transport Tunnel E"
+                            "region": "Tallon Overworld",
+                            "area": "Transport to Magmoor Caverns East",
+                            "node": "Teleporter to Magmoor Caverns"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Transport to Chozo Ruins East"
+                            "region": "Tallon Overworld",
+                            "area": "Transport to Phazon Mines East",
+                            "node": "Teleporter to Phazon Mines"
                         },
                         {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Transport to Chozo Ruins South"
-                        },
-                        {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Transport to Chozo Ruins West"
-                        },
-                        {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Transport to Magmoor Caverns East"
-                        },
-                        {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Transport to Phazon Mines East"
-                        },
-                        {
-                            "world_name": "Tallon Overworld",
-                            "area_name": "Waterfall Cavern"
+                            "region": "Tallon Overworld",
+                            "area": "Waterfall Cavern",
+                            "node": "Door to Landing Site"
                         }
                     ],
                     "available_locations": {
                         "randomization_mode": "full",
                         "excluded_indices": []
                     },
-                    "major_items_configuration": {
-                        "items_state": {
+                    "standard_pickup_configuration": {
+                        "pickups_state": {
                             "Charge Beam": {
                                 "num_shuffled_pickups": 1
                             },
                             "Power Beam": {
-                                "num_included_in_starting_items": 1
+                                "num_included_in_starting_pickups": 1
                             },
                             "Wave Beam": {
                                 "num_shuffled_pickups": 1
@@ -1121,7 +1362,7 @@
                                 "num_shuffled_pickups": 1
                             },
                             "Scan Visor": {
-                                "num_included_in_starting_items": 1
+                                "num_included_in_starting_pickups": 1
                             },
                             "Thermal Visor": {
                                 "num_shuffled_pickups": 1
@@ -1136,10 +1377,10 @@
                                 "num_shuffled_pickups": 14
                             },
                             "Morph Ball": {
-                                "num_included_in_starting_items": 1
+                                "num_included_in_starting_pickups": 1
                             },
                             "Morph Ball Bomb": {
-                                "num_included_in_starting_items": 1
+                                "num_included_in_starting_pickups": 1
                             },
                             "Boost Ball": {
                                 "num_shuffled_pickups": 1
@@ -1154,7 +1395,7 @@
                                 ]
                             },
                             "Power Suit": {
-                                "num_included_in_starting_items": 1
+                                "num_included_in_starting_pickups": 1
                             },
                             "Varia Suit": {
                                 "num_shuffled_pickups": 1
@@ -1178,25 +1419,25 @@
                                 "num_shuffled_pickups": 1
                             }
                         },
-                        "default_items": {},
-                        "minimum_random_starting_items": 0,
-                        "maximum_random_starting_items": 2
+                        "default_pickups": {},
+                        "minimum_random_starting_pickups": 0,
+                        "maximum_random_starting_pickups": 2
                     },
-                    "ammo_configuration": {
-                        "items_state": {
+                    "ammo_pickup_configuration": {
+                        "pickups_state": {
                             "Missile Expansion": {
                                 "ammo_count": [
                                     5
                                 ],
                                 "pickup_count": 49,
-                                "requires_major_item": false
+                                "requires_main_item": false
                             },
                             "Power Bomb Expansion": {
                                 "ammo_count": [
                                     0
                                 ],
                                 "pickup_count": 4,
-                                "requires_major_item": false
+                                "requires_main_item": false
                             }
                         }
                     },
@@ -1219,8 +1460,8 @@
                                     "Wave Door"
                                 ],
                                 "can_change_to": [
-                                    "Bomb Door",
-                                    "Charge Beam Door",
+                                    "Bomb Blast Shield",
+                                    "Charge Beam Blast Shield",
                                     "Flamethrower Blast Shield",
                                     "Ice Door",
                                     "Ice Spreader Blast Shield",
@@ -1233,26 +1474,15 @@
                                     "Wave Door",
                                     "Wavebuster Blast Shield"
                                 ]
-                            },
-                            "morph_ball": {
-                                "can_change_from": [],
-                                "can_change_to": []
-                            },
-                            "other": {
-                                "can_change_from": [],
-                                "can_change_to": []
                             }
                         }
                     },
-                    "elevators": {
+                    "single_set_for_pickups_that_solve": true,
+                    "staggered_multi_pickup_placement": true,
+                    "check_if_beatable_after_base_patches": false,
+                    "teleporters": {
                         "mode": "one-way-anything",
-                        "excluded_teleporters": [
-                            {
-                                "world_name": "Tallon Overworld",
-                                "area_name": "Artifact Temple",
-                                "node_name": "Teleport to Impact Crater - Crater Impact Point"
-                            }
-                        ],
+                        "excluded_teleporters": [],
                         "excluded_targets": [],
                         "skip_final_bosses": true,
                         "allow_unvisited_room_names": true
@@ -1263,11 +1493,11 @@
                     },
                     "energy_per_tank": 78,
                     "artifact_target": 9,
+                    "artifact_required": 9,
                     "artifact_minimum_progression": 6,
                     "heat_damage": 15.0,
                     "warp_to_start": true,
-                    "heat_protection_only_varia": true,
-                    "progressive_damage_reduction": false,
+                    "damage_reduction": "Default",
                     "allow_underwater_movement_without_gravity": true,
                     "small_samus": true,
                     "large_samus": false,
@@ -1279,18 +1509,16 @@
                     "submerged_probability": 287,
                     "room_rando": "Two-way",
                     "spring_ball": true,
-                    "deterministic_idrone": true,
-                    "deterministic_maze": true,
                     "main_plaza_door": true,
-                    "blue_save_doors": true,
+                    "blue_save_doors": false,
                     "backwards_frigate": false,
                     "backwards_labs": true,
                     "backwards_upper_mines": true,
                     "backwards_lower_mines": true,
                     "phazon_elite_without_dynamo": false,
-                    "qol_game_breaking": true,
-                    "qol_pickup_scans": true,
-                    "qol_cutscenes": "major",
+                    "legacy_mode": false,
+                    "qol_cutscenes": "SkippableCompetitive",
+                    "ingame_difficulty": "Normal",
                     "enemy_attributes": {
                         "enemy_rando_range_scale_low": 0.25,
                         "enemy_rando_range_scale_high": 5.25,
@@ -1303,7 +1531,8 @@
                         "enemy_rando_range_knockback_low": 15.5,
                         "enemy_rando_range_knockback_high": 200.35,
                         "enemy_rando_diff_xyz": true
-                    }
+                    },
+                    "nerf_oob": true
                 }
             }
         ]

--- a/test/test_files/patcher_data/prime1/dread_prime1_multiworld/world_2.json
+++ b/test/test_files/patcher_data/prime1/dread_prime1_multiworld/world_2.json
@@ -138,7 +138,8 @@
             "Artifact of Spirit": false,
             "Artifact of Newborn": false
         },
-        "requiredArtifactCount": 12
+        "requiredArtifactCount": 12,
+        "patchWallcrawling": false
     },
     "tweaks": {
         "hudColor": [

--- a/test/test_files/patcher_data/prime1/multi-am2r+cs+dread+prime1+prime2+msr/world_3.json
+++ b/test/test_files/patcher_data/prime1/multi-am2r+cs+dread+prime1+prime2+msr/world_3.json
@@ -134,7 +134,8 @@
             "Artifact of Spirit": false,
             "Artifact of Newborn": false
         },
-        "requiredArtifactCount": 12
+        "requiredArtifactCount": 12,
+        "patchWallcrawling": false
     },
     "tweaks": {},
     "levelData": {

--- a/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_2.json
+++ b/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_2.json
@@ -134,7 +134,8 @@
             "Artifact of Spirit": false,
             "Artifact of Newborn": false
         },
-        "requiredArtifactCount": 12
+        "requiredArtifactCount": 12,
+        "patchWallcrawling": false
     },
     "tweaks": {},
     "levelData": {

--- a/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_6.json
+++ b/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_6.json
@@ -134,7 +134,8 @@
             "Artifact of Spirit": false,
             "Artifact of Newborn": false
         },
-        "requiredArtifactCount": 12
+        "requiredArtifactCount": 12,
+        "patchWallcrawling": false
     },
     "tweaks": {},
     "levelData": {

--- a/test/test_files/patcher_data/prime1/prime1_and_2_multi/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_and_2_multi/world_1.json
@@ -139,6 +139,7 @@
             "Artifact of Newborn": true
         },
         "requiredArtifactCount": 12,
+        "patchWallcrawling": false,
         "startingMemo": "Artifact of Sun, 5 Missiles"
     },
     "tweaks": {

--- a/test/test_files/patcher_data/prime1/prime1_crazy_seed/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_crazy_seed/world_1.json
@@ -139,6 +139,7 @@
             "Artifact of Newborn": false
         },
         "requiredArtifactCount": 12,
+        "patchWallcrawling": true,
         "startingMemo": "Varia Suit"
     },
     "tweaks": {

--- a/test/test_files/patcher_data/prime1/prime1_crazy_seed_one_way_door/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_crazy_seed_one_way_door/world_1.json
@@ -143,7 +143,8 @@
             "Artifact of Spirit": false,
             "Artifact of Newborn": false
         },
-        "requiredArtifactCount": 12
+        "requiredArtifactCount": 12,
+        "patchWallcrawling": false
     },
     "tweaks": {
         "playerSize": 0.3,


### PR DESCRIPTION
I wasn't quite sure where to put the option in the GUI. I don't think right now that it is (currently) affecting logic in any way, since the only oob tricks are all single room. However, it didn't really seem fit for the "Quality of Life" tab, and I didn't want to create a new tab with only this as the option. So Chaos Options it is.

UI screenshot:
![grafik](https://github.com/randovania/randovania/assets/38186597/5d5399b0-d145-4418-becc-2addf982fd1a)

