### PR TITLE
Mypy: override typing for generic generated gui module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,3 +288,7 @@ disable_error_code = "method-assign"
 [[tool.mypy.overrides]]
 module = "randovania.games.*.gui.generated.*"
 disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = "randovania.gui.generated.*"
+disallow_untyped_defs = false


### PR DESCRIPTION
We don't want these typed either.