### PR TITLE
Fusion: add proper hint requirements

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -1136,7 +1136,17 @@
                         "type": "and",
                         "data": {
                             "comment": null,
-                            "items": []
+                            "items": [
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "items",
+                                        "name": "L2Locks",
+                                        "amount": 1,
+                                        "negate": false
+                                    }
+                                }
+                            ]
                         }
                     },
                     "connections": {
@@ -2990,7 +3000,17 @@
                         "type": "and",
                         "data": {
                             "comment": null,
-                            "items": []
+                            "items": [
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "items",
+                                        "name": "L4Locks",
+                                        "amount": 1,
+                                        "negate": false
+                                    }
+                                }
+                            ]
                         }
                     },
                     "connections": {

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -433,7 +433,17 @@
                         "type": "and",
                         "data": {
                             "comment": null,
-                            "items": []
+                            "items": [
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "items",
+                                        "name": "L1Locks",
+                                        "amount": 1,
+                                        "negate": false
+                                    }
+                                }
+                            ]
                         }
                     },
                     "connections": {

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -615,7 +615,17 @@
                         "type": "and",
                         "data": {
                             "comment": null,
-                            "items": []
+                            "items": [
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "items",
+                                        "name": "L1Locks",
+                                        "amount": 1,
+                                        "negate": false
+                                    }
+                                }
+                            ]
                         }
                     },
                     "connections": {

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -599,7 +599,17 @@
                         "type": "and",
                         "data": {
                             "comment": null,
-                            "items": []
+                            "items": [
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "items",
+                                        "name": "L2Locks",
+                                        "amount": 1,
+                                        "negate": false
+                                    }
+                                }
+                            ]
                         }
                     },
                     "connections": {

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -386,7 +386,17 @@
                         "type": "and",
                         "data": {
                             "comment": null,
-                            "items": []
+                            "items": [
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "items",
+                                        "name": "L2Locks",
+                                        "amount": 1,
+                                        "negate": false
+                                    }
+                                }
+                            ]
                         }
                     },
                     "connections": {

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -508,7 +508,17 @@
                         "type": "and",
                         "data": {
                             "comment": null,
-                            "items": []
+                            "items": [
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "items",
+                                        "name": "L3Locks",
+                                        "amount": 1,
+                                        "negate": false
+                                    }
+                                }
+                            ]
                         }
                     },
                     "connections": {

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -691,7 +691,17 @@
                         "type": "and",
                         "data": {
                             "comment": null,
-                            "items": []
+                            "items": [
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "items",
+                                        "name": "L3Locks",
+                                        "amount": 1,
+                                        "negate": false
+                                    }
+                                }
+                            ]
                         }
                     },
                     "connections": {


### PR DESCRIPTION
Adds them as discussed previously. Changes them now, as they do affect generation and I want to see that in advance.
S1 -> L1
S2 -> L1
S3 -> L2
S4 -> L2
S5 -> L3
S6 -> L3

Main Deck Top -> free
Main Deck Middle -> L2
Main Deck Bottom -> L4

