### PR TITLE
[DREAD] Freesink game modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
+- Added: Freesink can be enabled in a preset's Game Modifications -> Other tab. A more detailed description of this change can be found in the description. This option is **not** accounted for in logic.
+
 #### Logic Database
 
 ##### Artaria

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -385,6 +385,9 @@ class DreadPatchDataFactory(PatchDataFactory):
                     "fSfxVolume": c.sfx_volume / 100,
                     "fEnvironmentStreamsVolume": c.ambience_volume / 100,
                 },
+                "SubAreaManager": {
+                    "bKillPlayerOutsideScenario": not self.configuration.freesink,
+                },
             },
             "lua": {
                 "custom_init": {

--- a/randovania/games/dread/gui/preset_settings/__init__.py
+++ b/randovania/games/dread/gui/preset_settings/__init__.py
@@ -12,6 +12,7 @@ def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
     from randovania.games.dread.gui.preset_settings.dread_generation_tab import PresetDreadGeneration
     from randovania.games.dread.gui.preset_settings.dread_goal_tab import PresetDreadGoal
     from randovania.games.dread.gui.preset_settings.dread_item_pool_tab import DreadPresetItemPool
+    from randovania.games.dread.gui.preset_settings.dread_patches_chaos import PresetDreadChaos
     from randovania.games.dread.gui.preset_settings.dread_patches_tab import PresetDreadPatches
     from randovania.games.dread.gui.preset_settings.dread_teleporters_tab import PresetTeleportersDread
     from randovania.gui.preset_settings.dock_rando_tab import PresetDockRando
@@ -30,4 +31,5 @@ def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
         PresetDockRando,
         PresetDreadEnergy,
         PresetDreadPatches,
+        PresetDreadChaos,
     ]

--- a/randovania/games/dread/gui/preset_settings/dread_patches_chaos.py
+++ b/randovania/games/dread/gui/preset_settings/dread_patches_chaos.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import typing
+
+from PySide6 import QtWidgets
+
+from randovania.games.dread.gui.generated.preset_dread_chaos_ui import Ui_PresetDreadChaos
+from randovania.gui.lib import signal_handling
+from randovania.gui.preset_settings.preset_tab import PresetTab
+
+if typing.TYPE_CHECKING:
+    from randovania.game_description.game_description import GameDescription
+    from randovania.gui.lib.window_manager import WindowManager
+    from randovania.interface_common.preset_editor import PresetEditor
+    from randovania.layout.preset import Preset
+
+_FIELDS = [
+    "freesink",
+]
+
+
+class PresetDreadChaos(PresetTab, Ui_PresetDreadChaos):
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
+        self.setupUi(self)
+
+        self.chaos_label.setText(self.chaos_label.text().replace("color:#0000ff;", ""))
+
+        # Signals
+        for f in _FIELDS:
+            self._add_persist_option(getattr(self, f"{f}_check"), f)
+
+    @classmethod
+    def tab_title(cls) -> str:
+        return "Chaos Settings"
+
+    @classmethod
+    def is_experimental(cls) -> bool:
+        return True
+
+    @classmethod
+    def uses_patches_tab(cls) -> bool:
+        return True
+
+    def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str):
+        def persist(value: bool):
+            with self._editor as editor:
+                editor.set_configuration_field(attribute_name, value)
+
+        signal_handling.on_checked(check, persist)
+
+    def on_preset_changed(self, preset: Preset):
+        config = preset.configuration
+
+        for f in _FIELDS:
+            typing.cast(QtWidgets.QCheckBox, getattr(self, f"{f}_check")).setChecked(getattr(config, f))

--- a/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
@@ -20,7 +20,6 @@ _FIELDS = [
     "hanubia_easier_path_to_itorash",
     "x_starts_released",
     "nerf_power_bombs",
-    "freesink",
 ]
 
 

--- a/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
@@ -20,6 +20,7 @@ _FIELDS = [
     "hanubia_easier_path_to_itorash",
     "x_starts_released",
     "nerf_power_bombs",
+    "freesink",
 ]
 
 

--- a/randovania/games/dread/gui/ui_files/preset_dread_chaos.ui
+++ b/randovania/games/dread/gui/ui_files/preset_dread_chaos.ui
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PresetDreadChaos</class>
+ <widget class="QMainWindow" name="PresetDreadChaos">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>503</width>
+    <height>387</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Other</string>
+  </property>
+  <widget class="QWidget" name="centralWidget">
+   <property name="maximumSize">
+    <size>
+     <width>16777215</width>
+     <height>16777215</height>
+    </size>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="QScrollArea" name="scroll_area">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <widget class="QWidget" name="scroll_contents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>501</width>
+         <height>385</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="scroll_layout">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>2</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <spacer name="top_spacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>8</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="chaos_label">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This page contains experimental settings which do not yet have (or will never have) logic support. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="misc_group">
+          <property name="title">
+           <string>Miscellaneous</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_7">
+           <item>
+            <widget class="QCheckBox" name="freesink_check">
+             <property name="text">
+              <string>Enable Freesink</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="freesink_label">
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Usually, Samus will die if she is out of bounds, usually due to performing floor clips. When checked, this behavior is removed from the game and Samus can freely move out of bounds. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="bottom_spacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>

--- a/randovania/games/dread/gui/ui_files/preset_dread_chaos.ui
+++ b/randovania/games/dread/gui/ui_files/preset_dread_chaos.ui
@@ -55,16 +55,16 @@
        </property>
        <layout class="QVBoxLayout" name="scroll_layout">
         <property name="leftMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
         <property name="topMargin">
-         <number>2</number>
+         <number>6</number>
         </property>
         <property name="rightMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
         <property name="bottomMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
         <item>
          <spacer name="top_spacer">

--- a/randovania/games/dread/gui/ui_files/preset_dread_patches.ui
+++ b/randovania/games/dread/gui/ui_files/preset_dread_patches.ui
@@ -42,9 +42,9 @@
        <property name="geometry">
         <rect>
          <x>0</x>
-         <y>-583</y>
-         <width>438</width>
-         <height>848</height>
+         <y>0</y>
+         <width>498</width>
+         <height>754</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="scroll_layout">
@@ -190,32 +190,6 @@ When checked, the damage of Wave Beam and Ice Missiles will be increased to matc
              <property name="text">
               <string>The Power Bomb is one of the most powerful abilities in the game, as it can defeat most enemies and some bosses in one hit, as well as open Charge Beam doors, and destroy Enkies. 
 This setting removes the ability to destroy Enkies and open Charge Beam doors, making Ice Missiles and Charge Beam much more valuable. </string>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="freesink_check">
-             <property name="text">
-              <string>Freesink</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="freesink_label">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Usually, Samus will die if she is out of bounds. This can occur when the player executes a variety of Floor Clips, or when grappling onto a Spider Magnet wall without Spider Magnet at a sharp angle. &lt;/p&gt;&lt;p&gt;When checked, this behavior is removed from the game and Samus can move freely out of bounds. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;This setting is &lt;/span&gt;&lt;span style=&quot; font-weight:700; color:#ff0000;&quot;&gt;NOT&lt;/span&gt;&lt;span style=&quot; font-weight:700;&quot;&gt; accounted for in logic.&lt;/span&gt; It is recommended to only activate this patch if you are acquaintanced with Floor Clips. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="textFormat">
-              <enum>Qt::RichText</enum>
              </property>
              <property name="wordWrap">
               <bool>true</bool>

--- a/randovania/games/dread/gui/ui_files/preset_dread_patches.ui
+++ b/randovania/games/dread/gui/ui_files/preset_dread_patches.ui
@@ -42,9 +42,9 @@
        <property name="geometry">
         <rect>
          <x>0</x>
-         <y>0</y>
-         <width>498</width>
-         <height>754</height>
+         <y>-583</y>
+         <width>438</width>
+         <height>848</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="scroll_layout">
@@ -190,6 +190,32 @@ When checked, the damage of Wave Beam and Ice Missiles will be increased to matc
              <property name="text">
               <string>The Power Bomb is one of the most powerful abilities in the game, as it can defeat most enemies and some bosses in one hit, as well as open Charge Beam doors, and destroy Enkies. 
 This setting removes the ability to destroy Enkies and open Charge Beam doors, making Ice Missiles and Charge Beam much more valuable. </string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="freesink_check">
+             <property name="text">
+              <string>Freesink</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="freesink_label">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Usually, Samus will die if she is out of bounds. This can occur when the player executes a variety of Floor Clips, or when grappling onto a Spider Magnet wall without Spider Magnet at a sharp angle. &lt;/p&gt;&lt;p&gt;When checked, this behavior is removed from the game and Samus can move freely out of bounds. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;This setting is &lt;/span&gt;&lt;span style=&quot; font-weight:700; color:#ff0000;&quot;&gt;NOT&lt;/span&gt;&lt;span style=&quot; font-weight:700;&quot;&gt; accounted for in logic.&lt;/span&gt; It is recommended to only activate this patch if you are acquaintanced with Floor Clips. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="textFormat">
+              <enum>Qt::RichText</enum>
              </property>
              <property name="wordWrap">
               <bool>true</bool>

--- a/randovania/games/dread/layout/dread_configuration.py
+++ b/randovania/games/dread/layout/dread_configuration.py
@@ -61,6 +61,7 @@ class DreadConfiguration(BaseConfiguration):
     nerf_power_bombs: bool
     warp_to_start: bool
     april_fools_hints: bool
+    freesink: bool
     artifacts: DreadArtifactConfig
     constant_heat_damage: int | None = dataclasses.field(metadata={"min": 0, "max": 1000, "precision": 1})
     constant_cold_damage: int | None = dataclasses.field(metadata={"min": 0, "max": 1000, "precision": 1})

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1187,6 +1187,14 @@ def _migrate_v87(preset: dict) -> dict:
     return preset
 
 
+def _migrate_v88(preset: dict) -> dict:
+    if preset["game"] == "dread":
+        config = preset["configuration"]
+        config["freesink"] = False
+
+    return preset
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -1275,6 +1283,7 @@ _MIGRATIONS = [
     _migrate_v85,  # am2r configurable DR
     _migrate_v86,
     _migrate_v87,
+    _migrate_v88,  # dread freesink
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
@@ -4043,6 +4043,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/dread/crazy_settings/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/crazy_settings/world_1.json
@@ -3719,6 +3719,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/dread/custom_patcher_data/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/custom_patcher_data/world_1.json
@@ -3668,6 +3668,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/dread/custom_start/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/custom_start/world_1.json
@@ -3721,6 +3721,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_1.json
@@ -3863,6 +3863,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_2.json
+++ b/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_2.json
@@ -3883,6 +3883,9 @@
                 "fMusicVolume": 0.5,
                 "fSfxVolume": 0.5,
                 "fEnvironmentStreamsVolume": 0.5
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/dread/elevator_rando/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/elevator_rando/world_1.json
@@ -4073,6 +4073,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/dread/hide_all_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/hide_all_with_nothing/world_1.json
@@ -3932,6 +3932,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/dread/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/starter_preset/world_1.json
@@ -3697,6 +3697,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/dread_prime1_multiworld/world_1.json
+++ b/test/test_files/patcher_data/dread/dread_prime1_multiworld/world_1.json
@@ -3842,6 +3842,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2+msr/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2+msr/world_4.json
@@ -3952,6 +3952,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_4.json
@@ -3924,6 +3924,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_4.json
@@ -3954,6 +3954,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_8.json
+++ b/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_8.json
@@ -3955,6 +3955,9 @@
                 "fMusicVolume": 1.0,
                 "fSfxVolume": 1.0,
                 "fEnvironmentStreamsVolume": 1.0
+            },
+            "SubAreaManager": {
+                "bKillPlayerOutsideScenario": true
             }
         },
         "lua": {


### PR DESCRIPTION
- added a patch to Game Modification -> Other -> Miscellaneous that disables the SubAreaManager.bKillPlayerOutsideScenario tunable
- added a note explaining freesink (or at least attempting to lol)
- added a preset migration to default to disabled

Help appreciated on the wording, i spent about 30 minutes and still don't think its very good lmao. Also, I feel like the "experimental" label isn't particularly accurate since it is well-tested to do what it says on the box lol. I'd be happy to add that requirement if that's preferred. 