### PR TITLE
Planets (Zebeth): Implemented patch data factory

### DIFF
--- a/randovania/games/planets_zebeth/exporter/hint_namer.py
+++ b/randovania/games/planets_zebeth/exporter/hint_namer.py
@@ -1,0 +1,104 @@
+import dataclasses
+
+from randovania.exporter.hints.hint_formatters import LocationFormatter, RelativeAreaFormatter, TemplatedFormatter
+from randovania.exporter.hints.hint_namer import HintNamer, PickupLocation
+from randovania.exporter.hints.pickup_hint import PickupHint
+from randovania.exporter.hints.relative_item_formatter import RelativeItemFormatter
+from randovania.game_description import default_database
+from randovania.game_description.db.pickup_node import PickupNode
+from randovania.game_description.db.region_list import RegionList
+from randovania.game_description.game_patches import GamePatches
+from randovania.game_description.hint import Hint, HintLocationPrecision
+from randovania.game_description.resources.item_resource_info import ItemResourceInfo
+from randovania.games.game import RandovaniaGame
+from randovania.interface_common.players_configuration import PlayersConfiguration
+
+
+def _area_name(region_list: RegionList, pickup_node: PickupNode, hide_region: bool) -> str:
+    area = region_list.nodes_to_area(pickup_node)
+    if hide_region:
+        return area.name
+    else:
+        return region_list.area_name(area)
+
+
+class PlanetsZebethHintNamer(HintNamer):
+    location_formatters: dict[HintLocationPrecision, LocationFormatter]
+
+    def __init__(self, all_patches: dict[int, GamePatches], players_config: PlayersConfiguration):
+        patches = all_patches[players_config.player_index]
+        location_hint_template = "{determiner.title}{pickup} can be found in {node}."
+
+        self.location_formatters = {
+            HintLocationPrecision.DETAILED: TemplatedFormatter(
+                location_hint_template,
+                self,
+            ),
+            HintLocationPrecision.REGION_ONLY: TemplatedFormatter(
+                location_hint_template,
+                self,
+            ),
+            HintLocationPrecision.RELATIVE_TO_AREA: RelativeAreaFormatter(
+                patches,
+                lambda msg, with_color: msg,
+            ),
+            HintLocationPrecision.RELATIVE_TO_INDEX: RelativeItemFormatter(
+                patches,
+                lambda msg, with_color: msg,
+                players_config,
+            ),
+        }
+
+    def format_resource_is_starting(self, resource: ItemResourceInfo, with_color: bool) -> str:
+        """Used when for when an item has a guaranteed hint, but is a starting item."""
+        return f"Started with {resource.long_name}"
+
+    def format_guaranteed_resource(
+        self,
+        resource: ItemResourceInfo,
+        player_name: str | None,
+        location: PickupLocation,
+        hide_area: bool,
+        with_color: bool,
+    ) -> str:
+        determiner = ""
+        if player_name is not None:
+            determiner = self.format_player(player_name, with_color=with_color) + "'s "
+
+        fmt = "{} is located in {}{}."
+        location_name = self.format_location(location, with_region=True, with_area=not hide_area, with_color=with_color)
+
+        # TODO: create_guaranteed_hints_for_resources assumes that the resource is used by a singleton pickup, so we
+        # patch the name here instead. Fix it there at one point.
+        name = resource.long_name
+        if resource.short_name.startswith("Tourian Key "):
+            name = "Tourian Key"
+        return fmt.format(
+            name,
+            determiner,
+            location_name,
+        )
+
+    def format_location_hint(self, game: RandovaniaGame, pick_hint: PickupHint, hint: Hint, with_color: bool) -> str:
+        return self.location_formatters[hint.precision.location].format(
+            game,
+            dataclasses.replace(pick_hint, pickup_name=pick_hint.pickup_name),
+            hint,
+            with_color,
+        )
+
+    def format_region(self, location: PickupLocation, with_color: bool) -> str:
+        region_list = default_database.game_description_for(location.game).region_list
+        result = region_list.region_name_from_node(region_list.node_from_pickup_index(location.location), True)
+        return result
+
+    def format_area(self, location: PickupLocation, with_region: bool, with_color: bool) -> str:
+        region_list = default_database.game_description_for(location.game).region_list
+        result = _area_name(region_list, region_list.node_from_pickup_index(location.location), not with_region)
+        return result
+
+    def format_player(self, name: str, with_color: bool) -> str:
+        return name
+
+    def format_joke(self, joke: str, with_color: bool) -> str:
+        return joke

--- a/randovania/games/planets_zebeth/exporter/patch_data_factory.py
+++ b/randovania/games/planets_zebeth/exporter/patch_data_factory.py
@@ -31,7 +31,7 @@ class PlanetsZebethPatchDataFactory(PatchDataFactory):
         pickup_map_dict = {}
         for pickup in pickup_list:
             quantity = pickup.conditional_resources[0].resources[0][1] if not pickup.other_player else 0
-            object_id = self.game.region_list.node_from_pickup_index(pickup.index).extra["object_id"]
+            object_id = str(self.game.region_list.node_from_pickup_index(pickup.index).extra["object_id"])
             res_lock = pickup.original_pickup.resource_lock
             text_index = (
                 1

--- a/randovania/games/planets_zebeth/exporter/patch_data_factory.py
+++ b/randovania/games/planets_zebeth/exporter/patch_data_factory.py
@@ -1,12 +1,136 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from randovania.exporter import item_names, pickup_exporter
 from randovania.exporter.patch_data_factory import PatchDataFactory
+from randovania.game_description.assignment import PickupTarget
 from randovania.games.game import RandovaniaGame
+from randovania.generator.pickup_pool import pickup_creator
+from randovania.lib import json_lib
+
+if TYPE_CHECKING:
+    from random import Random
+
+    from randovania.exporter.pickup_exporter import ExportedPickupDetails
+    from randovania.games.planets_zebeth.layout.planets_zebeth_configuration import PlanetsZebethConfiguration
+    from randovania.games.planets_zebeth.layout.planets_zebeth_cosmetic_patches import PlanetsZebethCosmeticPatches
 
 
 class PlanetsZebethPatchDataFactory(PatchDataFactory):
+    cosmetic_patches: PlanetsZebethCosmeticPatches
+    configuration: PlanetsZebethConfiguration
+
+    def _create_pickups_dict(self, pickup_list: list[ExportedPickupDetails], item_info: dict, rng: Random) -> dict:
+        pickup_map_dict = {}
+        for pickup in pickup_list:
+            quantity = pickup.conditional_resources[0].resources[0][1] if not pickup.other_player else 0
+            object_id = self.game.region_list.node_from_pickup_index(pickup.index).extra["object_id"]
+            res_lock = pickup.original_pickup.resource_lock
+            text_index = (
+                1
+                if (
+                    res_lock is not None
+                    and "Locked" in res_lock.temporary_item.long_name
+                    and len(pickup.collection_text) > 1
+                )
+                else 0
+            )
+
+            pickup_map_dict[object_id] = {
+                "model": pickup.model.name,
+                "type": pickup.original_pickup.name if not pickup.other_player else "Nothing",
+                "quantity": quantity,
+                "text": {
+                    "header": item_info[pickup.name]["text_header"]
+                    if not self.players_config.is_multiworld
+                    else pickup.name,
+                    "description": pickup.collection_text[text_index],
+                },
+            }
+
+        return pickup_map_dict
+
+    def _create_starting_items_dict(self) -> dict:
+        starting_resources = self.patches.starting_resources()
+        return {resource.long_name: quantity for resource, quantity in starting_resources.as_resource_gain()}
+
+    def _create_starting_memo(self) -> str:
+        starting_memo = None
+        extra_starting = item_names.additional_starting_equipment(self.configuration, self.game, self.patches)
+        if extra_starting:
+            starting_memo = ", ".join(extra_starting)
+        return starting_memo
+
+    def _create_starting_location(self) -> dict:
+        return {
+            "x": self.game.region_list.node_by_identifier(self.patches.starting_location).extra["global_x"],
+            "y": self.game.region_list.node_by_identifier(self.patches.starting_location).extra["global_y"],
+        }
+
+    def _create_hash_dict(self) -> dict:
+        return {
+            "word_hash": self.description.shareable_word_hash,
+            "hash": self.description.shareable_hash,
+            "session_uuid": str(self.players_config.get_own_uuid()),
+        }
+
+    def _create_game_config_dict(self):
+        return {
+            "starting_room": self._create_starting_location(),
+            "seed_identifier": self._create_hash_dict(),
+            "starting_items": self._create_starting_items_dict(),
+            "starting_memo": self._create_starting_memo(),
+        }
+
+    def _create_cosmetics(self) -> dict:
+        c = self.cosmetic_patches
+        return {
+            "show_unexplored_map": c.show_unexplored_map,
+            "room_names_on_hud": c.show_room_names.value,
+        }
+
+    def _get_item_data(self):
+        item_data = json_lib.read_path(
+            RandovaniaGame.METROID_PLANETS_ZEBETH.data_path.joinpath("pickup_database", "item_data.json")
+        )
+
+        item_data["Missiles"] = item_data["Missile Tank"]
+        item_data["EnergyTransferModule"] = item_data["Nothing"]
+        return item_data
+
+    def _create_object_datas(self):
+        pass
+
     def game_enum(self) -> RandovaniaGame:
         return RandovaniaGame.METROID_PLANETS_ZEBETH
 
     def create_data(self) -> dict:
-        return {}
+        db = self.game
+
+        useless_target = PickupTarget(
+            pickup_creator.create_nothing_pickup(db.resource_database, "spr_ITEM_Nothing"),
+            self.players_config.player_index,
+        )
+
+        item_data = self._get_item_data()
+        memo_data = {key: value["text_desc"] for key, value in item_data.items()}
+        memo_data["Energy Tank"] = memo_data["Energy Tank"].format(Energy=100)
+
+        pickup_list = pickup_exporter.export_all_indices(
+            self.patches,
+            useless_target,
+            self.game.region_list,
+            self.rng,
+            self.configuration.pickup_model_style,
+            self.configuration.pickup_model_data_source,
+            exporter=pickup_exporter.create_pickup_exporter(memo_data, self.players_config, self.game_enum()),
+            visual_nothing=pickup_creator.create_visual_nothing(self.game_enum(), "spr_ITEM_Nothing"),
+        )
+
+        return {
+            "seed": self.description.get_seed_for_player(self.players_config.player_index),
+            "game_config": self._create_game_config_dict(),
+            "preferences": self._create_cosmetics(),
+            "level_data": {"room": "rm_Zebeth", "pickups": self._create_pickups_dict(pickup_list, item_data, self.rng)},
+        }

--- a/randovania/games/planets_zebeth/logic_database/Kraid.json
+++ b/randovania/games/planets_zebeth/logic_database/Kraid.json
@@ -21,7 +21,9 @@
                         "default"
                     ],
                     "extra": {
-                        "object_id": 100020
+                        "object_id": 100020,
+                        "global_x": 1664,
+                        "global_y": 4672
                     },
                     "valid_starting_location": false,
                     "dock_type": "teleporter",

--- a/randovania/games/planets_zebeth/logic_database/Kraid.txt
+++ b/randovania/games/planets_zebeth/logic_database/Kraid.txt
@@ -5,6 +5,8 @@ Extra - map_name: Kraid/x104_y337
   * Layers: default
   * Teleporter to Kraid Prelude/Teleporter to Kraid; Excluded from Dock Lock Rando
   * Extra - object_id: 100020
+  * Extra - global_x: 1664
+  * Extra - global_y: 4672
   > Door to Arrival Chamber
       Trivial
 

--- a/randovania/games/planets_zebeth/pickup_database/item_data.json
+++ b/randovania/games/planets_zebeth/pickup_database/item_data.json
@@ -1,0 +1,70 @@
+{
+	"Missile Tank": {
+		"text_desc": "Missile capacity {MissilesChanged} by {Missiles}",
+		"text_header": "Missile Tank acquired"
+	},
+	"Locked Missile Tank": {
+		"text_desc": "Missile capacity {Locked MissilesChanged} by {Locked Missiles} - Launcher still required",
+		"text_header": "Locked Missile Tank acquired"
+	},
+	"Big Missile Tank": {
+		"text_desc": "Missile capacity {MissilesChanged} by {Missiles}",
+		"text_header": "Big Missile Tank acquired"
+	},
+	"Locked Big Missile Tank": {
+		"text_desc": "Missile capacity {Locked MissilesChanged} by {Locked Missiles} - Launcher still required",
+		"text_header": "Locked Big Missile Tank acquired"
+	},
+	"Energy Tank": {
+		"text_desc": "Energy capacity increased by {Energy}",
+		"text_header": "Energy Tank acquired"
+	},
+	"Missile Launcher": {
+		"text_desc": "Missiles can now be fired. Missile capacity {MissilesChanged} by {Missiles}",
+		"text_header": "Missile Launcher acquired"
+	},
+	"Tourian Key": {
+		"text_desc": "Opens Tourian access when all of the keys are retrieved",
+		"text_header": "Tourian Key acquired"
+	},
+	"Bombs": {
+		"text_desc": "While morphed, press shoot to use",
+		"text_header": "Bombs acquired"
+	},
+	"Screw Attack": {
+		"text_desc": "Deal damage to enemies while spinning",
+		"text_header": "Screw Attack acquired"
+	},
+	"Varia Suit": {
+		"text_desc": "Reduces damage taken by 50 percent",
+		"text_header": "Varia Suit acquired"
+	},
+	"Hi-Jump Boots": {
+		"text_desc": "Increased jump height",
+		"text_header": "Hi-Jump Boots acquired"
+	},
+    "Long Beam": {
+		"text_desc": "Beam weapons can travel farther",
+		"text_header": "Long Beam acquired"
+	},
+	"Ice Beam": {
+		"text_desc": "Freeze enemies on contact",
+		"text_header": "Ice Beam acquired"
+	},
+	"Wave Beam": {
+		"text_desc": "Increased damage and passes through walls",
+		"text_header": "Wave Beam acquired"
+	},
+	"Morph Ball": {
+		"text_desc": "Tap down to activate",
+		"text_header": "Morph Ball acquired"
+	},
+	"Nothing": {
+		"text_desc": "A useless item",
+		"text_header": "Nothing acquired"
+	},
+	"Unknown item": {
+		"text_desc": "???",
+		"text_header": "Unknown Item acquired"
+	}
+}

--- a/test/games/test_log_file_export.py
+++ b/test/games/test_log_file_export.py
@@ -110,6 +110,9 @@ def pytest_generate_tests(metafunc: _pytest.python.Metafunc) -> None:
         "dread/custom_patcher_data.rdvgame",  # custom patcher data
         "dread/all_settings.rdvgame",  # all settings enabled
         "dread/hide_all_with_nothing.rdvgame",  # Model+scan+name hidden with nothing data
+        # Planets (Zebeth)
+        "planets_zebeth/starter_preset.rdvgame",  # starter preset (vanilla keys)
+        "planets_zebeth/starter_preset_shuffle_keys.rdvgame",  # starter preset (shuffled keys)
         # Prime 1
         "prime1_crazy_seed.rdvgame",  # chaos features
         "prime1_crazy_seed_one_way_door.rdvgame",  # same as above but 1-way doors

--- a/test/test_files/log_files/planets_zebeth/starter_preset.rdvgame
+++ b/test/test_files/log_files/planets_zebeth/starter_preset.rdvgame
@@ -1,0 +1,225 @@
+{
+    "schema_version": 29,
+    "info": {
+        "randovania_version": "8.4.0.dev114",
+        "randovania_version_git": "ffbd61bc",
+        "permalink": "DcbDrDf21P-9YbwJfBXbbRSk8EXWAOL8",
+        "has_spoiler": true,
+        "seed": 574772589,
+        "hash": "YOWDP5WU",
+        "word_hash": "Metroid Polyp Dessgeega",
+        "presets": [
+            {
+                "schema_version": 88,
+                "base_preset_uuid": null,
+                "name": "Starter Preset",
+                "uuid": "4f335b5e-d858-4adc-8794-eb301e81cd14",
+                "description": "Basic preset.",
+                "game": "planets_zebeth",
+                "configuration": {
+                    "trick_level": {
+                        "minimal_logic": false,
+                        "specific_levels": {}
+                    },
+                    "starting_location": [
+                        {
+                            "region": "Brinstar",
+                            "area": "Maru Mari Hall",
+                            "node": "Starting Point"
+                        }
+                    ],
+                    "available_locations": {
+                        "randomization_mode": "full",
+                        "excluded_indices": []
+                    },
+                    "standard_pickup_configuration": {
+                        "pickups_state": {
+                            "Bombs": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Screw Attack": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Varia Suit": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Hi-Jump Boots": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Ice Beam": {
+                                "num_shuffled_pickups": 2
+                            },
+                            "Wave Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Long Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Morph Ball": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Missile Launcher": {
+                                "num_shuffled_pickups": 1,
+                                "included_ammo": [
+                                    5
+                                ]
+                            },
+                            "Energy Tank": {
+                                "num_shuffled_pickups": 8
+                            }
+                        },
+                        "default_pickups": {},
+                        "minimum_random_starting_pickups": 0,
+                        "maximum_random_starting_pickups": 0
+                    },
+                    "ammo_pickup_configuration": {
+                        "pickups_state": {
+                            "Missile Tank": {
+                                "ammo_count": [
+                                    5
+                                ],
+                                "pickup_count": 20,
+                                "requires_main_item": true
+                            },
+                            "Big Missile Tank": {
+                                "ammo_count": [
+                                    75
+                                ],
+                                "pickup_count": 2,
+                                "requires_main_item": true
+                            }
+                        }
+                    },
+                    "damage_strictness": 1.5,
+                    "pickup_model_style": "all-visible",
+                    "pickup_model_data_source": "etm",
+                    "logical_resource_action": "randomly",
+                    "first_progression_must_be_local": false,
+                    "minimum_available_locations_for_hint_placement": 0,
+                    "minimum_location_weight_for_hint_placement": 0.0,
+                    "dock_rando": {
+                        "mode": "vanilla",
+                        "types_state": {
+                            "door": {
+                                "can_change_from": [
+                                    "Missile Door",
+                                    "Normal Door"
+                                ],
+                                "can_change_to": [
+                                    "Missile Door",
+                                    "Normal Door"
+                                ]
+                            }
+                        }
+                    },
+                    "single_set_for_pickups_that_solve": true,
+                    "staggered_multi_pickup_placement": true,
+                    "check_if_beatable_after_base_patches": false,
+                    "artifacts": {
+                        "vanilla_tourian_keys": true,
+                        "required_artifacts": 2
+                    },
+                    "energy_per_tank": 100,
+                    "include_extra_pickups": false
+                }
+            }
+        ]
+    },
+    "game_modifications": [
+        {
+            "game": "planets_zebeth",
+            "starting_equipment": {
+                "pickups": [
+                    "Tourian Key 3",
+                    "Tourian Key 4",
+                    "Tourian Key 5",
+                    "Tourian Key 6",
+                    "Tourian Key 7",
+                    "Tourian Key 8",
+                    "Tourian Key 9"
+                ]
+            },
+            "starting_location": "Brinstar/Maru Mari Hall/Starting Point",
+            "dock_connections": {
+                "Brinstar/Norfair Prelude/Teleporter to Norfair": "Norfair/Norfair Entrance/Teleporter to Brinstar",
+                "Brinstar/Kraid Prelude/Teleporter to Kraid": "Kraid/Kraid Entrance/Teleporter to Brinstar",
+                "Brinstar/Tourian Prelude/Teleporter to Tourian": "Tourian/Tourian Entrance/Teleporter to Brinstar",
+                "Kraid/Kraid Entrance/Teleporter to Brinstar": "Brinstar/Kraid Prelude/Teleporter to Kraid",
+                "Norfair/Norfair Entrance/Teleporter to Brinstar": "Brinstar/Norfair Prelude/Teleporter to Norfair",
+                "Norfair/Ridley Prelude/Teleporter to Ridley": "Ridley/Ridley Entrance/Teleporter to Norfair",
+                "Ridley/Ridley Entrance/Teleporter to Norfair": "Norfair/Ridley Prelude/Teleporter to Ridley",
+                "Tourian/Tourian Entrance/Teleporter to Brinstar": "Brinstar/Tourian Prelude/Teleporter to Tourian",
+                "Tourian/Escape Route/Teleporter to Escape Route": "Tourian/Escape Route/Event - End Game"
+            },
+            "dock_weakness": {},
+            "locations": {
+                "Brinstar": {
+                    "Blue Rocks East/Pickup (Energy Tank)": "Big Missile Tank",
+                    "Green Sanctuary E/Pickup (Energy Tank)": "Big Missile Tank",
+                    "Green Sanctuary E/Pickup (Missile Tank)": "Varia Suit",
+                    "Item Room (Bombs)/Pickup (Bombs)": "Missile Tank",
+                    "Item Room (Ice Beam)/Pickup (Ice Beam)": "Missile Tank",
+                    "Item Room (Long Beam)/Pickup (Long Beam)": "Hi-Jump Boots",
+                    "Item Room (Varia)/Pickup (Varia Suit)": "Missile Tank",
+                    "Maru Mari Hall/Pickup (Morph Ball)": "Morph Ball",
+                    "Orange Corridor/Pickup (Missile Launcher)": "Missile Tank",
+                    "The Overhang/Pickup (Energy Tank)": "Missile Tank"
+                },
+                "Kraid": {
+                    "Acid Pier/Pickup (Missile Tank)": "Energy Tank",
+                    "Arrival Chamber/Pickup (Missile Tank)": "Energy Tank",
+                    "Back Storage/Pickup (Missile Tank)": "Missile Tank",
+                    "Blue Closet/Pickup (Energy Tank)": "Energy Tank",
+                    "Kraid Arena/Pickup (Big Missile Tank)": "Energy Tank",
+                    "Kraid Arena/Pickup (Boss Key)": "Tourian Key 1",
+                    "Kraid Arena/Pickup (Energy Tank)": "Missile Tank",
+                    "Upper Hall/Pickup (Missile Tank)": "Screw Attack"
+                },
+                "Norfair": {
+                    "Basalt Cache/Pickup (Missile Tank)": "Missile Tank",
+                    "Bubble Cache/Pickup (Missile Tank 2)": "Missile Tank",
+                    "Bubble Cache/Pickup (Missile Tank)": "Missile Tank",
+                    "Bubble Wall/Pickup (Missile Tank)": "Missile Launcher",
+                    "Fire Sea/Pickup (Energy Tank)": "Missile Tank",
+                    "Gauntlet/Pickup (Missile Tank 2)": "Ice Beam",
+                    "Gauntlet/Pickup (Missile Tank)": "Missile Tank",
+                    "Hidden Cache/Pickup (Missile Tank 2)": "Missile Tank",
+                    "Hidden Cache/Pickup (Missile Tank)": "Missile Tank",
+                    "Item Room (High Jump)/Pickup (Hi-Jump)": "Energy Tank",
+                    "Item Room (Ice Beam)/Pickup (Ice Beam)": "Missile Tank",
+                    "Item Room (Screw Attack)/Pickup (Screw Attack)": "Long Beam",
+                    "Item Room (Wave Beam)/Pickup (Wave Beam)": "Missile Tank",
+                    "Path of Destruction/Pickup (Missile Tank)": "Energy Tank",
+                    "Weapons Cache/Pickup (Missile Tank 2)": "Missile Tank",
+                    "Weapons Cache/Pickup (Missile Tank 3)": "Bombs",
+                    "Weapons Cache/Pickup (Missile Tank)": "Missile Tank"
+                },
+                "Ridley": {
+                    "Artificial Passage/Pickup (Energy Tank)": "Ice Beam",
+                    "Central Cache/Pickup (Missile Tank)": "Energy Tank",
+                    "Infinite Gauntlet/Pickup (Missile Tank)": "Wave Beam",
+                    "Lava Reliquary/Pickup (Energy Tank)": "Energy Tank",
+                    "Purple Gauntlet/Pickup (Missile Tank)": "Missile Tank",
+                    "Ridley Arena/Pickup (Big Missile Tank)": "Missile Tank",
+                    "Ridley Arena/Pickup (Boss Key)": "Tourian Key 2"
+                }
+            },
+            "hints": {},
+            "game_specific": {}
+        }
+    ],
+    "item_order": [
+        "Morph Ball at Brinstar/Maru Mari Hall/Pickup (Morph Ball)",
+        "Missile Launcher at Norfair/Bubble Wall/Pickup (Missile Tank)",
+        "Hi-Jump Boots at Brinstar/Item Room (Long Beam)/Pickup (Long Beam)",
+        "Bombs at Norfair/Weapons Cache/Pickup (Missile Tank 3)",
+        "Ice Beam at Ridley/Artificial Passage/Pickup (Energy Tank)",
+        "Energy Tank at Norfair/Path of Destruction/Pickup (Missile Tank)",
+        "Missile Tank at Norfair/Hidden Cache/Pickup (Missile Tank)",
+        "Energy Tank at Kraid/Blue Closet/Pickup (Energy Tank)",
+        "Energy Tank at Ridley/Lava Reliquary/Pickup (Energy Tank)",
+        "Missile Tank at Norfair/Bubble Cache/Pickup (Missile Tank)",
+        "Big Missile Tank at Brinstar/Green Sanctuary E/Pickup (Energy Tank)"
+    ],
+    "checksum": "5eb091eb20273ac9682b762b267c8d4e7e3ce5428b1b93b76372789c3c69ec25884d68e41be9884d7808d6072e03b8729e8bd37b8fed3f65fcbcebba68415299"
+}

--- a/test/test_files/log_files/planets_zebeth/starter_preset_shuffle_keys.rdvgame
+++ b/test/test_files/log_files/planets_zebeth/starter_preset_shuffle_keys.rdvgame
@@ -1,0 +1,229 @@
+{
+    "schema_version": 29,
+    "info": {
+        "randovania_version": "8.4.0.dev114",
+        "randovania_version_git": "ffbd61bc",
+        "permalink": "Da26_ux7Vv-9YbwMY6vNF4saRfuVLRR0ANnA",
+        "has_spoiler": true,
+        "seed": 340891882,
+        "hash": "XL7OY62W",
+        "word_hash": "Wave Ice Brick",
+        "presets": [
+            {
+                "schema_version": 88,
+                "base_preset_uuid": null,
+                "name": "Starter Preset (Shuffle Keys)",
+                "uuid": "dc33eec9-332f-4296-99d2-6404df5d4e39",
+                "description": "Basic preset.",
+                "game": "planets_zebeth",
+                "configuration": {
+                    "trick_level": {
+                        "minimal_logic": false,
+                        "specific_levels": {}
+                    },
+                    "starting_location": [
+                        {
+                            "region": "Brinstar",
+                            "area": "Maru Mari Hall",
+                            "node": "Starting Point"
+                        }
+                    ],
+                    "available_locations": {
+                        "randomization_mode": "full",
+                        "excluded_indices": []
+                    },
+                    "standard_pickup_configuration": {
+                        "pickups_state": {
+                            "Bombs": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Screw Attack": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Varia Suit": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Hi-Jump Boots": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Ice Beam": {
+                                "num_shuffled_pickups": 2
+                            },
+                            "Wave Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Long Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Morph Ball": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Missile Launcher": {
+                                "num_shuffled_pickups": 1,
+                                "included_ammo": [
+                                    5
+                                ]
+                            },
+                            "Energy Tank": {
+                                "num_shuffled_pickups": 8
+                            }
+                        },
+                        "default_pickups": {},
+                        "minimum_random_starting_pickups": 0,
+                        "maximum_random_starting_pickups": 0
+                    },
+                    "ammo_pickup_configuration": {
+                        "pickups_state": {
+                            "Missile Tank": {
+                                "ammo_count": [
+                                    5
+                                ],
+                                "pickup_count": 13,
+                                "requires_main_item": true
+                            },
+                            "Big Missile Tank": {
+                                "ammo_count": [
+                                    75
+                                ],
+                                "pickup_count": 2,
+                                "requires_main_item": true
+                            }
+                        }
+                    },
+                    "damage_strictness": 1.5,
+                    "pickup_model_style": "all-visible",
+                    "pickup_model_data_source": "etm",
+                    "logical_resource_action": "randomly",
+                    "first_progression_must_be_local": false,
+                    "minimum_available_locations_for_hint_placement": 0,
+                    "minimum_location_weight_for_hint_placement": 0.0,
+                    "dock_rando": {
+                        "mode": "vanilla",
+                        "types_state": {
+                            "door": {
+                                "can_change_from": [
+                                    "Missile Door",
+                                    "Normal Door"
+                                ],
+                                "can_change_to": [
+                                    "Missile Door",
+                                    "Normal Door"
+                                ]
+                            }
+                        }
+                    },
+                    "single_set_for_pickups_that_solve": true,
+                    "staggered_multi_pickup_placement": true,
+                    "check_if_beatable_after_base_patches": false,
+                    "artifacts": {
+                        "vanilla_tourian_keys": false,
+                        "required_artifacts": 9
+                    },
+                    "energy_per_tank": 100,
+                    "include_extra_pickups": false
+                }
+            }
+        ]
+    },
+    "game_modifications": [
+        {
+            "game": "planets_zebeth",
+            "starting_equipment": {
+                "pickups": []
+            },
+            "starting_location": "Brinstar/Maru Mari Hall/Starting Point",
+            "dock_connections": {
+                "Brinstar/Norfair Prelude/Teleporter to Norfair": "Norfair/Norfair Entrance/Teleporter to Brinstar",
+                "Brinstar/Kraid Prelude/Teleporter to Kraid": "Kraid/Kraid Entrance/Teleporter to Brinstar",
+                "Brinstar/Tourian Prelude/Teleporter to Tourian": "Tourian/Tourian Entrance/Teleporter to Brinstar",
+                "Kraid/Kraid Entrance/Teleporter to Brinstar": "Brinstar/Kraid Prelude/Teleporter to Kraid",
+                "Norfair/Norfair Entrance/Teleporter to Brinstar": "Brinstar/Norfair Prelude/Teleporter to Norfair",
+                "Norfair/Ridley Prelude/Teleporter to Ridley": "Ridley/Ridley Entrance/Teleporter to Norfair",
+                "Ridley/Ridley Entrance/Teleporter to Norfair": "Norfair/Ridley Prelude/Teleporter to Ridley",
+                "Tourian/Tourian Entrance/Teleporter to Brinstar": "Brinstar/Tourian Prelude/Teleporter to Tourian",
+                "Tourian/Escape Route/Teleporter to Escape Route": "Tourian/Escape Route/Event - End Game"
+            },
+            "dock_weakness": {},
+            "locations": {
+                "Brinstar": {
+                    "Blue Rocks East/Pickup (Energy Tank)": "Tourian Key 8",
+                    "Green Sanctuary E/Pickup (Energy Tank)": "Tourian Key 6",
+                    "Green Sanctuary E/Pickup (Missile Tank)": "Wave Beam",
+                    "Item Room (Bombs)/Pickup (Bombs)": "Ice Beam",
+                    "Item Room (Ice Beam)/Pickup (Ice Beam)": "Missile Tank",
+                    "Item Room (Long Beam)/Pickup (Long Beam)": "Ice Beam",
+                    "Item Room (Varia)/Pickup (Varia Suit)": "Missile Tank",
+                    "Maru Mari Hall/Pickup (Morph Ball)": "Morph Ball",
+                    "Orange Corridor/Pickup (Missile Launcher)": "Missile Tank",
+                    "The Overhang/Pickup (Energy Tank)": "Missile Tank"
+                },
+                "Kraid": {
+                    "Acid Pier/Pickup (Missile Tank)": "Energy Tank",
+                    "Arrival Chamber/Pickup (Missile Tank)": "Screw Attack",
+                    "Back Storage/Pickup (Missile Tank)": "Energy Tank",
+                    "Blue Closet/Pickup (Energy Tank)": "Missile Tank",
+                    "Kraid Arena/Pickup (Big Missile Tank)": "Tourian Key 5",
+                    "Kraid Arena/Pickup (Boss Key)": "Tourian Key 9",
+                    "Kraid Arena/Pickup (Energy Tank)": "Missile Tank",
+                    "Upper Hall/Pickup (Missile Tank)": "Energy Tank"
+                },
+                "Norfair": {
+                    "Basalt Cache/Pickup (Missile Tank)": "Energy Tank",
+                    "Bubble Cache/Pickup (Missile Tank 2)": "Energy Tank",
+                    "Bubble Cache/Pickup (Missile Tank)": "Big Missile Tank",
+                    "Bubble Wall/Pickup (Missile Tank)": "Bombs",
+                    "Fire Sea/Pickup (Energy Tank)": "Tourian Key 2",
+                    "Gauntlet/Pickup (Missile Tank 2)": "Varia Suit",
+                    "Gauntlet/Pickup (Missile Tank)": "Missile Tank",
+                    "Hidden Cache/Pickup (Missile Tank 2)": "Big Missile Tank",
+                    "Hidden Cache/Pickup (Missile Tank)": "Missile Tank",
+                    "Item Room (High Jump)/Pickup (Hi-Jump)": "Energy Tank",
+                    "Item Room (Ice Beam)/Pickup (Ice Beam)": "Missile Tank",
+                    "Item Room (Screw Attack)/Pickup (Screw Attack)": "Tourian Key 1",
+                    "Item Room (Wave Beam)/Pickup (Wave Beam)": "Tourian Key 7",
+                    "Path of Destruction/Pickup (Missile Tank)": "Tourian Key 3",
+                    "Weapons Cache/Pickup (Missile Tank 2)": "Long Beam",
+                    "Weapons Cache/Pickup (Missile Tank 3)": "Tourian Key 4",
+                    "Weapons Cache/Pickup (Missile Tank)": "Hi-Jump Boots"
+                },
+                "Ridley": {
+                    "Artificial Passage/Pickup (Energy Tank)": "Missile Tank",
+                    "Central Cache/Pickup (Missile Tank)": "Energy Tank",
+                    "Infinite Gauntlet/Pickup (Missile Tank)": "Missile Launcher",
+                    "Lava Reliquary/Pickup (Energy Tank)": "Energy Tank",
+                    "Purple Gauntlet/Pickup (Missile Tank)": "Missile Tank",
+                    "Ridley Arena/Pickup (Big Missile Tank)": "Missile Tank",
+                    "Ridley Arena/Pickup (Boss Key)": "Missile Tank"
+                }
+            },
+            "hints": {},
+            "game_specific": {}
+        }
+    ],
+    "item_order": [
+        "Morph Ball at Brinstar/Maru Mari Hall/Pickup (Morph Ball)",
+        "Bombs at Norfair/Bubble Wall/Pickup (Missile Tank)",
+        "Missile Launcher at Ridley/Infinite Gauntlet/Pickup (Missile Tank)",
+        "Energy Tank at Kraid/Acid Pier/Pickup (Missile Tank)",
+        "Ice Beam at Brinstar/Item Room (Long Beam)/Pickup (Long Beam)",
+        "Hi-Jump Boots at Norfair/Weapons Cache/Pickup (Missile Tank)",
+        "Missile Tank at Brinstar/The Overhang/Pickup (Energy Tank)",
+        "Energy Tank at Ridley/Lava Reliquary/Pickup (Energy Tank)",
+        "Missile Tank at Brinstar/Item Room (Ice Beam)/Pickup (Ice Beam)",
+        "Energy Tank at Norfair/Bubble Cache/Pickup (Missile Tank 2)",
+        "Missile Tank at Ridley/Ridley Arena/Pickup (Boss Key)",
+        "Missile Tank at Kraid/Blue Closet/Pickup (Energy Tank)",
+        "Tourian Key 5 at Kraid/Kraid Arena/Pickup (Big Missile Tank)",
+        "Tourian Key 2 at Norfair/Fire Sea/Pickup (Energy Tank)",
+        "Tourian Key 9 at Kraid/Kraid Arena/Pickup (Boss Key)",
+        "Tourian Key 3 at Norfair/Path of Destruction/Pickup (Missile Tank)",
+        "Tourian Key 1 at Norfair/Item Room (Screw Attack)/Pickup (Screw Attack)",
+        "Tourian Key 8 at Brinstar/Blue Rocks East/Pickup (Energy Tank)",
+        "Tourian Key 7 at Norfair/Item Room (Wave Beam)/Pickup (Wave Beam)",
+        "Tourian Key 4 at Norfair/Weapons Cache/Pickup (Missile Tank 3)",
+        "Tourian Key 6 at Brinstar/Green Sanctuary E/Pickup (Energy Tank)",
+        "Missile Tank at Brinstar/Orange Corridor/Pickup (Missile Launcher)",
+        "Missile Tank at Kraid/Kraid Arena/Pickup (Energy Tank)"
+    ],
+    "checksum": "7b081b19713b66cefb2eb4c70ed892ce560cc22e36d3bc232eb96dcfd94c4b78d0eda7d994d749a0d3db54a149c97e6570499273dc1e74643cb7c3f3821797f5"
+}

--- a/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset/world_1.json
@@ -1,0 +1,567 @@
+{
+    "seed": 574772589,
+    "game_config": {
+        "starting_room": {
+            "x": 648,
+            "y": 3296
+        },
+        "seed_identifier": {
+            "word_hash": "Some Words",
+            "hash": "XXXXXXXX",
+            "session_uuid": "00000000-0000-1111-0000-000000000000"
+        },
+        "starting_items": {
+            "Tourian Key": 7
+        },
+        "starting_memo": null,
+        "credits_string": [
+            {
+                "header": "Bombs",
+                "description": [
+                    "Norfair - Weapons Cache"
+                ]
+            },
+            {
+                "header": "Screw Attack",
+                "description": [
+                    "Kraid - Upper Hall"
+                ]
+            },
+            {
+                "header": "Varia Suit",
+                "description": [
+                    "Brinstar - Green Sanctuary E"
+                ]
+            },
+            {
+                "header": "Hi-Jump Boots",
+                "description": [
+                    "Brinstar - Item Room (Long Beam)"
+                ]
+            },
+            {
+                "header": "Ice Beam",
+                "description": [
+                    "Norfair - Gauntlet",
+                    "Ridley - Artificial Passage"
+                ]
+            },
+            {
+                "header": "Wave Beam",
+                "description": [
+                    "Ridley - Infinite Gauntlet"
+                ]
+            },
+            {
+                "header": "Long Beam",
+                "description": [
+                    "Norfair - Item Room (Screw Attack)"
+                ]
+            },
+            {
+                "header": "Morph Ball",
+                "description": [
+                    "Brinstar - Maru Mari Hall"
+                ]
+            },
+            {
+                "header": "Missile Launcher",
+                "description": [
+                    "Norfair - Bubble Wall"
+                ]
+            },
+            {
+                "header": "Tourian Key 1",
+                "description": [
+                    "Kraid - Kraid Arena"
+                ]
+            },
+            {
+                "header": "Tourian Key 2",
+                "description": [
+                    "Ridley - Ridley Arena"
+                ]
+            }
+        ]
+    },
+    "preferences": {
+        "show_unexplored_map": true,
+        "room_names_on_hud": "WITH_FADE"
+    },
+    "level_data": {
+        "room": "rm_Zebeth",
+        "pickups": {
+            "100018": {
+                "model": "spr_ITEM_Morph",
+                "type": "Morph Ball",
+                "quantity": 1,
+                "text": {
+                    "header": "Morph Ball acquired",
+                    "description": [
+                        "Tap down to activate"
+                    ]
+                }
+            },
+            "100027": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100028": {
+                "model": "spr_ITEM_Jump_Boots",
+                "type": "Hi-Jump Boots",
+                "quantity": 1,
+                "text": {
+                    "header": "Hi-Jump Boots acquired",
+                    "description": [
+                        "Increased jump height"
+                    ]
+                }
+            },
+            "100029": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100030": {
+                "model": "spr_ITEM_Varia",
+                "type": "Varia Suit",
+                "quantity": 1,
+                "text": {
+                    "header": "Varia Suit acquired",
+                    "description": [
+                        "Reduces damage taken by 50",
+                        "percent"
+                    ]
+                }
+            },
+            "100031": {
+                "model": "spr_ITEM_Big_Missile",
+                "type": "Big Missile Tank",
+                "quantity": 75,
+                "text": {
+                    "header": "Big Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 75"
+                    ]
+                }
+            },
+            "100032": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100033": {
+                "model": "spr_ITEM_Big_Missile",
+                "type": "Big Missile Tank",
+                "quantity": 75,
+                "text": {
+                    "header": "Big Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 75"
+                    ]
+                }
+            },
+            "100034": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100035": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100036": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100037": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100038": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100039": {
+                "model": "spr_ITEM_Bomb",
+                "type": "Bombs",
+                "quantity": 1,
+                "text": {
+                    "header": "Bombs acquired",
+                    "description": [
+                        "While morphed, press shoot to use"
+                    ]
+                }
+            },
+            "100040": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100041": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100042": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100043": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100044": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100045": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100046": {
+                "model": "spr_ITEM_Ice_Beam",
+                "type": "Ice Beam",
+                "quantity": 1,
+                "text": {
+                    "header": "Ice Beam acquired",
+                    "description": [
+                        "Freeze enemies on contact"
+                    ]
+                }
+            },
+            "100047": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Launcher",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Launcher acquired",
+                    "description": [
+                        "Missiles can now be fired.",
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100048": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100049": {
+                "model": "spr_ITEM_Long_Beam",
+                "type": "Long Beam",
+                "quantity": 1,
+                "text": {
+                    "header": "Long Beam acquired",
+                    "description": [
+                        "Beam weapons can travel farther"
+                    ]
+                }
+            },
+            "100050": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100051": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100052": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100053": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100054": {
+                "model": "spr_ITEM_Ice_Beam",
+                "type": "Ice Beam",
+                "quantity": 1,
+                "text": {
+                    "header": "Ice Beam acquired",
+                    "description": [
+                        "Freeze enemies on contact"
+                    ]
+                }
+            },
+            "100055": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100056": {
+                "model": "spr_ITEM_Wave_Beam",
+                "type": "Wave Beam",
+                "quantity": 1,
+                "text": {
+                    "header": "Wave Beam acquired",
+                    "description": [
+                        "Increased damage and passes",
+                        "through walls"
+                    ]
+                }
+            },
+            "100057": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100058": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100059": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100060": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100061": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100062": {
+                "model": "spr_ITEM_Screw_Attack",
+                "type": "Screw Attack",
+                "quantity": 1,
+                "text": {
+                    "header": "Screw Attack acquired",
+                    "description": [
+                        "Deal damage to enemies while",
+                        "spinning"
+                    ]
+                }
+            },
+            "100063": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100083": {
+                "model": "spr_ITEM_Tourian_Key",
+                "type": "Tourian Key 1",
+                "quantity": 1,
+                "text": {
+                    "header": "Tourian Key acquired",
+                    "description": [
+                        "Opens Tourian access when all of",
+                        "the keys are retrieved"
+                    ]
+                }
+            },
+            "100084": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "10085": {
+                "model": "spr_ITEM_Tourian_Key",
+                "type": "Tourian Key 2",
+                "quantity": 1,
+                "text": {
+                    "header": "Tourian Key acquired",
+                    "description": [
+                        "Opens Tourian access when all of",
+                        "the keys are retrieved"
+                    ]
+                }
+            },
+            "100086": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            }
+        }
+    },
+    "_randovania_meta": {
+        "layout_was_user_modified": false
+    }
+}

--- a/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset_shuffle_keys/world_1.json
+++ b/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset_shuffle_keys/world_1.json
@@ -1,0 +1,614 @@
+{
+    "seed": 340891882,
+    "game_config": {
+        "starting_room": {
+            "x": 648,
+            "y": 3296
+        },
+        "seed_identifier": {
+            "word_hash": "Some Words",
+            "hash": "XXXXXXXX",
+            "session_uuid": "00000000-0000-1111-0000-000000000000"
+        },
+        "starting_items": {},
+        "starting_memo": null,
+        "credits_string": [
+            {
+                "header": "Bombs",
+                "description": [
+                    "Norfair - Bubble Wall"
+                ]
+            },
+            {
+                "header": "Screw Attack",
+                "description": [
+                    "Kraid - Arrival Chamber"
+                ]
+            },
+            {
+                "header": "Varia Suit",
+                "description": [
+                    "Norfair - Gauntlet"
+                ]
+            },
+            {
+                "header": "Hi-Jump Boots",
+                "description": [
+                    "Norfair - Weapons Cache"
+                ]
+            },
+            {
+                "header": "Ice Beam",
+                "description": [
+                    "Brinstar - Item Room (Bombs)",
+                    "Brinstar - Item Room (Long Beam)"
+                ]
+            },
+            {
+                "header": "Wave Beam",
+                "description": [
+                    "Brinstar - Green Sanctuary E"
+                ]
+            },
+            {
+                "header": "Long Beam",
+                "description": [
+                    "Norfair - Weapons Cache"
+                ]
+            },
+            {
+                "header": "Morph Ball",
+                "description": [
+                    "Brinstar - Maru Mari Hall"
+                ]
+            },
+            {
+                "header": "Missile Launcher",
+                "description": [
+                    "Ridley - Infinite Gauntlet"
+                ]
+            },
+            {
+                "header": "Tourian Key 1",
+                "description": [
+                    "Norfair - Item Room (Screw Attack)"
+                ]
+            },
+            {
+                "header": "Tourian Key 2",
+                "description": [
+                    "Norfair - Fire Sea"
+                ]
+            },
+            {
+                "header": "Tourian Key 3",
+                "description": [
+                    "Norfair - Path of Destruction"
+                ]
+            },
+            {
+                "header": "Tourian Key 4",
+                "description": [
+                    "Norfair - Weapons Cache"
+                ]
+            },
+            {
+                "header": "Tourian Key 5",
+                "description": [
+                    "Kraid - Kraid Arena"
+                ]
+            },
+            {
+                "header": "Tourian Key 6",
+                "description": [
+                    "Brinstar - Green Sanctuary E"
+                ]
+            },
+            {
+                "header": "Tourian Key 7",
+                "description": [
+                    "Norfair - Item Room (Wave Beam)"
+                ]
+            },
+            {
+                "header": "Tourian Key 8",
+                "description": [
+                    "Brinstar - Blue Rocks East"
+                ]
+            },
+            {
+                "header": "Tourian Key 9",
+                "description": [
+                    "Kraid - Kraid Arena"
+                ]
+            }
+        ]
+    },
+    "preferences": {
+        "show_unexplored_map": true,
+        "room_names_on_hud": "WITH_FADE"
+    },
+    "level_data": {
+        "room": "rm_Zebeth",
+        "pickups": {
+            "100018": {
+                "model": "spr_ITEM_Morph",
+                "type": "Morph Ball",
+                "quantity": 1,
+                "text": {
+                    "header": "Morph Ball acquired",
+                    "description": [
+                        "Tap down to activate"
+                    ]
+                }
+            },
+            "100027": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100028": {
+                "model": "spr_ITEM_Ice_Beam",
+                "type": "Ice Beam",
+                "quantity": 1,
+                "text": {
+                    "header": "Ice Beam acquired",
+                    "description": [
+                        "Freeze enemies on contact"
+                    ]
+                }
+            },
+            "100029": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100030": {
+                "model": "spr_ITEM_Wave_Beam",
+                "type": "Wave Beam",
+                "quantity": 1,
+                "text": {
+                    "header": "Wave Beam acquired",
+                    "description": [
+                        "Increased damage and passes",
+                        "through walls"
+                    ]
+                }
+            },
+            "100031": {
+                "model": "spr_ITEM_Tourian_Key",
+                "type": "Tourian Key 6",
+                "quantity": 1,
+                "text": {
+                    "header": "Tourian Key acquired",
+                    "description": [
+                        "Opens Tourian access when all of",
+                        "the keys are retrieved"
+                    ]
+                }
+            },
+            "100032": {
+                "model": "spr_ITEM_Ice_Beam",
+                "type": "Ice Beam",
+                "quantity": 1,
+                "text": {
+                    "header": "Ice Beam acquired",
+                    "description": [
+                        "Freeze enemies on contact"
+                    ]
+                }
+            },
+            "100033": {
+                "model": "spr_ITEM_Tourian_Key",
+                "type": "Tourian Key 8",
+                "quantity": 1,
+                "text": {
+                    "header": "Tourian Key acquired",
+                    "description": [
+                        "Opens Tourian access when all of",
+                        "the keys are retrieved"
+                    ]
+                }
+            },
+            "100034": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100035": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100036": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100037": {
+                "model": "spr_ITEM_Jump_Boots",
+                "type": "Hi-Jump Boots",
+                "quantity": 1,
+                "text": {
+                    "header": "Hi-Jump Boots acquired",
+                    "description": [
+                        "Increased jump height"
+                    ]
+                }
+            },
+            "100038": {
+                "model": "spr_ITEM_Long_Beam",
+                "type": "Long Beam",
+                "quantity": 1,
+                "text": {
+                    "header": "Long Beam acquired",
+                    "description": [
+                        "Beam weapons can travel farther"
+                    ]
+                }
+            },
+            "100039": {
+                "model": "spr_ITEM_Tourian_Key",
+                "type": "Tourian Key 4",
+                "quantity": 1,
+                "text": {
+                    "header": "Tourian Key acquired",
+                    "description": [
+                        "Opens Tourian access when all of",
+                        "the keys are retrieved"
+                    ]
+                }
+            },
+            "100040": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100041": {
+                "model": "spr_ITEM_Big_Missile",
+                "type": "Big Missile Tank",
+                "quantity": 75,
+                "text": {
+                    "header": "Big Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 75"
+                    ]
+                }
+            },
+            "100042": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100043": {
+                "model": "spr_ITEM_Tourian_Key",
+                "type": "Tourian Key 2",
+                "quantity": 1,
+                "text": {
+                    "header": "Tourian Key acquired",
+                    "description": [
+                        "Opens Tourian access when all of",
+                        "the keys are retrieved"
+                    ]
+                }
+            },
+            "100044": {
+                "model": "spr_ITEM_Tourian_Key",
+                "type": "Tourian Key 3",
+                "quantity": 1,
+                "text": {
+                    "header": "Tourian Key acquired",
+                    "description": [
+                        "Opens Tourian access when all of",
+                        "the keys are retrieved"
+                    ]
+                }
+            },
+            "100045": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100046": {
+                "model": "spr_ITEM_Varia",
+                "type": "Varia Suit",
+                "quantity": 1,
+                "text": {
+                    "header": "Varia Suit acquired",
+                    "description": [
+                        "Reduces damage taken by 50",
+                        "percent"
+                    ]
+                }
+            },
+            "100047": {
+                "model": "spr_ITEM_Bomb",
+                "type": "Bombs",
+                "quantity": 1,
+                "text": {
+                    "header": "Bombs acquired",
+                    "description": [
+                        "While morphed, press shoot to use"
+                    ]
+                }
+            },
+            "100048": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100049": {
+                "model": "spr_ITEM_Tourian_Key",
+                "type": "Tourian Key 1",
+                "quantity": 1,
+                "text": {
+                    "header": "Tourian Key acquired",
+                    "description": [
+                        "Opens Tourian access when all of",
+                        "the keys are retrieved"
+                    ]
+                }
+            },
+            "100050": {
+                "model": "spr_ITEM_Tourian_Key",
+                "type": "Tourian Key 7",
+                "quantity": 1,
+                "text": {
+                    "header": "Tourian Key acquired",
+                    "description": [
+                        "Opens Tourian access when all of",
+                        "the keys are retrieved"
+                    ]
+                }
+            },
+            "100051": {
+                "model": "spr_ITEM_Big_Missile",
+                "type": "Big Missile Tank",
+                "quantity": 75,
+                "text": {
+                    "header": "Big Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 75"
+                    ]
+                }
+            },
+            "100052": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100053": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100054": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100055": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100056": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Launcher",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Launcher acquired",
+                    "description": [
+                        "Missiles can now be fired.",
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100057": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100058": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100059": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100060": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100061": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100062": {
+                "model": "spr_ITEM_Energy_Tank",
+                "type": "Energy Tank",
+                "quantity": 1,
+                "text": {
+                    "header": "Energy Tank acquired",
+                    "description": [
+                        "Energy capacity increased by 100"
+                    ]
+                }
+            },
+            "100063": {
+                "model": "spr_ITEM_Screw_Attack",
+                "type": "Screw Attack",
+                "quantity": 1,
+                "text": {
+                    "header": "Screw Attack acquired",
+                    "description": [
+                        "Deal damage to enemies while",
+                        "spinning"
+                    ]
+                }
+            },
+            "100083": {
+                "model": "spr_ITEM_Tourian_Key",
+                "type": "Tourian Key 9",
+                "quantity": 1,
+                "text": {
+                    "header": "Tourian Key acquired",
+                    "description": [
+                        "Opens Tourian access when all of",
+                        "the keys are retrieved"
+                    ]
+                }
+            },
+            "100084": {
+                "model": "spr_ITEM_Tourian_Key",
+                "type": "Tourian Key 5",
+                "quantity": 1,
+                "text": {
+                    "header": "Tourian Key acquired",
+                    "description": [
+                        "Opens Tourian access when all of",
+                        "the keys are retrieved"
+                    ]
+                }
+            },
+            "10085": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            },
+            "100086": {
+                "model": "spr_ITEM_Missile",
+                "type": "Missile Tank",
+                "quantity": 5,
+                "text": {
+                    "header": "Missile Tank acquired",
+                    "description": [
+                        "Missile capacity increased by 5"
+                    ]
+                }
+            }
+        }
+    },
+    "_randovania_meta": {
+        "layout_was_user_modified": false
+    }
+}


### PR DESCRIPTION
[Planets (Zebeth) DB: Added missing starting area](https://github.com/UltiNaruto/randovania/commit/b7f8062f98808db253f1a30255be71c366e02339)

Added some missing starting areas which are elevator rooms.

[Planets (Zebeth): Implemented patch data factory](https://github.com/UltiNaruto/randovania/commit/6d64dc8410e6e00789f56193e9bb8c3050ced114)

Exporting to dict the game datas that will be used by the patcher to export the game.