### PR TITLE
Redesign the customize preset window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.6.x] - 2024-11-??
 
+- Changed: The "Customize Preset" window has been given a visual overhaul.
 - Changed: Filtering in the Generation Order tab is now case-insensitive.
 - Changed: The Area View of the Data Visualizer now always has a dark gray background to help with readability.
 

--- a/randovania/games/am2r/gui/preset_settings/am2r_chaos_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_chaos_tab.py
@@ -52,8 +52,8 @@ class PresetAM2RChaos(PresetTab, Ui_PresetAM2RChaos):
         return "Chaos Settings"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def on_preset_changed(self, preset: Preset) -> None:
         assert isinstance(preset.configuration, AM2RConfiguration)

--- a/randovania/games/am2r/gui/preset_settings/am2r_chaos_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_chaos_tab.py
@@ -52,8 +52,8 @@ class PresetAM2RChaos(PresetTab, Ui_PresetAM2RChaos):
         return "Chaos Settings"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def on_preset_changed(self, preset: Preset) -> None:
         assert isinstance(preset.configuration, AM2RConfiguration)

--- a/randovania/games/am2r/gui/preset_settings/am2r_gameplay_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_gameplay_tab.py
@@ -44,8 +44,8 @@ class PresetAM2RGameplay(PresetTab, Ui_PresetAM2RGameplay):
         return "Gameplay Changes"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return True
+    def header_name(cls) -> str | None:
+        return cls.GAME_MODIFICATIONS_HEADER
 
     def on_preset_changed(self, preset: Preset):
         config = preset.configuration

--- a/randovania/games/am2r/gui/preset_settings/am2r_gameplay_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_gameplay_tab.py
@@ -44,7 +44,7 @@ class PresetAM2RGameplay(PresetTab, Ui_PresetAM2RGameplay):
         return "Gameplay Changes"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return True
 
     def on_preset_changed(self, preset: Preset):

--- a/randovania/games/am2r/gui/preset_settings/am2r_goal_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_goal_tab.py
@@ -38,8 +38,8 @@ class PresetAM2RGoal(PresetTab, Ui_PresetAM2RGoal):
         return "Goal"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _update_slider_max(self) -> None:
         self.placed_slider.setMaximum(self.num_preferred_locations)

--- a/randovania/games/am2r/gui/preset_settings/am2r_goal_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_goal_tab.py
@@ -38,7 +38,7 @@ class PresetAM2RGoal(PresetTab, Ui_PresetAM2RGoal):
         return "Goal"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _update_slider_max(self) -> None:

--- a/randovania/games/am2r/gui/preset_settings/am2r_hints_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_hints_tab.py
@@ -31,7 +31,7 @@ class PresetAM2RHints(PresetTab, Ui_PresetAM2RHints):
         return "Hints"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _on_art_combo_changed(self, new_index: int):

--- a/randovania/games/am2r/gui/preset_settings/am2r_hints_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_hints_tab.py
@@ -31,8 +31,8 @@ class PresetAM2RHints(PresetTab, Ui_PresetAM2RHints):
         return "Hints"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _on_art_combo_changed(self, new_index: int):
         with self._editor as editor:

--- a/randovania/games/am2r/gui/preset_settings/am2r_room_design_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_room_design_tab.py
@@ -42,8 +42,8 @@ class PresetAM2RRoomDesign(PresetTab, Ui_PresetAM2RRoomDesign):
         return "Room Changes"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str):
         def persist(value: bool):

--- a/randovania/games/am2r/gui/preset_settings/am2r_room_design_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_room_design_tab.py
@@ -42,8 +42,8 @@ class PresetAM2RRoomDesign(PresetTab, Ui_PresetAM2RRoomDesign):
         return "Room Changes"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str):
         def persist(value: bool):

--- a/randovania/games/blank/gui/preset_settings/blank_patches_tab.py
+++ b/randovania/games/blank/gui/preset_settings/blank_patches_tab.py
@@ -41,7 +41,7 @@ class PresetBlankPatches(PresetTab):
         return "Other"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return True
 
     def on_preset_changed(self, preset: Preset) -> None:

--- a/randovania/games/blank/gui/preset_settings/blank_patches_tab.py
+++ b/randovania/games/blank/gui/preset_settings/blank_patches_tab.py
@@ -41,8 +41,8 @@ class PresetBlankPatches(PresetTab):
         return "Other"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return True
+    def header_name(cls) -> str | None:
+        return cls.GAME_MODIFICATIONS_HEADER
 
     def on_preset_changed(self, preset: Preset) -> None:
         config = preset.configuration

--- a/randovania/games/cave_story/gui/preset_settings/cs_goal_tab.py
+++ b/randovania/games/cave_story/gui/preset_settings/cs_goal_tab.py
@@ -38,7 +38,7 @@ class PresetCSObjective(PresetTab, Ui_PresetCSObjective):
         return "Objective"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _on_objective_changed(self):

--- a/randovania/games/cave_story/gui/preset_settings/cs_goal_tab.py
+++ b/randovania/games/cave_story/gui/preset_settings/cs_goal_tab.py
@@ -38,8 +38,8 @@ class PresetCSObjective(PresetTab, Ui_PresetCSObjective):
         return "Objective"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _on_objective_changed(self):
         combo_enum = self.goal_combo.currentData()

--- a/randovania/games/cave_story/gui/preset_settings/cs_hp_tab.py
+++ b/randovania/games/cave_story/gui/preset_settings/cs_hp_tab.py
@@ -24,8 +24,8 @@ class PresetCSHP(PresetTab, Ui_PresetCSHP):
         return "HP"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _on_starting_hp_changed(self):
         with self._editor as editor:

--- a/randovania/games/cave_story/gui/preset_settings/cs_hp_tab.py
+++ b/randovania/games/cave_story/gui/preset_settings/cs_hp_tab.py
@@ -24,8 +24,8 @@ class PresetCSHP(PresetTab, Ui_PresetCSHP):
         return "HP"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def _on_starting_hp_changed(self):
         with self._editor as editor:

--- a/randovania/games/cave_story/gui/preset_settings/cs_starting_area_tab.py
+++ b/randovania/games/cave_story/gui/preset_settings/cs_starting_area_tab.py
@@ -5,6 +5,10 @@ from randovania.gui.preset_settings.starting_area_tab import PresetStartingArea
 
 
 class PresetCSStartingArea(PresetStartingArea):
+    @classmethod
+    def starts_new_header(cls) -> bool:
+        return True
+
     def create_quick_fill_buttons(self):
         super().create_quick_fill_buttons()
 

--- a/randovania/games/cave_story/gui/preset_settings/cs_starting_area_tab.py
+++ b/randovania/games/cave_story/gui/preset_settings/cs_starting_area_tab.py
@@ -6,8 +6,8 @@ from randovania.gui.preset_settings.starting_area_tab import PresetStartingArea
 
 class PresetCSStartingArea(PresetStartingArea):
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return True
+    def header_name(cls) -> str | None:
+        return cls.GAME_MODIFICATIONS_HEADER
 
     def create_quick_fill_buttons(self):
         super().create_quick_fill_buttons()

--- a/randovania/games/dread/gui/preset_settings/dread_energy_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_energy_tab.py
@@ -46,8 +46,8 @@ class PresetDreadEnergy(PresetTab, Ui_PresetDreadEnergy):
         return "Energy"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def on_preset_changed(self, preset: Preset):
         config = preset.configuration

--- a/randovania/games/dread/gui/preset_settings/dread_energy_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_energy_tab.py
@@ -46,8 +46,8 @@ class PresetDreadEnergy(PresetTab, Ui_PresetDreadEnergy):
         return "Energy"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def on_preset_changed(self, preset: Preset):
         config = preset.configuration

--- a/randovania/games/dread/gui/preset_settings/dread_goal_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_goal_tab.py
@@ -35,7 +35,7 @@ class PresetDreadGoal(PresetTab, Ui_PresetDreadGoal):
         return "Goal"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _update_slider_max(self):

--- a/randovania/games/dread/gui/preset_settings/dread_goal_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_goal_tab.py
@@ -35,8 +35,8 @@ class PresetDreadGoal(PresetTab, Ui_PresetDreadGoal):
         return "Goal"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _update_slider_max(self):
         self.dna_slider.setMaximum(self.num_preferred_locations)

--- a/randovania/games/dread/gui/preset_settings/dread_patches_chaos.py
+++ b/randovania/games/dread/gui/preset_settings/dread_patches_chaos.py
@@ -39,8 +39,8 @@ class PresetDreadChaos(PresetTab, Ui_PresetDreadChaos):
         return True
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def header_name(cls) -> str | None:
+        return None
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str):
         def persist(value: bool):

--- a/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
@@ -43,8 +43,8 @@ class PresetDreadPatches(PresetTab, Ui_PresetDreadPatches):
         return "Other"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str):
         def persist(value: bool):

--- a/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
@@ -43,8 +43,8 @@ class PresetDreadPatches(PresetTab, Ui_PresetDreadPatches):
         return "Other"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str):
         def persist(value: bool):

--- a/randovania/games/dread/gui/preset_settings/dread_teleporters_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_teleporters_tab.py
@@ -66,6 +66,10 @@ class PresetTeleportersDread(PresetTeleporterTab, Ui_PresetTeleportersDread, Nod
     def tab_title(cls) -> str:
         return "Transporters"
 
+    @classmethod
+    def starts_new_header(cls) -> bool:
+        return True
+
     def _create_source_teleporters(self):
         row = 0
         region_list = self.game_description.region_list

--- a/randovania/games/dread/gui/preset_settings/dread_teleporters_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_teleporters_tab.py
@@ -67,8 +67,8 @@ class PresetTeleportersDread(PresetTeleporterTab, Ui_PresetTeleportersDread, Nod
         return "Transporters"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return True
+    def header_name(cls) -> str | None:
+        return cls.GAME_MODIFICATIONS_HEADER
 
     def _create_source_teleporters(self):
         row = 0

--- a/randovania/games/factorio/gui/preset_settings/factorio_patches_tab.py
+++ b/randovania/games/factorio/gui/preset_settings/factorio_patches_tab.py
@@ -26,8 +26,8 @@ class PresetFactorioPatches(PresetTab, Ui_PresetFactorioPatches):
         return "Changes"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def on_preset_changed(self, preset: Preset) -> None:
         config = preset.configuration

--- a/randovania/games/factorio/gui/preset_settings/factorio_patches_tab.py
+++ b/randovania/games/factorio/gui/preset_settings/factorio_patches_tab.py
@@ -26,7 +26,7 @@ class PresetFactorioPatches(PresetTab, Ui_PresetFactorioPatches):
         return "Changes"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def on_preset_changed(self, preset: Preset) -> None:

--- a/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
+++ b/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
@@ -36,7 +36,7 @@ class PresetFusionGoal(PresetTab, Ui_PresetFusionGoal):
         return "Goal"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _update_slider_max(self) -> None:

--- a/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
+++ b/randovania/games/fusion/gui/preset_settings/fusion_goal_tab.py
@@ -36,8 +36,8 @@ class PresetFusionGoal(PresetTab, Ui_PresetFusionGoal):
         return "Goal"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _update_slider_max(self) -> None:
         self.placed_slider.setMaximum(self.num_preferred_locations)

--- a/randovania/games/fusion/gui/preset_settings/fusion_hints_tab.py
+++ b/randovania/games/fusion/gui/preset_settings/fusion_hints_tab.py
@@ -32,8 +32,8 @@ class PresetFusionHints(PresetTab, Ui_PresetFusionHints):
         return "Hints"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _on_art_combo_changed(self, new_index: int) -> None:
         with self._editor as editor:

--- a/randovania/games/fusion/gui/preset_settings/fusion_hints_tab.py
+++ b/randovania/games/fusion/gui/preset_settings/fusion_hints_tab.py
@@ -32,7 +32,7 @@ class PresetFusionHints(PresetTab, Ui_PresetFusionHints):
         return "Hints"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _on_art_combo_changed(self, new_index: int) -> None:

--- a/randovania/games/fusion/gui/preset_settings/fusion_patches_tab.py
+++ b/randovania/games/fusion/gui/preset_settings/fusion_patches_tab.py
@@ -38,8 +38,8 @@ class PresetFusionPatches(PresetTab, Ui_PresetFusionPatches):
         return "Other"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str) -> None:
         def persist(value: bool) -> None:

--- a/randovania/games/fusion/gui/preset_settings/fusion_patches_tab.py
+++ b/randovania/games/fusion/gui/preset_settings/fusion_patches_tab.py
@@ -38,8 +38,8 @@ class PresetFusionPatches(PresetTab, Ui_PresetFusionPatches):
         return "Other"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str) -> None:
         def persist(value: bool) -> None:

--- a/randovania/games/planets_zebeth/gui/preset_settings/planets_zebeth_goal_tab.py
+++ b/randovania/games/planets_zebeth/gui/preset_settings/planets_zebeth_goal_tab.py
@@ -36,8 +36,8 @@ class PresetPlanetsZebethGoal(PresetTab, Ui_PresetPlanetsZebethGoal):
         return "Goal"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _update_slider(self) -> None:
         if self.vanilla_tourian_keys_check.isChecked():

--- a/randovania/games/planets_zebeth/gui/preset_settings/planets_zebeth_goal_tab.py
+++ b/randovania/games/planets_zebeth/gui/preset_settings/planets_zebeth_goal_tab.py
@@ -36,7 +36,7 @@ class PresetPlanetsZebethGoal(PresetTab, Ui_PresetPlanetsZebethGoal):
         return "Goal"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _update_slider(self) -> None:

--- a/randovania/games/planets_zebeth/gui/preset_settings/planets_zebeth_patches_tab.py
+++ b/randovania/games/planets_zebeth/gui/preset_settings/planets_zebeth_patches_tab.py
@@ -42,8 +42,8 @@ class PresetPlanetsZebethPatches(PresetTab):
         return "Other"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str) -> None:
         def persist(value: bool) -> None:

--- a/randovania/games/planets_zebeth/gui/preset_settings/planets_zebeth_patches_tab.py
+++ b/randovania/games/planets_zebeth/gui/preset_settings/planets_zebeth_patches_tab.py
@@ -42,8 +42,8 @@ class PresetPlanetsZebethPatches(PresetTab):
         return "Other"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str) -> None:
         def persist(value: bool) -> None:

--- a/randovania/games/prime1/gui/preset_settings/prime_enemy_stat_randomizer.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_enemy_stat_randomizer.py
@@ -42,8 +42,8 @@ class PresetEnemyAttributeRandomizer(PresetTab, Ui_EnemyAttributeRandomizer):
         return "Enemy Attributes"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     @classmethod
     def is_experimental(cls) -> bool:

--- a/randovania/games/prime1/gui/preset_settings/prime_enemy_stat_randomizer.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_enemy_stat_randomizer.py
@@ -42,8 +42,8 @@ class PresetEnemyAttributeRandomizer(PresetTab, Ui_EnemyAttributeRandomizer):
         return "Enemy Attributes"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     @classmethod
     def is_experimental(cls) -> bool:

--- a/randovania/games/prime1/gui/preset_settings/prime_goal_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_goal_tab.py
@@ -30,7 +30,7 @@ class PresetPrimeGoal(PresetTab, Ui_PresetPrimeGoal):
         return "Goal"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _update_editor(self) -> None:

--- a/randovania/games/prime1/gui/preset_settings/prime_goal_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_goal_tab.py
@@ -30,8 +30,8 @@ class PresetPrimeGoal(PresetTab, Ui_PresetPrimeGoal):
         return "Goal"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _update_editor(self) -> None:
         with self._editor as editor:

--- a/randovania/games/prime1/gui/preset_settings/prime_hints_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_hints_tab.py
@@ -37,8 +37,8 @@ class PresetPrimeHints(PresetTab, Ui_PresetPrimeHints):
         return "Hints"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _on_art_combo_changed(self, new_index: int):
         with self._editor as editor:

--- a/randovania/games/prime1/gui/preset_settings/prime_hints_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_hints_tab.py
@@ -37,7 +37,7 @@ class PresetPrimeHints(PresetTab, Ui_PresetPrimeHints):
         return "Hints"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _on_art_combo_changed(self, new_index: int):

--- a/randovania/games/prime1/gui/preset_settings/prime_patches_chaos.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_patches_chaos.py
@@ -53,8 +53,8 @@ class PresetPrimeChaos(PresetTab, Ui_PresetPrimeChaos):
         return True
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str):
         def persist(value: bool):

--- a/randovania/games/prime1/gui/preset_settings/prime_patches_chaos.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_patches_chaos.py
@@ -53,8 +53,8 @@ class PresetPrimeChaos(PresetTab, Ui_PresetPrimeChaos):
         return True
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str):
         def persist(value: bool):

--- a/randovania/games/prime1/gui/preset_settings/prime_patches_qol.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_patches_qol.py
@@ -70,8 +70,8 @@ cutscenes happen. Inferior to the above options, but kept around because it's fu
         return "Quality of Life"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str):
         def persist(value: bool):

--- a/randovania/games/prime1/gui/preset_settings/prime_patches_qol.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_patches_qol.py
@@ -70,8 +70,8 @@ cutscenes happen. Inferior to the above options, but kept around because it's fu
         return "Quality of Life"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str):
         def persist(value: bool):

--- a/randovania/games/prime2/gui/preset_settings/echoes_beam_configuration_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_beam_configuration_tab.py
@@ -113,8 +113,8 @@ class PresetEchoesBeamConfiguration(PresetTab, Ui_PresetEchoesBeamConfiguration)
         return "Beam Configuration"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _on_ammo_type_combo_changed(self, beam: str, combo: QComboBox, is_ammo_b: bool, _):
         with self._editor as editor:

--- a/randovania/games/prime2/gui/preset_settings/echoes_beam_configuration_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_beam_configuration_tab.py
@@ -113,8 +113,8 @@ class PresetEchoesBeamConfiguration(PresetTab, Ui_PresetEchoesBeamConfiguration)
         return "Beam Configuration"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def _on_ammo_type_combo_changed(self, beam: str, combo: QComboBox, is_ammo_b: bool, _):
         with self._editor as editor:

--- a/randovania/games/prime2/gui/preset_settings/echoes_goal_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_goal_tab.py
@@ -37,7 +37,7 @@ class PresetEchoesGoal(PresetTab, Ui_PresetEchoesGoal):
         return "Goal"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _set_slider_visible(self, visible: bool):

--- a/randovania/games/prime2/gui/preset_settings/echoes_goal_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_goal_tab.py
@@ -37,8 +37,8 @@ class PresetEchoesGoal(PresetTab, Ui_PresetEchoesGoal):
         return "Goal"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _set_slider_visible(self, visible: bool):
         for w in [self.skytemple_slider, self.skytemple_slider_label]:

--- a/randovania/games/prime2/gui/preset_settings/echoes_hints_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_hints_tab.py
@@ -34,7 +34,7 @@ class PresetEchoesHints(PresetTab, Ui_PresetEchoesHints):
         return "Hints"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _on_stk_combo_changed(self, new_index: int):

--- a/randovania/games/prime2/gui/preset_settings/echoes_hints_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_hints_tab.py
@@ -34,8 +34,8 @@ class PresetEchoesHints(PresetTab, Ui_PresetEchoesHints):
         return "Hints"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _on_stk_combo_changed(self, new_index: int):
         with self._editor as editor:

--- a/randovania/games/prime2/gui/preset_settings/echoes_patches_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_patches_tab.py
@@ -44,8 +44,8 @@ class PresetEchoesPatches(PresetTab, Ui_PresetEchoesPatches):
         return "Other"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def on_preset_changed(self, preset: Preset):
         config = preset.configuration

--- a/randovania/games/prime2/gui/preset_settings/echoes_patches_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_patches_tab.py
@@ -44,8 +44,8 @@ class PresetEchoesPatches(PresetTab, Ui_PresetEchoesPatches):
         return "Other"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def on_preset_changed(self, preset: Preset):
         config = preset.configuration

--- a/randovania/games/prime2/gui/preset_settings/echoes_translators_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_translators_tab.py
@@ -82,8 +82,8 @@ class PresetEchoesTranslators(PresetTab, Ui_PresetEchoesTranslators):
         return "Translators Gate"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def _on_randomize_all_gates_pressed(self):
         with self._editor as editor:

--- a/randovania/games/prime2/gui/preset_settings/echoes_translators_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_translators_tab.py
@@ -82,8 +82,8 @@ class PresetEchoesTranslators(PresetTab, Ui_PresetEchoesTranslators):
         return "Translators Gate"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _on_randomize_all_gates_pressed(self):
         with self._editor as editor:

--- a/randovania/games/samus_returns/gui/preset_settings/__init__.py
+++ b/randovania/games/samus_returns/gui/preset_settings/__init__.py
@@ -15,12 +15,12 @@ def msr_preset_tabs(editor: PresetEditor, window_manager: WindowManager) -> list
     from randovania.games.samus_returns.gui.preset_settings.msr_hints_tab import PresetMSRHints
     from randovania.games.samus_returns.gui.preset_settings.msr_patches_tab import PresetMSRPatches
     from randovania.games.samus_returns.gui.preset_settings.msr_reserves_tab import PresetMSRReserves
+    from randovania.games.samus_returns.gui.preset_settings.msr_starting_area import PresetMSRStartingArea
     from randovania.games.samus_returns.gui.preset_settings.msr_teleporters_tab import PresetTeleportersMSR
     from randovania.gui.preset_settings.dock_rando_tab import PresetDockRando
     from randovania.gui.preset_settings.generation_tab import PresetGeneration
     from randovania.gui.preset_settings.location_pool_tab import PresetLocationPool
     from randovania.gui.preset_settings.metroid_item_pool_tab import MetroidPresetItemPool
-    from randovania.gui.preset_settings.starting_area_tab import PresetMetroidStartingArea
     from randovania.gui.preset_settings.trick_level_tab import PresetTrickLevel
 
     return [
@@ -30,7 +30,7 @@ def msr_preset_tabs(editor: PresetEditor, window_manager: WindowManager) -> list
         PresetMSRHints,
         PresetLocationPool,
         MetroidPresetItemPool,
-        PresetMetroidStartingArea,
+        PresetMSRStartingArea,
         PresetTeleportersMSR,
         PresetDockRando,
         PresetMSRAeion,

--- a/randovania/games/samus_returns/gui/preset_settings/msr_aeion_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_aeion_tab.py
@@ -25,8 +25,8 @@ class PresetMSRAeion(PresetTab, Ui_PresetMSRAeion):
         return "Aeion"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def on_preset_changed(self, preset: Preset) -> None:
         config = preset.configuration

--- a/randovania/games/samus_returns/gui/preset_settings/msr_aeion_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_aeion_tab.py
@@ -25,8 +25,8 @@ class PresetMSRAeion(PresetTab, Ui_PresetMSRAeion):
         return "Aeion"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def on_preset_changed(self, preset: Preset) -> None:
         config = preset.configuration

--- a/randovania/games/samus_returns/gui/preset_settings/msr_energy_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_energy_tab.py
@@ -43,8 +43,8 @@ class PresetMSREnergy(PresetTab, Ui_PresetMSREnergy):
         return "Energy"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def on_preset_changed(self, preset: Preset) -> None:
         config = preset.configuration

--- a/randovania/games/samus_returns/gui/preset_settings/msr_energy_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_energy_tab.py
@@ -43,8 +43,8 @@ class PresetMSREnergy(PresetTab, Ui_PresetMSREnergy):
         return "Energy"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def on_preset_changed(self, preset: Preset) -> None:
         config = preset.configuration

--- a/randovania/games/samus_returns/gui/preset_settings/msr_goal_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_goal_tab.py
@@ -49,8 +49,8 @@ class PresetMSRGoal(PresetTab, Ui_PresetMSRGoal):
         return "Goal"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _update_slider_max(self) -> None:
         self.placed_slider.setMaximum(self.num_preferred_locations)

--- a/randovania/games/samus_returns/gui/preset_settings/msr_goal_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_goal_tab.py
@@ -49,7 +49,7 @@ class PresetMSRGoal(PresetTab, Ui_PresetMSRGoal):
         return "Goal"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _update_slider_max(self) -> None:

--- a/randovania/games/samus_returns/gui/preset_settings/msr_hints_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_hints_tab.py
@@ -38,8 +38,8 @@ class PresetMSRHints(PresetTab, Ui_PresetMSRHints):
         return "Hints"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _on_art_combo_changed(self, new_index: int) -> None:
         with self._editor as editor:

--- a/randovania/games/samus_returns/gui/preset_settings/msr_hints_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_hints_tab.py
@@ -38,7 +38,7 @@ class PresetMSRHints(PresetTab, Ui_PresetMSRHints):
         return "Hints"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def _on_art_combo_changed(self, new_index: int) -> None:

--- a/randovania/games/samus_returns/gui/preset_settings/msr_patches_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_patches_tab.py
@@ -43,8 +43,8 @@ class PresetMSRPatches(PresetTab, Ui_PresetMSRPatches):
         return "Optional Patches"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str) -> None:
         def persist(value: bool) -> None:

--- a/randovania/games/samus_returns/gui/preset_settings/msr_patches_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_patches_tab.py
@@ -43,8 +43,8 @@ class PresetMSRPatches(PresetTab, Ui_PresetMSRPatches):
         return "Optional Patches"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def _add_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str) -> None:
         def persist(value: bool) -> None:

--- a/randovania/games/samus_returns/gui/preset_settings/msr_reserves_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_reserves_tab.py
@@ -28,8 +28,8 @@ class PresetMSRReserves(PresetTab, Ui_PresetMSRReserves):
         return "Reserve Tanks"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def on_preset_changed(self, preset: Preset) -> None:
         config = preset.configuration

--- a/randovania/games/samus_returns/gui/preset_settings/msr_reserves_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_reserves_tab.py
@@ -28,8 +28,8 @@ class PresetMSRReserves(PresetTab, Ui_PresetMSRReserves):
         return "Reserve Tanks"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def on_preset_changed(self, preset: Preset) -> None:
         config = preset.configuration

--- a/randovania/games/samus_returns/gui/preset_settings/msr_starting_area.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_starting_area.py
@@ -1,0 +1,7 @@
+from randovania.gui.preset_settings.starting_area_tab import PresetMetroidStartingArea
+
+
+class PresetMSRStartingArea(PresetMetroidStartingArea):
+    @classmethod
+    def starts_new_header(cls) -> bool:
+        return True

--- a/randovania/games/samus_returns/gui/preset_settings/msr_starting_area.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_starting_area.py
@@ -3,5 +3,5 @@ from randovania.gui.preset_settings.starting_area_tab import PresetMetroidStarti
 
 class PresetMSRStartingArea(PresetMetroidStartingArea):
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return True
+    def header_name(cls) -> str | None:
+        return cls.GAME_MODIFICATIONS_HEADER

--- a/randovania/games/super_metroid/gui/preset_settings/super_patches_tab.py
+++ b/randovania/games/super_metroid/gui/preset_settings/super_patches_tab.py
@@ -61,7 +61,7 @@ class PresetSuperPatchConfiguration(PresetTab, Ui_PresetPatcherSuperPatches):
         return "Game Patches"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return True
 
     def _on_patch_checkbox_changed(self, field_name: str, checkbox: QCheckBox, value: int):

--- a/randovania/games/super_metroid/gui/preset_settings/super_patches_tab.py
+++ b/randovania/games/super_metroid/gui/preset_settings/super_patches_tab.py
@@ -61,8 +61,8 @@ class PresetSuperPatchConfiguration(PresetTab, Ui_PresetPatcherSuperPatches):
         return "Game Patches"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return True
+    def header_name(cls) -> str | None:
+        return cls.GAME_MODIFICATIONS_HEADER
 
     def _on_patch_checkbox_changed(self, field_name: str, checkbox: QCheckBox, value: int):
         with self._editor as editor:

--- a/randovania/gui/game_specific_gui.py
+++ b/randovania/gui/game_specific_gui.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import itertools
 from typing import TYPE_CHECKING
+
+from randovania.gui.preset_settings.customize_description_tab import PresetCustomizeDescription
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -24,4 +27,4 @@ def create_dialog_for_cosmetic_patches(
 
 
 def preset_editor_tabs_for(editor: PresetEditor, window_manager: WindowManager) -> Iterable[type[PresetTab]]:
-    return editor.game.gui.tab_provider(editor, window_manager)
+    return itertools.chain(editor.game.gui.tab_provider(editor, window_manager), {PresetCustomizeDescription})

--- a/randovania/gui/lib/theme.py
+++ b/randovania/gui/lib/theme.py
@@ -37,19 +37,39 @@ def set_dark_theme(active: bool, compact: bool = False, *, app: QtWidgets.QAppli
     }
         """
 
-    style += "QScrollArea { border: default; }"
+    style += """
+
+    QScrollArea {
+        border: default;
+    }
+
+    QListWidget::item {
+        padding: 6px;
+        border: 0px solid red; /* FIXME: ugly hack to make item not jump around on hover/selection*/
+    }
+    """
 
     if active:
         new_palette.setColor(QtGui.QPalette.Link, Qt.cyan)
         new_palette.setColor(QtGui.QPalette.LinkVisited, Qt.cyan)
         style += """
-    QToolTip {
-        background-color: black;
-        color: white;
-        border: black solid 1px
-    }
+        QToolTip {
+            background-color: black;
+            color: white;
+            border: black solid 1px
+        }
+
+        QListWidget::item::disabled {
+            color: rgba(204, 205, 206, 1.000);
+        }
         """
     else:
+        style += """
+        QListWidget::item::disabled {
+            color: rgba(72, 74, 76, 1.000);
+        }
+        """
+
         new_palette.setColor(QtGui.QPalette.Link, Qt.blue)
 
     _current_dark_theme = active

--- a/randovania/gui/lib/theme.py
+++ b/randovania/gui/lib/theme.py
@@ -45,6 +45,7 @@ def set_dark_theme(active: bool, compact: bool = False, *, app: QtWidgets.QAppli
     QListWidget::item {
         padding: 6px;
         border: 0px solid red; /* FIXME: ugly hack to make item not jump around on hover/selection*/
+    }
 
     QStatusBar QLabel:hover {
         background: transparent;

--- a/randovania/gui/lib/theme.py
+++ b/randovania/gui/lib/theme.py
@@ -49,7 +49,7 @@ def set_dark_theme(active: bool, compact: bool = False, *, app: QtWidgets.QAppli
     QStatusBar QLabel:hover {
         background: transparent;
     }
-    
+
     QStatusBar QProgressBar:hover {
         background: transparent;
     }

--- a/randovania/gui/preset_settings/customize_description_tab.py
+++ b/randovania/gui/preset_settings/customize_description_tab.py
@@ -24,8 +24,8 @@ class PresetCustomizeDescription(PresetTab, Ui_PresetCustomizeDescription):
         return "Preset Description"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return True
+    def header_name(cls) -> str | None:
+        return "Preset Info"
 
     def on_preset_changed(self, preset: Preset):
         self.description_edit.setText(preset.description)

--- a/randovania/gui/preset_settings/customize_description_tab.py
+++ b/randovania/gui/preset_settings/customize_description_tab.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from randovania.gui.generated.preset_customize_description_ui import Ui_PresetCustomizeDescription
+from randovania.gui.preset_settings.preset_tab import PresetTab
+
+if TYPE_CHECKING:
+    from randovania.game_description.game_description import GameDescription
+    from randovania.gui.lib.window_manager import WindowManager
+    from randovania.interface_common.preset_editor import PresetEditor
+    from randovania.layout.preset import Preset
+
+
+class PresetCustomizeDescription(PresetTab, Ui_PresetCustomizeDescription):
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
+        self.setupUi(self)
+
+        self.description_edit.setText(editor.description)
+        self.description_edit.textChanged.connect(self._edit_description)
+
+    @classmethod
+    def tab_title(cls) -> str:
+        return "Preset Description"
+
+    @classmethod
+    def uses_patches_tab(cls) -> bool:
+        return False
+
+    def on_preset_changed(self, preset: Preset):
+        return
+
+    def _edit_description(self):
+        with self._editor as editor:
+            editor.description = self.description_edit.toPlainText()

--- a/randovania/gui/preset_settings/customize_description_tab.py
+++ b/randovania/gui/preset_settings/customize_description_tab.py
@@ -17,7 +17,6 @@ class PresetCustomizeDescription(PresetTab, Ui_PresetCustomizeDescription):
         super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
-        self.description_edit.setText(editor.description)
         self.description_edit.textChanged.connect(self._edit_description)
 
     @classmethod
@@ -29,7 +28,7 @@ class PresetCustomizeDescription(PresetTab, Ui_PresetCustomizeDescription):
         return False
 
     def on_preset_changed(self, preset: Preset):
-        return
+        self.description_edit.setText(preset.description)
 
     def _edit_description(self):
         with self._editor as editor:

--- a/randovania/gui/preset_settings/customize_description_tab.py
+++ b/randovania/gui/preset_settings/customize_description_tab.py
@@ -24,8 +24,8 @@ class PresetCustomizeDescription(PresetTab, Ui_PresetCustomizeDescription):
         return "Preset Description"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return False
+    def starts_new_header(cls) -> bool:
+        return True
 
     def on_preset_changed(self, preset: Preset):
         self.description_edit.setText(preset.description)

--- a/randovania/gui/preset_settings/customize_preset_dialog.py
+++ b/randovania/gui/preset_settings/customize_preset_dialog.py
@@ -62,23 +62,26 @@ class CustomizePresetDialog(QtWidgets.QDialog, Ui_CustomizePresetDialog):
         self.window_manager = window_manager
         _tab_types = list(game_specific_gui.preset_editor_tabs_for(editor, window_manager))
         self._current_tab = None
-        self.listToWidget = {}
+        self.item_to_widget = {}
 
         header_indices = []
         max_title_characters = 0
 
         first_selection = None
-        # Add child tabs, will be positioned under their corresponding headers
+
+        # Add entries
         for extra_tab in _tab_types:
+            # Skip experimental if we don't have the setting on
             if not self.editor._options.experimental_settings and extra_tab.is_experimental():
                 continue
 
             tab = PresetTabRoot(self, extra_tab)
             list_item = QtWidgets.QListWidgetItem(tab.tab_type.tab_title())
 
-            self.listToWidget[list_item.text()] = tab
+            self.item_to_widget[list_item.text()] = tab
             self.stackedWidget.addWidget(tab)
 
+            # Add placeholder header entry, that gets proper text later
             if extra_tab.starts_new_header():
                 header_indices.append(self.listWidget.count())
                 seperator = QtWidgets.QListWidgetItem("")
@@ -99,7 +102,8 @@ class CustomizePresetDialog(QtWidgets.QDialog, Ui_CustomizePresetDialog):
 
         self.listWidget.setCurrentItem(first_selection)
         self.listWidget.currentItemChanged.connect(self.changed_list_item_selection)
-        self.listWidget.setMaximumWidth(self.listWidget.sizeHintForColumn(0) * 1.1)
+        # Need some extra space to adjust for scrollbar
+        self.listWidget.setMaximumWidth(self.listWidget.sizeHintForColumn(0) * 1.12)
 
         self.name_edit.textEdited.connect(self._edit_name)
         self.button_box.accepted.connect(self.accept)
@@ -112,7 +116,7 @@ class CustomizePresetDialog(QtWidgets.QDialog, Ui_CustomizePresetDialog):
             self._current_tab = tab
 
     def changed_list_item_selection(self, item: QtWidgets.QListWidgetItem):
-        widget = self.listToWidget[item.text()]
+        widget = self.item_to_widget[item.text()]
         self.stackedWidget.setCurrentWidget(widget)
 
     # Options

--- a/randovania/gui/preset_settings/customize_preset_dialog.py
+++ b/randovania/gui/preset_settings/customize_preset_dialog.py
@@ -82,7 +82,7 @@ class CustomizePresetDialog(QtWidgets.QDialog, Ui_CustomizePresetDialog):
             self.stackedWidget.addWidget(tab)
 
             # Add placeholder header entry, that gets proper text later
-            if extra_tab.starts_new_header():
+            if extra_tab.header_name():
                 header_indices.append(self.listWidget.count())
                 seperator = QtWidgets.QListWidgetItem("")
                 seperator.setFlags(QtGui.Qt.ItemFlag.NoItemFlags)

--- a/randovania/gui/preset_settings/customize_preset_dialog.py
+++ b/randovania/gui/preset_settings/customize_preset_dialog.py
@@ -64,9 +64,6 @@ class CustomizePresetDialog(QtWidgets.QDialog, Ui_CustomizePresetDialog):
         self._current_tab = None
         self.item_to_widget = {}
 
-        header_indices = []
-        max_title_characters = 0
-
         first_selection = None
 
         # Add entries
@@ -83,22 +80,22 @@ class CustomizePresetDialog(QtWidgets.QDialog, Ui_CustomizePresetDialog):
 
             # Add placeholder header entry, that gets proper text later
             if extra_tab.header_name():
-                header_indices.append(self.listWidget.count())
-                seperator = QtWidgets.QListWidgetItem("")
-                seperator.setFlags(QtGui.Qt.ItemFlag.NoItemFlags)
-                self.listWidget.addItem(seperator)
+                if self.listWidget.count() > 0:
+                    seperator = QtWidgets.QListWidgetItem("")
+                    seperator.setFlags(QtGui.Qt.ItemFlag.NoItemFlags)
+                    self.listWidget.addItem(seperator)
+                header = QtWidgets.QListWidgetItem(extra_tab.header_name())
+                font = header.font()
+                font.setBold(True)
+                font.setPointSizeF(font.pointSize() * 1.2)
+                header.setFont(font)
+                header.setFlags(QtGui.Qt.ItemFlag.NoItemFlags)
+                self.listWidget.addItem(header)
 
             self.listWidget.addItem(list_item)
 
-            if len(extra_tab.tab_title()) > max_title_characters:
-                max_title_characters = len(extra_tab.tab_title())
-
             if first_selection is None:
                 first_selection = list_item
-
-        # Change seperator placeholders to have proper text
-        for index in header_indices:
-            self.listWidget.item(index).setText("─" * max_title_characters)
 
         self.listWidget.setCurrentItem(first_selection)
         self.listWidget.currentItemChanged.connect(self.changed_list_item_selection)

--- a/randovania/gui/preset_settings/customize_preset_dialog.py
+++ b/randovania/gui/preset_settings/customize_preset_dialog.py
@@ -41,7 +41,6 @@ class PresetTabRoot(QtWidgets.QWidget):
             self.current_tab.on_preset_changed(editor.create_custom_preset_with())
             self.owner.set_visible_tab(self)
             self.current_tab.update_experimental_visibility()
-            self.owner.update_experimental_visibility()
 
         return super().showEvent(arg)
 
@@ -52,9 +51,12 @@ class PresetTabRoot(QtWidgets.QWidget):
 
 class CustomizePresetDialog(QtWidgets.QDialog, Ui_CustomizePresetDialog):
     _tab_types: list[type[PresetTab]]
-    _tabs: dict[type[PresetTab], PresetTabRoot]
     _editor: PresetEditor
     _current_tab: PresetTabRoot | None
+
+    def _changed(self, item: QtWidgets.QListWidgetItem):
+        widget = self.listToWidget[item.text()]
+        self.stackedWidget.setCurrentWidget(widget)
 
     def __init__(self, window_manager: WindowManager, editor: PresetEditor):
         super().__init__()
@@ -64,37 +66,63 @@ class CustomizePresetDialog(QtWidgets.QDialog, Ui_CustomizePresetDialog):
         self._editor = editor
         self.window_manager = window_manager
         self._tab_types = list(game_specific_gui.preset_editor_tabs_for(editor, window_manager))
-        self._tabs = {}
         self._current_tab = None
+        self.listToWidget = {}
 
+        randomizer_item = QtWidgets.QListWidgetItem()
+        patches_item = QtWidgets.QListWidgetItem()
+        preset_item = QtWidgets.QListWidgetItem()
+        tmp_mapping = []
+        for header_name, header_entry in [
+            ("Randomizer Logic", randomizer_item),
+            ("Game Modifications", patches_item),
+            ("Preset Info", preset_item),
+        ]:
+            header_entry = QtWidgets.QListWidgetItem(header_name)
+            font = header_entry.font()
+            font.setBold(True)
+            font.setUnderline(True)
+            font.setPointSizeF(font.pointSize() * 1.2)
+            header_entry.setFont(font)
+            header_entry.setFlags(QtGui.Qt.ItemFlag.NoItemFlags)
+            self.listWidget.addItem(header_entry)
+            tmp_mapping.append(self.listWidget.count())
+
+        rando_index, patches_index, preset_index = tmp_mapping
+
+        first_selection = None
         for extra_tab in self._tab_types:
-            if extra_tab.uses_patches_tab():
-                parent_tab = self.patches_tab_widget
+            if not self.editor._options.experimental_settings and extra_tab.is_experimental():
+                continue
+
+            tab = PresetTabRoot(self, extra_tab)
+            list_item = QtWidgets.QListWidgetItem(tab.tab_type.tab_title())
+
+            self.listToWidget[list_item.text()] = tab
+            self.stackedWidget.addWidget(tab)
+            if extra_tab.tab_title() == "Preset Description":
+                self.listWidget.insertItem(preset_index, list_item)
+                preset_index += 1
+            elif extra_tab.uses_patches_tab():
+                self.listWidget.insertItem(patches_index, list_item)
+                patches_index += 1
+                preset_index += 1
             else:
-                parent_tab = self.logic_tab_widget
+                self.listWidget.insertItem(rando_index, list_item)
+                rando_index += 1
+                patches_index += 1
+                preset_index += 1
 
-            tab = self._tabs[extra_tab] = PresetTabRoot(self, extra_tab)
-            parent_tab.addTab(tab, extra_tab.tab_title())
+            if first_selection is None:
+                first_selection = list_item
 
-        for i in range(self.main_tab_widget.count()):
-            tab_widget = self.main_tab_widget.widget(i)
-            if isinstance(tab_widget, QtWidgets.QTabWidget):
-                self.main_tab_widget.setTabVisible(i, tab_widget.count() > 0)
+        self.listWidget.setCurrentItem(first_selection)
+        self.listWidget.currentItemChanged.connect(self._changed)
+        self.listWidget.setMaximumWidth(self.listWidget.sizeHintForColumn(0) * 1.1)
 
         self.name_edit.textEdited.connect(self._edit_name)
-        self.description_edit.textChanged.connect(self._edit_description)
         self.button_box.accepted.connect(self.accept)
         self.button_box.rejected.connect(self.reject)
-
-    def update_experimental_visibility(self):
-        for parent, tabs in [
-            (self.patches_tab_widget, [x for x in self._tab_types if x.uses_patches_tab()]),
-            (self.logic_tab_widget, [x for x in self._tab_types if not x.uses_patches_tab()]),
-        ]:
-            for i in range(parent.count()):
-                tab = tabs[i]
-                visible = self.editor._options.experimental_settings or not tab.is_experimental()
-                parent.setTabVisible(i, visible)
 
     def set_visible_tab(self, tab: PresetTabRoot):
         if tab != self._current_tab:
@@ -105,17 +133,12 @@ class CustomizePresetDialog(QtWidgets.QDialog, Ui_CustomizePresetDialog):
     # Options
     def on_preset_changed(self, preset: Preset):
         common_qt_lib.set_edit_if_different(self.name_edit, preset.name)
-        common_qt_lib.set_edit_if_different_text(self.description_edit, preset.description)
         if (tab := self.current_preset_tab) is not None:
             tab.on_preset_changed(preset)
 
     def _edit_name(self, value: str):
         with self._editor as editor:
             editor.name = value
-
-    def _edit_description(self):
-        with self._editor as editor:
-            editor.description = self.description_edit.toPlainText()
 
     @property
     def editor(self):

--- a/randovania/gui/preset_settings/dock_rando_tab.py
+++ b/randovania/gui/preset_settings/dock_rando_tab.py
@@ -45,8 +45,8 @@ class PresetDockRando(PresetTab, Ui_PresetDockRando):
         return "Door Locks"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def on_preset_changed(self, preset: Preset):
         dock_rando = preset.configuration.dock_rando

--- a/randovania/gui/preset_settings/dock_rando_tab.py
+++ b/randovania/gui/preset_settings/dock_rando_tab.py
@@ -45,8 +45,8 @@ class PresetDockRando(PresetTab, Ui_PresetDockRando):
         return "Door Locks"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     def on_preset_changed(self, preset: Preset):
         dock_rando = preset.configuration.dock_rando

--- a/randovania/gui/preset_settings/generation_tab.py
+++ b/randovania/gui/preset_settings/generation_tab.py
@@ -92,7 +92,7 @@ class PresetGeneration(PresetTab, Ui_PresetGeneration):
         return "Generation"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     @property

--- a/randovania/gui/preset_settings/generation_tab.py
+++ b/randovania/gui/preset_settings/generation_tab.py
@@ -92,8 +92,8 @@ class PresetGeneration(PresetTab, Ui_PresetGeneration):
         return "Generation"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     @property
     def game_enum(self) -> RandovaniaGame:

--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -116,7 +116,7 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
         return "Item Pool"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     def on_preset_changed(self, preset: Preset):

--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -116,8 +116,8 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
         return "Item Pool"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     def on_preset_changed(self, preset: Preset):
         layout = preset.configuration

--- a/randovania/gui/preset_settings/location_pool_tab.py
+++ b/randovania/gui/preset_settings/location_pool_tab.py
@@ -94,8 +94,8 @@ class PresetLocationPool(PresetTab, Ui_PresetLocationPool, NodeListHelper):
         return "Location Pool"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     @property
     def game_enum(self) -> RandovaniaGame:

--- a/randovania/gui/preset_settings/location_pool_tab.py
+++ b/randovania/gui/preset_settings/location_pool_tab.py
@@ -94,7 +94,7 @@ class PresetLocationPool(PresetTab, Ui_PresetLocationPool, NodeListHelper):
         return "Location Pool"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     @property

--- a/randovania/gui/preset_settings/patcher_energy_tab.py
+++ b/randovania/gui/preset_settings/patcher_energy_tab.py
@@ -79,8 +79,8 @@ class PresetPatcherEnergy(PresetTab, Ui_PresetPatcherEnergy):
         return "Energy"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return True
+    def header_name(cls) -> str | None:
+        return cls.GAME_MODIFICATIONS_HEADER
 
     def on_preset_changed(self, preset: Preset) -> None:
         config = preset.configuration

--- a/randovania/gui/preset_settings/patcher_energy_tab.py
+++ b/randovania/gui/preset_settings/patcher_energy_tab.py
@@ -79,7 +79,7 @@ class PresetPatcherEnergy(PresetTab, Ui_PresetPatcherEnergy):
         return "Energy"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return True
 
     def on_preset_changed(self, preset: Preset) -> None:

--- a/randovania/gui/preset_settings/preset_tab.py
+++ b/randovania/gui/preset_settings/preset_tab.py
@@ -13,6 +13,9 @@ if typing.TYPE_CHECKING:
 
 
 class PresetTab(QtWidgets.QMainWindow):
+    RANDOMIZER_LOGIC_HEADER = "Randomizer Logic"
+    GAME_MODIFICATIONS_HEADER = "Game Modifications"
+
     def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
         super().__init__()
         self._editor = editor
@@ -36,7 +39,8 @@ class PresetTab(QtWidgets.QMainWindow):
         raise NotImplementedError
 
     @classmethod
-    def starts_new_header(cls) -> bool:
+    def header_name(cls) -> str | None:
+        """If this tab starts a new header, returns the name of the header. If it doesn't, returns None."""
         raise NotImplementedError
 
     def on_preset_changed(self, preset: Preset):

--- a/randovania/gui/preset_settings/preset_tab.py
+++ b/randovania/gui/preset_settings/preset_tab.py
@@ -36,7 +36,7 @@ class PresetTab(QtWidgets.QMainWindow):
         raise NotImplementedError
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         raise NotImplementedError
 
     def on_preset_changed(self, preset: Preset):

--- a/randovania/gui/preset_settings/preset_teleporter_tab.py
+++ b/randovania/gui/preset_settings/preset_teleporter_tab.py
@@ -69,8 +69,8 @@ class PresetTeleporterTab(PresetTab, NodeListHelper):
         raise NotImplementedError
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     @property
     def game_enum(self):

--- a/randovania/gui/preset_settings/preset_teleporter_tab.py
+++ b/randovania/gui/preset_settings/preset_teleporter_tab.py
@@ -69,8 +69,8 @@ class PresetTeleporterTab(PresetTab, NodeListHelper):
         raise NotImplementedError
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     @property
     def game_enum(self):

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -69,8 +69,8 @@ class PresetStartingArea(PresetTab, Ui_PresetStartingArea, NodeListHelper):
         return "Starting Area"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
-        return True
+    def starts_new_header(cls) -> bool:
+        return False
 
     @property
     def game_enum(self) -> RandovaniaGame:

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -69,8 +69,8 @@ class PresetStartingArea(PresetTab, Ui_PresetStartingArea, NodeListHelper):
         return "Starting Area"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     @property
     def game_enum(self) -> RandovaniaGame:

--- a/randovania/gui/preset_settings/trick_level_tab.py
+++ b/randovania/gui/preset_settings/trick_level_tab.py
@@ -109,7 +109,7 @@ class PresetTrickLevel(PresetTab, Ui_PresetTrickLevel):
         return "Trick Level"
 
     @classmethod
-    def uses_patches_tab(cls) -> bool:
+    def starts_new_header(cls) -> bool:
         return False
 
     @property

--- a/randovania/gui/preset_settings/trick_level_tab.py
+++ b/randovania/gui/preset_settings/trick_level_tab.py
@@ -110,7 +110,7 @@ class PresetTrickLevel(PresetTab, Ui_PresetTrickLevel):
 
     @classmethod
     def header_name(cls) -> str | None:
-        return None
+        return cls.RANDOMIZER_LOGIC_HEADER
 
     @property
     def game_enum(self) -> RandovaniaGame:

--- a/randovania/gui/preset_settings/trick_level_tab.py
+++ b/randovania/gui/preset_settings/trick_level_tab.py
@@ -109,8 +109,8 @@ class PresetTrickLevel(PresetTab, Ui_PresetTrickLevel):
         return "Trick Level"
 
     @classmethod
-    def starts_new_header(cls) -> bool:
-        return False
+    def header_name(cls) -> str | None:
+        return None
 
     @property
     def game_enum(self) -> RandovaniaGame:

--- a/randovania/gui/ui_files/customize_preset_dialog.ui
+++ b/randovania/gui/ui_files/customize_preset_dialog.ui
@@ -6,16 +6,46 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
-    <height>768</height>
+    <width>952</width>
+    <height>717</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Customize Preset</string>
   </property>
   <layout class="QVBoxLayout" name="root_layout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="name_layout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>6</number>
+     </property>
+     <property name="topMargin">
+      <number>6</number>
+     </property>
+     <property name="rightMargin">
+      <number>6</number>
+     </property>
+     <property name="bottomMargin">
+      <number>6</number>
+     </property>
      <item>
       <widget class="QLabel" name="name_label">
        <property name="text">
@@ -29,60 +59,112 @@
     </layout>
    </item>
    <item>
-    <widget class="QTabWidget" name="main_tab_widget">
-     <property name="tabPosition">
-      <enum>QTabWidget::North</enum>
-     </property>
-     <property name="tabShape">
-      <enum>QTabWidget::Rounded</enum>
-     </property>
-     <property name="currentIndex">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="spacing">
       <number>0</number>
      </property>
-     <property name="documentMode">
-      <bool>true</bool>
-     </property>
-     <property name="tabBarAutoHide">
-      <bool>false</bool>
-     </property>
-     <widget class="QTabWidget" name="logic_tab_widget">
-      <attribute name="title">
-       <string>Randomizer Logic</string>
-      </attribute>
-     </widget>
-     <widget class="QTabWidget" name="patches_tab_widget">
-      <attribute name="title">
-       <string>Game Modifications</string>
-      </attribute>
-     </widget>
-     <widget class="QWidget" name="description_tab_widget">
-      <attribute name="title">
-       <string>Preset Description</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="description_layout">
+     <item>
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
        <item>
-        <widget class="QLabel" name="description_label">
-         <property name="text">
-          <string>Enter a description for your preset below.</string>
+        <widget class="QListWidget" name="listWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="wordWrap">
-          <bool>true</bool>
+         <property name="baseSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::SelectedClicked</set>
+         </property>
+         <property name="flow">
+          <enum>QListView::TopToBottom</enum>
+         </property>
+         <property name="resizeMode">
+          <enum>QListView::Adjust</enum>
+         </property>
+         <property name="spacing">
+          <number>0</number>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QTextEdit" name="description_edit"/>
+        <widget class="Line" name="line_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QStackedWidget" name="stackedWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+        </widget>
        </item>
       </layout>
-     </widget>
-    </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="leftMargin">
+      <number>6</number>
      </property>
-    </widget>
+     <property name="topMargin">
+      <number>6</number>
+     </property>
+     <property name="rightMargin">
+      <number>6</number>
+     </property>
+     <property name="bottomMargin">
+      <number>6</number>
+     </property>
+     <item>
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/randovania/gui/ui_files/preset_customize_description.ui
+++ b/randovania/gui/ui_files/preset_customize_description.ui
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PresetCustomizeDescription</class>
+ <widget class="QMainWindow" name="PresetCustomizeDescription">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>476</width>
+    <height>628</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Door Locks</string>
+  </property>
+  <widget class="QWidget" name="centralWidget">
+   <property name="maximumSize">
+    <size>
+     <width>16777215</width>
+     <height>16777215</height>
+    </size>
+   </property>
+   <layout class="QVBoxLayout" name="main_layout">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="description_label">
+        <property name="text">
+         <string>Enter a description for your preset below.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTextEdit" name="description_edit"/>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This redesigns the customize preset window to remove the nested tabs, and instead use a more familiar list-view-on-the-left-and-content-on-the-right design (surely designers have come up with a name for that).
PR 1 of a few more UI redesigns PRs I'm planning while talking with a few designers.


![grafik](https://github.com/user-attachments/assets/fda5aa36-c9c8-4175-8e6a-e0752e218eb3)


It automatically hides headers if they're not relevant:
![grafik](https://github.com/user-attachments/assets/c0b5c525-2ea4-4744-bd4c-8851ba7fed26)


And also doesn't show experimental tabs (if experimental is disabled):
![grafik](https://github.com/user-attachments/assets/fa4b5bb1-fabb-4deb-be0a-60ae50857042)
![grafik](https://github.com/user-attachments/assets/b8126842-2732-42a3-bff7-dc1f6b1e726c)
