### PR TITLE
fusion: Document tricks and logic in Sector 2

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -3978,6 +3978,27 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Freeze the Ki Hunter - https://youtu.be/LEEYMe7prOA",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Freeze Enemies"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "StandOnFrozenEnemies",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -5055,6 +5076,27 @@
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Freeze the Enemies - https://youtu.be/Zdyr1CPJCr4",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "StandOnFrozenEnemies",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Freeze Enemies"
                                                             }
                                                         ]
                                                     }
@@ -8118,7 +8160,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Freeze the fishies - https://youtu.be/bhR_vlIitqU",
                                             "items": [
                                                 {
                                                     "type": "template",
@@ -8129,6 +8171,41 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "StandOnFrozenEnemies",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Single-Wall Jump with Gravity and Screw Attack - https://youtu.be/3aR9WT-MO9o",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "ScrewAttack",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "GravitySuit",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "WallJump",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -8195,6 +8272,27 @@
                                                         "name": "UnderwaterWallJump",
                                                         "amount": 3,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Freeze the fishies - https://youtu.be/VdAeMqAsquw",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Freeze Enemies"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "StandOnFrozenEnemies",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -3982,7 +3982,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Freeze the Ki Hunter - https://youtu.be/LEEYMe7prOA",
+                                                        "comment": "Freeze the Ki Hunter - https://youtu.be/ZjoyUYi0MtQ",
                                                         "items": [
                                                             {
                                                                 "type": "template",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -3993,7 +3993,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "StandOnFrozenEnemies",
-                                                                    "amount": 2,
+                                                                    "amount": 3,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -8181,7 +8181,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Single-Wall Jump with Gravity and Screw Attack - https://youtu.be/3aR9WT-MO9o",
+                                            "comment": "Single-Wall Jump with Gravity - https://youtu.be/3aR9WT-MO9o",
                                             "items": [
                                                 {
                                                     "type": "template",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -5083,7 +5083,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Freeze the Enemies - https://youtu.be/Zdyr1CPJCr4",
+                                                        "comment": "Freeze the Ki Hunters - https://youtu.be/Zdyr1CPJCr4",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -8184,13 +8184,8 @@
                                             "comment": "Single-Wall Jump with Gravity and Screw Attack - https://youtu.be/3aR9WT-MO9o",
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Can Screw Single Walljump"
                                                 },
                                                 {
                                                     "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -670,7 +670,10 @@ Extra - room_id: [20, 34]
   > Door to Nettori Arena
       All of the following:
           Can Kill Eye Door
-          Wall Jump (Beginner) or Can Climb High Jump Wall
+          Any of the following:
+              Wall Jump (Beginner) or Can Climb High Jump Wall
+              # Freeze the Ki Hunter - https://youtu.be/LEEYMe7prOA
+              Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies
 
 > Door to Shooting Gallery; Heals? False
   * Layers: default
@@ -812,6 +815,8 @@ Extra - room_id: [24, 36]
               # Shinespark up
               Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
               Hi-Jump and Wall Jump (Intermediate)
+              # Freeze the Enemies - https://youtu.be/Zdyr1CPJCr4
+              Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies
 
 ----------------
 Oasis Storage
@@ -1296,13 +1301,18 @@ Extra - room_id: [42]
   > Pickup (Missile Tank)
       Any of the following:
           Can Climb High Jump Wall
+          # Freeze the fishies - https://youtu.be/bhR_vlIitqU
           Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies
+          # Single-Wall Jump with Gravity and Screw Attack - https://youtu.be/3aR9WT-MO9o
+          Gravity Suit and Screw Attack and Wall Jump (Intermediate)
   > Door to Oasis Storage
       All of the following:
           Morph Ball
           Any of the following:
               Underwater Wall Jump (Advanced) or Can Activate Pillar
               Gravity Suit and Hi-Jump
+              # Freeze the fishies - https://youtu.be/VdAeMqAsquw
+              Stand On Frozen Enemies (Beginner) and Can Freeze Enemies
 
 ----------------
 Maintenance Annex

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -815,7 +815,7 @@ Extra - room_id: [24, 36]
               # Shinespark up
               Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
               Hi-Jump and Wall Jump (Intermediate)
-              # Freeze the Enemies - https://youtu.be/Zdyr1CPJCr4
+              # Freeze the Ki Hunters - https://youtu.be/Zdyr1CPJCr4
               Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies
 
 ----------------
@@ -1304,7 +1304,7 @@ Extra - room_id: [42]
           # Freeze the fishies - https://youtu.be/bhR_vlIitqU
           Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies
           # Single-Wall Jump with Gravity and Screw Attack - https://youtu.be/3aR9WT-MO9o
-          Gravity Suit and Screw Attack and Wall Jump (Intermediate)
+          Gravity Suit and Wall Jump (Intermediate) and Can Single Walljump
   > Door to Oasis Storage
       All of the following:
           Morph Ball

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -672,7 +672,7 @@ Extra - room_id: [20, 34]
           Can Kill Eye Door
           Any of the following:
               Wall Jump (Beginner) or Can Climb High Jump Wall
-              # Freeze the Ki Hunter - https://youtu.be/LEEYMe7prOA
+              # Freeze the Ki Hunter - https://youtu.be/ZjoyUYi0MtQ
               Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies
 
 > Door to Shooting Gallery; Heals? False

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -673,7 +673,7 @@ Extra - room_id: [20, 34]
           Any of the following:
               Wall Jump (Beginner) or Can Climb High Jump Wall
               # Freeze the Ki Hunter - https://youtu.be/ZjoyUYi0MtQ
-              Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies
+              Stand On Frozen Enemies (Advanced) and Can Freeze Enemies
 
 > Door to Shooting Gallery; Heals? False
   * Layers: default
@@ -1303,7 +1303,7 @@ Extra - room_id: [42]
           Can Climb High Jump Wall
           # Freeze the fishies - https://youtu.be/bhR_vlIitqU
           Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies
-          # Single-Wall Jump with Gravity and Screw Attack - https://youtu.be/3aR9WT-MO9o
+          # Single-Wall Jump with Gravity - https://youtu.be/3aR9WT-MO9o
           Gravity Suit and Wall Jump (Intermediate) and Can Single Walljump
   > Door to Oasis Storage
       All of the following:


### PR DESCRIPTION
Documents several tricks in Sector 2:
* Nettori Access
  * Accessing the upper half of the room with frozen enemies 
* Oasis
  * Retrieving the item in the room in multiple ways
  * Navigating to Oasis Storage with only frozen enemies
* Overgrown Entrance
  * Using Frozen Ki Hunters as platforms