### PR TITLE
Fusion: tweak etank weight

### DIFF
--- a/randovania/games/fusion/pickup_database/pickup-database.json
+++ b/randovania/games/fusion/pickup_database/pickup-database.json
@@ -519,7 +519,9 @@
             "custom_count_for_shuffled_case": 20,
             "extra": {
                 "StartingItemCategory": "Energy"
-            }
+            },
+            "probability_offset": 2.0,
+            "probability_multiplier": 2.0
         },
         "Level 0 Locks": {
             "pickup_category": "misc",


### PR DESCRIPTION
Causes etanks to be spread out more and not dumped all at the end when the generator realized it needs access to dna/bosses.