### PR TITLE
Revert "Bump cryptography from 42.0.8 to 43.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ contourpy==1.2.1
     # via matplotlib
 coverage==7.6.0
     # via pytest-cov
-cryptography==43.0.0
+cryptography==42.0.8
     # via
     #   pyopenssl
     #   randovania (setup.py)


### PR DESCRIPTION
Reverts randovania/randovania#6947

in case it's breaking things