### PR TITLE
Resolver: Fix using the wrong state when finding the resources gained

### DIFF
--- a/randovania/resolver/resolver.py
+++ b/randovania/resolver/resolver.py
@@ -203,7 +203,7 @@ async def _inner_advance_depth(
                 if new_result[0] is None:
                     additional = logic.get_additional_requirements(action).alternatives
 
-                    resources = [x for x, _ in action.resource_gain_on_collect(potential_state.node_context())]
+                    resources = [x for x, _ in action.resource_gain_on_collect(state.node_context())]
 
                     logic.set_additional_requirements(
                         state.node, _simplify_additional_requirement_set(additional, state, resources)


### PR DESCRIPTION
These resources are meant to be be the resources gained by collecting the node that's being rolled back. Given that the resource can depends on the current inventory, it must use the state from before collecting the node.

Particularly in the case of progressive items, it matters that we pass the context from before collecting the node into this function.

These resources are used to detect the point at which we roll back collecting a dangerous resource that where we see the requirement that makes it dangerous. If any games would have a chain of progressive items where any of the items in the chain were dangerous, then this fix would likely be important.