### PR TITLE
Sentry: Fallback to non-empty string in cpu.processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: Reduced some visual noise in the main window and customize preset window.
 - Changed: Don't show unnecessary lines on Door Lock and Teleporter rando customization tabs.
+- Fixed: In multiworld sessions, creating a new world with a preset with unsupported features is now properly rejected.
 
 ### AM2R
 

--- a/randovania/monitoring/__init__.py
+++ b/randovania/monitoring/__init__.py
@@ -154,7 +154,7 @@ def client_init() -> None:
     global_scope = sentry_sdk.Scope.get_global_scope()
     global_scope.set_tag("frozen", randovania.is_frozen())
     global_scope.set_tag("cpu.architecture", platform.machine())
-    global_scope.set_tag("cpu.processor", platform.processor())
+    global_scope.set_tag("cpu.processor", platform.processor() or "unknown")  # Empty string is an invalid value
     global_scope.set_tag("cpu.count", os.cpu_count())
 
     # Ignore the "packet queue is empty, aborting" message


### PR DESCRIPTION
Plus changelog entry for #6976 that I forgot to commit.