### PR TITLE
Readme: Mention to uncheck "copy main branch only" on fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Integration written by [Thanatos](https://github.com/ThanatosGit).
 ## Setup
 
 Getting started:
-   1. Clone this repository. (downloading the zip is *not* supported and will not work)
+   1. Clone this repository. If you want to clone your fork, make sure that during the forking process you **uncheck** the `Copy main branch only` checkbox.
    2. Open a terminal in the repository root
    3. Run the following file:
       1. Windows: `tools/prepare_virtual_env.bat`

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Integration written by [Thanatos](https://github.com/ThanatosGit).
 ## Setup
 
 Getting started:
-   1. Clone this repository. If you want to clone your fork, make sure that during the forking process you **uncheck** the `Copy main branch only` checkbox.
+   1. Clone this repository. If you want to clone your fork, make sure that during the forking process you **uncheck** the `Copy main branch only` checkbox. Because the git history is needed, downloading the zip is *not* supported and will not work.
    2. Open a terminal in the repository root
    3. Run the following file:
       1. Windows: `tools/prepare_virtual_env.bat`


### PR DESCRIPTION
it is really unintuitive that we do not mention this anywhere, and even when it fails we only have a vague 
```
if len(self.randovania_version) != 4:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```
message.


Theoretically, we could add a mention on how to add upstream and use its tags should one have forgotten to uncheck it, but if one notices it that early they can just delete the fork and refork.