### PR TITLE
Move Dock from Surface West to "final-boss-not-ridley" layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed: Rare case of the connector not being able to reconnect until Randovania is restarted.
 - Fixed: Speed Booster offworld not displaying correctly for Metroid Dread.
+- Fixed: Map tracker could not be opened if the final boss is Ridley.
 - Changed: The preset entry for Aeion and Energy are now combined into one.
 - Changed: The preset entries for the Goal and Hints don't enforce a minimum size anymore.
 - Changed: Adjust spacing on the Elevator preset entry.

--- a/randovania/games/samus_returns/logic_database/Surface East.json
+++ b/randovania/games/samus_returns/logic_database/Surface East.json
@@ -589,7 +589,7 @@
                     },
                     "description": "",
                     "layers": [
-                        "default"
+                        "final-boss-not-ridley"
                     ],
                     "extra": {},
                     "valid_starting_location": false,

--- a/randovania/games/samus_returns/logic_database/Surface East.txt
+++ b/randovania/games/samus_returns/logic_database/Surface East.txt
@@ -99,7 +99,7 @@ Extra - asset_id: collision_camera_000
       Trivial
 
 > Dock from Surface West; Heals? False
-  * Layers: default
+  * Layers: final-boss-not-ridley
   * Blocked Passage to Landing Site/Dock to Surface East
   > Ship
       Trivial


### PR DESCRIPTION
Fixes #7334

If I'm not mistaken, this node should be part of the "final-boss-not-ridley" layer because the other side only exists if the final boss is not ridley to teleport back to surface east after ridley was beaten.