### PR TITLE
Prime: Document non-ntsc ruined shrine NSJ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Ext. Gamma Nest NE Access now has corrected Morph Ball requirements and trick types.
 - Fixed: Ext. Zeta Nest West Access now has corrected Morph Ball requirements and trick types.
 
+### Metroid Prime
+
+#### Logic Database
+
+##### Chozo Ruins
+
+- Added: Ruined Shrine NSJ climb now has both NTSC and non-NTSC versions documented.
+
 ### Metroid Prime 2: Echoes
 
 - Added: FAQ for Sanctuary Entrance Kinetic Orb Cannon.

--- a/randovania/games/prime1/logic_database/Chozo Ruins.json
+++ b/randovania/games/prime1/logic_database/Chozo Ruins.json
@@ -2568,7 +2568,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://youtu.be/lkdoZR7aZ5s?t=35",
+                                            "comment": "NTSC ONLY NSJ https://youtu.be/lkdoZR7aZ5s?t=35",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -2576,6 +2576,32 @@
                                                         "type": "tricks",
                                                         "name": "Standable",
                                                         "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "LJump",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Non-NTSC NSJ https://www.youtube.com/watch?v=2YM21Ql50P0",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Standable",
+                                                        "amount": 4,
                                                         "negate": false
                                                     }
                                                 },

--- a/randovania/games/prime1/logic_database/Chozo Ruins.txt
+++ b/randovania/games/prime1/logic_database/Chozo Ruins.txt
@@ -428,8 +428,10 @@ Extra - aabb: [-95.53676, -38.609608, -1.0693345, -22.250599, 43.303684, 30.2103
           Space Jump Boots and Standable Terrain (Beginner)
           # https://youtu.be/lkdoZR7aZ5s
           Scan Visor and Combat/Scan Dash (Advanced) and Standable Terrain (Advanced)
-          # https://youtu.be/lkdoZR7aZ5s?t=35
+          # NTSC ONLY NSJ https://youtu.be/lkdoZR7aZ5s?t=35
           L-Jump (Intermediate) and Standable Terrain (Advanced)
+          # Non-NTSC NSJ https://www.youtube.com/watch?v=2YM21Ql50P0
+          L-Jump (Intermediate) and Standable Terrain (Expert)
   > Pickup (Missile Expansion Half Pipe)
       All of the following:
           Morph Ball


### PR DESCRIPTION
technically still a logic issue due to version differences in collision, but this improves things by documentation at the least.
as a reminder, this is the branch that is missing.
![image](https://github.com/user-attachments/assets/bb2b5565-948f-4a54-91ce-88d927adaf5f)
