### PR TITLE
AM2R: Fix several tower connecting rooms 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.3.x] - 2024-08-??
 
-- Nothing yet! Add changes here.
+### AM2R
+
+#### Logic Database
+
+##### The Tower
+
+- Fixed: Ext. Zeta Nest East Access now has corrected Morph Ball requirements and trick types.
+- Fixed: Ext. Zeta Nest West Access now has corrected Morph Ball requirements and trick types.
+- Fixed: Ext. Gamma Nest NE Access now has corrected Morph Ball requirements and trick types.
+- Fixed: Ext. Zeta Nest West Access now has corrected Morph Ball requirements and trick types.
 
 ## [8.2.0] - 2024-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### The Tower
 
+- Added: Ext. Zeta Nest East Access now has an IBJ(intermediate) + Spider method of crossing the room from the right.
 - Fixed: Ext. Zeta Nest East Access now has corrected Morph Ball requirements and trick types.
 - Fixed: Ext. Zeta Nest West Access now has corrected Morph Ball requirements and trick types.
 - Fixed: Ext. Gamma Nest NE Access now has corrected Morph Ball requirements and trick types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### The Tower
 
-- Added: Ext. Zeta Nest East Access now has an IBJ(intermediate) + Spider method of crossing the room from the right.
+- Added: Ext. Zeta Nest East Access now has an IBJ (intermediate) + Knowledge (Beginner) + Spider method of crossing the room from the right.
+- Added: Gamma Nest West Access now has an IBJ (intermediate) + Knowledge (Beginner) + Spider method of crossing the room from center to right.
 - Fixed: Ext. Zeta Nest East Access now has corrected Morph Ball requirements and trick types.
 - Fixed: Ext. Zeta Nest West Access now has corrected Morph Ball requirements and trick types.
 - Fixed: Ext. Gamma Nest NE Access now has corrected Morph Ball requirements and trick types.

--- a/randovania/games/am2r/logic_database/The Tower.json
+++ b/randovania/games/am2r/logic_database/The Tower.json
@@ -3589,6 +3589,15 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Can Use Spider Ball"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -3757,6 +3766,15 @@
                                                                 "data": "Can Use Spring Ball"
                                                             }
                                                         ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -5132,6 +5150,65 @@
                                                         "name": "Morph Ball",
                                                         "amount": 1,
                                                         "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can IBJ"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "IBJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Use Spider Ball"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Knowledge",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "MorphGlide",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/am2r/logic_database/The Tower.json
+++ b/randovania/games/am2r/logic_database/The Tower.json
@@ -3478,6 +3478,15 @@
                                                         "amount": 2,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -3555,6 +3564,31 @@
                                                         "amount": 2,
                                                         "negate": false
                                                     }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "IBJ up to ceiling and spider across",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "IBJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Bombs"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Spider Ball"
                                                 }
                                             ]
                                         }
@@ -3644,6 +3678,15 @@
                                                         "amount": 3,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -3683,8 +3726,41 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Spider Ball"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Spider Ball"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "MidAirMorph",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Bombs"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Spring Ball"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -4230,6 +4306,15 @@
                                                         "amount": 3,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -4651,8 +4736,17 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "MidAirMorph",
+                                                        "name": "MorphGlide",
                                                         "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -5026,8 +5120,17 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "MidAirMorph",
+                                                        "name": "MorphGlide",
                                                         "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -5890,7 +5993,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "MidAirMorph",
+                                                        "name": "MorphGlide",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -6011,7 +6114,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "MidAirMorph",
+                                                        "name": "MorphGlide",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -6369,7 +6472,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "MidAirMorph",
+                                                        "name": "MorphGlide",
                                                         "amount": 3,
                                                         "negate": false
                                                     }

--- a/randovania/games/am2r/logic_database/The Tower.txt
+++ b/randovania/games/am2r/logic_database/The Tower.txt
@@ -404,20 +404,25 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
   > Horizontal Dock to Tower Exterior South East
       Any of the following:
           Space Jump
-          Hi-Jump Boots and Morph Glide (Intermediate)
+          Hi-Jump Boots and Morph Ball and Morph Glide (Intermediate)
           Damage Boost (Beginner) and Normal Damage ≥ 25
           Diagonal Infinite Bomb Jumping (Intermediate) and Can IBJ and Can Use Bombs
           Speed Booster and Shinesparking Tricks (Intermediate)
+          # IBJ up to ceiling and spider across
+          Infinite Bomb Jumping (Intermediate) and Can Use Bombs and Can Use Spider Ball
 
 > Horizontal Dock to Tower Exterior South East; Heals? False
   * Layers: default
   * 3-Tiles High Dock to Tower Exterior South East/Horizontal Dock to Exterior Zeta Nest East Access
   > Horizontal Dock to Exterior Zeta Nest East
       Any of the following:
-          Space Jump or Can Use Spider Ball
+          Space Jump
           Damage Boost (Beginner) and Normal Damage ≥ 50
-          Hi-Jump Boots and Morph Glide (Advanced)
+          Hi-Jump Boots and Morph Ball and Morph Glide (Advanced)
           Diagonal Infinite Bomb Jumping (Intermediate) and Can IBJ and Can Use Bombs
+          All of the following:
+              Can Use Spider Ball
+              Mid-Air Morph (Beginner) or Can Use Bombs or Can Use Spring Ball
 
 ----------------
 Exterior Zeta Nest East
@@ -506,7 +511,7 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
   > Middle
       Any of the following:
           Space Jump
-          Hi-Jump Boots and Morph Glide (Advanced)
+          Hi-Jump Boots and Morph Ball and Morph Glide (Advanced)
           Damage Boost (Beginner) and Normal Damage ≥ 50
 
 > Middle; Heals? False
@@ -569,7 +574,7 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
               Any of the following:
                   Power Grip
                   Walljump (Intermediate) and Can Walljump
-          Hi-Jump Boots and Mid-Air Morph (Intermediate)
+          Hi-Jump Boots and Morph Ball and Morph Glide (Intermediate)
 
 > Horizontal Dock to Gamma Nest West; Heals? False
   * Layers: default
@@ -611,7 +616,7 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
               Any of the following:
                   Power Grip
                   Walljump (Intermediate) and Can Walljump
-          Hi-Jump Boots and Mid-Air Morph (Intermediate)
+          Hi-Jump Boots and Morph Ball and Morph Glide (Intermediate)
   > Left Spike Tunnel
       Any of the following:
           Morph Ball
@@ -694,7 +699,7 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
   > Middle Platform
       Any of the following:
           Hi-Jump Boots or Space Jump
-          Morph Ball and Mid-Air Morph (Intermediate)
+          Morph Ball and Morph Glide (Intermediate)
           Damage Boost (Beginner) and Normal Damage ≥ 25
 
 > Middle Platform; Heals? False
@@ -703,7 +708,7 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
       Any of the following:
           Space Jump
           Damage Boost (Beginner) and Normal Damage ≥ 25
-          Hi-Jump Boots and Morph Ball and Mid-Air Morph (Intermediate)
+          Hi-Jump Boots and Morph Ball and Morph Glide (Intermediate)
   > Right Platform
       Any of the following:
           Space Jump
@@ -725,7 +730,7 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
       Any of the following:
           Space Jump
           Damage Boost (Beginner) and Normal Damage ≥ 50
-          Hi-Jump Boots and Morph Ball and Mid-Air Morph (Advanced)
+          Hi-Jump Boots and Morph Ball and Morph Glide (Advanced)
 
 ----------------
 Exterior Zeta Nest West

--- a/randovania/games/am2r/logic_database/The Tower.txt
+++ b/randovania/games/am2r/logic_database/The Tower.txt
@@ -409,7 +409,7 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
           Diagonal Infinite Bomb Jumping (Intermediate) and Can IBJ and Can Use Bombs
           Speed Booster and Shinesparking Tricks (Intermediate)
           # IBJ up to ceiling and spider across
-          Infinite Bomb Jumping (Intermediate) and Can Use Bombs and Can Use Spider Ball
+          Infinite Bomb Jumping (Intermediate) and Knowledge (Beginner) and Can Use Bombs and Can Use Spider Ball
 
 > Horizontal Dock to Tower Exterior South East; Heals? False
   * Layers: default
@@ -421,7 +421,7 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
           Hi-Jump Boots and Morph Ball and Morph Glide (Advanced)
           Diagonal Infinite Bomb Jumping (Intermediate) and Can IBJ and Can Use Bombs
           All of the following:
-              Can Use Spider Ball
+              Knowledge (Beginner) and Can Use Spider Ball
               Mid-Air Morph (Beginner) or Can Use Bombs or Can Use Spring Ball
 
 ----------------
@@ -617,6 +617,11 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
                   Power Grip
                   Walljump (Intermediate) and Can Walljump
           Hi-Jump Boots and Morph Ball and Morph Glide (Intermediate)
+          All of the following:
+              Infinite Bomb Jumping (Intermediate) and Can IBJ
+              Any of the following:
+                  Morph Glide (Intermediate)
+                  Knowledge (Beginner) and Can Use Spider Ball
   > Left Spike Tunnel
       Any of the following:
           Morph Ball


### PR DESCRIPTION
multiple missing morph ball requirements, tricks listed as mid-air morph rather than glide, and added a new method for crossing Zeta East Access