### PR TITLE
Main deck: Add missing damage boost to a pirate

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -8246,7 +8246,7 @@
                                         "data": "Can Kill Tough Beam-Resistant Enemy"
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": "Dodge Pirates: https://www.youtube.com/watch?v=QAffTKp5seU",
                                             "items": [
@@ -8258,13 +8258,39 @@
                                                         "amount": 2,
                                                         "negate": false
                                                     }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "SpaceJump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Damage Boost",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DamageBoosts",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "SpaceJump",
-                                                        "amount": 1,
+                                                        "type": "damage",
+                                                        "name": "NormalDamage",
+                                                        "amount": 158,
                                                         "negate": false
                                                     }
                                                 }
@@ -8365,7 +8391,7 @@
                                         "data": "Can Kill Tough Beam-Resistant Enemy"
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": "Dodge Pirates: https://www.youtube.com/watch?v=u8_gclW4-gQ",
                                             "items": [
@@ -8377,13 +8403,39 @@
                                                         "amount": 2,
                                                         "negate": false
                                                     }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "SpaceJump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Damage boost",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DamageBoosts",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "SpaceJump",
-                                                        "amount": 1,
+                                                        "type": "damage",
+                                                        "name": "NormalDamage",
+                                                        "amount": 94,
                                                         "negate": false
                                                     }
                                                 }

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -1405,9 +1405,11 @@ Extra - room_id: [50]
   * Extra - door_idx: (114,)
   > Beside Pickup
       Any of the following:
-          Can Kill Tough Beam-Resistant Enemy
+          Space Jump or Can Kill Tough Beam-Resistant Enemy
           # Dodge Pirates: https://www.youtube.com/watch?v=QAffTKp5seU
-          Space Jump or Combat (Intermediate)
+          Combat (Intermediate)
+          # Damage Boost
+          Damage Boosts (Beginner) and Normal Damage ≥ 158
 
 > Other to Silo Scaffolding; Heals? False
   * Layers: default
@@ -1425,9 +1427,11 @@ Extra - room_id: [50]
       Trivial
   > Door to Central Reactor Core
       Any of the following:
-          Can Kill Tough Beam-Resistant Enemy
+          Space Jump or Can Kill Tough Beam-Resistant Enemy
           # Dodge Pirates: https://www.youtube.com/watch?v=u8_gclW4-gQ
-          Space Jump or Combat (Intermediate)
+          Combat (Intermediate)
+          # Damage boost
+          Damage Boosts (Beginner) and Normal Damage ≥ 94
   > Other to Silo Scaffolding
       # Jump over the item
       Movement (Intermediate)


### PR DESCRIPTION
For when you dont want to dodge it.