### PR TITLE
Fix CI not uploading binaries to release

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -563,7 +563,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: packages/Randovania*
+          file: packages/Randovania**
           file_glob: true
           tag: ${{ github.ref }}
           overwrite: true


### PR DESCRIPTION
The binaries are in `Randovania *` subdirectories, so a single glob doesn't work to get them.