### PR TITLE
Fusion: hack very dangerous ponrs

### DIFF
--- a/randovania/games/fusion/generator/bootstrap.py
+++ b/randovania/games/fusion/generator/bootstrap.py
@@ -32,6 +32,7 @@ class FusionBootstrap(MetroidBootstrap):
         if configuration.dock_rando.is_enabled():
             enabled_resources.add("DoorLockRando")
         enabled_resources.add("BomblessPBs")
+        enabled_resources.add("GeneratorHack")
         return enabled_resources
 
     def assign_pool_results(self, rng: Random, patches: GamePatches, pool_results: PoolResults) -> GamePatches:

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -1820,12 +1820,8 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Destroy bomb blocks with SJ: https://youtu.be/3taYvq79AmA",
+                                            "comment": "Destroy bomb blocks and go up with SJ",
                                             "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Use Any Bombs"
-                                                },
                                                 {
                                                     "type": "resource",
                                                     "data": {
@@ -1836,12 +1832,36 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "MidAirMorph",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Destroy via mid air morph: https://youtu.be/3taYvq79AmA",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "MidAirMorph",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Use Bombs"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Power Bombs"
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -9203,7 +9223,7 @@
                         "y": 188.0,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "FIXME: Collecting the pump event is by the generator definition not considered\nsafe. The generator workaround is assuming here that if you reach this PonR,\nthat you were able to collect the event.",
                     "layers": [
                         "default"
                     ],
@@ -9262,6 +9282,15 @@
                                                                                 "amount": 1,
                                                                                 "negate": false
                                                                             }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "GeneratorHack",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
                                                                         }
                                                                     ]
                                                                 }
@@ -9311,6 +9340,15 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "GeneratorHack",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -9351,6 +9389,15 @@
                                                                 "data": {
                                                                     "type": "events",
                                                                     "name": "LowerWaterLevel",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "GeneratorHack",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -261,8 +261,13 @@ Extra - room_id: [6]
                   Hi-Jump
                   # NHJ: https://youtu.be/6RhuTs1mD1c
                   Movement (Intermediate)
-          # Destroy bomb blocks with SJ: https://youtu.be/3taYvq79AmA
-          Space Jump and Mid-Air Morph (Beginner) and Can Use Any Bombs
+          All of the following:
+              # Destroy bomb blocks and go up with SJ
+              Space Jump
+              Any of the following:
+                  Can Use Power Bombs
+                  # Destroy via mid air morph: https://youtu.be/3taYvq79AmA
+                  Mid-Air Morph (Beginner) and Can Use Bombs
           All of the following:
               # Speedboost through blocks
               Speed Booster
@@ -1376,6 +1381,9 @@ Extra - room_id: [33]
 
 > Next to Pickup; Heals? False
   * Layers: default
+  * FIXME: Collecting the pump event is by the generator definition not considered
+safe. The generator workaround is assuming here that if you reach this PonR,
+that you were able to collect the event.
   > Pickup (Missile Tank)
       Trivial
   > Door to Pump Control Access
@@ -1385,17 +1393,17 @@ Extra - room_id: [33]
               Can Use Springball
               All of the following:
                   Can Use Bombs
-                  Gravity Suit or After Sector 4 Water Level Lowered
+                  Gravity Suit or After Sector 4 Water Level Lowered or Enabled Generator Workaround
           Any of the following:
               # Get through water
-              After Sector 4 Water Level Lowered
+              After Sector 4 Water Level Lowered or Enabled Generator Workaround
               Damage Runs (Beginner) and Electrified Water Damage ≥ 15
   > Behind Speed Blocks
       Any of the following:
           Can Use Springball
           All of the following:
               Can Use Bombs
-              Gravity Suit or After Sector 4 Water Level Lowered
+              Gravity Suit or After Sector 4 Water Level Lowered or Enabled Generator Workaround
 
 ----------------
 Security Bypass

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -6802,6 +6802,49 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "FIXME: generator trap, where it goes here and then gets stuck and frantically places items.",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "GeneratorHack",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "Nightmare",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 5,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -1113,6 +1113,10 @@ Extra - room_id: [34]
                   Mid-Air Morph (Advanced) or Can Use Springball
               # 100% strat, crumble block side: https://youtu.be/uUAoOZGU9HI
               Movement (Advanced)
+          All of the following:
+              # FIXME: generator trap, where it goes here and then gets stuck and frantically places items.
+              Enabled Generator Workaround
+              After Boss Nightmare Defeated or Movement (Hypermode)
   > Other to Nightmare Arena
       Morph Ball
 

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -2756,6 +2756,49 @@
                                             "amount": 1,
                                             "negate": true
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "FIXME: generator gets stuck and doesn't know what to place to get out",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "GeneratorHack",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "ChargeBeam",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "ShinesparkTrick",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -378,8 +378,13 @@ Extra - room_id: [9]
   * L0 Hatch to Nocturnal Playground/Door to Clogged Cavern
   * Extra - door_idx: (17, 72)
   > Door to Cavern Save Access
-      # This can safely not have Door Lock Rando check
-      Speed Booster and Disabled Entrance Rando
+      All of the following:
+          # This can safely not have Door Lock Rando check
+          Speed Booster and Disabled Entrance Rando
+          All of the following:
+              # FIXME: generator gets stuck and doesn't know what to place to get out
+              Enabled Generator Workaround
+              Charge Beam or Shinespark Tricks (Intermediate)
 
 > Door to Shell Access; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -720,6 +720,12 @@
             "BomblessPBs": {
                 "long_name": "Power Bombs Without Bombs",
                 "extra": {}
+            },
+            "GeneratorHack": {
+                "long_name": "Generator Workaround",
+                "extra": {
+                    "description": "A resource for working around current shortcomings in the generator"
+                }
             }
         },
         "requirement_template": {


### PR DESCRIPTION
This PR avoids 3 very bad pitfalls for the generator right now: water pump, a5 nightmare nook, a6 shell access/zozoro wine cellar

Water pump is now a safe action for the generator
Nightmare nook and lower left a6 we stop the generator from going there unless it can get out, as the generator there is unable to see what it needs to get out and spends ~10 actions just frantically placing arbitrary items

A6 is still a bit of an issue, but now it takes way less actions to get out if it gets stuck there. 

Also adds a trickless path to exit a4 with PBs+SJ