### PR TITLE
Fixed "QSlider" capitalization in UI custom widget definition

### DIFF
--- a/randovania/games/am2r/gui/ui_files/preset_am2r_chaos.ui
+++ b/randovania/games/am2r/gui/ui_files/preset_am2r_chaos.ui
@@ -377,7 +377,7 @@
  <customwidgets>
   <customwidget>
    <class>ScrollProtectedSlider</class>
-   <extends>Qslider</extends>
+   <extends>QSlider</extends>
    <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>

--- a/randovania/games/dread/gui/ui_files/dread_cosmetic_patches_dialog.ui
+++ b/randovania/games/dread/gui/ui_files/dread_cosmetic_patches_dialog.ui
@@ -319,7 +319,7 @@
  <customwidgets>
   <customwidget>
    <class>ScrollProtectedSlider</class>
-   <extends>Qslider</extends>
+   <extends>QSlider</extends>
    <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>

--- a/randovania/games/dread/gui/ui_files/preset_dread_goal.ui
+++ b/randovania/games/dread/gui/ui_files/preset_dread_goal.ui
@@ -138,7 +138,7 @@
  <customwidgets>
   <customwidget>
    <class>ScrollProtectedSlider</class>
-   <extends>Qslider</extends>
+   <extends>QSlider</extends>
    <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>

--- a/randovania/games/fusion/gui/ui_files/preset_fusion_goal.ui
+++ b/randovania/games/fusion/gui/ui_files/preset_fusion_goal.ui
@@ -228,7 +228,7 @@
  <customwidgets>
   <customwidget>
    <class>ScrollProtectedSlider</class>
-   <extends>Qslider</extends>
+   <extends>QSlider</extends>
    <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>

--- a/randovania/games/planets_zebeth/gui/ui_files/preset_planets_zebeth_goal.ui
+++ b/randovania/games/planets_zebeth/gui/ui_files/preset_planets_zebeth_goal.ui
@@ -137,7 +137,7 @@
  <customwidgets>
   <customwidget>
    <class>ScrollProtectedSlider</class>
-   <extends>Qslider</extends>
+   <extends>QSlider</extends>
    <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>

--- a/randovania/games/prime1/gui/ui_files/preset_prime_chaos.ui
+++ b/randovania/games/prime1/gui/ui_files/preset_prime_chaos.ui
@@ -401,7 +401,7 @@
  <customwidgets>
   <customwidget>
    <class>ScrollProtectedSlider</class>
-   <extends>Qslider</extends>
+   <extends>QSlider</extends>
    <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>

--- a/randovania/games/prime1/gui/ui_files/preset_prime_goal.ui
+++ b/randovania/games/prime1/gui/ui_files/preset_prime_goal.ui
@@ -129,7 +129,7 @@ This controls how many Artifacts are needed in order to unlock Impact Crater. Th
  <customwidgets>
   <customwidget>
    <class>ScrollProtectedSlider</class>
-   <extends>Qslider</extends>
+   <extends>QSlider</extends>
    <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>

--- a/randovania/games/prime1/gui/ui_files/prime_cosmetic_patches_dialog.ui
+++ b/randovania/games/prime1/gui/ui_files/prime_cosmetic_patches_dialog.ui
@@ -587,7 +587,7 @@
  <customwidgets>
   <customwidget>
    <class>ScrollProtectedSlider</class>
-   <extends>Qslider</extends>
+   <extends>QSlider</extends>
    <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>

--- a/randovania/games/prime2/gui/ui_files/echoes_cosmetic_patches_dialog.ui
+++ b/randovania/games/prime2/gui/ui_files/echoes_cosmetic_patches_dialog.ui
@@ -1007,7 +1007,7 @@
   </customwidget>
   <customwidget>
    <class>ScrollProtectedSlider</class>
-   <extends>Qslider</extends>
+   <extends>QSlider</extends>
    <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>

--- a/randovania/games/prime2/gui/ui_files/preset_echoes_goal.ui
+++ b/randovania/games/prime2/gui/ui_files/preset_echoes_goal.ui
@@ -124,7 +124,7 @@
  <customwidgets>
   <customwidget>
    <class>ScrollProtectedSlider</class>
-   <extends>Qslider</extends>
+   <extends>QSlider</extends>
    <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>

--- a/randovania/games/samus_returns/gui/ui_files/msr_cosmetic_patches_dialog.ui
+++ b/randovania/games/samus_returns/gui/ui_files/msr_cosmetic_patches_dialog.ui
@@ -608,7 +608,7 @@
  <customwidgets>
   <customwidget>
    <class>ScrollProtectedSlider</class>
-   <extends>Qslider</extends>
+   <extends>QSlider</extends>
    <header>randovania/gui/lib/scroll_protected.h</header>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
Fixed custom scroll protected slider "QSlider" import in UI files from the previous PR.  I don't know enough to say what it broke to have the wrong uncapitalized class extended, or why it functions anyway, but this fixes it :)