### PR TITLE
Fusion: add missing room ID for operations maintenance shaft

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -5796,7 +5796,8 @@
             "extra": {
                 "map_name": "Main Deck35",
                 "room_id": [
-                    35, 36
+                    35,
+                    36
                 ]
             },
             "nodes": {

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -5796,7 +5796,7 @@
             "extra": {
                 "map_name": "Main Deck35",
                 "room_id": [
-                    35
+                    35, 36
                 ]
             },
             "nodes": {

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -978,7 +978,7 @@ Extra - room_id: [34, 43]
 ----------------
 Operations Maintenance Shaft
 Extra - map_name: Main Deck35
-Extra - room_id: [35]
+Extra - room_id: [35, 36]
 > Pickup (Missile Tank); Heals? False
   * Layers: default
   * Pickup 2; Category? Minor


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7f97a189-32e8-4298-8942-66779e1c0807)
![image](https://github.com/user-attachments/assets/527ceb02-2208-414b-a5cf-a6f65d555c5e)
