### PR TITLE
Allow tweaking multipliers for ammo

### DIFF
--- a/randovania/game_description/pickup/ammo_pickup.py
+++ b/randovania/game_description/pickup/ammo_pickup.py
@@ -30,6 +30,8 @@ class AmmoPickupDefinition(JsonDataclass):
     additional_resources: frozendict[str, int] = dataclasses.field(default_factory=frozendict, metadata=EXCLUDE_DEFAULT)
     unlocked_by: str | None = dataclasses.field(default=None, metadata=EXCLUDE_DEFAULT)
     temporary: str | None = dataclasses.field(default=None, metadata=EXCLUDE_DEFAULT)
+    probability_offset: float = dataclasses.field(default=0.0, metadata=EXCLUDE_DEFAULT)
+    probability_multiplier: float = dataclasses.field(default=2.0, metadata=EXCLUDE_DEFAULT)
     allows_negative: bool | None = dataclasses.field(default=None, metadata=EXCLUDE_DEFAULT)
     description: str | None = dataclasses.field(default=None, metadata=EXCLUDE_DEFAULT)
     include_expected_counts: bool = dataclasses.field(default=True, metadata=EXCLUDE_DEFAULT)

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -99,7 +99,8 @@ def create_ammo_pickup(
         resource_lock=ammo.create_resource_lock(resource_database),
         generator_params=PickupGeneratorParams(
             preferred_location_category=ammo.preferred_location_category,
-            probability_multiplier=2,
+            probability_offset=ammo.probability_offset,
+            probability_multiplier=ammo.probability_multiplier,
         ),
     )
 


### PR DESCRIPTION
Fusion (and other games maybe too?) would benefit from changing missile tank weights.
I don't know if this needs a migration