### PR TITLE
MW: hide generate without retries for non-preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.4.x] - 2024-08-??
 
 - Fixed: The "Last Activity" text on the Multiplayer Session window is not aligned properly.
+- Changed: Generating a Multiworld game without any retries is now locked behind the "preview" command line flag.
 
 ### Metroid Dread
 

--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -225,7 +225,8 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         self.import_layout_action = QtGui.QAction("Import game/spoiler", self.generate_game_menu)
 
         self.generate_game_menu.addAction(self.generate_game_with_spoiler_action)
-        self.generate_game_menu.addAction(self.generate_game_with_spoiler_no_retry_action)
+        if self._window_manager.is_preview_mode:
+            self.generate_game_menu.addAction(self.generate_game_with_spoiler_no_retry_action)
         self.generate_game_menu.addAction(self.generate_game_without_spoiler_action)
         self.generate_game_menu.addAction(self.import_permalink_action)
         self.generate_game_menu.addAction(self.import_layout_action)


### PR DESCRIPTION
Unsure if i should mention in the changelog whether its locked behind preview, or just straight up say its removed.