### PR TITLE
MP3 - Fix Hidden Court Edge Case with the battery

### DIFF
--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
@@ -4921,6 +4921,24 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event41",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event42",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
@@ -725,7 +725,7 @@ Extra - asset_id: 14006603351279167667
       Trivial
   > Pickup (Energy Cell)
       All of the following:
-          After North Jungle Court Battery and Use Ship Grapple
+          After Machineworks Bridge Cliffside and After Machineworks Bridge Jungleside and After North Jungle Court Battery and Use Ship Grapple
           Any of the following:
               Space Jump Boots
               Movement (Beginner) and Use Screw Attack (No Space Jump)


### PR DESCRIPTION
Logic assumed it was possible to fly to the Cliffside from Jungle Bryyo after getting the battery, which is impossible. Now the Energy Cell in Hidden Court also checks for both sides of Machineworks Bridge to be opened in order to access the Energy Cell location.