### PR TITLE
Few fixes for Planets

### DIFF
--- a/randovania/games/planets_zebeth/exporter/patch_data_factory.py
+++ b/randovania/games/planets_zebeth/exporter/patch_data_factory.py
@@ -27,7 +27,7 @@ class PlanetsZebethPatchDataFactory(PatchDataFactory):
     cosmetic_patches: PlanetsZebethCosmeticPatches
     configuration: PlanetsZebethConfiguration
 
-    def _create_pickups_dict(self, pickup_list: list[ExportedPickupDetails], item_info: dict, rng: Random) -> dict:
+    def _create_pickups_dict(self, pickup_list: list[ExportedPickupDetails], _rng: Random) -> dict:
         pickup_map_dict = {}
         for pickup in pickup_list:
             quantity = pickup.conditional_resources[0].resources[0][1] if not pickup.other_player else 0
@@ -50,12 +50,11 @@ class PlanetsZebethPatchDataFactory(PatchDataFactory):
                 else:
                     pickup_type = pickup.original_pickup.name
 
-            acquired_msg = f"{pickup.name} acquired"
+            acquired_msg = pickup.name
             if not self.players_config.is_multiworld:
-                acquired_msg = item_info[pickup.name]["text_header"].replace(pickup_type, pickup.original_pickup.name)
+                acquired_msg = f"{pickup.original_pickup.name} acquired"
 
             pickup_map_dict[object_id] = {
-                "index": pickup.index.index,
                 "model": pickup.model.name,
                 "type": pickup_type,
                 "quantity": quantity,
@@ -150,8 +149,7 @@ class PlanetsZebethPatchDataFactory(PatchDataFactory):
 
     def create_memo_data(self) -> dict:
         """Used to generate pickup collection messages."""
-        text_data = self._get_item_data()
-        memo_data = {key: value["text_desc"] for key, value in text_data.items()}
+        memo_data = self._get_item_data()
         memo_data["Energy Tank"] = memo_data["Energy Tank"].format(Energy=self.configuration.energy_per_tank)
         return memo_data
 
@@ -167,13 +165,11 @@ class PlanetsZebethPatchDataFactory(PatchDataFactory):
         return pickup_creator.create_visual_nothing(self.game_enum(), "spr_ITEM_Nothing")
 
     def create_game_specific_data(self) -> dict:
-        item_data = self._get_item_data()
-
         pickup_list = self.export_pickup_list()
 
         return {
             "seed": self.description.get_seed_for_player(self.players_config.player_index),
             "game_config": self._create_game_config_dict(),
             "preferences": self._create_cosmetics(),
-            "level_data": {"room": "rm_Zebeth", "pickups": self._create_pickups_dict(pickup_list, item_data, self.rng)},
+            "level_data": {"room": "rm_Zebeth", "pickups": self._create_pickups_dict(pickup_list, self.rng)},
         }

--- a/randovania/games/planets_zebeth/exporter/patch_data_factory.py
+++ b/randovania/games/planets_zebeth/exporter/patch_data_factory.py
@@ -43,14 +43,24 @@ class PlanetsZebethPatchDataFactory(PatchDataFactory):
                 else 0
             )
 
+            pickup_type = "Nothing"
+            if not pickup.other_player:
+                if pickup.original_pickup.name.startswith("Tourian Key"):
+                    pickup_type = "Tourian Key"
+                else:
+                    pickup_type = pickup.original_pickup.name
+
+            acquired_msg = f"{pickup.name} acquired"
+            if not self.players_config.is_multiworld:
+                acquired_msg = item_info[pickup.name]["text_header"].replace(pickup_type, pickup.original_pickup.name)
+
             pickup_map_dict[object_id] = {
+                "index": pickup.index.index,
                 "model": pickup.model.name,
-                "type": pickup.original_pickup.name if not pickup.other_player else "Nothing",
+                "type": pickup_type,
                 "quantity": quantity,
                 "text": {
-                    "header": item_info[pickup.name]["text_header"]
-                    if not self.players_config.is_multiworld
-                    else pickup.name,
+                    "header": acquired_msg,
                     "description": textwrap.wrap(
                         pickup.collection_text[text_index], width=MAX_CHARS_LIMIT_FOR_INGAME_MESSAGE_BOX
                     ),

--- a/randovania/games/planets_zebeth/logic_database/Ridley.json
+++ b/randovania/games/planets_zebeth/logic_database/Ridley.json
@@ -2139,7 +2139,7 @@
                         "default"
                     ],
                     "extra": {
-                        "object_id": 10085
+                        "object_id": 100085
                     },
                     "valid_starting_location": false,
                     "pickup_index": 40,

--- a/randovania/games/planets_zebeth/logic_database/Ridley.txt
+++ b/randovania/games/planets_zebeth/logic_database/Ridley.txt
@@ -414,7 +414,7 @@ Extra - map_name: Ridley/x264_y427
 > Pickup (Boss Key); Heals? False
   * Layers: default
   * Pickup 40; Category? Major
-  * Extra - object_id: 10085
+  * Extra - object_id: 100085
   > Pickup (Big Missile Tank)
       Trivial
 

--- a/randovania/games/planets_zebeth/pickup_database/item_data.json
+++ b/randovania/games/planets_zebeth/pickup_database/item_data.json
@@ -1,70 +1,19 @@
 {
-	"Missile Tank": {
-		"text_desc": "Missile capacity {MissilesChanged} by {Missiles}",
-		"text_header": "Missile Tank acquired"
-	},
-	"Locked Missile Tank": {
-		"text_desc": "Missile capacity {Locked MissilesChanged} by {Locked Missiles} - Launcher still required",
-		"text_header": "Locked Missile Tank acquired"
-	},
-	"Big Missile Tank": {
-		"text_desc": "Missile capacity {MissilesChanged} by {Missiles}",
-		"text_header": "Big Missile Tank acquired"
-	},
-	"Locked Big Missile Tank": {
-		"text_desc": "Missile capacity {Locked MissilesChanged} by {Locked Missiles} - Launcher still required",
-		"text_header": "Locked Big Missile Tank acquired"
-	},
-	"Energy Tank": {
-		"text_desc": "Energy capacity increased by {Energy}",
-		"text_header": "Energy Tank acquired"
-	},
-	"Missile Launcher": {
-		"text_desc": "Missiles can now be fired. Missile capacity {MissilesChanged} by {Missiles}",
-		"text_header": "Missile Launcher acquired"
-	},
-	"Tourian Key": {
-		"text_desc": "Opens Tourian access when all of the keys are retrieved",
-		"text_header": "Tourian Key acquired"
-	},
-	"Bombs": {
-		"text_desc": "While morphed, press shoot to use",
-		"text_header": "Bombs acquired"
-	},
-	"Screw Attack": {
-		"text_desc": "Deal damage to enemies while spinning",
-		"text_header": "Screw Attack acquired"
-	},
-	"Varia Suit": {
-		"text_desc": "Reduces damage taken by 50 percent",
-		"text_header": "Varia Suit acquired"
-	},
-	"Hi-Jump Boots": {
-		"text_desc": "Increased jump height",
-		"text_header": "Hi-Jump Boots acquired"
-	},
-    "Long Beam": {
-		"text_desc": "Beam weapons can travel farther",
-		"text_header": "Long Beam acquired"
-	},
-	"Ice Beam": {
-		"text_desc": "Freeze enemies on contact",
-		"text_header": "Ice Beam acquired"
-	},
-	"Wave Beam": {
-		"text_desc": "Increased damage and passes through walls",
-		"text_header": "Wave Beam acquired"
-	},
-	"Morph Ball": {
-		"text_desc": "Tap down to activate",
-		"text_header": "Morph Ball acquired"
-	},
-	"Nothing": {
-		"text_desc": "A useless item",
-		"text_header": "Nothing acquired"
-	},
-	"Unknown item": {
-		"text_desc": "???",
-		"text_header": "Unknown Item acquired"
-	}
+	"Missile Tank": "Missile capacity {MissilesChanged} by {Missiles}",
+	"Locked Missile Tank": "Missile capacity {Locked MissilesChanged} by {Locked Missiles} - Launcher still required",
+	"Big Missile Tank": "Missile capacity {MissilesChanged} by {Missiles}",
+	"Locked Big Missile Tank": "Missile capacity {Locked MissilesChanged} by {Locked Missiles} - Launcher still required",
+	"Energy Tank": "Energy capacity increased by {Energy}",
+	"Missile Launcher": "Missiles can now be fired. Missile capacity {MissilesChanged} by {Missiles}",
+	"Tourian Key": "Opens Tourian access when all of the keys are retrieved",
+	"Bombs": "While morphed, press shoot to use",
+	"Screw Attack": "Deal damage to enemies while spinning",
+	"Varia Suit": "Reduces damage taken by 50 percent",
+	"Hi-Jump Boots": "Increased jump height",
+    "Long Beam": "Beam weapons can travel farther",
+	"Ice Beam": "Freeze enemies on contact",
+	"Wave Beam": "Increased damage and passes through walls",
+	"Morph Ball": "Tap down to activate",
+	"Nothing": "A useless item",
+	"Unknown item": "???"
 }

--- a/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset/world_1.json
@@ -92,6 +92,7 @@
         "room": "rm_Zebeth",
         "pickups": {
             "100018": {
+                "index": 0,
                 "model": "spr_ITEM_Morph",
                 "type": "Morph Ball",
                 "quantity": 1,
@@ -103,6 +104,7 @@
                 }
             },
             "100027": {
+                "index": 1,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -114,6 +116,7 @@
                 }
             },
             "100028": {
+                "index": 2,
                 "model": "spr_ITEM_Jump_Boots",
                 "type": "Hi-Jump Boots",
                 "quantity": 1,
@@ -125,6 +128,7 @@
                 }
             },
             "100029": {
+                "index": 3,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -136,6 +140,7 @@
                 }
             },
             "100030": {
+                "index": 4,
                 "model": "spr_ITEM_Varia",
                 "type": "Varia Suit",
                 "quantity": 1,
@@ -148,6 +153,7 @@
                 }
             },
             "100031": {
+                "index": 5,
                 "model": "spr_ITEM_Big_Missile",
                 "type": "Big Missile Tank",
                 "quantity": 75,
@@ -159,6 +165,7 @@
                 }
             },
             "100032": {
+                "index": 6,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -170,6 +177,7 @@
                 }
             },
             "100033": {
+                "index": 7,
                 "model": "spr_ITEM_Big_Missile",
                 "type": "Big Missile Tank",
                 "quantity": 75,
@@ -181,6 +189,7 @@
                 }
             },
             "100034": {
+                "index": 8,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -192,6 +201,7 @@
                 }
             },
             "100035": {
+                "index": 9,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -203,6 +213,7 @@
                 }
             },
             "100036": {
+                "index": 10,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -214,6 +225,7 @@
                 }
             },
             "100037": {
+                "index": 11,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -225,6 +237,7 @@
                 }
             },
             "100038": {
+                "index": 12,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -236,6 +249,7 @@
                 }
             },
             "100039": {
+                "index": 13,
                 "model": "spr_ITEM_Bomb",
                 "type": "Bombs",
                 "quantity": 1,
@@ -247,6 +261,7 @@
                 }
             },
             "100040": {
+                "index": 14,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -258,6 +273,7 @@
                 }
             },
             "100041": {
+                "index": 15,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -269,6 +285,7 @@
                 }
             },
             "100042": {
+                "index": 16,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -280,6 +297,7 @@
                 }
             },
             "100043": {
+                "index": 17,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -291,6 +309,7 @@
                 }
             },
             "100044": {
+                "index": 18,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -302,6 +321,7 @@
                 }
             },
             "100045": {
+                "index": 19,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -313,6 +333,7 @@
                 }
             },
             "100046": {
+                "index": 20,
                 "model": "spr_ITEM_Ice_Beam",
                 "type": "Ice Beam",
                 "quantity": 1,
@@ -324,6 +345,7 @@
                 }
             },
             "100047": {
+                "index": 21,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Launcher",
                 "quantity": 5,
@@ -336,6 +358,7 @@
                 }
             },
             "100048": {
+                "index": 22,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -347,6 +370,7 @@
                 }
             },
             "100049": {
+                "index": 23,
                 "model": "spr_ITEM_Long_Beam",
                 "type": "Long Beam",
                 "quantity": 1,
@@ -358,6 +382,7 @@
                 }
             },
             "100050": {
+                "index": 24,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -369,6 +394,7 @@
                 }
             },
             "100051": {
+                "index": 25,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -380,6 +406,7 @@
                 }
             },
             "100052": {
+                "index": 26,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -391,6 +418,7 @@
                 }
             },
             "100053": {
+                "index": 27,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -402,6 +430,7 @@
                 }
             },
             "100054": {
+                "index": 28,
                 "model": "spr_ITEM_Ice_Beam",
                 "type": "Ice Beam",
                 "quantity": 1,
@@ -413,6 +442,7 @@
                 }
             },
             "100055": {
+                "index": 29,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -424,6 +454,7 @@
                 }
             },
             "100056": {
+                "index": 30,
                 "model": "spr_ITEM_Wave_Beam",
                 "type": "Wave Beam",
                 "quantity": 1,
@@ -436,6 +467,7 @@
                 }
             },
             "100057": {
+                "index": 31,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -447,6 +479,7 @@
                 }
             },
             "100058": {
+                "index": 32,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -458,6 +491,7 @@
                 }
             },
             "100059": {
+                "index": 33,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -469,6 +503,7 @@
                 }
             },
             "100060": {
+                "index": 34,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -480,6 +515,7 @@
                 }
             },
             "100061": {
+                "index": 35,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -491,6 +527,7 @@
                 }
             },
             "100062": {
+                "index": 36,
                 "model": "spr_ITEM_Screw_Attack",
                 "type": "Screw Attack",
                 "quantity": 1,
@@ -503,6 +540,7 @@
                 }
             },
             "100063": {
+                "index": 37,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -514,11 +552,12 @@
                 }
             },
             "100083": {
+                "index": 38,
                 "model": "spr_ITEM_Tourian_Key",
-                "type": "Tourian Key 1",
+                "type": "Tourian Key",
                 "quantity": 1,
                 "text": {
-                    "header": "Tourian Key acquired",
+                    "header": "Tourian Key 1 acquired",
                     "description": [
                         "Opens Tourian access when all of",
                         "the keys are retrieved"
@@ -526,6 +565,7 @@
                 }
             },
             "100084": {
+                "index": 39,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -536,12 +576,13 @@
                     ]
                 }
             },
-            "10085": {
+            "100085": {
+                "index": 40,
                 "model": "spr_ITEM_Tourian_Key",
-                "type": "Tourian Key 2",
+                "type": "Tourian Key",
                 "quantity": 1,
                 "text": {
-                    "header": "Tourian Key acquired",
+                    "header": "Tourian Key 2 acquired",
                     "description": [
                         "Opens Tourian access when all of",
                         "the keys are retrieved"
@@ -549,6 +590,7 @@
                 }
             },
             "100086": {
+                "index": 41,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,

--- a/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset/world_1.json
@@ -92,7 +92,6 @@
         "room": "rm_Zebeth",
         "pickups": {
             "100018": {
-                "index": 0,
                 "model": "spr_ITEM_Morph",
                 "type": "Morph Ball",
                 "quantity": 1,
@@ -104,7 +103,6 @@
                 }
             },
             "100027": {
-                "index": 1,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -116,7 +114,6 @@
                 }
             },
             "100028": {
-                "index": 2,
                 "model": "spr_ITEM_Jump_Boots",
                 "type": "Hi-Jump Boots",
                 "quantity": 1,
@@ -128,7 +125,6 @@
                 }
             },
             "100029": {
-                "index": 3,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -140,7 +136,6 @@
                 }
             },
             "100030": {
-                "index": 4,
                 "model": "spr_ITEM_Varia",
                 "type": "Varia Suit",
                 "quantity": 1,
@@ -153,7 +148,6 @@
                 }
             },
             "100031": {
-                "index": 5,
                 "model": "spr_ITEM_Big_Missile",
                 "type": "Big Missile Tank",
                 "quantity": 75,
@@ -165,7 +159,6 @@
                 }
             },
             "100032": {
-                "index": 6,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -177,7 +170,6 @@
                 }
             },
             "100033": {
-                "index": 7,
                 "model": "spr_ITEM_Big_Missile",
                 "type": "Big Missile Tank",
                 "quantity": 75,
@@ -189,7 +181,6 @@
                 }
             },
             "100034": {
-                "index": 8,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -201,7 +192,6 @@
                 }
             },
             "100035": {
-                "index": 9,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -213,7 +203,6 @@
                 }
             },
             "100036": {
-                "index": 10,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -225,7 +214,6 @@
                 }
             },
             "100037": {
-                "index": 11,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -237,7 +225,6 @@
                 }
             },
             "100038": {
-                "index": 12,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -249,7 +236,6 @@
                 }
             },
             "100039": {
-                "index": 13,
                 "model": "spr_ITEM_Bomb",
                 "type": "Bombs",
                 "quantity": 1,
@@ -261,7 +247,6 @@
                 }
             },
             "100040": {
-                "index": 14,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -273,7 +258,6 @@
                 }
             },
             "100041": {
-                "index": 15,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -285,7 +269,6 @@
                 }
             },
             "100042": {
-                "index": 16,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -297,7 +280,6 @@
                 }
             },
             "100043": {
-                "index": 17,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -309,7 +291,6 @@
                 }
             },
             "100044": {
-                "index": 18,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -321,7 +302,6 @@
                 }
             },
             "100045": {
-                "index": 19,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -333,7 +313,6 @@
                 }
             },
             "100046": {
-                "index": 20,
                 "model": "spr_ITEM_Ice_Beam",
                 "type": "Ice Beam",
                 "quantity": 1,
@@ -345,7 +324,6 @@
                 }
             },
             "100047": {
-                "index": 21,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Launcher",
                 "quantity": 5,
@@ -358,7 +336,6 @@
                 }
             },
             "100048": {
-                "index": 22,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -370,7 +347,6 @@
                 }
             },
             "100049": {
-                "index": 23,
                 "model": "spr_ITEM_Long_Beam",
                 "type": "Long Beam",
                 "quantity": 1,
@@ -382,7 +358,6 @@
                 }
             },
             "100050": {
-                "index": 24,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -394,7 +369,6 @@
                 }
             },
             "100051": {
-                "index": 25,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -406,7 +380,6 @@
                 }
             },
             "100052": {
-                "index": 26,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -418,7 +391,6 @@
                 }
             },
             "100053": {
-                "index": 27,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -430,7 +402,6 @@
                 }
             },
             "100054": {
-                "index": 28,
                 "model": "spr_ITEM_Ice_Beam",
                 "type": "Ice Beam",
                 "quantity": 1,
@@ -442,7 +413,6 @@
                 }
             },
             "100055": {
-                "index": 29,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -454,7 +424,6 @@
                 }
             },
             "100056": {
-                "index": 30,
                 "model": "spr_ITEM_Wave_Beam",
                 "type": "Wave Beam",
                 "quantity": 1,
@@ -467,7 +436,6 @@
                 }
             },
             "100057": {
-                "index": 31,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -479,7 +447,6 @@
                 }
             },
             "100058": {
-                "index": 32,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -491,7 +458,6 @@
                 }
             },
             "100059": {
-                "index": 33,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -503,7 +469,6 @@
                 }
             },
             "100060": {
-                "index": 34,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -515,7 +480,6 @@
                 }
             },
             "100061": {
-                "index": 35,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -527,7 +491,6 @@
                 }
             },
             "100062": {
-                "index": 36,
                 "model": "spr_ITEM_Screw_Attack",
                 "type": "Screw Attack",
                 "quantity": 1,
@@ -540,7 +503,6 @@
                 }
             },
             "100063": {
-                "index": 37,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -552,7 +514,6 @@
                 }
             },
             "100083": {
-                "index": 38,
                 "model": "spr_ITEM_Tourian_Key",
                 "type": "Tourian Key",
                 "quantity": 1,
@@ -565,7 +526,6 @@
                 }
             },
             "100084": {
-                "index": 39,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -577,7 +537,6 @@
                 }
             },
             "100085": {
-                "index": 40,
                 "model": "spr_ITEM_Tourian_Key",
                 "type": "Tourian Key",
                 "quantity": 1,
@@ -590,7 +549,6 @@
                 }
             },
             "100086": {
-                "index": 41,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,

--- a/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset_shuffle_keys/world_1.json
+++ b/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset_shuffle_keys/world_1.json
@@ -132,6 +132,7 @@
         "room": "rm_Zebeth",
         "pickups": {
             "100018": {
+                "index": 0,
                 "model": "spr_ITEM_Morph",
                 "type": "Morph Ball",
                 "quantity": 1,
@@ -143,6 +144,7 @@
                 }
             },
             "100027": {
+                "index": 1,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -154,6 +156,7 @@
                 }
             },
             "100028": {
+                "index": 2,
                 "model": "spr_ITEM_Ice_Beam",
                 "type": "Ice Beam",
                 "quantity": 1,
@@ -165,6 +168,7 @@
                 }
             },
             "100029": {
+                "index": 3,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -176,6 +180,7 @@
                 }
             },
             "100030": {
+                "index": 4,
                 "model": "spr_ITEM_Wave_Beam",
                 "type": "Wave Beam",
                 "quantity": 1,
@@ -188,11 +193,12 @@
                 }
             },
             "100031": {
+                "index": 5,
                 "model": "spr_ITEM_Tourian_Key",
-                "type": "Tourian Key 6",
+                "type": "Tourian Key",
                 "quantity": 1,
                 "text": {
-                    "header": "Tourian Key acquired",
+                    "header": "Tourian Key 6 acquired",
                     "description": [
                         "Opens Tourian access when all of",
                         "the keys are retrieved"
@@ -200,6 +206,7 @@
                 }
             },
             "100032": {
+                "index": 6,
                 "model": "spr_ITEM_Ice_Beam",
                 "type": "Ice Beam",
                 "quantity": 1,
@@ -211,11 +218,12 @@
                 }
             },
             "100033": {
+                "index": 7,
                 "model": "spr_ITEM_Tourian_Key",
-                "type": "Tourian Key 8",
+                "type": "Tourian Key",
                 "quantity": 1,
                 "text": {
-                    "header": "Tourian Key acquired",
+                    "header": "Tourian Key 8 acquired",
                     "description": [
                         "Opens Tourian access when all of",
                         "the keys are retrieved"
@@ -223,6 +231,7 @@
                 }
             },
             "100034": {
+                "index": 8,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -234,6 +243,7 @@
                 }
             },
             "100035": {
+                "index": 9,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -245,6 +255,7 @@
                 }
             },
             "100036": {
+                "index": 10,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -256,6 +267,7 @@
                 }
             },
             "100037": {
+                "index": 11,
                 "model": "spr_ITEM_Jump_Boots",
                 "type": "Hi-Jump Boots",
                 "quantity": 1,
@@ -267,6 +279,7 @@
                 }
             },
             "100038": {
+                "index": 12,
                 "model": "spr_ITEM_Long_Beam",
                 "type": "Long Beam",
                 "quantity": 1,
@@ -278,11 +291,12 @@
                 }
             },
             "100039": {
+                "index": 13,
                 "model": "spr_ITEM_Tourian_Key",
-                "type": "Tourian Key 4",
+                "type": "Tourian Key",
                 "quantity": 1,
                 "text": {
-                    "header": "Tourian Key acquired",
+                    "header": "Tourian Key 4 acquired",
                     "description": [
                         "Opens Tourian access when all of",
                         "the keys are retrieved"
@@ -290,6 +304,7 @@
                 }
             },
             "100040": {
+                "index": 14,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -301,6 +316,7 @@
                 }
             },
             "100041": {
+                "index": 15,
                 "model": "spr_ITEM_Big_Missile",
                 "type": "Big Missile Tank",
                 "quantity": 75,
@@ -312,6 +328,7 @@
                 }
             },
             "100042": {
+                "index": 16,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -323,11 +340,12 @@
                 }
             },
             "100043": {
+                "index": 17,
                 "model": "spr_ITEM_Tourian_Key",
-                "type": "Tourian Key 2",
+                "type": "Tourian Key",
                 "quantity": 1,
                 "text": {
-                    "header": "Tourian Key acquired",
+                    "header": "Tourian Key 2 acquired",
                     "description": [
                         "Opens Tourian access when all of",
                         "the keys are retrieved"
@@ -335,11 +353,12 @@
                 }
             },
             "100044": {
+                "index": 18,
                 "model": "spr_ITEM_Tourian_Key",
-                "type": "Tourian Key 3",
+                "type": "Tourian Key",
                 "quantity": 1,
                 "text": {
-                    "header": "Tourian Key acquired",
+                    "header": "Tourian Key 3 acquired",
                     "description": [
                         "Opens Tourian access when all of",
                         "the keys are retrieved"
@@ -347,6 +366,7 @@
                 }
             },
             "100045": {
+                "index": 19,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -358,6 +378,7 @@
                 }
             },
             "100046": {
+                "index": 20,
                 "model": "spr_ITEM_Varia",
                 "type": "Varia Suit",
                 "quantity": 1,
@@ -370,6 +391,7 @@
                 }
             },
             "100047": {
+                "index": 21,
                 "model": "spr_ITEM_Bomb",
                 "type": "Bombs",
                 "quantity": 1,
@@ -381,6 +403,7 @@
                 }
             },
             "100048": {
+                "index": 22,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -392,11 +415,12 @@
                 }
             },
             "100049": {
+                "index": 23,
                 "model": "spr_ITEM_Tourian_Key",
-                "type": "Tourian Key 1",
+                "type": "Tourian Key",
                 "quantity": 1,
                 "text": {
-                    "header": "Tourian Key acquired",
+                    "header": "Tourian Key 1 acquired",
                     "description": [
                         "Opens Tourian access when all of",
                         "the keys are retrieved"
@@ -404,11 +428,12 @@
                 }
             },
             "100050": {
+                "index": 24,
                 "model": "spr_ITEM_Tourian_Key",
-                "type": "Tourian Key 7",
+                "type": "Tourian Key",
                 "quantity": 1,
                 "text": {
-                    "header": "Tourian Key acquired",
+                    "header": "Tourian Key 7 acquired",
                     "description": [
                         "Opens Tourian access when all of",
                         "the keys are retrieved"
@@ -416,6 +441,7 @@
                 }
             },
             "100051": {
+                "index": 25,
                 "model": "spr_ITEM_Big_Missile",
                 "type": "Big Missile Tank",
                 "quantity": 75,
@@ -427,6 +453,7 @@
                 }
             },
             "100052": {
+                "index": 26,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -438,6 +465,7 @@
                 }
             },
             "100053": {
+                "index": 27,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -449,6 +477,7 @@
                 }
             },
             "100054": {
+                "index": 28,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -460,6 +489,7 @@
                 }
             },
             "100055": {
+                "index": 29,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -471,6 +501,7 @@
                 }
             },
             "100056": {
+                "index": 30,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Launcher",
                 "quantity": 5,
@@ -483,6 +514,7 @@
                 }
             },
             "100057": {
+                "index": 31,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -494,6 +526,7 @@
                 }
             },
             "100058": {
+                "index": 32,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -505,6 +538,7 @@
                 }
             },
             "100059": {
+                "index": 33,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -516,6 +550,7 @@
                 }
             },
             "100060": {
+                "index": 34,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -527,6 +562,7 @@
                 }
             },
             "100061": {
+                "index": 35,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -538,6 +574,7 @@
                 }
             },
             "100062": {
+                "index": 36,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -549,6 +586,7 @@
                 }
             },
             "100063": {
+                "index": 37,
                 "model": "spr_ITEM_Screw_Attack",
                 "type": "Screw Attack",
                 "quantity": 1,
@@ -561,11 +599,12 @@
                 }
             },
             "100083": {
+                "index": 38,
                 "model": "spr_ITEM_Tourian_Key",
-                "type": "Tourian Key 9",
+                "type": "Tourian Key",
                 "quantity": 1,
                 "text": {
-                    "header": "Tourian Key acquired",
+                    "header": "Tourian Key 9 acquired",
                     "description": [
                         "Opens Tourian access when all of",
                         "the keys are retrieved"
@@ -573,18 +612,20 @@
                 }
             },
             "100084": {
+                "index": 39,
                 "model": "spr_ITEM_Tourian_Key",
-                "type": "Tourian Key 5",
+                "type": "Tourian Key",
                 "quantity": 1,
                 "text": {
-                    "header": "Tourian Key acquired",
+                    "header": "Tourian Key 5 acquired",
                     "description": [
                         "Opens Tourian access when all of",
                         "the keys are retrieved"
                     ]
                 }
             },
-            "10085": {
+            "100085": {
+                "index": 40,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -596,6 +637,7 @@
                 }
             },
             "100086": {
+                "index": 41,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,

--- a/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset_shuffle_keys/world_1.json
+++ b/test/test_files/patcher_data/planets_zebeth/planets_zebeth/starter_preset_shuffle_keys/world_1.json
@@ -132,7 +132,6 @@
         "room": "rm_Zebeth",
         "pickups": {
             "100018": {
-                "index": 0,
                 "model": "spr_ITEM_Morph",
                 "type": "Morph Ball",
                 "quantity": 1,
@@ -144,7 +143,6 @@
                 }
             },
             "100027": {
-                "index": 1,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -156,7 +154,6 @@
                 }
             },
             "100028": {
-                "index": 2,
                 "model": "spr_ITEM_Ice_Beam",
                 "type": "Ice Beam",
                 "quantity": 1,
@@ -168,7 +165,6 @@
                 }
             },
             "100029": {
-                "index": 3,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -180,7 +176,6 @@
                 }
             },
             "100030": {
-                "index": 4,
                 "model": "spr_ITEM_Wave_Beam",
                 "type": "Wave Beam",
                 "quantity": 1,
@@ -193,7 +188,6 @@
                 }
             },
             "100031": {
-                "index": 5,
                 "model": "spr_ITEM_Tourian_Key",
                 "type": "Tourian Key",
                 "quantity": 1,
@@ -206,7 +200,6 @@
                 }
             },
             "100032": {
-                "index": 6,
                 "model": "spr_ITEM_Ice_Beam",
                 "type": "Ice Beam",
                 "quantity": 1,
@@ -218,7 +211,6 @@
                 }
             },
             "100033": {
-                "index": 7,
                 "model": "spr_ITEM_Tourian_Key",
                 "type": "Tourian Key",
                 "quantity": 1,
@@ -231,7 +223,6 @@
                 }
             },
             "100034": {
-                "index": 8,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -243,7 +234,6 @@
                 }
             },
             "100035": {
-                "index": 9,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -255,7 +245,6 @@
                 }
             },
             "100036": {
-                "index": 10,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -267,7 +256,6 @@
                 }
             },
             "100037": {
-                "index": 11,
                 "model": "spr_ITEM_Jump_Boots",
                 "type": "Hi-Jump Boots",
                 "quantity": 1,
@@ -279,7 +267,6 @@
                 }
             },
             "100038": {
-                "index": 12,
                 "model": "spr_ITEM_Long_Beam",
                 "type": "Long Beam",
                 "quantity": 1,
@@ -291,7 +278,6 @@
                 }
             },
             "100039": {
-                "index": 13,
                 "model": "spr_ITEM_Tourian_Key",
                 "type": "Tourian Key",
                 "quantity": 1,
@@ -304,7 +290,6 @@
                 }
             },
             "100040": {
-                "index": 14,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -316,7 +301,6 @@
                 }
             },
             "100041": {
-                "index": 15,
                 "model": "spr_ITEM_Big_Missile",
                 "type": "Big Missile Tank",
                 "quantity": 75,
@@ -328,7 +312,6 @@
                 }
             },
             "100042": {
-                "index": 16,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -340,7 +323,6 @@
                 }
             },
             "100043": {
-                "index": 17,
                 "model": "spr_ITEM_Tourian_Key",
                 "type": "Tourian Key",
                 "quantity": 1,
@@ -353,7 +335,6 @@
                 }
             },
             "100044": {
-                "index": 18,
                 "model": "spr_ITEM_Tourian_Key",
                 "type": "Tourian Key",
                 "quantity": 1,
@@ -366,7 +347,6 @@
                 }
             },
             "100045": {
-                "index": 19,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -378,7 +358,6 @@
                 }
             },
             "100046": {
-                "index": 20,
                 "model": "spr_ITEM_Varia",
                 "type": "Varia Suit",
                 "quantity": 1,
@@ -391,7 +370,6 @@
                 }
             },
             "100047": {
-                "index": 21,
                 "model": "spr_ITEM_Bomb",
                 "type": "Bombs",
                 "quantity": 1,
@@ -403,7 +381,6 @@
                 }
             },
             "100048": {
-                "index": 22,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -415,7 +392,6 @@
                 }
             },
             "100049": {
-                "index": 23,
                 "model": "spr_ITEM_Tourian_Key",
                 "type": "Tourian Key",
                 "quantity": 1,
@@ -428,7 +404,6 @@
                 }
             },
             "100050": {
-                "index": 24,
                 "model": "spr_ITEM_Tourian_Key",
                 "type": "Tourian Key",
                 "quantity": 1,
@@ -441,7 +416,6 @@
                 }
             },
             "100051": {
-                "index": 25,
                 "model": "spr_ITEM_Big_Missile",
                 "type": "Big Missile Tank",
                 "quantity": 75,
@@ -453,7 +427,6 @@
                 }
             },
             "100052": {
-                "index": 26,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -465,7 +438,6 @@
                 }
             },
             "100053": {
-                "index": 27,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -477,7 +449,6 @@
                 }
             },
             "100054": {
-                "index": 28,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -489,7 +460,6 @@
                 }
             },
             "100055": {
-                "index": 29,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -501,7 +471,6 @@
                 }
             },
             "100056": {
-                "index": 30,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Launcher",
                 "quantity": 5,
@@ -514,7 +483,6 @@
                 }
             },
             "100057": {
-                "index": 31,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -526,7 +494,6 @@
                 }
             },
             "100058": {
-                "index": 32,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -538,7 +505,6 @@
                 }
             },
             "100059": {
-                "index": 33,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -550,7 +516,6 @@
                 }
             },
             "100060": {
-                "index": 34,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -562,7 +527,6 @@
                 }
             },
             "100061": {
-                "index": 35,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -574,7 +538,6 @@
                 }
             },
             "100062": {
-                "index": 36,
                 "model": "spr_ITEM_Energy_Tank",
                 "type": "Energy Tank",
                 "quantity": 1,
@@ -586,7 +549,6 @@
                 }
             },
             "100063": {
-                "index": 37,
                 "model": "spr_ITEM_Screw_Attack",
                 "type": "Screw Attack",
                 "quantity": 1,
@@ -599,7 +561,6 @@
                 }
             },
             "100083": {
-                "index": 38,
                 "model": "spr_ITEM_Tourian_Key",
                 "type": "Tourian Key",
                 "quantity": 1,
@@ -612,7 +573,6 @@
                 }
             },
             "100084": {
-                "index": 39,
                 "model": "spr_ITEM_Tourian_Key",
                 "type": "Tourian Key",
                 "quantity": 1,
@@ -625,7 +585,6 @@
                 }
             },
             "100085": {
-                "index": 40,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,
@@ -637,7 +596,6 @@
                 }
             },
             "100086": {
-                "index": 41,
                 "model": "spr_ITEM_Missile",
                 "type": "Missile Tank",
                 "quantity": 5,


### PR DESCRIPTION
## Fixed internal id for Ridley - Ridley Arena - Pickup(Tourian Key)

The internal id was set to 10085 instead of 100085.

## Fixed Tourian Key not being picked as Tourian Key

The pickup type was set to `Tourian Key #` instead of `Tourian Key`.

## Fixed Tourian Key message not including the number of the key

It would say `Tourian Key acquired` instead of `Tourian Key # acquired`