### PR TITLE
Make vanilla progressives for am2r and MSR too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.3.x] - 2024-08-??
 
+### AM2R
+
+- Added: Progressive pickups can now be configured to be placed vanilla.
+
 ### Metroid: Samus Returns
 
+- Added: Progressive pickups can now be configured to be placed vanilla.
 - Changed: Room Names on the HUD are now enabled by default.
 
 ## [8.2.0] - 2024-07-03

--- a/randovania/games/am2r/pickup_database/pickup-database.json
+++ b/randovania/games/am2r/pickup_database/pickup-database.json
@@ -279,7 +279,11 @@
                 "Space Jump"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "missing"
+            "expected_case_for_describer": "missing",
+            "original_locations": [
+                4,
+                6
+            ]
         },
         "Gravity Suit": {
             "pickup_category": "suit",
@@ -315,7 +319,11 @@
                 "Gravity Suit"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "missing"
+            "expected_case_for_describer": "missing",
+            "original_locations": [
+                5,
+                9
+            ]
         },
         "Charge Beam": {
             "pickup_category": "beam",

--- a/randovania/games/samus_returns/pickup_database/pickup-database.json
+++ b/randovania/games/samus_returns/pickup_database/pickup-database.json
@@ -178,7 +178,12 @@
                 "Plasma"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled"
+            "expected_case_for_describer": "shuffled",
+            "original_locations": [
+                46,
+                84,
+                125
+            ]
         },
         "Charge Beam": {
             "pickup_category": "beam",
@@ -415,7 +420,11 @@
                 "Gravity"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled"
+            "expected_case_for_describer": "shuffled",
+            "original_locations": [
+                45,
+                124
+            ]
         },
         "Morph Ball": {
             "pickup_category": "morph_ball",
@@ -565,7 +574,11 @@
                 "Space"
             ],
             "preferred_location_category": "major",
-            "expected_case_for_describer": "shuffled"
+            "expected_case_for_describer": "shuffled",
+            "original_locations": [
+                44,
+                99
+            ]
         },
         "Screw Attack": {
             "pickup_category": "misc",


### PR DESCRIPTION
I thought these were added when they got added for dread and echoes. apparently not.