### PR TITLE
Bump OSRR to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid: Samus Returns
 
 - Added: Option to change the final boss to be Arachnus, Diggernaut, Metroid Queen, or Proteus Ridley (default).
+- Changed: The DNA counter on the HUD now counts down to 0 from the amount DNA that is required to access the final boss instead of counting up to 39.
 
 ## [8.4.0] - 2024-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: Option to change the final boss to be Arachnus, Diggernaut, Metroid Queen, or Proteus Ridley (default).
 - Changed: The DNA counter on the HUD now counts down to 0 from the amount DNA that is required to access the final boss instead of counting up to 39.
+- Changed: The automatic item tracker now shows the collected DNA out of the required DNA.
 
 ## [8.4.0] - 2024-09-04
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ exporters = [
     "mp2hudcolor>=1.0.10",
 
     # Metroid: Samus Returns
-    "open-samus-returns-rando>=2.5.0",
+    "open-samus-returns-rando>=2.6.0",
 
     # Super Metroid
     "SuperDuperMetroid>=1.2.0",

--- a/randovania/data/gui_assets/tracker/samus-returns-game-progressive.json
+++ b/randovania/data/gui_assets/tracker/samus-returns-game-progressive.json
@@ -63,8 +63,7 @@
         { "row": 6, "column": 2, "resources": ["Missile Reserve Tank"], "image_path": "gui_assets/tracker/game-images/samus_returns/Missile Reserve Tank.png"},
         { "row": 6, "column": 3, "resources": ["Baby Metroid"], "image_path": "gui_assets/tracker/game-images/samus_returns/Baby.png"},
         { "row": 6, "column": 4, "resources": [], "image_path": "gui_assets/tracker/game-images/samus_returns/DNA.png" },
-        { "row": 7, "column": 4, "label": "x {capacity}/{max_capacity}", "resources": [
-            "Metroid DNA 1", "Metroid DNA 2", "Metroid DNA 3", "Metroid DNA 4", "Metroid DNA 5", "Metroid DNA 6", "Metroid DNA 7", "Metroid DNA 8", "Metroid DNA 9", "Metroid DNA 10", "Metroid DNA 11", "Metroid DNA 12", "Metroid DNA 13", "Metroid DNA 14", "Metroid DNA 15", "Metroid DNA 16", "Metroid DNA 17", "Metroid DNA 18", "Metroid DNA 19", "Metroid DNA 20", "Metroid DNA 21", "Metroid DNA 22", "Metroid DNA 23", "Metroid DNA 24", "Metroid DNA 25", "Metroid DNA 26", "Metroid DNA 27", "Metroid DNA 28", "Metroid DNA 29", "Metroid DNA 30", "Metroid DNA 31", "Metroid DNA 32", "Metroid DNA 33", "Metroid DNA 34", "Metroid DNA 35", "Metroid DNA 36", "Metroid DNA 37", "Metroid DNA 38", "Metroid DNA 39"
-        ]}
+        { "row": 7, "column": 3, "col_span": 3, "label": "    x {capacity} ", "resources": ["Collected Metroid DNA"]},
+        { "row": 7, "column": 4, "label": "    /{capacity}", "resources": ["Required Metroid DNA"]}
     ]
 }

--- a/randovania/data/gui_assets/tracker/samus-returns-game.json
+++ b/randovania/data/gui_assets/tracker/samus-returns-game.json
@@ -34,8 +34,7 @@
         { "row": 6, "column": 2, "resources": ["Missile Reserve Tank"], "image_path": "gui_assets/tracker/game-images/samus_returns/Missile Reserve Tank.png"},
         { "row": 6, "column": 3, "resources": ["Baby Metroid"], "image_path": "gui_assets/tracker/game-images/samus_returns/Baby.png"},
         { "row": 6, "column": 4, "resources": [], "image_path": "gui_assets/tracker/game-images/samus_returns/DNA.png" },
-        { "row": 7, "column": 4, "label": "x {capacity}/{max_capacity}", "resources": [
-            "Metroid DNA 1", "Metroid DNA 2", "Metroid DNA 3", "Metroid DNA 4", "Metroid DNA 5", "Metroid DNA 6", "Metroid DNA 7", "Metroid DNA 8", "Metroid DNA 9", "Metroid DNA 10", "Metroid DNA 11", "Metroid DNA 12", "Metroid DNA 13", "Metroid DNA 14", "Metroid DNA 15", "Metroid DNA 16", "Metroid DNA 17", "Metroid DNA 18", "Metroid DNA 19", "Metroid DNA 20", "Metroid DNA 21", "Metroid DNA 22", "Metroid DNA 23", "Metroid DNA 24", "Metroid DNA 25", "Metroid DNA 26", "Metroid DNA 27", "Metroid DNA 28", "Metroid DNA 29", "Metroid DNA 30", "Metroid DNA 31", "Metroid DNA 32", "Metroid DNA 33", "Metroid DNA 34", "Metroid DNA 35", "Metroid DNA 36", "Metroid DNA 37", "Metroid DNA 38", "Metroid DNA 39"
-        ]}
+        { "row": 7, "column": 3, "col_span": 3, "label": "    x {capacity} ", "resources": ["Collected Metroid DNA"]},
+        { "row": 7, "column": 4, "label": "    /{capacity}", "resources": ["Required Metroid DNA"]}
     ]
 }

--- a/randovania/games/samus_returns/assets/lua/bootstrap_part_1.lua
+++ b/randovania/games/samus_returns/assets/lua/bootstrap_part_1.lua
@@ -1,6 +1,9 @@
 function RL.GetInventoryAndSend()
     local r={}
     local playerName = Game.GetPlayerName()
+    local collected_dna = Init.iRequiredDNA - Game.GetItemAmount(playerName, "ITEM_ADN")
+    Game.SetItemAmount(playerName, "ITEM_REQUIRED_DNA", Init.iRequiredDNA)
+    Game.SetItemAmount(playerName, "ITEM_COLLECTED_DNA", collected_dna)
     for i,n in ipairs(RL.InventoryItems) do
         r[i]=Game.GetItemAmount(playerName, n)
     end

--- a/randovania/games/samus_returns/generator/bootstrap.py
+++ b/randovania/games/samus_returns/generator/bootstrap.py
@@ -115,12 +115,13 @@ class MSRBootstrap(MetroidBootstrap):
                 1,
             )
 
-        # If Diggernaut is the final boss, move the Grapple Block by the elevator
-        if configuration.final_boss == FinalBossConfiguration.DIGGERNAUT and not configuration.elevator_grapple_blocks:
-            yield (
-                resource_database.get_event("Area 6 - Transport to Area 7 Grapple Block Pull"),
-                1,
-            )
+        # If Diggernaut is the final boss, remove the Grapple Blocks by the elevator
+        if configuration.final_boss == FinalBossConfiguration.DIGGERNAUT:
+            for name in [
+                "Area 6 - Transport to Area 7 Grapple Block Pull",
+                "Area 6 - Transport to Area 7 Grapple Block Top",
+            ]:
+                yield resource_database.get_event(name), 1
 
     def assign_pool_results(self, rng: Random, patches: GamePatches, pool_results: PoolResults) -> GamePatches:
         assert isinstance(patches.configuration, MSRConfiguration)

--- a/randovania/games/samus_returns/gui/preset_settings/msr_goal_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_goal_tab.py
@@ -164,7 +164,9 @@ class PresetMSRGoal(PresetTab, Ui_PresetMSRGoal):
         if final_boss == FinalBossConfiguration.ARACHNUS:
             self.boss_info_label.setText("After defeating Arachnus, you must re-enter Dam Exterior to finish.")
         elif final_boss == FinalBossConfiguration.DIGGERNAUT:
-            self.boss_info_label.setText("The Grapple block in Area 6 - Transport to Area 7 will be moved by default.")
+            self.boss_info_label.setText(
+                "The top Grapple blocks in Area 6 - Transport to Area 7 will be moved by default."
+            )
         elif final_boss == FinalBossConfiguration.QUEEN:
             self.boss_info_label.setText(
                 "To fight the Queen, you must also collect Ice Beam and defeat all 10 Larva Metroids.\n"

--- a/randovania/games/samus_returns/logic_database/Area 6.json
+++ b/randovania/games/samus_returns/logic_database/Area 6.json
@@ -6146,7 +6146,7 @@
                     },
                     "description": "",
                     "layers": [
-                        "final-boss-not-diggernaut"
+                        "default"
                     ],
                     "extra": {
                         "actor_name": "LE_Item_004",
@@ -6272,10 +6272,41 @@
                             }
                         },
                         "Door to Diggernaut Arena": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "FinalBossDiggernaut",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "FinalBossDiggernaut",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "All DNA"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Top Platform": {

--- a/randovania/games/samus_returns/logic_database/Area 6.txt
+++ b/randovania/games/samus_returns/logic_database/Area 6.txt
@@ -813,7 +813,7 @@ Extra - total_boundings: {'x1': -22350.0, 'x2': -21050.0, 'y1': -7800.0, 'y2': -
 Extra - polygon: [[-22350.0, -3400.0], [-22350.0, -7800.0], [-21050.0, -7800.0], [-21050.0, -3400.0]]
 Extra - asset_id: collision_camera_045
 > Pickup (Power Bomb Tank); Heals? False
-  * Layers: final-boss-not-diggernaut
+  * Layers: default
   * Pickup 131; Category? Minor
   * Extra - actor_name: LE_Item_004
   * Extra - actor_type: item_powerbombtank
@@ -834,7 +834,9 @@ Extra - asset_id: collision_camera_045
                   # Defeat the Gulluggs
                   Combat (Advanced) or Defeat Weak Enemies
   > Door to Diggernaut Arena
-      Trivial
+      Any of the following:
+          Disabled Final Boss Diggernaut
+          Enabled Final Boss Diggernaut and All DNA
   > Top Platform
       Any of the following:
           Single-wall Wall Jump (Expert)

--- a/randovania/games/samus_returns/logic_database/header.json
+++ b/randovania/games/samus_returns/logic_database/header.json
@@ -244,6 +244,20 @@
                     "item_capacity_id": "ITEM_MAX_SPECIAL_ENERGY"
                 }
             },
+            "Required Metroid DNA": {
+                "long_name": "Required Metroid DNA",
+                "max_capacity": 1,
+                "extra": {
+                    "item_id": "ITEM_REQUIRED_DNA"
+                }
+            },
+            "Collected Metroid DNA": {
+                "long_name": "Collected Metroid DNA",
+                "max_capacity": 1,
+                "extra": {
+                    "item_id": "ITEM_COLLECTED_DNA"
+                }
+            },
             "Metroid DNA 1": {
                 "long_name": "Metroid DNA 1",
                 "max_capacity": 1,

--- a/requirements.txt
+++ b/requirements.txt
@@ -181,7 +181,7 @@ open-dread-rando==2.12.3
     # via randovania (setup.py)
 open-prime-rando==0.13.0
     # via randovania (setup.py)
-open-samus-returns-rando==2.5.0
+open-samus-returns-rando==2.6.0
     # via randovania (setup.py)
 packaging==24.1
     # via

--- a/test/test_files/patcher_data/samus_returns/samus_returns/custom_final_boss_free_placement_dna/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/custom_final_boss_free_placement_dna/world_1.json
@@ -2606,6 +2606,25 @@
         },
         {
             "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 0
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
             "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
             "resources": [
                 [


### PR DESCRIPTION
- Accessing the item behind Diggernaut is now possible if Diggernaut is the final boss
  - This also includes backdooring Diggernaut to start the fight from the left side
- The item tracker now shows the collected DNA out of the required DNA instead of being DNA you start with out of 39

`0 collected / 39 required`
![image](https://github.com/user-attachments/assets/e5f5a678-f731-4b49-98d0-c5cab189f215)

`0 collected / 4 required`
![image](https://github.com/user-attachments/assets/0b8d8974-2aa0-4f9e-82f9-2fb0d7d92440)

Fixes https://github.com/randovania/open-samus-returns-rando/issues/468