### PR TITLE
Remove Charge Beam from `Have Any Beam Upgrade` template

### DIFF
--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -1592,15 +1592,6 @@
                                 "type": "resource",
                                 "data": {
                                     "type": "items",
-                                    "name": "ChargeBeam",
-                                    "amount": 1,
-                                    "negate": false
-                                }
-                            },
-                            {
-                                "type": "resource",
-                                "data": {
-                                    "type": "items",
                                     "name": "WideBeam",
                                     "amount": 1,
                                     "negate": false

--- a/randovania/games/fusion/logic_database/header.txt
+++ b/randovania/games/fusion/logic_database/header.txt
@@ -98,7 +98,7 @@ Templates
       Diffusion Missile Data and Ice Missile Data and Missile Data and Super Missile Data
 
 * Have Any Beam Upgrade:
-      Charge Beam or Ice Beam or Plasma Beam or Wave Beam or Wide Beam
+      Ice Beam or Plasma Beam or Wave Beam or Wide Beam
 
 * Can Kill Tough Beam-Weak Enemy:
       Missiles ≥ 5 or Screw Attack or Combat (Intermediate) or Can Freeze Enemies or Can Use Power Bombs or Have Any Beam Upgrade


### PR DESCRIPTION
seems like this was in here by accident? we have a a lot of cases of: `All of: charge + beam upgrade` resulting in a case of having just charge satisfying the requirement. Idk ask Miepee for more details