### PR TITLE
MSR - Area 3 MC Gravitt Garden Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: Area 6 - The Door to Chozo Seal West Intersection Terminal from Crumbling Stairwell is excluded from Door Lock Rando.
 
+#### Area 3 Metroid Caverns
+
+- Fixed: The Grapple block between Letum Shrine and Gravitt Garden can now be removed from both sides.
+
 ## [8.3.x] - 2024-08-??
 
 - Changed: Reduced some visual noise in the main window and customize preset window.

--- a/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.json
@@ -2756,6 +2756,15 @@
                                     }
                                 ]
                             }
+                        },
+                        "Event - Grapple Block": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Grapple",
+                                "amount": 1,
+                                "negate": false
+                            }
                         }
                     }
                 },
@@ -2777,6 +2786,31 @@
                     "valid_starting_location": true,
                     "connections": {
                         "Door to Alpha+ Arena North": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Grapple Block": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -5699.31,
+                        "y": -1339.2,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "Area 3 (Metroid Caverns) - Letum Shrine Grapple Block",
+                    "connections": {
+                        "Below Grapple Point": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 Metroid Caverns.txt
@@ -437,11 +437,19 @@ Extra - asset_id: collision_camera_012
       Morph Ball and Shoot Any Missile
   > Tunnel to Letum Shrine
       Morph Ball and After Area 3 (Metroid Caverns) - Letum Shrine Grapple Block
+  > Event - Grapple Block
+      Grapple Beam
 
 > Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - start_point_actor_name: ST_SG_Alpha_003
   > Door to Alpha+ Arena North
+      Trivial
+
+> Event - Grapple Block; Heals? False
+  * Layers: default
+  * Event Area 3 (Metroid Caverns) - Letum Shrine Grapple Block
+  > Below Grapple Point
       Trivial
 
 ----------------


### PR DESCRIPTION
Adds a missing connection to remove the Grapple block between Leetum Shrine and Gravitt Garden, since the block is only one tile wide and can be destroyed from both sides.