### PR TITLE
fusion: rename internal long names for atmospheric stabilizers

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -142,16 +142,16 @@ Extra - room_id: [4]
 
 > Event - Stabilizer 1 Online; Heals? False
   * Layers: default
-  * Event Stabilizer 1 Restored
+  * Event Stabilizer Northwest Restored
   > Room Center
       Trivial
 
 > Room Center; Heals? False
   * Layers: default
   > Door to Yameba Corridor
-      After Stabilizer 1 Restored
+      After Stabilizer Northwest Restored
   > Door to Hornoad Hole
-      After Stabilizer 1 Restored
+      After Stabilizer Northwest Restored
   > Event - Stabilizer 1 Online
       Any of the following:
           Can Kill Stabilizer Geron
@@ -307,9 +307,9 @@ Extra - room_id: [9]
 > Room Center; Heals? False
   * Layers: default
   > Door to Charge Core Escape
-      After Stabilizer 5 Restored
+      After Stabilizer Central Restored
   > Door to Checkpoint
-      After Stabilizer 5 Restored
+      After Stabilizer Central Restored
   > Event - Stabilizer 5 Online
       Any of the following:
           # Charge Beam can kill the Geron because the beam cannon can be stuck inside the shell and fire past it without touching the shell
@@ -333,7 +333,7 @@ Extra - room_id: [9]
 
 > Event - Stabilizer 5 Online; Heals? False
   * Layers: default
-  * Event Stabilizer 5 Restored
+  * Event Stabilizer Central Restored
   > Room Center
       Trivial
 
@@ -429,7 +429,7 @@ Extra - room_id: [13]
       Trivial
   > Event - Stabilizer 3 Online
       # Speed Boost the Stabilizer: https://youtu.be/V20W0F4dZP0
-      Level 0 Locks and Speed Booster and After Stabilizer 4 Restored and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
+      Level 0 Locks and Speed Booster and After Stabilizer Southeast Restored and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Door to Sciser Puddle; Heals? False
   * Layers: default
@@ -441,9 +441,9 @@ Extra - room_id: [13]
 > Room Center; Heals? False
   * Layers: default
   > Door to Moto Manor
-      After Stabilizer 3 Restored
+      After Stabilizer Southwest Restored
   > Door to Sciser Puddle
-      After Stabilizer 3 Restored
+      After Stabilizer Southwest Restored
   > Event - Stabilizer 3 Online
       Any of the following:
           Can Kill Stabilizer Geron
@@ -452,7 +452,7 @@ Extra - room_id: [13]
 
 > Event - Stabilizer 3 Online; Heals? False
   * Layers: default
-  * Event Stabilizer 3 Restored
+  * Event Stabilizer Southwest Restored
   > Room Center
       Trivial
 
@@ -502,11 +502,11 @@ Extra - room_id: [15]
 > Room Center; Heals? False
   * Layers: default
   > Door to Sciser Storage
-      After Stabilizer 4 Restored
+      After Stabilizer Southeast Restored
   > Door to Screw Shaft
-      After Stabilizer 4 Restored
+      After Stabilizer Southeast Restored
   > Door to Zebesian Zag
-      After Stabilizer 4 Restored
+      After Stabilizer Southeast Restored
   > Event - Stabilizer 4 Online
       Any of the following:
           Charge Beam or Missiles
@@ -524,7 +524,7 @@ Extra - room_id: [15]
 
 > Event - Stabilizer 4 Online; Heals? False
   * Layers: default
-  * Event Stabilizer 4 Restored
+  * Event Stabilizer Southeast Restored
   > Room Center
       Trivial
 
@@ -1218,7 +1218,7 @@ Extra - room_id: [32]
 > Room Center; Heals? False
   * Layers: default
   > Door to Northwestern Intersection
-      After Stabilizer 2 Restored
+      After Stabilizer Northeast Restored
   > Event - Stabilizer 2 Online
       Any of the following:
           Can Kill Stabilizer Geron
@@ -1233,7 +1233,7 @@ Extra - room_id: [32]
 
 > Event - Stabilizer 2 Online; Heals? False
   * Layers: default
-  * Event Stabilizer 2 Restored
+  * Event Stabilizer Northeast Restored
   > Room Center
       Trivial
 
@@ -1347,7 +1347,7 @@ Extra - room_id: [35]
           # Navigate the room Damageless: https://youtu.be/Lh9D7Ye3rw8
           Combat (Intermediate)
           # Shinespark from Atmospheric Stabilizer Room: https://youtu.be/_PmmHN9YvKw
-          Level 0 Locks and Speed Booster and After Stabilizer 4 Restored and Disabled Door Lock Rando and Disabled Entrance Rando
+          Level 0 Locks and Speed Booster and After Stabilizer Southeast Restored and Disabled Door Lock Rando and Disabled Entrance Rando
           # Damage Boost. Holding into the ladder makes you able to climb it
           Damage Boosts (Beginner) and Normal Damage ≥ 131
 

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -539,23 +539,23 @@
                 "extra": {}
             },
             "Stabilizer1": {
-                "long_name": "Stabilizer 1 Restored",
+                "long_name": "Stabilizer Northwest Restored",
                 "extra": {}
             },
             "Stabilizer2": {
-                "long_name": "Stabilizer 2 Restored",
+                "long_name": "Stabilizer Northeast Restored",
                 "extra": {}
             },
             "Stabilizer3": {
-                "long_name": "Stabilizer 3 Restored",
+                "long_name": "Stabilizer Southwest Restored",
                 "extra": {}
             },
             "Stabilizer4": {
-                "long_name": "Stabilizer 4 Restored",
+                "long_name": "Stabilizer Southeast Restored",
                 "extra": {}
             },
             "Stabilizer5": {
-                "long_name": "Stabilizer 5 Restored",
+                "long_name": "Stabilizer Central Restored",
                 "extra": {}
             },
             "Cooling": {


### PR DESCRIPTION
This will make the selections in the logic editor consistent with the room name for less confusion.