### PR TITLE
Default InfiniteTimer to not strict

### DIFF
--- a/randovania/lib/infinite_timer.py
+++ b/randovania/lib/infinite_timer.py
@@ -15,7 +15,7 @@ class InfiniteTimer(QtCore.QObject):
     should_start_timer: bool = False
     _current_task: asyncio.Task | None = None
 
-    def __init__(self, target: Callable[[], Awaitable[None]], interval: float, *, strict: bool = True):
+    def __init__(self, target: Callable[[], Awaitable[None]], interval: float, *, strict: bool = False):
         super().__init__()
         self._dt = interval
         self.target = target
@@ -57,5 +57,5 @@ class InfiniteTimer(QtCore.QObject):
             return
 
         assert self._current_task is None
-        self._current_task = asyncio.create_task(self._target_wrap())
+        self._current_task = asyncio.create_task(self._target_wrap(), name=f"Infinite Timer for {self.target}")
         self._current_task.add_done_callback(_error_handler)


### PR DESCRIPTION
Dunc had the correct idea when hii made the CS connector use a non-strict timer: if `target` runs for longer than `interval`, then `_current_task` will be not-None in `_on_timeout`. Since we use this timer to make network calls, it's perfectly reasonable for them to take forever.

For an infinitely repeatable timer, we don't really mind skipping a few triggers so defaulting strict to false.

No changelog because I'm not even sure this error shows up visibly for users. And the message would be something like "Fixed: An invisible error that could happen in rare cases with is now fixed."