### PR TITLE
Prime: remove redundant Hive Totem connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,16 +71,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid Prime
 
 - Fixed: Typo on the Quality of Life preset tab.
+- Changed: Open Map can be used with Elevator Randomization (Unvisited rooms do not reveal their name. Unvisited Elevators do not reveal their destination.)
 
 #### Logic Database
 
+##### Chozo Ruins
+
+- Fixed: Removed redundant connection to Hive Totem.
+
 ##### Tallon Overworld
 
-- Fixed: Overgrown Cavern now has the correct node marked as player spawn
-
-### Metroid Prime
-
-- Changed: Open Map can be used with Elevator Randomization (Unvisited rooms do not reveal their name. Unvisited Elevators do not reveal their destination.)
+- Fixed: Overgrown Cavern now has the correct node marked as player spawn.
 
 ### Metroid Prime 2: Echoes
 

--- a/randovania/games/prime1/logic_database/Chozo Ruins.json
+++ b/randovania/games/prime1/logic_database/Chozo Ruins.json
@@ -9645,13 +9645,6 @@
                                 ]
                             }
                         },
-                        "Event - Hive Mecha": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Event - Fallen Rubble": {
                             "type": "and",
                             "data": {

--- a/randovania/games/prime1/logic_database/Chozo Ruins.txt
+++ b/randovania/games/prime1/logic_database/Chozo Ruins.txt
@@ -1553,8 +1553,6 @@ Extra - aabb: [41.40501, 247.89255, -4.7951803, 128.55772, 339.1442, 14.098242]
           Space Jump Boots or After Chozo - Fallen Rubble
           Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
           Scan Visor and Combat/Scan Dash (Beginner)
-  > Event - Hive Mecha
-      Trivial
   > Event - Fallen Rubble
       Trivial
 


### PR DESCRIPTION
- remove redundant connection causing logically incompleteable seeds
- minor changelog fixes