### PR TITLE
Pure asyncio timers for InfiniteTimer

### DIFF
--- a/randovania/lib/infinite_timer.py
+++ b/randovania/lib/infinite_timer.py
@@ -4,45 +4,46 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-import shiboken6
-from PySide6 import QtCore
-
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
 
-class InfiniteTimer(QtCore.QObject):
+class InfiniteTimer:
     should_start_timer: bool = False
+    _timer: asyncio.Handle | None = None
     _current_task: asyncio.Task | None = None
 
     def __init__(self, target: Callable[[], Awaitable[None]], interval: float, *, strict: bool = False):
         super().__init__()
         self._dt = interval
         self.target = target
-
-        self._timer = QtCore.QTimer(self)
-        self._timer.timeout.connect(self._on_timeout)
-        self._timer.setInterval(int(self._dt * 1000))
-        self._timer.setSingleShot(True)
-
         self.strict = strict
 
     def start(self) -> None:
-        self._timer.start()
         self.should_start_timer = True
+        self._schedule_timer()
 
     def stop(self) -> None:
         self.should_start_timer = False
-        self._timer.stop()
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+
         if self._current_task is not None:
             self._current_task.cancel()
+
+    def _schedule_timer(self) -> None:
+        self._timer = asyncio.get_event_loop().call_later(
+            self._dt,
+            self._on_timeout,
+        )
 
     async def _target_wrap(self) -> None:
         try:
             return await self.target()
         finally:
-            if shiboken6.isValid(self) and self.should_start_timer:
-                self._timer.start()
+            if self.should_start_timer:
+                self._schedule_timer()
 
     def _on_timeout(self) -> None:
         def _error_handler(t: asyncio.Task) -> None:

--- a/test/lib/test_infinite_timer.py
+++ b/test/lib/test_infinite_timer.py
@@ -1,60 +1,67 @@
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from randovania.lib.infinite_timer import InfiniteTimer
 
+if TYPE_CHECKING:
+    import pytest_mock
 
-def test_start(skip_qtbot) -> None:
+
+async def test_start(mocker: pytest_mock.MockFixture) -> None:
+    mock_on_timeout = mocker.patch("randovania.lib.infinite_timer.InfiniteTimer._on_timeout")
     target = AsyncMock()
 
     timer = InfiniteTimer(target, 0.001)
-    timer._timer = MagicMock()
     timer.start()
-    timer._timer.start.assert_called_once_with()
+    await asyncio.sleep(0.001)
+    mock_on_timeout.assert_called_once_with()
 
 
 @pytest.mark.parametrize("has_task", [False, True])
-def test_stop(skip_qtbot, has_task: bool) -> None:
+async def test_stop(mocker: pytest_mock.MockFixture, has_task: bool) -> None:
+    mock_on_timeout = mocker.patch("randovania.lib.infinite_timer.InfiniteTimer._on_timeout")
+
     target = AsyncMock()
+    cur_task = MagicMock()
 
     timer = InfiniteTimer(target, 0.001)
-    timer._timer = MagicMock()
     if has_task:
-        cur_task = MagicMock()
         timer._current_task = cur_task
+
+    timer.start()
     timer.stop()
 
-    timer._timer.stop.assert_called_once_with()
+    await asyncio.sleep(0.001)
+
+    mock_on_timeout.assert_not_called()
     if has_task:
         cur_task.cancel.assert_called_once_with()
 
 
-async def test_on_timeout(skip_qtbot) -> None:
+async def test_on_timeout() -> None:
     target = AsyncMock()
 
     timer = InfiniteTimer(target, 0.001)
-    timer.should_start_timer = True
-    timer._timer = MagicMock()
-
+    assert timer._current_task is None
     timer._on_timeout()
+    assert timer._current_task is not None
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
 
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
     target.assert_awaited_once_with()
-    timer._timer.start.assert_called_once_with()
     assert timer._current_task is None
 
 
-async def test_on_timeout_and_cancel(skip_qtbot) -> None:
+async def test_on_timeout_and_cancel() -> None:
     target = AsyncMock()
 
     timer = InfiniteTimer(target, 0.001)
     timer.should_start_timer = True
-    timer._timer = MagicMock()
 
     timer._on_timeout()
     assert timer._current_task is not None
@@ -64,6 +71,5 @@ async def test_on_timeout_and_cancel(skip_qtbot) -> None:
     await asyncio.sleep(0)
 
     target.assert_not_awaited()
-    timer._timer.start.assert_not_called()
     assert timer._current_task is None
     assert not timer.should_start_timer


### PR DESCRIPTION
I always hated using Qt for the Game Connector. If we also stop using signals we can have a non-qt build of Randovania that can do multiworld things.

Plus if we're calling the timeout via the event loop, hopefully https://randovania.sentry.io/issues/3920644751/ won't happen anymore.

Leaving for next release because I want a full month of testing for this.