### PR TITLE
Align "last activity" on MW session window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.4.x] - 2024-08-??
 
+- Fixed: The "Last Activity" text on the Multiplayer Session window is not aligned properly.
+
 ### Metroid Dread
 
 #### Logic Database

--- a/randovania/gui/widgets/multiplayer_session_users_widget.py
+++ b/randovania/gui/widgets/multiplayer_session_users_widget.py
@@ -80,7 +80,7 @@ class WorldWidgetEntry:
 
         if detail is not None:
             self.item.setText(4, "Last Activity:")
-            self.item.setTextAlignment(4, QtCore.Qt.AlignmentFlag.AlignRight)
+            self.item.setTextAlignment(4, QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignCenter)
             self.item.setData(
                 5,
                 QtCore.Qt.ItemDataRole.DisplayRole,


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/f34ebd09-c8ae-4585-85df-ca390c4a7c66)


Fixes #6974 