### PR TITLE
Bump OSRR to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,10 +102,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: More starting locations have been added for all areas.
 - Added: Progressive pickups can now be configured to be placed vanilla.
 - Added: New generic offworld items for Missiles, Beams, and Suits in multiworld.
+- Added: A unique icon for major items on the map.
 - Changed: Room Names on the HUD are now enabled by default.
 - Changed: Power Bomb drop rates have been bumped to 20% from 10-15% for nearly all enemies.
 - Changed: The music in Surface West now plays the Surface East - Landing Site theme if you do not have the Baby and all DNA collected.
 - Changed: The Aeion orbs after collecting major upgrades has been restored.
+- Changed: Beams have been rebalanced again Diggernaut.
 - Fixed: The hidden area in Area 7 - Spider Boost Tunnel South not being removed fully.
 - Fixed: Negative Metroid count if defeating the Larva Metroids in reverse.
 - Fixed: Visual bug where Samus would display incorrectly after reloading to checkpoint from a boss fight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Power Bomb drop rates have been bumped to 20% from 10-15% for nearly all enemies.
 - Changed: The music in Surface West now plays the Surface East - Landing Site theme if you do not have the Baby and all DNA collected.
 - Changed: The Aeion orbs after collecting major upgrades has been restored.
-- Changed: Beams have been rebalanced again Diggernaut.
+- Changed: Beams have been rebalanced against Diggernaut.
 - Fixed: The hidden area in Area 7 - Spider Boost Tunnel South not being removed fully.
 - Fixed: Negative Metroid count if defeating the Larva Metroids in reverse.
 - Fixed: Visual bug where Samus would display incorrectly after reloading to checkpoint from a boss fight.

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ colorama==0.4.6
     # via
     #   click
     #   pytest
-construct==2.10.68
+construct==2.10.70
     # via
     #   mercury-engine-data-structures
     #   randovania (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -146,7 +146,7 @@ markupsafe==2.1.5
     #   werkzeug
 matplotlib==3.9.1
     # via randovania (setup.py)
-mercury-engine-data-structures==0.30.0
+mercury-engine-data-structures==0.31.1
     # via
     #   open-dread-rando
     #   open-samus-returns-rando

--- a/requirements.txt
+++ b/requirements.txt
@@ -179,7 +179,7 @@ open-dread-rando==2.12.2
     # via randovania (setup.py)
 open-prime-rando==0.13.0
     # via randovania (setup.py)
-open-samus-returns-rando==2.3.0
+open-samus-returns-rando==2.4.0
     # via randovania (setup.py)
 packaging==24.1
     # via


### PR DESCRIPTION
> Add toggle for tanks fully refilling ammo

and

> Support shuffling block types

are not listed, because RDV doesnt have toggles for them yet.

The performance improvements by Henrique also have not been listed cause I wasn't sure if I should put it in.