### PR TITLE
MSR: make GUI stuff more consistent

### DIFF
--- a/randovania/games/samus_returns/gui/ui_files/preset_msr_aeion.ui
+++ b/randovania/games/samus_returns/gui/ui_files/preset_msr_aeion.ui
@@ -43,8 +43,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>512</width>
-         <height>432</height>
+         <width>493</width>
+         <height>456</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -54,17 +54,20 @@
         </sizepolicy>
        </property>
        <layout class="QVBoxLayout" name="scroll_area_layout">
+        <property name="spacing">
+         <number>6</number>
+        </property>
         <property name="leftMargin">
-         <number>1</number>
+         <number>6</number>
         </property>
         <property name="topMargin">
-         <number>1</number>
+         <number>6</number>
         </property>
         <property name="rightMargin">
-         <number>1</number>
+         <number>6</number>
         </property>
         <property name="bottomMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
         <item>
          <widget class="QGroupBox" name="groupBox">

--- a/randovania/games/samus_returns/gui/ui_files/preset_msr_energy.ui
+++ b/randovania/games/samus_returns/gui/ui_files/preset_msr_energy.ui
@@ -43,8 +43,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>512</width>
-         <height>432</height>
+         <width>514</width>
+         <height>434</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -55,16 +55,16 @@
        </property>
        <layout class="QVBoxLayout" name="scroll_area_layout">
         <property name="leftMargin">
-         <number>1</number>
+         <number>6</number>
         </property>
         <property name="topMargin">
-         <number>1</number>
+         <number>6</number>
         </property>
         <property name="rightMargin">
-         <number>1</number>
+         <number>6</number>
         </property>
         <property name="bottomMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
         <item>
          <widget class="QGroupBox" name="constant_environment_damage_box">

--- a/randovania/games/samus_returns/gui/ui_files/preset_msr_goal.ui
+++ b/randovania/games/samus_returns/gui/ui_files/preset_msr_goal.ui
@@ -22,16 +22,16 @@
    </property>
    <layout class="QVBoxLayout" name="goal_layout">
     <property name="leftMargin">
-     <number>4</number>
+     <number>6</number>
     </property>
     <property name="topMargin">
-     <number>8</number>
+     <number>6</number>
     </property>
     <property name="rightMargin">
-     <number>4</number>
+     <number>6</number>
     </property>
     <property name="bottomMargin">
-     <number>8</number>
+     <number>6</number>
     </property>
     <item>
      <widget class="QLabel" name="description_label">
@@ -45,8 +45,26 @@
     </item>
     <item>
      <layout class="QHBoxLayout" name="dna_slider_layout">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
       <item>
        <widget class="QSlider" name="dna_slider">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="maximum">
          <number>39</number>
         </property>
@@ -64,14 +82,14 @@
       <item>
        <widget class="QLabel" name="dna_slider_label">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
         <property name="minimumSize">
          <size>
-          <width>20</width>
+          <width>0</width>
           <height>0</height>
          </size>
         </property>
@@ -93,6 +111,12 @@
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <widget class="QRadioButton" name="restrict_placement_radiobutton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>Restricted Placement</string>
          </property>
@@ -100,6 +124,9 @@
        </item>
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="spacing">
+          <number>6</number>
+         </property>
          <property name="leftMargin">
           <number>20</number>
          </property>
@@ -115,6 +142,12 @@
          </item>
          <item>
           <widget class="QCheckBox" name="prefer_metroids_check">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Prefer Standard Metroids (10 Alphas, 9 Gammas, 3 Zetas, 3 Omegas)</string>
            </property>
@@ -122,6 +155,12 @@
          </item>
          <item>
           <widget class="QCheckBox" name="prefer_stronger_metroids_check">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Prefer Stronger Metroids (7 Alpha+, 5 Gamma+, 1 Zeta+, 1 Omega+)</string>
            </property>
@@ -129,6 +168,12 @@
          </item>
          <item>
           <widget class="QCheckBox" name="prefer_bosses_check">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
             <string>Prefer Bosses (Arachnus, Diggernaut Chase Reward, Diggernaut, Queen Metroid)</string>
            </property>
@@ -138,6 +183,12 @@
        </item>
        <item>
         <widget class="QRadioButton" name="free_placement_radiobutton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>Free Placement</string>
          </property>
@@ -159,19 +210,6 @@
        </item>
       </layout>
      </widget>
-    </item>
-    <item>
-     <spacer name="spacer">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>20</width>
-        <height>40</height>
-       </size>
-      </property>
-     </spacer>
     </item>
    </layout>
   </widget>

--- a/randovania/games/samus_returns/gui/ui_files/preset_msr_hints.ui
+++ b/randovania/games/samus_returns/gui/ui_files/preset_msr_hints.ui
@@ -22,16 +22,16 @@
    </property>
    <layout class="QVBoxLayout" name="hint_layout">
     <property name="leftMargin">
-     <number>4</number>
+     <number>6</number>
     </property>
     <property name="topMargin">
-     <number>8</number>
+     <number>6</number>
     </property>
     <property name="rightMargin">
-     <number>4</number>
+     <number>6</number>
     </property>
     <property name="bottomMargin">
-     <number>0</number>
+     <number>6</number>
     </property>
     <item>
      <widget class="QGroupBox" name="hint_artifact_group">

--- a/randovania/games/samus_returns/gui/ui_files/preset_msr_patches.ui
+++ b/randovania/games/samus_returns/gui/ui_files/preset_msr_patches.ui
@@ -46,7 +46,7 @@
      <widget class="QScrollArea" name="scroll_area">
       <property name="minimumSize">
        <size>
-        <width>438</width>
+        <width>0</width>
         <height>0</height>
        </size>
       </property>
@@ -58,8 +58,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>626</width>
-         <height>635</height>
+         <width>621</width>
+         <height>742</height>
         </rect>
        </property>
        <property name="minimumSize">
@@ -70,33 +70,17 @@
        </property>
        <layout class="QVBoxLayout" name="scroll_layout">
         <property name="leftMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
         <property name="topMargin">
-         <number>2</number>
+         <number>6</number>
         </property>
         <property name="rightMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
         <property name="bottomMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
-        <item>
-         <spacer name="top_spacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>8</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
         <item>
          <widget class="QGroupBox" name="environment_group">
           <property name="title">

--- a/randovania/games/samus_returns/gui/ui_files/preset_msr_reserves.ui
+++ b/randovania/games/samus_returns/gui/ui_files/preset_msr_reserves.ui
@@ -46,7 +46,7 @@
      <widget class="QScrollArea" name="scroll_area">
       <property name="minimumSize">
        <size>
-        <width>438</width>
+        <width>0</width>
         <height>0</height>
        </size>
       </property>
@@ -58,7 +58,7 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>498</width>
+         <width>493</width>
          <height>469</height>
         </rect>
        </property>
@@ -70,16 +70,16 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="leftMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
         <property name="topMargin">
-         <number>2</number>
+         <number>6</number>
         </property>
         <property name="rightMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
         <property name="bottomMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
         <item>
          <widget class="QLabel" name="reserve_tank_description">
@@ -104,67 +104,10 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <widget class="QSpinBox" name="energy_capacity_spin_box">
-             <property name="suffix">
-              <string> energy</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>1099</number>
-             </property>
-             <property name="singleStep">
-              <number>10</number>
-             </property>
-             <property name="value">
-              <number>299</number>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QSpinBox" name="aeion_capacity_spin_box">
-             <property name="suffix">
-              <string> aeion</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>2200</number>
-             </property>
-             <property name="singleStep">
-              <number>10</number>
-             </property>
-             <property name="value">
-              <number>500</number>
-             </property>
-            </widget>
-           </item>
            <item row="3" column="0" colspan="2">
             <widget class="Line" name="line_2">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QSpinBox" name="super_missile_capacity_spin_box">
-             <property name="suffix">
-              <string> super missiles</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>99</number>
-             </property>
-             <property name="singleStep">
-              <number>10</number>
-             </property>
-             <property name="value">
-              <number>10</number>
              </property>
             </widget>
            </item>
@@ -182,8 +125,55 @@
              </property>
             </widget>
            </item>
+           <item row="4" column="0" rowspan="2">
+            <widget class="QLabel" name="missile_capacity_label">
+             <property name="text">
+              <string>Missile Reserve Tank</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QSpinBox" name="super_missile_capacity_spin_box">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="wrapping">
+              <bool>true</bool>
+             </property>
+             <property name="frame">
+              <bool>true</bool>
+             </property>
+             <property name="suffix">
+              <string> super missiles</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>99</number>
+             </property>
+             <property name="singleStep">
+              <number>10</number>
+             </property>
+             <property name="value">
+              <number>10</number>
+             </property>
+            </widget>
+           </item>
            <item row="4" column="1">
             <widget class="QSpinBox" name="missile_capacity_spin_box">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="wrapping">
+              <bool>true</bool>
+             </property>
              <property name="suffix">
               <string> missiles</string>
              </property>
@@ -201,10 +191,59 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="0" rowspan="2">
-            <widget class="QLabel" name="missile_capacity_label">
-             <property name="text">
-              <string>Missile Reserve Tank</string>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="aeion_capacity_spin_box">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="wrapping">
+              <bool>true</bool>
+             </property>
+             <property name="suffix">
+              <string> aeion</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>2200</number>
+             </property>
+             <property name="singleStep">
+              <number>10</number>
+             </property>
+             <property name="value">
+              <number>500</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="energy_capacity_spin_box">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="wrapping">
+              <bool>true</bool>
+             </property>
+             <property name="suffix">
+              <string> energy</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>1099</number>
+             </property>
+             <property name="singleStep">
+              <number>10</number>
+             </property>
+             <property name="value">
+              <number>299</number>
              </property>
             </widget>
            </item>

--- a/randovania/games/samus_returns/gui/ui_files/preset_teleporters_msr.ui
+++ b/randovania/games/samus_returns/gui/ui_files/preset_teleporters_msr.ui
@@ -43,22 +43,22 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>503</width>
-         <height>461</height>
+         <width>505</width>
+         <height>463</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="teleporters_layout">
         <property name="leftMargin">
-         <number>4</number>
+         <number>6</number>
         </property>
         <property name="topMargin">
          <number>6</number>
         </property>
         <property name="rightMargin">
-         <number>4</number>
+         <number>6</number>
         </property>
         <property name="bottomMargin">
-         <number>0</number>
+         <number>6</number>
         </property>
         <item>
          <widget class="ScrollProtectedComboBox" name="teleporters_combo"/>
@@ -90,19 +90,19 @@
           </property>
           <layout class="QGridLayout" name="teleporters_source_layout">
            <property name="leftMargin">
-            <number>1</number>
+            <number>6</number>
            </property>
            <property name="topMargin">
-            <number>1</number>
+            <number>6</number>
            </property>
            <property name="rightMargin">
-            <number>1</number>
+            <number>6</number>
            </property>
            <property name="bottomMargin">
-            <number>1</number>
+            <number>6</number>
            </property>
            <property name="spacing">
-            <number>3</number>
+            <number>6</number>
            </property>
           </layout>
          </widget>
@@ -114,19 +114,19 @@
           </property>
           <layout class="QGridLayout" name="teleporters_target_layout">
            <property name="leftMargin">
-            <number>1</number>
+            <number>6</number>
            </property>
            <property name="topMargin">
-            <number>1</number>
+            <number>6</number>
            </property>
            <property name="rightMargin">
-            <number>1</number>
+            <number>6</number>
            </property>
            <property name="bottomMargin">
-            <number>1</number>
+            <number>6</number>
            </property>
            <property name="spacing">
-            <number>3</number>
+            <number>6</number>
            </property>
           </layout>
          </widget>


### PR DESCRIPTION
This is really hard to visualize, idk if the screenshot help. But this was applied to a bunch of MSR ui files in order to have consistent padding/margins.
![grafik](https://github.com/user-attachments/assets/84543737-910a-441c-8167-226b3238a121)
