### PR TITLE
Ignore ConnectionError when sending exceptions to Sentry

### DIFF
--- a/randovania/monitoring/__init__.py
+++ b/randovania/monitoring/__init__.py
@@ -74,6 +74,11 @@ def before_breadcrumb(crumb: dict[str, typing.Any], hint: sentry_sdk.types.Hint)
 
 
 def before_send(event: sentry_sdk.types.Event, hint: sentry_sdk.types.Hint) -> sentry_sdk.types.Event | None:
+    if "exc_info" in hint:
+        exc_type, exc_value, tb = hint["exc_info"]
+        if isinstance(exc_value, ConnectionError):
+            return None
+
     _filter_user_home(event)
     return event
 


### PR DESCRIPTION
Should cover the `Incompatible client version '8.2', expected '8.3'` entries, but also the `An existing connection was forcibly closed by the remote host` and `The specified network name is no longer available` ones.