### PR TITLE
Fix frigate orpheon ship being immedately usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Prime
 
+- Changed: Updated tournament winners scan text
 - Fixed: Crash in Central Dynamo/Quarantine Access A due to the memory from extra blast shields
 - Fixed: Crash in Deck Beta Security Hall due to the memory from extra blast shields and auto-loads
 - Fixed: Non-NTSC 0-00 Ruined Courtyard thermal conduit patch exploit where Super Missiles could be skipped
@@ -94,9 +95,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Black bars sometimes disappearing prematurely in the Chozo Ice Temple cutscene
 - Fixed: Missing screen fade-in from Arrival cutscenes in Transport to Chozo Ruins East and Transport to Tallon Overworld South when skipped
 - Fixed: Ghost music in Furnace not playing when coming from Energy Core
-- Changed: Updated tournament winners scan text
 
 #### Logic Database
+
+- Fixed: When elevators are shuffled one-way (cycles/replacement/anywhere), and an elevator leads into the Ship on uncrashed Frigate Orpheon, coming back now properly needs Parasite Queen defeated.
 
 ##### Chozo Ruins
 

--- a/randovania/games/prime1/logic_database/Frigate Orpheon.json
+++ b/randovania/games/prime1/logic_database/Frigate Orpheon.json
@@ -140,7 +140,7 @@
                         "area": "Landing Site",
                         "node": "Ship"
                     },
-                    "default_dock_weakness": "Teleporter",
+                    "default_dock_weakness": "Frigate Ship Teleporter",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,

--- a/randovania/games/prime1/logic_database/Frigate Orpheon.txt
+++ b/randovania/games/prime1/logic_database/Frigate Orpheon.txt
@@ -21,7 +21,7 @@ Extra - aabb: [-104.01521, 58.089508, -62.7767, 157.58212, 264.77844, 85.15653]
 
 > Teleporter to Tallon Overworld; Heals? False
   * Layers: default
-  * Teleporter to Landing Site/Ship; Custom name: Exterior Docking Hangar
+  * Frigate Ship Teleporter to Landing Site/Ship; Custom name: Exterior Docking Hangar
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: 134218592
   > Ship Save

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -2167,6 +2167,27 @@
                             }
                         },
                         "lock": null
+                    },
+                    "Frigate Ship Teleporter": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event33",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "lock": null
                     }
                 },
                 "dock_rando": null

--- a/randovania/games/prime1/logic_database/header.txt
+++ b/randovania/games/prime1/logic_database/header.txt
@@ -256,5 +256,11 @@ Dock Weaknesses
           Trivial
       No lock
 
+
+  * Frigate Ship Teleporter
+      Open:
+          After Parasite Queen
+      No lock
+
   > Dock Rando: Disabled
 


### PR DESCRIPTION
Yay for last minute major bug findings

The generator can go through a node, when it is able to fullfill its "open" and "lock" requirements. Thus, if a Teleporter leads to frigate, the generator is able to leave instantly again, even though in-game you would be expected to go through the whole frigate to kill Parasite Queen.

Thus we change the open requirements on the ship teleporter to require the queen to be killed and for scan visor, as you'll need to scan the ship in order to activate the teleportation.