### PR TITLE
Fusion: a few main deck changes

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -775,8 +775,17 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "ShinesparkTrick",
-                                                        "amount": 2,
+                                                        "amount": 3,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "OpenHatchLockRando",
+                                                        "amount": 1,
+                                                        "negate": true
                                                     }
                                                 }
                                             ]
@@ -2456,6 +2465,27 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Climb up wall",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "WallJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Climb High Jump Wall"
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -2982,7 +3012,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "Movement",
-                                                                    "amount": 2,
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -4332,6 +4362,15 @@
                                                     "data": {
                                                         "type": "misc",
                                                         "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "OpenHatchLockRando",
                                                         "amount": 1,
                                                         "negate": true
                                                     }
@@ -5873,7 +5912,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "ShinesparkTrick",
-                                                        "amount": 2,
+                                                        "amount": 3,
                                                         "negate": false
                                                     }
                                                 },
@@ -7654,6 +7693,23 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
+                        "Door to Scaffolding Access": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Movement",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Door to Silo Save Room": {
                             "type": "and",
                             "data": {
@@ -7695,6 +7751,23 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
+                        "Door to Silo Entry": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Movement",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Door to Silo Save Room": {
                             "type": "and",
                             "data": {
@@ -7760,55 +7833,12 @@
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": "Open the gate. Without Charge, the shot must be precisely timed. With Charge, just let go of beam while in the transition.",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ChargeBeam",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Movement",
-                                                        "amount": 3,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "WideBeam",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Movement",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "ChargeBeam",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     },
                                     {
@@ -7891,6 +7921,41 @@
                                             "name": "ShinesparkTrick",
                                             "amount": 3,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "OpenHatchLockRando",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Without Wave Beam, you have only one attempt.",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "WaveBeam",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "ShinesparkTrick",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -8034,6 +8099,15 @@
                                                     "data": {
                                                         "type": "misc",
                                                         "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "OpenHatchLockRando",
                                                         "amount": 1,
                                                         "negate": true
                                                     }
@@ -8300,7 +8374,7 @@
                                         "data": "Can Kill Tough Beam-Resistant Enemy"
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": "Dodge Pirates: https://www.youtube.com/watch?v=u8_gclW4-gQ",
                                             "items": [
@@ -9930,7 +10004,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "SWJ",
+                                                        "comment": "SWJ - TODO: revisit with HJ only after SWJ is patched",
                                                         "items": [
                                                             {
                                                                 "type": "template",
@@ -10742,6 +10816,13 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
+                        "Door to Habitation Deck Entrance (Middle)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Other to Habitation Ventilation (Lower)": {
                             "type": "or",
                             "data": {

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -132,7 +132,7 @@ Extra - room_id: [7]
           # Skip collecting the item. Break PB blocks first, then reload the room: https://www.youtube.com/watch?v=2WbnkPhd7tk
           Disabled Entrance Rando and Can Bounce in Ball and Can Use Power Bombs
           # Shinespark and spam jump at the ceiling: https://www.youtube.com/watch?v=QpbgjolExgE
-          Speed Booster and Shinespark Tricks (Intermediate) and Disabled Entrance Rando
+          Speed Booster and Shinespark Tricks (Advanced) and Disabled Entrance Rando and Disabled Open Hatch Lock Rando
 
 > Door to Central Hub; Heals? False
   * Layers: default
@@ -396,7 +396,10 @@ Extra - room_id: [14]
   * Open Passage to Eastern Hub/Other to Maintenance Corridor
   * Extra - door_idx: (35,)
   > Other to Arachnus Arena
-      Morph Ball
+      All of the following:
+          Morph Ball
+          # Climb up wall
+          Wall Jump (Beginner) or Can Climb High Jump Wall
 
 ----------------
 Habitation Deck Entrance
@@ -494,7 +497,7 @@ Extra - room_id: [17, 77]
               # Shinespark into the corner
               Shinespark Tricks (Intermediate)
               # Jump mid-speedboost: https://www.youtube.com/watch?v=u3xzqtz6Gro
-              Movement (Intermediate)
+              Movement (Beginner)
           # Get to the item while in the cage
           Space Jump or Wall Jump (Intermediate)
 
@@ -701,7 +704,7 @@ Extra - room_id: [23]
       Any of the following:
           Morph Ball
           # Shinespark from the Navigation Station: https://www.youtube.com/watch?v=QcD2-t9UDrg
-          Speed Booster and Shinespark Tricks (Intermediate) and Disabled Entrance Rando
+          Speed Booster and Shinespark Tricks (Intermediate) and Disabled Entrance Rando and Disabled Open Hatch Lock Rando
   > Door to Quarantine Bay
       Trivial
 
@@ -1000,7 +1003,7 @@ Extra - room_id: [35]
       Any of the following:
           Can Kill Missile Geron
           # Shinespark from Operations Deck: https://www.youtube.com/watch?v=Y3k5lGKTX4Y
-          Level 0 Locks and Speed Booster and After Main Deck Operations Deck Missile Shield and Knowledge (Beginner) and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
+          Level 0 Locks and Speed Booster and After Main Deck Operations Deck Missile Shield and Knowledge (Beginner) and Shinespark Tricks (Advanced) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Other to Operations Maintenance Storage; Heals? False
   * Layers: default
@@ -1323,6 +1326,8 @@ Extra - room_id: [49, 59]
   * Layers: default
   * Open Hatch to Silo Entry/Door to Central Reactor Core
   * Extra - door_idx: (112, 134)
+  > Door to Scaffolding Access
+      Movement (Beginner)
   > Door to Silo Save Room
       Trivial
 
@@ -1330,6 +1335,8 @@ Extra - room_id: [49, 59]
   * Layers: default
   * Open Hatch to Scaffolding Access/Door to Central Reactor Core
   * Extra - door_idx: (113, 136)
+  > Door to Silo Entry
+      Movement (Beginner)
   > Door to Silo Save Room
       Trivial
 
@@ -1340,11 +1347,7 @@ Extra - room_id: [49, 59]
   > Other to Silo Tunnel
       All of the following:
           # Charge shinespark from Auxilary Power Station: https://www.youtube.com/watch?v=vVG5YNwzGjw
-          Speed Booster and Shinespark Tricks (Advanced) and Disabled Entrance Rando
-          Any of the following:
-              # Open the gate. Without Charge, the shot must be precisely timed. With Charge, just let go of beam while in the transition.
-              Charge Beam or Movement (Advanced)
-              Wide Beam and Movement (Intermediate)
+          Charge Beam and Speed Booster and Shinespark Tricks (Advanced) and Disabled Entrance Rando and Disabled Open Hatch Lock Rando
           # Get high enough to spark
           Hi-Jump or Wall Jump (Intermediate)
           Any of the following:
@@ -1352,6 +1355,8 @@ Extra - room_id: [49, 59]
               After Boss Nettori Defeated or Mid-Air Morph (Advanced) or Can Bounce in Ball
               # Jump, then shoot vine below so you can grab the ledge
               Movement (Intermediate)
+          # Without Wave Beam, you have only one attempt.
+          Wave Beam or Shinespark Tricks (Expert)
   > Door to Silo Save Room
       Trivial
 
@@ -1370,7 +1375,7 @@ Extra - room_id: [49, 59]
       Any of the following:
           Space Jump
           # Shinespark from Save Station: https://www.youtube.com/watch?v=x7CqxW4JyJ4
-          Speed Booster and Shinespark Tricks (Beginner) and Disabled Entrance Rando
+          Speed Booster and Shinespark Tricks (Beginner) and Disabled Entrance Rando and Disabled Open Hatch Lock Rando
   > Door to Scaffolding Access
       Wall Jump (Beginner) or Can Climb High Jump Wall
   > Door to Silo Checkpoint
@@ -1422,7 +1427,7 @@ Extra - room_id: [50]
       Any of the following:
           Can Kill Tough Beam-Resistant Enemy
           # Dodge Pirates: https://www.youtube.com/watch?v=u8_gclW4-gQ
-          Space Jump and Combat (Intermediate)
+          Space Jump or Combat (Intermediate)
   > Other to Silo Scaffolding
       # Jump over the item
       Movement (Intermediate)
@@ -1700,7 +1705,7 @@ Extra - room_id: [62]
           Screw Attack
           Any of the following:
               Space Jump
-              # SWJ
+              # SWJ - TODO: revisit with HJ only after SWJ is patched
               Wall Jump (Beginner) and Can Single Walljump
 
 ----------------
@@ -1862,6 +1867,8 @@ Generation gets stuck after giving SJ and speed and trying to reach this event.
 
 > Above Pickup; Heals? False
   * Layers: default
+  > Door to Habitation Deck Entrance (Middle)
+      Trivial
   > Other to Habitation Ventilation (Lower)
       Speed Booster
   > Beside Pickup

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -610,6 +610,10 @@
             "EnemyRando": {
                 "long_name": "Enemy Rando",
                 "extra": {}
+            },
+            "OpenHatchLockRando": {
+                "long_name": "Open Hatch Lock Rando",
+                "extra": {}
             }
         },
         "requirement_template": {


### PR DESCRIPTION
Reactor core now has a platform to allow non-dangerous-nettori traversal. Image in the DB is getting replaced soon:tm:
![grafik](https://github.com/user-attachments/assets/760d8f2b-210d-457c-8ba3-fdc2f1744ff3)

Added a new misc resource for when open transition hatches are not shuffled in DLR (currently thats not implemented, and while the plan is to implement them at one point, no clue when that will be)
Rest should be self explanantory.