### PR TITLE
Make qsliders in UI unscrollable

### DIFF
--- a/randovania/games/am2r/gui/ui_files/preset_am2r_chaos.ui
+++ b/randovania/games/am2r/gui/ui_files/preset_am2r_chaos.ui
@@ -101,7 +101,7 @@
               <number>6</number>
              </property>
              <item>
-              <widget class="QSlider" name="darkness_slider">
+              <widget class="ScrollProtectedSlider" name="darkness_slider">
                <property name="maximum">
                 <number>1000</number>
                </property>
@@ -265,7 +265,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QSlider" name="submerged_water_slider">
+              <widget class="ScrollProtectedSlider" name="submerged_water_slider">
                <property name="maximum">
                 <number>1000</number>
                </property>
@@ -326,7 +326,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QSlider" name="submerged_lava_slider">
+              <widget class="ScrollProtectedSlider" name="submerged_lava_slider">
                <property name="maximum">
                 <number>1000</number>
                </property>
@@ -374,6 +374,13 @@
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+  <customwidgets>
+  <customwidget>
+   <class>ScrollProtectedSlider</class>
+   <extends>Qslider</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/randovania/games/am2r/gui/ui_files/preset_am2r_goal.ui
+++ b/randovania/games/am2r/gui/ui_files/preset_am2r_goal.ui
@@ -65,7 +65,7 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QSlider" name="placed_slider">
+       <widget class="ScrollProtectedSlider" name="placed_slider">
         <property name="maximum">
          <number>46</number>
         </property>
@@ -126,7 +126,7 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QSlider" name="required_slider">
+       <widget class="ScrollProtectedSlider" name="required_slider">
         <property name="maximum">
          <number>46</number>
         </property>
@@ -235,6 +235,13 @@
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+  <customwidgets>
+  <customwidget>
+   <class>ScrollProtectedSlider</class>
+   <extends>Qslider</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/randovania/games/dread/gui/ui_files/dread_cosmetic_patches_dialog.ui
+++ b/randovania/games/dread/gui/ui_files/dread_cosmetic_patches_dialog.ui
@@ -144,7 +144,7 @@
           <item>
            <layout class="QHBoxLayout" name="music_group">
             <item>
-             <widget class="QSlider" name="music_slider">
+             <widget class="ScrollProtectedSlider" name="music_slider">
               <property name="maximum">
                <number>100</number>
               </property>
@@ -175,7 +175,7 @@
           <item>
            <layout class="QHBoxLayout" name="sfx_group">
             <item>
-             <widget class="QSlider" name="sfx_slider">
+             <widget class="ScrollProtectedSlider" name="sfx_slider">
               <property name="maximum">
                <number>100</number>
               </property>
@@ -206,7 +206,7 @@
           <item>
            <layout class="QHBoxLayout" name="ambience_group">
             <item>
-             <widget class="QSlider" name="ambience_slider">
+             <widget class="ScrollProtectedSlider" name="ambience_slider">
               <property name="maximum">
                <number>100</number>
               </property>
@@ -316,6 +316,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+  <customwidgets>
+  <customwidget>
+   <class>ScrollProtectedSlider</class>
+   <extends>Qslider</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/randovania/games/dread/gui/ui_files/preset_dread_goal.ui
+++ b/randovania/games/dread/gui/ui_files/preset_dread_goal.ui
@@ -46,7 +46,7 @@
     <item>
      <layout class="QHBoxLayout" name="dna_slider_layout">
       <item>
-       <widget class="QSlider" name="dna_slider">
+       <widget class="ScrollProtectedSlider" name="dna_slider">
         <property name="maximum">
          <number>12</number>
         </property>
@@ -135,6 +135,13 @@
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+  <customwidgets>
+  <customwidget>
+   <class>ScrollProtectedSlider</class>
+   <extends>Qslider</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/randovania/games/prime1/gui/ui_files/preset_prime_chaos.ui
+++ b/randovania/games/prime1/gui/ui_files/preset_prime_chaos.ui
@@ -296,7 +296,7 @@
            <item>
             <layout class="QHBoxLayout" name="superheated_slider_layout">
              <item>
-              <widget class="QSlider" name="superheated_slider">
+              <widget class="ScrollProtectedSlider" name="superheated_slider">
                <property name="maximum">
                 <number>1000</number>
                </property>
@@ -348,7 +348,7 @@
            <item>
             <layout class="QHBoxLayout" name="submerged_slider_layout">
              <item>
-              <widget class="QSlider" name="submerged_slider">
+              <widget class="ScrollProtectedSlider" name="submerged_slider">
                <property name="maximum">
                 <number>1000</number>
                </property>
@@ -398,6 +398,13 @@
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+  <customwidgets>
+  <customwidget>
+   <class>ScrollProtectedSlider</class>
+   <extends>Qslider</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/randovania/games/prime1/gui/ui_files/preset_prime_goal.ui
+++ b/randovania/games/prime1/gui/ui_files/preset_prime_goal.ui
@@ -46,7 +46,7 @@
     <item>
      <layout class="QHBoxLayout" name="slider_layout">
       <item>
-       <widget class="QSlider" name="placed_slider">
+       <widget class="ScrollProtectedSlider" name="placed_slider">
         <property name="maximum">
          <number>12</number>
         </property>
@@ -101,7 +101,7 @@ This controls how many Artifacts are needed in order to unlock Impact Crater. Th
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QSlider" name="required_slider">
+       <widget class="ScrollProtectedSlider" name="required_slider">
         <property name="maximum">
          <number>12</number>
         </property>
@@ -126,6 +126,13 @@ This controls how many Artifacts are needed in order to unlock Impact Crater. Th
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+  <customwidgets>
+  <customwidget>
+   <class>ScrollProtectedSlider</class>
+   <extends>Qslider</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/randovania/games/prime1/gui/ui_files/prime_cosmetic_patches_dialog.ui
+++ b/randovania/games/prime1/gui/ui_files/prime_cosmetic_patches_dialog.ui
@@ -313,7 +313,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QSlider" name="helmet_alpha_slider">
+           <widget class="ScrollProtectedSlider" name="helmet_alpha_slider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -344,7 +344,7 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QSlider" name="hud_alpha_slider">
+           <widget class="ScrollProtectedSlider" name="hud_alpha_slider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -436,7 +436,7 @@
            <widget class="QComboBox" name="sound_mode_combo"/>
           </item>
           <item row="1" column="1">
-           <widget class="QSlider" name="sfx_volume_slider">
+           <widget class="ScrollProtectedSlider" name="sfx_volume_slider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -446,7 +446,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QSlider" name="music_volume_slider">
+           <widget class="ScrollProtectedSlider" name="music_volume_slider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -493,7 +493,7 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QSlider" name="screen_brightness_slider">
+           <widget class="ScrollProtectedSlider" name="screen_brightness_slider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -503,7 +503,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QSlider" name="screen_y_offset_slider">
+           <widget class="ScrollProtectedSlider" name="screen_y_offset_slider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -520,7 +520,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QSlider" name="screen_x_offset_slider">
+           <widget class="ScrollProtectedSlider" name="screen_x_offset_slider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -530,7 +530,7 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QSlider" name="screen_stretch_slider">
+           <widget class="ScrollProtectedSlider" name="screen_stretch_slider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -584,6 +584,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+  <customwidgets>
+  <customwidget>
+   <class>ScrollProtectedSlider</class>
+   <extends>Qslider</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/randovania/games/prime2/gui/ui_files/echoes_cosmetic_patches_dialog.ui
+++ b/randovania/games/prime2/gui/ui_files/echoes_cosmetic_patches_dialog.ui
@@ -718,7 +718,7 @@
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QSlider" name="helmet_alpha_slider">
+              <widget class="ScrollProtectedSlider" name="helmet_alpha_slider">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -749,7 +749,7 @@
               </widget>
              </item>
              <item row="0" column="1">
-              <widget class="QSlider" name="hud_alpha_slider">
+              <widget class="ScrollProtectedSlider" name="hud_alpha_slider">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -834,7 +834,7 @@
               <widget class="QComboBox" name="sound_mode_combo"/>
              </item>
              <item row="1" column="1">
-              <widget class="QSlider" name="sfx_volume_slider">
+              <widget class="ScrollProtectedSlider" name="sfx_volume_slider">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -844,7 +844,7 @@
               </widget>
              </item>
              <item row="2" column="1">
-              <widget class="QSlider" name="music_volume_slider">
+              <widget class="ScrollProtectedSlider" name="music_volume_slider">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -891,7 +891,7 @@
               </widget>
              </item>
              <item row="0" column="1">
-              <widget class="QSlider" name="screen_brightness_slider">
+              <widget class="ScrollProtectedSlider" name="screen_brightness_slider">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -901,7 +901,7 @@
               </widget>
              </item>
              <item row="2" column="1">
-              <widget class="QSlider" name="screen_y_offset_slider">
+              <widget class="ScrollProtectedSlider" name="screen_y_offset_slider">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -918,7 +918,7 @@
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QSlider" name="screen_x_offset_slider">
+              <widget class="ScrollProtectedSlider" name="screen_x_offset_slider">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -928,7 +928,7 @@
               </widget>
              </item>
              <item row="3" column="1">
-              <widget class="QSlider" name="screen_stretch_slider">
+              <widget class="ScrollProtectedSlider" name="screen_stretch_slider">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -1004,6 +1004,11 @@
    <extends>QWidget</extends>
    <header>randovania/gui/lib/foldable.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ScrollProtectedSlider</class>
+   <extends>Qslider</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/randovania/games/prime2/gui/ui_files/preset_echoes_goal.ui
+++ b/randovania/games/prime2/gui/ui_files/preset_echoes_goal.ui
@@ -65,7 +65,7 @@
     <item>
      <layout class="QHBoxLayout" name="skytemple_slider_layout">
       <item>
-       <widget class="QSlider" name="skytemple_slider">
+       <widget class="ScrollProtectedSlider" name="skytemple_slider">
         <property name="maximum">
          <number>9</number>
         </property>
@@ -121,6 +121,13 @@
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+  <customwidgets>
+  <customwidget>
+   <class>ScrollProtectedSlider</class>
+   <extends>Qslider</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/randovania/games/samus_returns/gui/ui_files/msr_cosmetic_patches_dialog.ui
+++ b/randovania/games/samus_returns/gui/ui_files/msr_cosmetic_patches_dialog.ui
@@ -443,7 +443,7 @@
           <item row="3" column="1">
            <layout class="QHBoxLayout" name="ambience_group">
             <item>
-             <widget class="QSlider" name="ambience_slider">
+             <widget class="ScrollProtectedSlider" name="ambience_slider">
               <property name="maximum">
                <number>100</number>
               </property>
@@ -474,7 +474,7 @@
           <item row="1" column="1">
            <layout class="QHBoxLayout" name="music_group">
             <item>
-             <widget class="QSlider" name="music_slider">
+             <widget class="ScrollProtectedSlider" name="music_slider">
               <property name="maximum">
                <number>100</number>
               </property>
@@ -605,6 +605,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+  <customwidgets>
+  <customwidget>
+   <class>ScrollProtectedSlider</class>
+   <extends>Qslider</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/randovania/games/samus_returns/gui/ui_files/preset_msr_goal.ui
+++ b/randovania/games/samus_returns/gui/ui_files/preset_msr_goal.ui
@@ -65,7 +65,7 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QSlider" name="placed_slider">
+       <widget class="ScrollProtectedSlider" name="placed_slider">
         <property name="maximum">
          <number>39</number>
         </property>
@@ -126,7 +126,7 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QSlider" name="required_slider">
+       <widget class="ScrollProtectedSlider" name="required_slider">
         <property name="maximum">
          <number>39</number>
         </property>
@@ -330,6 +330,13 @@
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+  <customwidgets>
+  <customwidget>
+   <class>ScrollProtectedSlider</class>
+   <extends>Qslider</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/randovania/gui/lib/scroll_protected.py
+++ b/randovania/gui/lib/scroll_protected.py
@@ -16,7 +16,7 @@ class ScrollProtectedSlider(QtWidgets.QSlider):
     def focusOutEvent(self, event: QEvent):
         self.setFocusPolicy(Qt.StrongFocus)
 
-    def eventFilter(self, obj: QtWidgets.QSluider, event: QEvent) -> bool:
+    def eventFilter(self, obj: QtWidgets.QSlider, event: QEvent) -> bool:
         if event.type() == QEvent.Wheel and isinstance(obj, QtWidgets.QSlider):
             if obj.focusPolicy() == Qt.WheelFocus:
                 event.accept()

--- a/randovania/gui/lib/scroll_protected.py
+++ b/randovania/gui/lib/scroll_protected.py
@@ -4,6 +4,29 @@ from PySide6 import QtWidgets
 from PySide6.QtCore import QEvent, Qt
 
 
+class ScrollProtectedSlider(QtWidgets.QSlider):
+    def __init__(self, orientation: Qt.Orientation, parent: QtWidgets.QWidget | None = None):
+        super().__init__(orientation, parent)
+        self.installEventFilter(self)
+        self.setFocusPolicy(Qt.StrongFocus)
+
+    def focusInEvent(self, event: QEvent):
+        self.setFocusPolicy(Qt.WheelFocus)
+
+    def focusOutEvent(self, event: QEvent):
+        self.setFocusPolicy(Qt.StrongFocus)
+
+    def eventFilter(self, obj: QtWidgets.QSluider, event: QEvent) -> bool:
+        if event.type() == QEvent.Wheel and isinstance(obj, QtWidgets.QSlider):
+            if obj.focusPolicy() == Qt.WheelFocus:
+                event.accept()
+                return False
+            else:
+                event.ignore()
+                return True
+        return super().eventFilter(obj, event)
+
+
 class ScrollProtectedSpinBox(QtWidgets.QSpinBox):
     def __init__(self, parent):
         super().__init__(parent)

--- a/randovania/gui/preset_settings/trick_level_tab.py
+++ b/randovania/gui/preset_settings/trick_level_tab.py
@@ -11,6 +11,7 @@ from randovania.games.prime1.layout.prime_configuration import PrimeConfiguratio
 from randovania.gui.dialog.trick_details_popup import BaseResourceDetailsPopup, ResourceDetailsPopup, TrickDetailsPopup
 from randovania.gui.generated.preset_trick_level_ui import Ui_PresetTrickLevel
 from randovania.gui.lib import signal_handling
+from randovania.gui.lib.scroll_protected import ScrollProtectedSlider
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.layout.base.trick_level import LayoutTrickLevel
 from randovania.layout.lib import trick_lib
@@ -22,23 +23,6 @@ if TYPE_CHECKING:
     from randovania.gui.lib.window_manager import WindowManager
     from randovania.interface_common.preset_editor import PresetEditor
     from randovania.layout.preset import Preset
-
-
-class TrickSlider(QtWidgets.QSlider):
-    """
-    A custom implementation of QSlider that filters out mouse wheel events
-    """
-
-    def __init__(self, orientation: QtCore.Qt.Orientation, parent: QtWidgets.QWidget | None = None):
-        super().__init__(orientation, parent)
-
-    def eventFilter(self, watched: QtCore.QObject, event: QtCore.QEvent) -> bool:
-        # filter out "Wheel" type events
-        if event.type() == QtCore.QEvent.Type.Wheel:
-            event.ignore()
-            return True
-
-        return super().eventFilter(watched, event)
 
 
 class PresetTrickLevel(PresetTab, Ui_PresetTrickLevel):
@@ -89,8 +73,7 @@ class PresetTrickLevel(PresetTab, Ui_PresetTrickLevel):
             for i in range(12):
                 slider_layout.setColumnStretch(i, 1)
 
-            horizontal_slider = TrickSlider(self.trick_level_scroll_contents)
-            horizontal_slider.installEventFilter(horizontal_slider)  # enables scroll wheel filter
+            horizontal_slider = ScrollProtectedSlider(self.trick_level_scroll_contents)
             horizontal_slider.setMaximum(5)
             horizontal_slider.setPageStep(2)
             horizontal_slider.setOrientation(QtCore.Qt.Orientation.Horizontal)


### PR DESCRIPTION
PR re: https://github.com/randovania/randovania/issues/7009

Work done: replaced qsliders in stable game UI with a new custom qslider class that cannot be scrolled with scroll wheel.

Tested by scrolling over sliders in all prime 1 UI dialogues with sliders; the new sliders work as intended and are not scrollable with the wheel, unless they are currently active.

This PR addresses the linked issue, but I personally think it would be good to replace all comboboxes and spinboxes in the UI with unscrollable ones too, seeing as they have the same issue where there are many vertical windows in rdv that are scrolled thourgh without wanting to change things, so I will be awaiting feedback on whether that seems reasonable before I address anything outside of the linked issue.  There may be objects that are desirable to remain scrollable that I do not know about.  For similar reasons, I have only replaced the sliders in stable games.