### PR TITLE
Resolver: Fix wrong additional requirement when rolling back progress…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Filtering in the Generation Order tab is now case-insensitive.
 - Changed: The Area View of the Data Visualizer now always has a dark gray background to help with readability.
 
+### Resolver
+
+- Fixed: Some seeds being considered impossible when finding a progressive item in an area where a later item in the progressive chain is required to leave.
+
 ### AM2R
 
 #### Logic Database


### PR DESCRIPTION
…ives

If one progressive item is located in a position where a later item in the same progressive chain is required to escape, and the resolver finds that item first, then the resolver must not set the later progressive item as an additonal requirement when rolling back obtaining the earlier progressive item.