### PR TITLE
Pickup Database/Offworld Model Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Prime
 
+- Changed: The Missile Launcher now shows up as a Missile Tank when offworld in Metroid Dread.
 - Fixed: Typo on the Quality of Life preset tab.
 
 #### Logic Database
@@ -94,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: When collecting a Reserve Tank, the HUD will now properly update instead of disabling the bottom screen.
 - Changed: Area 1 - Inner Temple East Hall - The top crumble block no longer respawns to help prevent a possible softlock in Door Lock Rando.
 - Changed: Area 4 Crystal Mines - The upper door in Mines Entrance can now be shuffled in Door Lock Rando.
+- Changed: The description for the `Missile Reserve Tank` is now more explicit about when it can be used.
 - Fixed: When exporting a new seed, any leftover data from previous seeds will be deleted.
 - Fixed: If progressives are enabled, the models for Wave Beam and High Jump Boots now face right to be more recognizable.
 - Fixed: Beam Doors are no longer mismatched with the door they are attached to, which would prevent certain doors from being opened.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Progressive pickups can now be configured to be placed vanilla.
 - Changed: The water in Early Cloak Room in Artaria will disappear after the blob is broken, instead of flooding the lower section with the tunnel.
 - Changed: Water will no longer appear in First Tutorial after using the water device in EMMI Zone Hub in Artaria.
+- Changed: Prime 1's Missile Launcher now shows up as a Missile Tank.
 - Fixed: Entering Intro Room in Artaria will no longer cause long loads or crash the game.
 - Fixed: The Navigation Station in Itorash now has a map icon.
 - Fixed: The Thermal Gate blocking the Morph Launcher to Experiment Z-57 now has a map icon.
@@ -67,7 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Prime
 
-- Changed: The Missile Launcher now shows up as a Missile Tank when offworld in Metroid Dread.
 - Fixed: Typo on the Quality of Life preset tab.
 
 #### Logic Database

--- a/randovania/games/prime1/pickup_database/pickup-database.json
+++ b/randovania/games/prime1/pickup_database/pickup-database.json
@@ -188,7 +188,7 @@
             "model_name": "Missile",
             "offworld_models": {
                 "am2r": "sItemMissile",
-                "dread": "powerup_missile",
+                "dread": "item_missiletank",
                 "prime2": "MissileExpansionPrime1",
                 "samus_returns": "item_missiletank"
             },
@@ -363,7 +363,8 @@
             "offworld_models": {
                 "am2r": "sItemBoostBallPrime",
                 "dread": "powerup_speedbooster",
-                "prime2": "BoostBall"
+                "prime2": "BoostBall",
+                "samus_returns": "powerup_speedbooster"
             },
             "progression": [
                 "Boost"

--- a/randovania/games/prime2/pickup_database/pickup-database.json
+++ b/randovania/games/prime2/pickup_database/pickup-database.json
@@ -937,7 +937,8 @@
             "broad_category": "beam_related",
             "model_name": "DarkBeamAmmoExpansion",
             "offworld_models": {
-                "am2r": "sItemDarkAmmoEchoes"
+                "am2r": "sItemDarkAmmoEchoes",
+                "samus_returns": "item_senergytank"
             },
             "items": [
                 "DarkAmmo"
@@ -952,7 +953,8 @@
             "broad_category": "beam_related",
             "model_name": "LightBeamAmmoExpansion",
             "offworld_models": {
-                "am2r": "sItemLightAmmoEchoes"
+                "am2r": "sItemLightAmmoEchoes",
+                "samus_returns": "item_senergytank"
             },
             "items": [
                 "LightAmmo"

--- a/randovania/games/prime2/pickup_database/pickup-database.json
+++ b/randovania/games/prime2/pickup_database/pickup-database.json
@@ -459,7 +459,8 @@
             "offworld_models": {
                 "am2r": "sItemBoostBallPrime",
                 "prime1": "Boost Ball",
-                "dread": "powerup_speedbooster"
+                "dread": "powerup_speedbooster",
+                "samus_returns": "powerup_speedbooster"
             },
             "progression": [
                 "Boost"
@@ -528,7 +529,8 @@
             "offworld_models": {
                 "am2r": "sItemCannonBallEchoes",
                 "prime1": "Boost Ball",
-                "dread": "powerup_speedbooster"
+                "dread": "powerup_speedbooster",
+                "samus_returns": "powerup_speedbooster"
             },
             "progression": [
                 "CannonBall"
@@ -965,7 +967,8 @@
             "broad_category": "beam_related",
             "model_name": "BeamAmmoExpansion",
             "offworld_models": {
-                "am2r": "sItemBeamAmmoEchoes"
+                "am2r": "sItemBeamAmmoEchoes",
+                "samus_returns": "item_senergytank"
             },
             "items": [
                 "DarkAmmo",

--- a/randovania/games/samus_returns/pickup_database/pickup-database.json
+++ b/randovania/games/samus_returns/pickup_database/pickup-database.json
@@ -304,7 +304,8 @@
             "broad_category": "aeion",
             "model_name": "powerup_energyshield",
             "offworld_models": {
-                "am2r": "sItemLightningArmorMSR"
+                "am2r": "sItemLightningArmorMSR",
+                "dread": "powerup_opticcamo"
             },
             "progression": [
                 "Armor"
@@ -344,7 +345,8 @@
             "broad_category": "aeion",
             "model_name": "powerup_phasedisplacement",
             "offworld_models": {
-                "am2r": "sItemPhaseDriftMSR"
+                "am2r": "sItemPhaseDriftMSR",
+                "dread": "powerup_ghostaura"
             },
             "progression": [
                 "Phase"
@@ -386,7 +388,7 @@
                 "am2r": "sItemGravitySuit",
                 "dread": "powerup_gravitysuit",
                 "prime1": "Gravity Suit",
-                "prime2": "VariaSuit INCOMPLETE"
+                "prime2": "GravityBoost"
             },
             "progression": [
                 "Gravity"
@@ -458,7 +460,7 @@
             "model_name": "powerup_bomb",
             "offworld_models": {
                 "am2r": "sItemBombsMSR",
-                "dread": "powerup_morphball",
+                "dread": "powerup_bomb",
                 "prime1": "Morph Ball Bomb",
                 "prime2": "MorphBallBomb"
             },
@@ -648,7 +650,7 @@
             ],
             "preferred_location_category": "minor",
             "expected_case_for_describer": "shuffled",
-            "description": "Due to limitations, this is unusable until the Missile Launcher is acquired."
+            "description": "Due to limitations, this is not usable in-game until after the Missile Launcher is acquired."
         }
     },
     "ammo_pickups": {

--- a/test/test_files/patcher_data/dread/dread_prime1_multiworld/world_1.json
+++ b/test/test_files/patcher_data/dread/dread_prime1_multiworld/world_1.json
@@ -218,12 +218,12 @@
                 "actor": "Item_MissileTank003"
             },
             "model": [
-                "powerup_missile"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "WORLD 2'S MISSILE LAUNCHER",
-                    "base_icon": "powerup_missile"
+                    "base_icon": "item_missiletank"
                 }
             }
         },

--- a/test/test_files/patcher_data/samus_returns/multi-am2r+cs+dread+prime1+prime2+msr/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/multi-am2r+cs+dread+prime1+prime2+msr/world_1.json
@@ -1369,7 +1369,7 @@
                 "actor": "LE_Item_007"
             },
             "model": [
-                "item_offworld"
+                "item_senergytank"
             ]
         },
         {
@@ -1844,7 +1844,7 @@
                 "actor": "LE_Item_009"
             },
             "model": [
-                "item_offworld"
+                "item_senergytank"
             ]
         },
         {
@@ -2912,7 +2912,7 @@
                 "actor": "LE_Item_012"
             },
             "model": [
-                "item_offworld"
+                "item_senergytank"
             ]
         },
         {
@@ -3292,7 +3292,7 @@
                 "actor": "HiddenPowerup002"
             },
             "model": [
-                "item_offworld"
+                "item_senergytank"
             ]
         },
         {

--- a/test/test_files/patcher_data/samus_returns/multi-am2r+cs+dread+prime1+prime2+msr/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/multi-am2r+cs+dread+prime1+prime2+msr/world_1.json
@@ -666,7 +666,7 @@
                 "actor": "LE_Item_001"
             },
             "model": [
-                "item_offworld"
+                "powerup_speedbooster"
             ]
         },
         {


### PR DESCRIPTION
- Fixed Dread using Morph Ball for MSR Bomb
- Fixes Dread using Missile Launcher for Prime 1 Missile Launcher
- Beam Ammo in Prime 2 now shows up as Aeion Tank in MSR
- Boost Ball for Prime 1/2 now shows up as Speed Booster in MSR
- Cannon Ball for Prime 2 now shows up as Speed Booster in MSR
- Phantom Cloak and Flash Shift now show up as Lightning Armor and Phase Drift respectively in MSR
- Gravity Boost for Prime 2 now shows up as Gravity Suit in MSR
- Updated Missile Reserve Tank description