### PR TITLE
Sentry Filtering: Account for multiple forward-and-backward slashes in a row

### DIFF
--- a/randovania/monitoring/__init__.py
+++ b/randovania/monitoring/__init__.py
@@ -57,7 +57,7 @@ def _filter_data(data: object, str_filter: typing.Callable[[str], str]) -> typin
     return result
 
 
-_HOME_RE = re.compile(r"(:?[/\\](?:home|Users)[/\\])([^/\\]+)([/\\])")
+_HOME_RE = re.compile(r"(:?[/\\](?:home|Users)[/\\]+)([^/\\]+)([/\\])")
 
 
 def _filter_user_home(data: typing.Any) -> typing.Any | None:


### PR DESCRIPTION
Fifth time's the charm right? I'm guessing it's only the fifth time I lost track already.

When sentry reports the stack it includes all local variables, which sometimes is an imported module which is converted to a string. Doing so on Windows gets something like `<module 'open_dread_rando' from 'C:\\Users\\henri\\programming\\randovania\\venv-3.12\\Lib\\site-packages\\open_dread_rando\\__init__.py'>`, including the double slashes. (nice python bug by the way)