### PR TITLE
start clearing AQA notes

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -3270,7 +3270,12 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Any Bombs"
+                                    }
+                                ]
                             }
                         },
                         "Door to Escape Save Room": {
@@ -3307,6 +3312,10 @@
                                             "amount": 2,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Any Bombs"
                                     }
                                 ]
                             }
@@ -3340,23 +3349,6 @@
                             "data": {
                                 "comment": null,
                                 "items": []
-                            }
-                        },
-                        "Beside Pickup": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "MorphBall",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
                             }
                         }
                     }
@@ -4275,15 +4267,6 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "WallJump",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
                                                                     "name": "StandOnFrozenEnemies",
                                                                     "amount": 3,
                                                                     "negate": false
@@ -4301,6 +4284,27 @@
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "GravitySuit",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Screw Single Walljump"
                                                             }
                                                         ]
                                                     }
@@ -4693,12 +4697,73 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "items",
-                                            "name": "ScrewAttack",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "ScrewAttack",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "TODO: add vid",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "SpeedBooster",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "ShinesparkTrick",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLockRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "EntranceRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "L0Locks",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -4776,6 +4841,15 @@
                                             "name": "DoorLockRando",
                                             "amount": 1,
                                             "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "L0Locks",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -5262,66 +5336,6 @@
                                 ]
                             }
                         },
-                        "Other to Waterway": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "SpeedBooster",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "LowerWaterLevel",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": "TODO: Add dmg",
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "GravitySuit",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "DamageRuns",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Other to Breeding Tank Access": {
                             "type": "or",
                             "data": {
@@ -5330,6 +5344,32 @@
                                     {
                                         "type": "template",
                                         "data": "Can Use Any Bombs"
+                                    }
+                                ]
+                            }
+                        },
+                        "Bottom of Room": {
+                            "type": "or",
+                            "data": {
+                                "comment": "todo: damage",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "LowerWaterLevel",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "DamageRuns",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -5459,6 +5499,49 @@
                                     }
                                 ]
                             }
+                        },
+                        "Bottom of Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "todo: damage",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "LowerWaterLevel",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DamageRuns",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -5493,27 +5576,35 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Skultera Sanctuary": {
+                        "Bottom of Room": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "todo: damage",
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "SpeedBooster",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "EntranceRando",
-                                            "amount": 1,
-                                            "negate": true
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpeedBooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -5522,18 +5613,9 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "LowerWaterLevel",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "TODO: damage requirements",
+                                                        "comment": null,
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -5554,6 +5636,15 @@
                                                                 }
                                                             }
                                                         ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "LowerWaterLevel",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -5615,6 +5706,215 @@
                                     {
                                         "type": "template",
                                         "data": "Can Break Single Bomb Blocks"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Bottom of Room": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 512.0,
+                        "y": 89.21567600593522,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
+                        "Door to Skultera Sanctuary": {
+                            "type": "or",
+                            "data": {
+                                "comment": "todo: damage",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "LowerWaterLevel",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "DamageRuns",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Door to Pump Control Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "todo: damage",
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "GravitySuit",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "DamageRuns",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "LowerWaterLevel",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "SpeedBooster",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "ShinesparkTrick",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Climb High Jump Wall"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Other to Waterway": {
+                            "type": "and",
+                            "data": {
+                                "comment": "todo: damage",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "SpeedBooster",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "GravitySuit",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "DamageRuns",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "LowerWaterLevel",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -9420,15 +9720,6 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Missiles",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "or",
                                         "data": {
                                             "comment": null,
@@ -9475,15 +9766,6 @@
                                                                             }
                                                                         }
                                                                     ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "SpaceJump",
-                                                                    "amount": 1,
-                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -10079,26 +10361,60 @@
                                             "comment": "Destroy Geron (Template doesn't work underwater)",
                                             "items": [
                                                 {
-                                                    "type": "and",
+                                                    "type": "or",
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Missiles",
-                                                                    "amount": 3,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Missiles",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "SuperMissileData",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "SuperMissileData",
-                                                                    "amount": 1,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "MorphBall",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "PowerBombs",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -10129,29 +10445,12 @@
                                                                                 "comment": null,
                                                                                 "items": [
                                                                                     {
-                                                                                        "type": "or",
+                                                                                        "type": "resource",
                                                                                         "data": {
-                                                                                            "comment": null,
-                                                                                            "items": [
-                                                                                                {
-                                                                                                    "type": "resource",
-                                                                                                    "data": {
-                                                                                                        "type": "items",
-                                                                                                        "name": "ScrewAttack",
-                                                                                                        "amount": 1,
-                                                                                                        "negate": false
-                                                                                                    }
-                                                                                                },
-                                                                                                {
-                                                                                                    "type": "resource",
-                                                                                                    "data": {
-                                                                                                        "type": "items",
-                                                                                                        "name": "PowerBombs",
-                                                                                                        "amount": 2,
-                                                                                                        "negate": false
-                                                                                                    }
-                                                                                                }
-                                                                                            ]
+                                                                                            "type": "items",
+                                                                                            "name": "ScrewAttack",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
                                                                                         }
                                                                                     },
                                                                                     {
@@ -10864,6 +11163,15 @@
                                                                     "amount": 1,
                                                                     "negate": true
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "L0Locks",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -10987,15 +11295,6 @@
                                                                                 "name": "SpeedBooster",
                                                                                 "amount": 1,
                                                                                 "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "misc",
-                                                                                "name": "DoorLockRando",
-                                                                                "amount": 1,
-                                                                                "negate": true
                                                                             }
                                                                         },
                                                                         {
@@ -11471,12 +11770,46 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Other to Security Access": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "MorphBall",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "GravitySuit",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "UnderwaterWallJump",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -4247,12 +4247,83 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "or",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "SpaceJump",
-                                                                    "amount": 1,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "SpaceJump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Can Screw Single Walljump"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "or",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "and",
+                                                                                                    "data": {
+                                                                                                        "comment": "https://youtu.be/GlJ90IW3FuA",
+                                                                                                        "items": [
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "items",
+                                                                                                                    "name": "Hi-Jump",
+                                                                                                                    "amount": 1,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "tricks",
+                                                                                                                    "name": "WallJump",
+                                                                                                                    "amount": 2,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "and",
+                                                                                                    "data": {
+                                                                                                        "comment": "https://youtu.be/Ed5b1Yl4c68",
+                                                                                                        "items": [
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "tricks",
+                                                                                                                    "name": "WallJump",
+                                                                                                                    "amount": 3,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -4284,27 +4355,6 @@
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "GravitySuit",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Can Screw Single Walljump"
                                                             }
                                                         ]
                                                     }
@@ -4428,8 +4478,34 @@
                                         "data": {
                                             "type": "tricks",
                                             "name": "Combat",
-                                            "amount": 2,
+                                            "amount": 3,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "NormalDamage",
+                                                        "amount": 499,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DamageBoosts",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -4713,7 +4789,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "TODO: add vid",
+                                                        "comment": "https://youtu.be/pKQF2grjqDw",
                                                         "items": [
                                                             {
                                                                 "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -3016,7 +3016,7 @@
                 ]
             },
             "nodes": {
-                "Pickup (Hidden Missile Tank)": {
+                "Pickup (Upper Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -3038,7 +3038,7 @@
                     "pickup_index": 60,
                     "location_category": "minor",
                     "connections": {
-                        "Beside Pickup": {
+                        "Beside Upper Pickup": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3047,7 +3047,7 @@
                         }
                     }
                 },
-                "Pickup (Missile Tank)": {
+                "Pickup (Lower Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -3069,7 +3069,7 @@
                     "pickup_index": 61,
                     "location_category": "minor",
                     "connections": {
-                        "Beside Other Pickup": {
+                        "Beside Lower Pickup": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3196,7 +3196,7 @@
                                 "items": []
                             }
                         },
-                        "Beside Pickup": {
+                        "Beside Upper Pickup": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -3251,12 +3251,12 @@
                         }
                     }
                 },
-                "Beside Pickup": {
+                "Beside Upper Pickup": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 454.64586288416075,
-                        "y": 411.0070921985816,
+                        "x": 454.65,
+                        "y": 411.01,
                         "z": 0.0
                     },
                     "description": "",
@@ -3266,7 +3266,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Pickup (Hidden Missile Tank)": {
+                        "Pickup (Upper Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3290,7 +3290,7 @@
                                 ]
                             }
                         },
-                        "Beside Other Pickup": {
+                        "Beside Lower Pickup": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3322,12 +3322,12 @@
                         }
                     }
                 },
-                "Beside Other Pickup": {
+                "Beside Lower Pickup": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 391.6293144208038,
-                        "y": 253.0950354609929,
+                        "x": 391.63,
+                        "y": 253.1,
                         "z": 0.0
                     },
                     "description": "",
@@ -3337,7 +3337,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Pickup (Missile Tank)": {
+                        "Pickup (Lower Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5427,7 +5427,7 @@
                         "Bottom of Room": {
                             "type": "or",
                             "data": {
-                                "comment": "todo: damage",
+                                "comment": "TODO: damage",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -5593,7 +5593,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "todo: damage",
+                                            "comment": "TODO: damage",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -5655,7 +5655,7 @@
                         "Bottom of Room": {
                             "type": "and",
                             "data": {
-                                "comment": "todo: damage",
+                                "comment": "TODO: damage",
                                 "items": [
                                     {
                                         "type": "and",
@@ -5806,7 +5806,7 @@
                         "Door to Skultera Sanctuary": {
                             "type": "or",
                             "data": {
-                                "comment": "todo: damage",
+                                "comment": "TODO: damage",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -5851,7 +5851,7 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": "todo: damage",
+                                                        "comment": "TODO: damage",
                                                         "items": [
                                                             {
                                                                 "type": "and",
@@ -5938,7 +5938,7 @@
                         "Other to Waterway": {
                             "type": "and",
                             "data": {
-                                "comment": "todo: damage",
+                                "comment": "TODO: damage",
                                 "items": [
                                     {
                                         "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -4412,8 +4412,34 @@
                                         "data": {
                                             "type": "tricks",
                                             "name": "Combat",
-                                            "amount": 2,
+                                            "amount": 3,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "NormalDamage",
+                                                        "amount": 499,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DamageBoosts",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -10413,6 +10413,15 @@
                                                                                 "amount": 2,
                                                                                 "negate": false
                                                                             }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Knowledge",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
                                                                         }
                                                                     ]
                                                                 }

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -11814,6 +11814,15 @@
                                                         "amount": 2,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Hi-Jump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -453,24 +453,24 @@ Extra - room_id: [12]
 Serris Escape
 Extra - map_name: Sector 413
 Extra - room_id: [13]
-> Pickup (Hidden Missile Tank); Heals? False
+> Pickup (Upper Missile Tank); Heals? False
   * Layers: default
   * Pickup 60; Category? Minor
   * Extra - area: 4
   * Extra - room: 13
   * Extra - blockx: 24
   * Extra - blocky: 9
-  > Beside Pickup
+  > Beside Upper Pickup
       Trivial
 
-> Pickup (Missile Tank); Heals? False
+> Pickup (Lower Missile Tank); Heals? False
   * Layers: default
   * Pickup 61; Category? Minor
   * Extra - area: 4
   * Extra - room: 13
   * Extra - blockx: 38
   * Extra - blocky: 15
-  > Beside Other Pickup
+  > Beside Lower Pickup
       Trivial
 
 > Other to Serris Speedway; Heals? False
@@ -493,7 +493,7 @@ Extra - room_id: [13]
   * Extra - door_idx: (117,)
   > Other to Reservoir East
       Trivial
-  > Beside Pickup
+  > Beside Upper Pickup
       Any of the following:
           Can Use Bombs
           All of the following:
@@ -503,18 +503,18 @@ Extra - room_id: [13]
                   # Mid-Air Morph: https://youtu.be/F-XptNF7OOg
                   Mid-Air Morph (Advanced)
 
-> Beside Pickup; Heals? False
+> Beside Upper Pickup; Heals? False
   * Layers: default
-  > Pickup (Hidden Missile Tank)
+  > Pickup (Upper Missile Tank)
       Can Use Any Bombs
   > Door to Escape Save Room
       Can Use Any Bombs
-  > Beside Other Pickup
+  > Beside Lower Pickup
       Missiles ≥ 2 and Morph Ball and Can Use Any Bombs
 
-> Beside Other Pickup; Heals? False
+> Beside Lower Pickup; Heals? False
   * Layers: default
-  > Pickup (Missile Tank)
+  > Pickup (Lower Missile Tank)
       Trivial
   > Door to Escape Save Room
       Trivial
@@ -797,7 +797,7 @@ Extra - room_id: [20]
   > Other to Breeding Tank Access
       Can Use Any Bombs
   > Bottom of Room
-      # todo: damage
+      # TODO: damage
       After Sector 4 Water Level Lowered or Damage Runs (Beginner)
 
 > Door to Pump Control Access; Heals? False
@@ -818,7 +818,7 @@ Extra - room_id: [20]
   > Bottom of Room
       All of the following:
           Morph Ball
-          # todo: damage
+          # TODO: damage
           After Sector 4 Water Level Lowered or Damage Runs (Beginner)
 
 > Other to Waterway; Heals? False
@@ -827,7 +827,7 @@ Extra - room_id: [20]
   * Extra - door_idx: (59,)
   > Bottom of Room
       All of the following:
-          # todo: damage
+          # TODO: damage
           Speed Booster and Disabled Entrance Rando
           Any of the following:
               After Sector 4 Water Level Lowered
@@ -845,13 +845,13 @@ Extra - room_id: [20]
 > Bottom of Room; Heals? False
   * Layers: default
   > Door to Skultera Sanctuary
-      # todo: damage
+      # TODO: damage
       After Sector 4 Water Level Lowered or Damage Runs (Beginner)
   > Door to Pump Control Access
       All of the following:
           Morph Ball
           Any of the following:
-              # todo: damage
+              # TODO: damage
               After Sector 4 Water Level Lowered
               Gravity Suit and Damage Runs (Beginner)
           Any of the following:
@@ -859,7 +859,7 @@ Extra - room_id: [20]
               Speed Booster and Shinespark Tricks (Beginner)
   > Other to Waterway
       All of the following:
-          # todo: damage
+          # TODO: damage
           Speed Booster
           Any of the following:
               After Sector 4 Water Level Lowered

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -672,7 +672,9 @@ Extra - room_id: [17]
   * L0 Hatch to Evir Shaft/Door to Aquarium Tank
   * Extra - door_idx: (38,)
   > Door to Aquarium Shaft West
-      Combat (Intermediate) or Can Kill Tough Beam-Resistant Enemy
+      Any of the following:
+          Combat (Advanced) or Can Kill Tough Beam-Resistant Enemy
+          Damage Boosts (Intermediate) and Normal Damage ≥ 499
 
 > Door to Aquarium Shaft West; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -653,11 +653,19 @@ Extra - room_id: [17]
       All of the following:
           Can Use Power Bombs
           Any of the following:
-              # Use frozen enemies to escape: https://youtu.be/4Msq5vtRTzw
-              Hi-Jump and Stand On Frozen Enemies (Advanced) and Can Freeze Enemies
               All of the following:
                   Gravity Suit
-                  Space Jump or Can Single Walljump
+                  Any of the following:
+                      Space Jump
+                      All of the following:
+                          Can Single Walljump
+                          Any of the following:
+                              # https://youtu.be/GlJ90IW3FuA
+                              Hi-Jump and Wall Jump (Intermediate)
+                              # https://youtu.be/Ed5b1Yl4c68
+                              Wall Jump (Advanced)
+              # Use frozen enemies to escape: https://youtu.be/4Msq5vtRTzw
+              Hi-Jump and Stand On Frozen Enemies (Advanced) and Can Freeze Enemies
 
 > Door to Evir Shaft; Heals? False
   * Layers: default
@@ -673,7 +681,9 @@ Extra - room_id: [17]
   > Pickup (Missile Tank)
       Can Use Power Bombs
   > Door to Evir Shaft
-      Combat (Intermediate) or Can Kill Tough Beam-Resistant Enemy
+      Any of the following:
+          Combat (Advanced) or Can Kill Tough Beam-Resistant Enemy
+          Damage Boosts (Intermediate) and Normal Damage ≥ 499
 
 ----------------
 Aquarium Hub Access
@@ -716,7 +726,7 @@ Extra - room_id: [19]
           Gravity Suit
           Any of the following:
               Screw Attack
-              # TODO: add vid
+              # https://youtu.be/pKQF2grjqDw
               Level 0 Locks and Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Door to Drain Pipe; Heals? False

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -506,11 +506,11 @@ Extra - room_id: [13]
 > Beside Pickup; Heals? False
   * Layers: default
   > Pickup (Hidden Missile Tank)
-      Trivial
+      Can Use Any Bombs
   > Door to Escape Save Room
       Can Use Any Bombs
   > Beside Other Pickup
-      Missiles ≥ 2 and Morph Ball
+      Missiles ≥ 2 and Morph Ball and Can Use Any Bombs
 
 > Beside Other Pickup; Heals? False
   * Layers: default
@@ -518,8 +518,6 @@ Extra - room_id: [13]
       Trivial
   > Door to Escape Save Room
       Trivial
-  > Beside Pickup
-      Morph Ball
 
 ----------------
 Aquarium Shaft West
@@ -655,9 +653,11 @@ Extra - room_id: [17]
       All of the following:
           Can Use Power Bombs
           Any of the following:
-              Gravity Suit and Space Jump
               # Use frozen enemies to escape: https://youtu.be/4Msq5vtRTzw
-              Hi-Jump and Stand On Frozen Enemies (Advanced) and Wall Jump (Intermediate) and Can Freeze Enemies
+              Hi-Jump and Stand On Frozen Enemies (Advanced) and Can Freeze Enemies
+              All of the following:
+                  Gravity Suit
+                  Space Jump or Can Single Walljump
 
 > Door to Evir Shaft; Heals? False
   * Layers: default
@@ -712,14 +712,19 @@ Extra - room_id: [19]
       # Shinespark from adjacent room: https://youtu.be/ID3TOSUmCa8
       Gravity Suit and Level 0 Locks and Speed Booster and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
   > Room Center
-      Gravity Suit and Screw Attack
+      All of the following:
+          Gravity Suit
+          Any of the following:
+              Screw Attack
+              # TODO: add vid
+              Level 0 Locks and Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Door to Drain Pipe; Heals? False
   * Layers: default
   * L0 Hatch to Drain Pipe/Door to Aquarium Hub
   * Extra - door_idx: (90,)
   > Door to Aquarium Speedway
-      Gravity Suit and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+      Gravity Suit and Level 0 Locks and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
   > Room Center
       Any of the following:
           # To destroy Powamp
@@ -779,15 +784,11 @@ Extra - room_id: [20]
               Can Climb High Jump Wall
               # Shinespark up
               Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
-  > Other to Waterway
-      All of the following:
-          Speed Booster
-          Any of the following:
-              After Sector 4 Water Level Lowered
-              # TODO: Add dmg
-              Gravity Suit and Damage Runs (Beginner)
   > Other to Breeding Tank Access
       Can Use Any Bombs
+  > Bottom of Room
+      # todo: damage
+      After Sector 4 Water Level Lowered or Damage Runs (Beginner)
 
 > Door to Pump Control Access; Heals? False
   * Layers: default
@@ -804,17 +805,22 @@ Extra - room_id: [20]
           Gravity Suit or After Sector 4 Water Level Lowered or Can Climb High Jump Wall
   > Other to Breeding Tank Access
       Can Break Single Bomb Blocks
+  > Bottom of Room
+      All of the following:
+          Morph Ball
+          # todo: damage
+          After Sector 4 Water Level Lowered or Damage Runs (Beginner)
 
 > Other to Waterway; Heals? False
   * Layers: default
   * Open Passage to Waterway/Other to Reservoir West
   * Extra - door_idx: (59,)
-  > Door to Skultera Sanctuary
+  > Bottom of Room
       All of the following:
+          # todo: damage
           Speed Booster and Disabled Entrance Rando
           Any of the following:
               After Sector 4 Water Level Lowered
-              # TODO: damage requirements
               Gravity Suit and Damage Runs (Beginner)
 
 > Other to Breeding Tank Access; Heals? False
@@ -825,6 +831,29 @@ Extra - room_id: [20]
       Can Use Any Bombs
   > Door to Pump Control Access
       Can Break Single Bomb Blocks
+
+> Bottom of Room; Heals? False
+  * Layers: default
+  > Door to Skultera Sanctuary
+      # todo: damage
+      After Sector 4 Water Level Lowered or Damage Runs (Beginner)
+  > Door to Pump Control Access
+      All of the following:
+          Morph Ball
+          Any of the following:
+              # todo: damage
+              After Sector 4 Water Level Lowered
+              Gravity Suit and Damage Runs (Beginner)
+          Any of the following:
+              Can Climb High Jump Wall
+              Speed Booster and Shinespark Tricks (Beginner)
+  > Other to Waterway
+      All of the following:
+          # todo: damage
+          Speed Booster
+          Any of the following:
+              After Sector 4 Water Level Lowered
+              Gravity Suit and Damage Runs (Beginner)
 
 ----------------
 Pump Control Access
@@ -1401,20 +1430,18 @@ Extra - room_id: [35]
   > Door to Glass Tube to Sector 2 (TRO)
       Gravity Suit and Screw Attack
   > Upper Ladder
-      All of the following:
-          Missiles
-          Any of the following:
-              All of the following:
-                  # Gravityless method - Need SJ to get out of "air" section
-                  Space Jump and Stand On Frozen Enemies (Beginner) and Can Freeze Enemies
-                  Hi-Jump or Movement (Advanced)
-              All of the following:
-                  # Gravity method
-                  Gravity Suit
-                  Any of the following:
-                      Space Jump
-                      # Shinespark
-                      Level 0 Locks and Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
+      Any of the following:
+          All of the following:
+              # Gravityless method - Need SJ to get out of "air" section
+              Stand On Frozen Enemies (Beginner) and Can Freeze Enemies
+              Hi-Jump or Movement (Advanced)
+          All of the following:
+              # Gravity method
+              Gravity Suit
+              Any of the following:
+                  Space Jump
+                  # Shinespark
+                  Level 0 Locks and Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Door to Glass Tube to Sector 2 (TRO); Heals? False
   * Layers: default
@@ -1490,12 +1517,11 @@ Extra - room_id: [36]
               # Destroy Geron (Template doesn't work underwater)
               Wave Beam
               Missiles ≥ 3 and Super Missile Data
+              Morph Ball and Power Bombs ≥ 2
               All of the following:
                   Gravity Suit
                   Any of the following:
-                      All of the following:
-                          Knowledge (Beginner)
-                          Power Bombs ≥ 2 or Screw Attack
+                      Screw Attack and Knowledge (Beginner)
                       # Run past Geron spawning
                       Movement (Intermediate)
   > Door to Aquarium Storage
@@ -1594,7 +1620,7 @@ Extra - room_id: [38]
           Gravity Suit
           Any of the following:
               Screw Attack
-              Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
+              Level 0 Locks and Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Other to Aquarium Speedway; Heals? False
   * Layers: default
@@ -1609,7 +1635,7 @@ Extra - room_id: [38]
           Any of the following:
               Gravity Suit or Space Jump
               # Shinespark
-              Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+              Speed Booster and Disabled Entrance Rando
               Hi-Jump and Wall Jump (Beginner)
           Any of the following:
               Underwater Wall Jump (Hypermode)
@@ -1666,7 +1692,9 @@ Extra - room_id: [40]
   * L0 Hatch to Sanctuary Cache/Door to Sciser Sanctuary
   * Extra - door_idx: (102,)
   > Other to Security Access
-      Morph Ball
+      All of the following:
+          Morph Ball
+          Gravity Suit or Underwater Wall Jump (Intermediate)
 
 ----------------
 Sanctuary Cache

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -1517,7 +1517,7 @@ Extra - room_id: [36]
               # Destroy Geron (Template doesn't work underwater)
               Wave Beam
               Missiles ≥ 3 and Super Missile Data
-              Morph Ball and Power Bombs ≥ 2
+              Morph Ball and Power Bombs ≥ 2 and Knowledge (Beginner)
               All of the following:
                   Gravity Suit
                   Any of the following:

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -1694,7 +1694,7 @@ Extra - room_id: [40]
   > Other to Security Access
       All of the following:
           Morph Ball
-          Gravity Suit or Underwater Wall Jump (Intermediate)
+          Gravity Suit or Hi-Jump or Underwater Wall Jump (Intermediate)
 
 ----------------
 Sanctuary Cache


### PR DESCRIPTION
- West Reservoir: added a new node to isolate the speedboost block connection
- Serris Escape: added logic for destorying the bomb block chain, removed connection for going back up
- Aquarium Hub: added logic for speedboosting the kago from the right
- Drain Pipe: pulled out the PB method for killing the geron so that it no longer needs grav
- Sciser Sanctuary: added checks for grav and UWJ for leaving the room
- Aquarium Tank: removed walljump trick for climbing back out
- added l0 checks for various speedboosts
- Powamp Shaft: removed space jump from gravityless climbing method connection