### PR TITLE
Dread: Early Gravity logic fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,15 +57,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid Dread
 
 - Fixed: The option to hide scans with Nothing data now behaves as expected.
-Fixed: Seeds with more than 3 starting Energy Parts can be exported and played.
+- Fixed: Seeds with more than 3 starting Energy Parts can be exported and played.
 
 #### Logic Database
 
 ##### Burenia
 
 - Added: Use Pseudo Wave Beam (Intermediate) with Diffusion Beam to break the Early Gravity Blob through the wall.
-- Removed: Using Water Bomb Jumps to reach the Blob Alcove in Gravity Suit Tower.
 - Fixed: The Early Gravity Speed Booster puzzle now correctly requires Speed Booster Conservation set to Beginner.
+- Removed: Using Water Bomb Jumps to reach the Blob Alcove in Gravity Suit Tower.
 
 ##### Cataris
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Fixed: Seeds with more than 3 starting Energy Parts can be exported and played.
 
 - Added: Use Pseudo Wave Beam (Intermediate) with Diffusion Beam to break the Early Gravity Blob through the wall.
 - Removed: Using Water Bomb Jumps to reach the Blob Alcove in Gravity Suit Tower.
+- Fixed: The Early Gravity Speed Booster puzzle now correctly requires Speed Booster Conservation set to Beginner.
 
 ##### Cataris
 

--- a/randovania/games/dread/logic_database/Burenia.json
+++ b/randovania/games/dread/logic_database/Burenia.json
@@ -12906,29 +12906,12 @@
                             }
                         },
                         "Dock to Early Gravity Speedboost Room 1 (Lower)": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "BureniaEarlyGravSpeedBlocks",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Speedbooster",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "type": "events",
+                                "name": "BureniaEarlyGravSpeedBlocks",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Water Pit": {
@@ -12960,6 +12943,15 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Speedbooster",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -12982,7 +12974,7 @@
                     "valid_starting_location": false,
                     "event_name": "BureniaEarlyGravSpeedBlocks",
                     "connections": {
-                        "Dock to Early Gravity Speedboost Room 1 (Lower)": {
+                        "Slope Top": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/logic_database/Burenia.txt
+++ b/randovania/games/dread/logic_database/Burenia.txt
@@ -2091,16 +2091,16 @@ Extra - asset_id: collision_camera_019
               Spider Magnet or Grapple Movement (Beginner)
           Flash Shift and Wall Jump (Beginner)
   > Dock to Early Gravity Speedboost Room 1 (Lower)
-      After Burenia - Early Gravity Speed Blocks Destroyed and Speed Booster Conservation (Beginner)
+      After Burenia - Early Gravity Speed Blocks Destroyed
   > Water Pit
       Trivial
   > Event - Early Gravity Speed Blocks Destroyed
-      Speed Booster and After Burenia - Ghavoran Teleoport Speed Blocks Destroyed
+      Speed Booster and After Burenia - Ghavoran Teleoport Speed Blocks Destroyed and Speed Booster Conservation (Beginner)
 
 > Event - Early Gravity Speed Blocks Destroyed; Heals? False
   * Layers: default
   * Event Burenia - Early Gravity Speed Blocks Destroyed
-  > Dock to Early Gravity Speedboost Room 1 (Lower)
+  > Slope Top
       Trivial
 
 ----------------


### PR DESCRIPTION
Makes the Early Gravity puzzle require Speed Booster Conservation instead of being trickless, as was intended back when the trick was added to this section.