### PR TITLE
Extra video documentation for the Corruption DB, as well as a few suggestions

### DIFF
--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -1053,7 +1053,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": "Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE",
+                                                                    "comment": null,
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",
@@ -1065,12 +1065,46 @@
                                                                             }
                                                                         },
                                                                         {
-                                                                            "type": "resource",
+                                                                            "type": "or",
                                                                             "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Movement",
-                                                                                "amount": 1,
-                                                                                "negate": false
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "and",
+                                                                                        "data": {
+                                                                                            "comment": "Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE",
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "items",
+                                                                                                        "name": "ScanVisor",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "tricks",
+                                                                                                        "name": "Movement",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Movement",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         }
                                                                     ]

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -1053,7 +1053,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": "https://youtu.be/Z-XICpMJWoE",
+                                                                    "comment": "Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",
@@ -1071,15 +1071,6 @@
                                                                                 "name": "Movement",
                                                                                 "amount": 1,
                                                                                 "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "events",
-                                                                                "name": "Event155",
-                                                                                "amount": 1,
-                                                                                "negate": true
                                                                             }
                                                                         }
                                                                     ]

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -1049,6 +1049,41 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "https://www.youtube.com/watch?v=Z-XICpMJWoE",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "StandableTerrain",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "events",
+                                                                                "name": "Event155",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -696,7 +696,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=9FQFcMIH1vQ",
+                                            "comment": "https://youtu.be/9FQFcMIH1vQ",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -1053,7 +1053,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": "https://www.youtube.com/watch?v=Z-XICpMJWoE",
+                                                                    "comment": "https://youtu.be/Z-XICpMJWoE",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",
@@ -1432,7 +1432,7 @@
                         "Door to Gel Purification Site": {
                             "type": "and",
                             "data": {
-                                "comment": "https://www.youtube.com/watch?v=nQRQKSyq7vU",
+                                "comment": "https://youtu.be/nQRQKSyq7vU",
                                 "items": [
                                     {
                                         "type": "template",
@@ -1705,7 +1705,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=ihLjH0TGkIg",
+                                            "comment": "https://youtu.be/ihLjH0TGkIg",
                                             "items": [
                                                 {
                                                     "type": "and",

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -140,6 +140,8 @@ Extra - asset_id: 4215957264467390882
               Any of the following:
                   After Imperial Hall Grapple Lasso Walls or Bomb/Spring Space Jump (Advanced)
                   Boost Ball and Bomb/Spring Space Jump (Intermediate)
+                  # https://www.youtube.com/watch?v=Z-XICpMJWoE
+                  Before Imperial Hall Grapple Lasso Walls and Movement (Beginner) and Standable Terrain (Beginner)
   > Event - Grapple Lasso Walls
       Grapple Lasso
 

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -140,8 +140,12 @@ Extra - asset_id: 4215957264467390882
               Any of the following:
                   After Imperial Hall Grapple Lasso Walls or Bomb/Spring Space Jump (Advanced)
                   Boost Ball and Bomb/Spring Space Jump (Intermediate)
-                  # Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE
-                  Movement (Beginner) and Standable Terrain (Beginner)
+                  All of the following:
+                      Standable Terrain (Beginner)
+                      Any of the following:
+                          Movement (Intermediate)
+                          # Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE
+                          Scan Visor and Movement (Beginner)
   > Event - Grapple Lasso Walls
       Grapple Lasso
 

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -140,8 +140,8 @@ Extra - asset_id: 4215957264467390882
               Any of the following:
                   After Imperial Hall Grapple Lasso Walls or Bomb/Spring Space Jump (Advanced)
                   Boost Ball and Bomb/Spring Space Jump (Intermediate)
-                  # https://youtu.be/Z-XICpMJWoE
-                  Before Imperial Hall Grapple Lasso Walls and Movement (Beginner) and Standable Terrain (Beginner)
+                  # Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE
+                  Movement (Beginner) and Standable Terrain (Beginner)
   > Event - Grapple Lasso Walls
       Grapple Lasso
 

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -99,7 +99,7 @@ Extra - asset_id: 4215957264467390882
   > Door to Gel Refinery Site
       Any of the following:
           After Imperial Hall Fuel Gel Walls
-          # https://www.youtube.com/watch?v=9FQFcMIH1vQ
+          # https://youtu.be/9FQFcMIH1vQ
           Space Jump Boots and Morph Ball and Bomb/Spring Space Jump (Beginner) and Standable Terrain (Beginner)
   > Event - Fuel Gel Walls
       Charge Beam or Plasma Beam
@@ -140,7 +140,7 @@ Extra - asset_id: 4215957264467390882
               Any of the following:
                   After Imperial Hall Grapple Lasso Walls or Bomb/Spring Space Jump (Advanced)
                   Boost Ball and Bomb/Spring Space Jump (Intermediate)
-                  # https://www.youtube.com/watch?v=Z-XICpMJWoE
+                  # https://youtu.be/Z-XICpMJWoE
                   Before Imperial Hall Grapple Lasso Walls and Movement (Beginner) and Standable Terrain (Beginner)
   > Event - Grapple Lasso Walls
       Grapple Lasso
@@ -201,7 +201,7 @@ Extra - asset_id: 691790544662692104
   * Normal Door to Main Lift/Door to Gel Refinery Site
   * Extra - dock_index: 3
   > Door to Gel Purification Site
-      # https://www.youtube.com/watch?v=nQRQKSyq7vU
+      # https://youtu.be/nQRQKSyq7vU
       Movement (Expert) and Use Screw Attack (Space Jump)
   > Room Center
       Trivial
@@ -237,7 +237,7 @@ Extra - asset_id: 691790544662692104
       All of the following:
           Morph Ball Bomb and Space Jump Boots and Morph Ball
           Any of the following:
-              # https://www.youtube.com/watch?v=ihLjH0TGkIg
+              # https://youtu.be/ihLjH0TGkIg
               Bomb/Spring Space Jump (Expert)
               # https://youtu.be/_sSWzSqM_0g
               Screw Attack and Bomb/Spring Space Jump (Advanced)

--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
@@ -628,7 +628,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=inJ7_pTqlg0",
+                                            "comment": "https://youtu.be/inJ7_pTqlg0",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -911,7 +911,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=gEu-XdXFx8M",
+                                            "comment": "https://youtu.be/gEu-XdXFx8M",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -937,7 +937,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=5E81JfTtv7k",
+                                            "comment": "https://youtu.be/5E81JfTtv7k",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -3347,7 +3347,7 @@
                         "Door to Reliquary III": {
                             "type": "and",
                             "data": {
-                                "comment": "https://www.youtube.com/watch?v=9A-GvQiuUSA",
+                                "comment": "https://youtu.be/9A-GvQiuUSA",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -4358,7 +4358,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=I5LtCOvlR80",
+                                            "comment": "https://youtu.be/I5LtCOvlR80",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -5041,7 +5041,7 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": "https://www.youtube.com/watch?v=bFFKq-oSBJg",
+                                                        "comment": "https://youtu.be/bFFKq-oSBJg",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -5136,7 +5136,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "https://www.youtube.com/watch?v=0h-6eP6M7tY",
+                                                        "comment": "https://youtu.be/0h-6eP6M7tY",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -6287,7 +6287,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "https://www.youtube.com/watch?v=oEPrZMgEPhM",
+                                                        "comment": "https://youtu.be/oEPrZMgEPhM",
                                                         "items": [
                                                             {
                                                                 "type": "template",
@@ -6763,7 +6763,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": "https://www.youtube.com/watch?v=LW0nbio3u78",
+                                                                    "comment": "https://youtu.be/LW0nbio3u78",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",

--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
@@ -4358,7 +4358,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "Get to the ledge at Field Access, then return https://youtu.be/I5LtCOvlR80",
+                                            "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -4370,12 +4370,29 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Knowledge",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": "Get to the ledge at Field Access, then return https://youtu.be/I5LtCOvlR80",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Knowledge",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "EntrRand",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
@@ -628,7 +628,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://youtu.be/eHJKUTiMgO8&t=75",
+                                            "comment": "https://www.youtube.com/watch?v=inJ7_pTqlg0",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -911,7 +911,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "https://www.youtube.com/watch?v=gEu-XdXFx8M",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -4354,6 +4354,32 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "https://www.youtube.com/watch?v=I5LtCOvlR80",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "Event47",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -5015,7 +5041,7 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "https://www.youtube.com/watch?v=bFFKq-oSBJg",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -6737,7 +6763,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": null,
+                                                                    "comment": "https://www.youtube.com/watch?v=LW0nbio3u78",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",

--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
@@ -628,7 +628,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://youtu.be/inJ7_pTqlg0",
+                                            "comment": "Jump on the lip near the ledge and morph at the apex of the jump https://youtu.be/inJ7_pTqlg0",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -4358,7 +4358,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "https://youtu.be/I5LtCOvlR80",
+                                            "comment": "Get to the ledge at Field Access, then return https://youtu.be/I5LtCOvlR80",
                                             "items": [
                                                 {
                                                     "type": "resource",

--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.json
@@ -628,7 +628,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Jump on the lip near the ledge and morph at the apex of the jump https://youtu.be/inJ7_pTqlg0",
+                                            "comment": "Jump on the lip near the ledge https://youtu.be/inJ7_pTqlg0",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -911,7 +911,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://youtu.be/gEu-XdXFx8M",
+                                            "comment": "Jump on the lip close to the Lasso platforms https://youtu.be/gEu-XdXFx8M",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -4379,7 +4379,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "Knowledge",
-                                                                    "amount": 1,
+                                                                    "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -5058,7 +5058,7 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": "https://youtu.be/bFFKq-oSBJg",
+                                                        "comment": "Jump into the corner of the plateau right of the gel morph tunnel https://youtu.be/bFFKq-oSBJg",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -6780,7 +6780,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": "https://youtu.be/LW0nbio3u78",
+                                                                    "comment": "Jump on the right lower statue's shoulder, then SSJ on the left upper statue https://youtu.be/LW0nbio3u78",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",

--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
@@ -98,7 +98,7 @@ Extra - asset_id: 15814834557214288722
   > G.F.S. Theseus Upper Ledge
       Any of the following:
           Morph Ball Bomb and Morph Ball and After G.F.S. Theseus Satellite
-          # https://www.youtube.com/watch?v=inJ7_pTqlg0
+          # https://youtu.be/inJ7_pTqlg0
           Space Jump Boots and Slope Jump (Beginner) and Terminal Fall Abuse (Beginner)
 
 > G.F.S. Theseus Upper Ledge; Heals? False
@@ -134,9 +134,9 @@ Extra - asset_id: 2768064962148517187
               Any of the following:
                   Space Jump Boots and Bomb/Spring Space Jump (Beginner)
                   Morph Ball Bomb and Bomb/Spring Space Jump (Advanced)
-          # https://www.youtube.com/watch?v=gEu-XdXFx8M
+          # https://youtu.be/gEu-XdXFx8M
           Space Jump Boots and Slope Jump (Intermediate)
-          # https://www.youtube.com/watch?v=5E81JfTtv7k
+          # https://youtu.be/5E81JfTtv7k
           Scan Visor and Movement (Advanced)
 
 > Bridge; Heals? False
@@ -478,7 +478,7 @@ Extra - asset_id: 18411620122976788705
   * Normal Door to Grand Court Path/Door to Grand Court
   * Extra - dock_index: 1
   > Door to Reliquary III
-      # https://www.youtube.com/watch?v=9A-GvQiuUSA
+      # https://youtu.be/9A-GvQiuUSA
       Boost Ball and Space Jump Boots and Morph Ball and Bomb/Spring Space Jump (Advanced)
   > Morph Tunnel Ledge
       Trivial
@@ -637,7 +637,7 @@ Extra - asset_id: 6613311822671481119
   > Event - Leviathan Shield
       All of the following:
           After Jungle Generator Ship Missile Attempt and After North Jungle Court Turret and Use Ship Missile
-          # https://www.youtube.com/watch?v=I5LtCOvlR80
+          # https://youtu.be/I5LtCOvlR80
           After South Jungle Court Turret or Knowledge (Beginner)
   > Event - Ship Missile Attempt
       Use Ship Missile
@@ -745,7 +745,7 @@ Extra - asset_id: 14006603351279167667
           All of the following:
               Space Jump Boots
               Any of the following:
-                  # https://www.youtube.com/watch?v=bFFKq-oSBJg
+                  # https://youtu.be/bFFKq-oSBJg
                   Slope Jump (Beginner)
                   Morph Ball and Bomb/Spring Space Jump (Beginner)
   > Door to Ruined Shrine
@@ -755,7 +755,7 @@ Extra - asset_id: 14006603351279167667
           After Hidden Court Burrow Gate
           Any of the following:
               Space Jump Boots or Grapple Swing
-              # https://www.youtube.com/watch?v=0h-6eP6M7tY
+              # https://youtu.be/0h-6eP6M7tY
               Boost Ball and Morph Ball and Bomb/Spring Space Jump (Advanced)
   > Door to Falls of Fire
       Trivial
@@ -926,7 +926,7 @@ Extra - asset_id: 15861154386655212106
           Morph Ball
           Any of the following:
               Boost Ball
-              # https://www.youtube.com/watch?v=oEPrZMgEPhM
+              # https://youtu.be/oEPrZMgEPhM
               Morph Ball Bomb and Bomb/Spring Space Jump (Expert) and Use Screw Attack (Space Jump)
 
 > Pickup (Missile Expansion); Heals? False
@@ -1000,7 +1000,7 @@ Extra - asset_id: 18426339925276965129
               Charge Beam or Missile ≥ 4
               Any of the following:
                   Use Screw Attack (Space Jump)
-                  # https://www.youtube.com/watch?v=LW0nbio3u78
+                  # https://youtu.be/LW0nbio3u78
                   Space Jump Boots and Morph Ball and Bomb/Spring Space Jump (Intermediate)
                   All of the following:
                       Grapple Swing

--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
@@ -98,7 +98,7 @@ Extra - asset_id: 15814834557214288722
   > G.F.S. Theseus Upper Ledge
       Any of the following:
           Morph Ball Bomb and Morph Ball and After G.F.S. Theseus Satellite
-          # https://youtu.be/inJ7_pTqlg0
+          # Jump on the lip near the ledge and morph at the apex of the jump https://youtu.be/inJ7_pTqlg0
           Space Jump Boots and Slope Jump (Beginner) and Terminal Fall Abuse (Beginner)
 
 > G.F.S. Theseus Upper Ledge; Heals? False
@@ -637,7 +637,7 @@ Extra - asset_id: 6613311822671481119
   > Event - Leviathan Shield
       All of the following:
           After Jungle Generator Ship Missile Attempt and After North Jungle Court Turret and Use Ship Missile
-          # https://youtu.be/I5LtCOvlR80
+          # Get to the ledge at Field Access, then return https://youtu.be/I5LtCOvlR80
           After South Jungle Court Turret or Knowledge (Beginner)
   > Event - Ship Missile Attempt
       Use Ship Missile

--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
@@ -637,8 +637,10 @@ Extra - asset_id: 6613311822671481119
   > Event - Leviathan Shield
       All of the following:
           After Jungle Generator Ship Missile Attempt and After North Jungle Court Turret and Use Ship Missile
-          # Get to the ledge at Field Access, then return https://youtu.be/I5LtCOvlR80
-          After South Jungle Court Turret or Knowledge (Beginner)
+          Any of the following:
+              After South Jungle Court Turret
+              # Get to the ledge at Field Access, then return https://youtu.be/I5LtCOvlR80
+              Knowledge (Beginner) and Disabled Entrance Randomizer
   > Event - Ship Missile Attempt
       Use Ship Missile
 

--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
@@ -98,7 +98,7 @@ Extra - asset_id: 15814834557214288722
   > G.F.S. Theseus Upper Ledge
       Any of the following:
           Morph Ball Bomb and Morph Ball and After G.F.S. Theseus Satellite
-          # https://youtu.be/eHJKUTiMgO8&t=75
+          # https://www.youtube.com/watch?v=inJ7_pTqlg0
           Space Jump Boots and Slope Jump (Beginner) and Terminal Fall Abuse (Beginner)
 
 > G.F.S. Theseus Upper Ledge; Heals? False
@@ -134,6 +134,7 @@ Extra - asset_id: 2768064962148517187
               Any of the following:
                   Space Jump Boots and Bomb/Spring Space Jump (Beginner)
                   Morph Ball Bomb and Bomb/Spring Space Jump (Advanced)
+          # https://www.youtube.com/watch?v=gEu-XdXFx8M
           Space Jump Boots and Slope Jump (Intermediate)
           # https://www.youtube.com/watch?v=5E81JfTtv7k
           Scan Visor and Movement (Advanced)
@@ -634,7 +635,10 @@ Extra - asset_id: 6613311822671481119
   > Pickup (Missile Expansion)
       Trivial
   > Event - Leviathan Shield
-      After Jungle Generator Ship Missile Attempt and After North Jungle Court Turret and Use Ship Missile
+      All of the following:
+          After Jungle Generator Ship Missile Attempt and After North Jungle Court Turret and Use Ship Missile
+          # https://www.youtube.com/watch?v=I5LtCOvlR80
+          After South Jungle Court Turret or Knowledge (Beginner)
   > Event - Ship Missile Attempt
       Use Ship Missile
 
@@ -741,6 +745,7 @@ Extra - asset_id: 14006603351279167667
           All of the following:
               Space Jump Boots
               Any of the following:
+                  # https://www.youtube.com/watch?v=bFFKq-oSBJg
                   Slope Jump (Beginner)
                   Morph Ball and Bomb/Spring Space Jump (Beginner)
   > Door to Ruined Shrine
@@ -995,6 +1000,7 @@ Extra - asset_id: 18426339925276965129
               Charge Beam or Missile ≥ 4
               Any of the following:
                   Use Screw Attack (Space Jump)
+                  # https://www.youtube.com/watch?v=LW0nbio3u78
                   Space Jump Boots and Morph Ball and Bomb/Spring Space Jump (Intermediate)
                   All of the following:
                       Grapple Swing

--- a/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Reptilicus.txt
@@ -98,7 +98,7 @@ Extra - asset_id: 15814834557214288722
   > G.F.S. Theseus Upper Ledge
       Any of the following:
           Morph Ball Bomb and Morph Ball and After G.F.S. Theseus Satellite
-          # Jump on the lip near the ledge and morph at the apex of the jump https://youtu.be/inJ7_pTqlg0
+          # Jump on the lip near the ledge https://youtu.be/inJ7_pTqlg0
           Space Jump Boots and Slope Jump (Beginner) and Terminal Fall Abuse (Beginner)
 
 > G.F.S. Theseus Upper Ledge; Heals? False
@@ -134,7 +134,7 @@ Extra - asset_id: 2768064962148517187
               Any of the following:
                   Space Jump Boots and Bomb/Spring Space Jump (Beginner)
                   Morph Ball Bomb and Bomb/Spring Space Jump (Advanced)
-          # https://youtu.be/gEu-XdXFx8M
+          # Jump on the lip close to the Lasso platforms https://youtu.be/gEu-XdXFx8M
           Space Jump Boots and Slope Jump (Intermediate)
           # https://youtu.be/5E81JfTtv7k
           Scan Visor and Movement (Advanced)
@@ -640,7 +640,7 @@ Extra - asset_id: 6613311822671481119
           Any of the following:
               After South Jungle Court Turret
               # Get to the ledge at Field Access, then return https://youtu.be/I5LtCOvlR80
-              Knowledge (Beginner) and Disabled Entrance Randomizer
+              Knowledge (Intermediate) and Disabled Entrance Randomizer
   > Event - Ship Missile Attempt
       Use Ship Missile
 
@@ -747,7 +747,7 @@ Extra - asset_id: 14006603351279167667
           All of the following:
               Space Jump Boots
               Any of the following:
-                  # https://youtu.be/bFFKq-oSBJg
+                  # Jump into the corner of the plateau right of the gel morph tunnel https://youtu.be/bFFKq-oSBJg
                   Slope Jump (Beginner)
                   Morph Ball and Bomb/Spring Space Jump (Beginner)
   > Door to Ruined Shrine
@@ -1002,7 +1002,7 @@ Extra - asset_id: 18426339925276965129
               Charge Beam or Missile ≥ 4
               Any of the following:
                   Use Screw Attack (Space Jump)
-                  # https://youtu.be/LW0nbio3u78
+                  # Jump on the right lower statue's shoulder, then SSJ on the left upper statue https://youtu.be/LW0nbio3u78
                   Space Jump Boots and Morph Ball and Bomb/Spring Space Jump (Intermediate)
                   All of the following:
                       Grapple Swing

--- a/randovania/games/prime3/logic_database/GFS Valhalla.json
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.json
@@ -1613,7 +1613,7 @@
                                                                                     {
                                                                                         "type": "and",
                                                                                         "data": {
-                                                                                            "comment": "https://youtu.be/nd6HL1_2GfA",
+                                                                                            "comment": "Jump on the rubble in the corner between the E-Cell slopes and Repair Bayhttps://youtu.be/nd6HL1_2GfA",
                                                                                             "items": [
                                                                                                 {
                                                                                                     "type": "resource",

--- a/randovania/games/prime3/logic_database/GFS Valhalla.json
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.json
@@ -1051,7 +1051,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": null,
+                                                                    "comment": "https://www.youtube.com/watch?v=qY6QMWgiXoI",
                                                                     "items": [
                                                                         {
                                                                             "type": "template",
@@ -1613,17 +1613,8 @@
                                                                                     {
                                                                                         "type": "and",
                                                                                         "data": {
-                                                                                            "comment": "https://youtu.be/6G8jyu4bkJ4",
+                                                                                            "comment": "https://www.youtube.com/watch?v=nd6HL1_2GfA",
                                                                                             "items": [
-                                                                                                {
-                                                                                                    "type": "resource",
-                                                                                                    "data": {
-                                                                                                        "type": "items",
-                                                                                                        "name": "ScrewAttack",
-                                                                                                        "amount": 1,
-                                                                                                        "negate": false
-                                                                                                    }
-                                                                                                },
                                                                                                 {
                                                                                                     "type": "resource",
                                                                                                     "data": {

--- a/randovania/games/prime3/logic_database/GFS Valhalla.json
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.json
@@ -1613,7 +1613,7 @@
                                                                                     {
                                                                                         "type": "and",
                                                                                         "data": {
-                                                                                            "comment": "Jump on the rubble in the corner between the E-Cell slopes and Repair Bayhttps://youtu.be/nd6HL1_2GfA",
+                                                                                            "comment": "Jump on the rubble in the corner between the E-Cell slopes and Repair Bay https://youtu.be/nd6HL1_2GfA",
                                                                                             "items": [
                                                                                                 {
                                                                                                     "type": "resource",

--- a/randovania/games/prime3/logic_database/GFS Valhalla.json
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.json
@@ -487,7 +487,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=1XqFPtXY90Y",
+                                            "comment": "https://youtu.be/1XqFPtXY90Y",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -1051,7 +1051,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": "https://www.youtube.com/watch?v=qY6QMWgiXoI",
+                                                                    "comment": "https://youtu.be/qY6QMWgiXoI",
                                                                     "items": [
                                                                         {
                                                                             "type": "template",
@@ -1613,7 +1613,7 @@
                                                                                     {
                                                                                         "type": "and",
                                                                                         "data": {
-                                                                                            "comment": "https://www.youtube.com/watch?v=nd6HL1_2GfA",
+                                                                                            "comment": "https://youtu.be/nd6HL1_2GfA",
                                                                                             "items": [
                                                                                                 {
                                                                                                     "type": "resource",

--- a/randovania/games/prime3/logic_database/GFS Valhalla.json
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.json
@@ -1051,7 +1051,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": "https://youtu.be/qY6QMWgiXoI",
+                                                                    "comment": "Hit the bridge with Screw Attack https://youtu.be/qY6QMWgiXoI",
                                                                     "items": [
                                                                         {
                                                                             "type": "template",

--- a/randovania/games/prime3/logic_database/GFS Valhalla.txt
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.txt
@@ -166,6 +166,7 @@ Extra - asset_id: 6410596230384865511
           Space Jump Boots
           Any of the following:
               After Metroid Hatcher (Valhalla)
+              # https://www.youtube.com/watch?v=qY6QMWgiXoI
               Terminal Fall Abuse (Beginner) and Use Screw Attack (Space Jump)
               All of the following:
                   Morph Ball and Bomb/Spring Space Jump (Advanced) and Terminal Fall Abuse (Advanced)
@@ -230,8 +231,8 @@ Extra - asset_id: 7569990525320728426
                       Any of the following:
                           # https://youtu.be/p3LKN-9NaTk?t=5
                           Bomb/Spring Space Jump (Beginner)
-                          # https://youtu.be/6G8jyu4bkJ4
-                          Screw Attack and Slope Jump (Beginner)
+                          # https://www.youtube.com/watch?v=nd6HL1_2GfA
+                          Slope Jump (Beginner)
                   Morph Ball Bomb and Screw Attack and Bomb/Spring Space Jump (Advanced) and Movement (Intermediate)
   > Event - Stairwell Ramps
       All of the following:

--- a/randovania/games/prime3/logic_database/GFS Valhalla.txt
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.txt
@@ -231,7 +231,7 @@ Extra - asset_id: 7569990525320728426
                       Any of the following:
                           # https://youtu.be/p3LKN-9NaTk?t=5
                           Bomb/Spring Space Jump (Beginner)
-                          # Jump on the rubble in the corner between the E-Cell slopes and Repair Bayhttps://youtu.be/nd6HL1_2GfA
+                          # Jump on the rubble in the corner between the E-Cell slopes and Repair Bay https://youtu.be/nd6HL1_2GfA
                           Slope Jump (Beginner)
                   Morph Ball Bomb and Screw Attack and Bomb/Spring Space Jump (Advanced) and Movement (Intermediate)
   > Event - Stairwell Ramps

--- a/randovania/games/prime3/logic_database/GFS Valhalla.txt
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.txt
@@ -166,7 +166,7 @@ Extra - asset_id: 6410596230384865511
           Space Jump Boots
           Any of the following:
               After Metroid Hatcher (Valhalla)
-              # https://youtu.be/qY6QMWgiXoI
+              # Hit the bridge with Screw Attack https://youtu.be/qY6QMWgiXoI
               Terminal Fall Abuse (Beginner) and Use Screw Attack (Space Jump)
               All of the following:
                   Morph Ball and Bomb/Spring Space Jump (Advanced) and Terminal Fall Abuse (Advanced)

--- a/randovania/games/prime3/logic_database/GFS Valhalla.txt
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.txt
@@ -231,7 +231,7 @@ Extra - asset_id: 7569990525320728426
                       Any of the following:
                           # https://youtu.be/p3LKN-9NaTk?t=5
                           Bomb/Spring Space Jump (Beginner)
-                          # https://youtu.be/nd6HL1_2GfA
+                          # Jump on the rubble in the corner between the E-Cell slopes and Repair Bayhttps://youtu.be/nd6HL1_2GfA
                           Slope Jump (Beginner)
                   Morph Ball Bomb and Screw Attack and Bomb/Spring Space Jump (Advanced) and Movement (Intermediate)
   > Event - Stairwell Ramps

--- a/randovania/games/prime3/logic_database/GFS Valhalla.txt
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.txt
@@ -70,7 +70,7 @@ Extra - asset_id: 10896162079835248148
   > Door to Security Station
       Any of the following:
           Space Jump Boots
-          # https://www.youtube.com/watch?v=1XqFPtXY90Y
+          # https://youtu.be/1XqFPtXY90Y
           Boost Ball and Morph Ball and Bomb/Spring Space Jump (Intermediate)
 
 > Door to Stairwell; Heals? False
@@ -166,7 +166,7 @@ Extra - asset_id: 6410596230384865511
           Space Jump Boots
           Any of the following:
               After Metroid Hatcher (Valhalla)
-              # https://www.youtube.com/watch?v=qY6QMWgiXoI
+              # https://youtu.be/qY6QMWgiXoI
               Terminal Fall Abuse (Beginner) and Use Screw Attack (Space Jump)
               All of the following:
                   Morph Ball and Bomb/Spring Space Jump (Advanced) and Terminal Fall Abuse (Advanced)
@@ -231,7 +231,7 @@ Extra - asset_id: 7569990525320728426
                       Any of the following:
                           # https://youtu.be/p3LKN-9NaTk?t=5
                           Bomb/Spring Space Jump (Beginner)
-                          # https://www.youtube.com/watch?v=nd6HL1_2GfA
+                          # https://youtu.be/nd6HL1_2GfA
                           Slope Jump (Beginner)
                   Morph Ball Bomb and Screw Attack and Bomb/Spring Space Jump (Advanced) and Movement (Intermediate)
   > Event - Stairwell Ramps

--- a/randovania/games/prime3/logic_database/header.json
+++ b/randovania/games/prime3/logic_database/header.json
@@ -1275,6 +1275,10 @@
             "SkipCells": {
                 "long_name": "Skipping Energy Cells",
                 "extra": {}
+            },
+            "EntrRand": {
+                "long_name": "Entrance Randomizer",
+                "extra": {}
             }
         },
         "requirement_template": {


### PR DESCRIPTION
While this PR is mostly about adding new strat vids or replacing the existing ones with (hopefully) more catered towards rando strats, I've also taken the liberty of modifying some existing logic which I will list below : 

# Bryyo - Fire
## Imperial Hall
 - Front of Lasso Walls -> Pickup (Missile Expansion) : 
 Added a new trick to reach the item pickup with a standable ; Beginner Standable Terrain and Movement, with video

# Bryyo - Reptilicus
## Crash Site
 - G.F.S Theseus Lower Ledge -> G.F.S Theseus Upper Ledge - Beginner Slope Jump and Terminal Fall Abuse : 
 Replaced the existing video with a fully dedicated strat vid
## Gateway Hall
 - Door to Gateway -> Bridge - Intermediate Slope Jump : 
 Added strat vid
## Jungle Generator
 - Room Center -> Event - Leviathan Shield : 
 Added either beginner knowledge or After South Jungle Court Turret to existing conditions;
 I don't think it's fair to expect completely new players to know that Jungle Court South can be skipped entirely, or how to destroy the generator after the skip. Also added video on how to do that
## Hidden Court
 - Bottom Floor -> Door to Hidden Court Hall - Beginner Slope Jump :
 Added strat vid
## Ruined Shrine
 - Door to Hidden Court -> Door to Hangar Bay - Space Jump and Morph Ball and Bomb/Spring Space Jump (Intermediate) :
 Added strat vid

# G.F.S Valhalla
## Stairwell
 - Door to Repair Bay -> Door to Weapons Cache - Beginner Slope Jump :
 Added strat vid and removed Screw Attack requirement (new vid doesn't use it)
## Aurora Chamber
 - Door to Aurora Access -> Door to Control Room Access - Beginner Terminal Fall Abuse :
 Added strat vid

I will also drop a few more general suggestions/Comments here : 
 - For quite a few strat vids I recorded, I used scan visor to gain to properties of L-Movement to make it easier and more consistent, especially when it comes to Slope Jumps. While most of the time it isn't necessary, it does make the trick much easier to perform. I'm not sure whether this should be accounted for by the logic? Also considering some rooms might not have ennemies as a substitute for a scan point, Scan Visor might also end up being an additionnal requirement in these rooms. Maybe a template like "Can use Lock-On movement" could be helpful if we decide to account for this factor?
 - Some of the added videos added are there to replace others that were already here, but those that got replaced were usually speedrun strat videos that didn't really take the time to show what exactly is being used (and often were longer than necessary), or showed a faster, but harder way to perform the same trick, which might not reflect the expected trick setting