### PR TITLE
MSR - Enable room names on HUD by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.3.x] - 2024-08-??
 
-- Nothing yet! Add changes here.
+### Metroid: Samus Returns
+
+- Changed: Room Names on the HUD are now enabled by default.
 
 ## [8.2.0] - 2024-07-03
 

--- a/randovania/games/samus_returns/layout/msr_cosmetic_patches.py
+++ b/randovania/games/samus_returns/layout/msr_cosmetic_patches.py
@@ -47,7 +47,7 @@ class MSRCosmeticPatches(BaseCosmeticPatches):
     energy_tank_color: tuple[int, int, int] = DEFAULT_ENERGY_TANK_COLOR
     aeion_bar_color: tuple[int, int, int] = DEFAULT_AEION_BAR_COLOR
     ammo_hud_color: tuple[int, int, int] = DEFAULT_AMMO_HUD_COLOR
-    show_room_names: MSRRoomGuiType = MSRRoomGuiType.NONE
+    show_room_names: MSRRoomGuiType = MSRRoomGuiType.ALWAYS
     enable_remote_lua: bool = False
 
     @classmethod

--- a/randovania/interface_common/persisted_options.py
+++ b/randovania/interface_common/persisted_options.py
@@ -226,7 +226,7 @@ _CONVERTER_FOR_VERSION = [
     _dread_linux_ryujinx_path,  # added Dread Ryujinx export to Unix systems
     _msr_cosmetic_laser_color,  # remove the Grapple Laser color checkbox for MSR Cosmetics
     _msr_exheader_path,  # adds empty exheader path for MSR
-    _msr_room_names_visible, # forces room name display to be on by default
+    _msr_room_names_visible,  # forces room name display to be on by default
 ]
 _CURRENT_OPTIONS_FILE_VERSION = migration_lib.get_version(_CONVERTER_FOR_VERSION)
 

--- a/randovania/interface_common/persisted_options.py
+++ b/randovania/interface_common/persisted_options.py
@@ -186,6 +186,13 @@ def _msr_exheader_path(options: dict) -> dict:
     return options
 
 
+def _msr_room_names_visible(options: dict) -> dict:
+    if "game_samus_returns" in options:
+        options["game_samus_returns"]["cosmetic_patches"]["show_room_names"] = "Always"
+
+    return options
+
+
 _CONVERTER_FOR_VERSION = [
     None,
     None,
@@ -219,6 +226,7 @@ _CONVERTER_FOR_VERSION = [
     _dread_linux_ryujinx_path,  # added Dread Ryujinx export to Unix systems
     _msr_cosmetic_laser_color,  # remove the Grapple Laser color checkbox for MSR Cosmetics
     _msr_exheader_path,  # adds empty exheader path for MSR
+    _msr_room_names_visible, # forces room name display to be on by default
 ]
 _CURRENT_OPTIONS_FILE_VERSION = migration_lib.get_version(_CONVERTER_FOR_VERSION)
 

--- a/test/test_files/patcher_data/samus_returns/multi-am2r+cs+dread+prime1+prime2+msr/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/multi-am2r+cs+dread+prime1+prime2+msr/world_1.json
@@ -4151,7 +4151,7 @@
     ],
     "baby_metroid_hint": "A Baby's Cry can be heard echoing from|World 5's Plantation.",
     "cosmetic_patches": {
-        "enable_room_name_display": "NEVER",
+        "enable_room_name_display": "ALWAYS",
         "camera_names_dict": {
             "s000_surface": {
                 "collision_camera_000": "Landing Site",

--- a/test/test_files/patcher_data/samus_returns/samus_returns/door_lock/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/door_lock/world_1.json
@@ -4237,7 +4237,7 @@
     ],
     "baby_metroid_hint": "A Baby's Cry can be heard echoing from|Area 1.",
     "cosmetic_patches": {
-        "enable_room_name_display": "NEVER",
+        "enable_room_name_display": "ALWAYS",
         "camera_names_dict": {
             "s000_surface": {
                 "collision_camera_000": "Landing Site",

--- a/test/test_files/patcher_data/samus_returns/samus_returns/door_lock_access_open/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/door_lock_access_open/world_1.json
@@ -4237,7 +4237,7 @@
     ],
     "baby_metroid_hint": "A Baby's Cry can be heard echoing from|Area 6.",
     "cosmetic_patches": {
-        "enable_room_name_display": "NEVER",
+        "enable_room_name_display": "ALWAYS",
         "camera_names_dict": {
             "s000_surface": {
                 "collision_camera_000": "Landing Site",

--- a/test/test_files/patcher_data/samus_returns/samus_returns/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/starter_preset/world_1.json
@@ -4237,7 +4237,7 @@
     ],
     "baby_metroid_hint": "A Baby's Cry can be heard echoing from|Area 2 Dam Interior.",
     "cosmetic_patches": {
-        "enable_room_name_display": "NEVER",
+        "enable_room_name_display": "ALWAYS",
         "camera_names_dict": {
             "s000_surface": {
                 "collision_camera_000": "Landing Site",


### PR DESCRIPTION
I believe this change is necessary because DNA hints are a thing. Plus, it doesn't block the map much so being defaulted to on is fine. 