### PR TITLE
Don't show unnecessary lines in DLR and Teleporter tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.3.x] - 2024-08-??
 
+- Changed: Don't show unnecessary lines on Door Lock and Teleporter rando customization tabs.
+
 ### AM2R
 
 - Added: 10 more joke hints have been added.

--- a/randovania/games/am2r/gui/preset_settings/am2r_teleporters_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_teleporters_tab.py
@@ -20,6 +20,9 @@ if TYPE_CHECKING:
     from PySide6 import QtWidgets
 
     from randovania.game_description.db.node_identifier import NodeIdentifier
+    from randovania.game_description.game_description import GameDescription
+    from randovania.gui.lib.window_manager import WindowManager
+    from randovania.interface_common.preset_editor import PresetEditor
     from randovania.layout.preset import Preset
 
 
@@ -41,8 +44,16 @@ class PresetTeleportersAM2R(PresetTeleporterTab, Ui_PresetTeleportersAM2R, NodeL
         ),
     }
 
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager) -> None:
+        super().__init__(editor, game_description, window_manager)
+        self.teleporters_line.setVisible(self.teleporters_combo.currentData() != TeleporterShuffleMode.VANILLA)
+
     def setup_ui(self) -> None:
         self.setupUi(self)
+
+    def _update_teleporter_mode(self) -> None:
+        super()._update_teleporter_mode()
+        self.teleporters_line.setVisible(self.teleporters_combo.currentData() != TeleporterShuffleMode.VANILLA)
 
     @classmethod
     def tab_title(cls) -> str:

--- a/randovania/games/dread/gui/preset_settings/dread_teleporters_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_teleporters_tab.py
@@ -21,7 +21,10 @@ if TYPE_CHECKING:
 
     from randovania.game_description.db.area import Area
     from randovania.game_description.db.node_identifier import NodeIdentifier
+    from randovania.game_description.game_description import GameDescription
     from randovania.games.dread.layout.dread_configuration import DreadConfiguration
+    from randovania.gui.lib.window_manager import WindowManager
+    from randovania.interface_common.preset_editor import PresetEditor
     from randovania.layout.preset import Preset
 
 
@@ -48,8 +51,16 @@ class PresetTeleportersDread(PresetTeleporterTab, Ui_PresetTeleportersDread, Nod
         ),
     }
 
-    def setup_ui(self):
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager) -> None:
+        super().__init__(editor, game_description, window_manager)
+        self.teleporters_line.setVisible(self.teleporters_combo.currentData() != TeleporterShuffleMode.VANILLA)
+
+    def setup_ui(self) -> None:
         self.setupUi(self)
+
+    def _update_teleporter_mode(self) -> None:
+        super()._update_teleporter_mode()
+        self.teleporters_line.setVisible(self.teleporters_combo.currentData() != TeleporterShuffleMode.VANILLA)
 
     @classmethod
     def tab_title(cls) -> str:

--- a/randovania/games/samus_returns/gui/preset_settings/msr_teleporters_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_teleporters_tab.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
     from PySide6 import QtWidgets
 
     from randovania.game_description.db.node_identifier import NodeIdentifier
+    from randovania.game_description.game_description import GameDescription
+    from randovania.gui.lib.window_manager import WindowManager
+    from randovania.interface_common.preset_editor import PresetEditor
     from randovania.layout.preset import Preset
 
 
@@ -47,8 +50,16 @@ class PresetTeleportersMSR(PresetTeleporterTab, Ui_PresetTeleportersMSR, NodeLis
         ),
     }
 
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager) -> None:
+        super().__init__(editor, game_description, window_manager)
+        self.teleporters_line.setVisible(self.teleporters_combo.currentData() != TeleporterShuffleMode.VANILLA)
+
     def setup_ui(self) -> None:
         self.setupUi(self)
+
+    def _update_teleporter_mode(self) -> None:
+        super()._update_teleporter_mode()
+        self.teleporters_line.setVisible(self.teleporters_combo.currentData() != TeleporterShuffleMode.VANILLA)
 
     @classmethod
     def tab_title(cls) -> str:

--- a/randovania/gui/preset_settings/dock_rando_tab.py
+++ b/randovania/gui/preset_settings/dock_rando_tab.py
@@ -54,6 +54,7 @@ class PresetDockRando(PresetTab, Ui_PresetDockRando):
         self.mode_description.setText(dock_rando.mode.description)
 
         self.multiworld_label.setVisible(len(dock_rando.settings_incompatible_with_multiworld()) > 0)
+        self.line.setVisible(self.multiworld_label.isVisible())
         self.dock_types_group.setVisible(dock_rando.mode != DockRandoMode.VANILLA)
 
         for dock_type, weakness_checks in self.type_checks.items():


### PR DESCRIPTION
Before:
![grafik](https://github.com/user-attachments/assets/a06a3720-a876-4694-aff9-299e03190c9f)

![grafik](https://github.com/user-attachments/assets/77d4a440-7313-4840-97a3-f3cac4984a49)


After:
![grafik](https://github.com/user-attachments/assets/d2d229f3-2f21-41e1-9fe6-9e7167762b75)
![grafik](https://github.com/user-attachments/assets/0a441b65-0eef-49f9-be2a-a886f8040f45)
