### PR TITLE
Prime 1: rename long name of "room rando" to "entrance rando"

### DIFF
--- a/randovania/games/prime1/logic_database/Tallon Overworld.txt
+++ b/randovania/games/prime1/logic_database/Tallon Overworld.txt
@@ -609,7 +609,7 @@ Extra - aabb: [-703.2118, 297.52924, -49.04736, -619.3062, 378.77765, 64.30938]
   > Out of Bounds (Skywalk)
       All of the following:
           # https://youtu.be/imhkxmwiU9o
-          Boost Ball and Morph Ball and Power Bomb and Movement (Expert) and Single Room Out of Bounds (Advanced) and Disabled Dock Rando and Disabled Room Rando
+          Boost Ball and Morph Ball and Power Bomb and Movement (Expert) and Single Room Out of Bounds (Advanced) and Disabled Dock Rando and Disabled Entrance Rando
           Any of the following:
               Morph Ball Bomb and Bomb Space Jump (Advanced)
               # Wall Boost off door frame into IUJ

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -798,7 +798,7 @@
                 "extra": {}
             },
             "room_rando": {
-                "long_name": "Room Rando",
+                "long_name": "Entrance Rando",
                 "extra": {}
             }
         },


### PR DESCRIPTION
Entrance rando is the usual RDV terminology.