### PR TITLE
Update open-dread-rando

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ exporters = [
     "factorio-randovania-mod>=0.4.1",
 
     # Metroid Dread
-    "open-dread-rando>=2.11.0",
+    "open-dread-rando>=2.14.0",
 
     # Metroid Prime 1
     "py_randomprime>=1.27.0",

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -163,11 +163,15 @@ class DreadPatchDataFactory(PatchDataFactory):
 
     def _teleporter_ref_for(self, node: Node, actor_key: str = "actor_name") -> dict:
         try:
-            return {
+            actor_reference = {
                 "scenario": self._level_name_for(node),
-                "layer": node.extra.get("actor_layer", "default"),
                 "actor": node.extra[actor_key],
             }
+
+            if "actor_sublayer" in node.extra:
+                actor_reference["sublayer"] = node.extra["actor_sublayer"]
+
+            return actor_reference
         except KeyError as e:
             raise self._key_error_for_node(node, e)
 
@@ -475,7 +479,7 @@ class DreadPatchDataFactory(PatchDataFactory):
         return [
             # beam blocks -> speedboost blocks in Artaria EMMI zone Speed Booster puzzle to prevent softlock
             {
-                "actor": {"scenario": "s010_cave", "layer": "breakables", "actor": "breakabletilegroup_060"},
+                "actor": {"scenario": "s010_cave", "sublayer": "breakables", "actor": "breakabletilegroup_060"},
                 "tiletype": "SPEEDBOOST",
             }
         ]

--- a/randovania/games/dread/logic_database/Artaria.json
+++ b/randovania/games/dread/logic_database/Artaria.json
@@ -11223,7 +11223,7 @@
                     "extra": {
                         "actor_name": "Door054 (PW-PW)",
                         "actor_def": "actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad",
-                        "actor_layer": "Boss",
+                        "actor_sublayer": "Boss",
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
@@ -23820,7 +23820,7 @@
                     "extra": {
                         "actor_name": "Door054 (PW-PW)",
                         "actor_def": "actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad",
-                        "actor_layer": "Boss",
+                        "actor_sublayer": "Boss",
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",

--- a/randovania/games/dread/logic_database/Artaria.txt
+++ b/randovania/games/dread/logic_database/Artaria.txt
@@ -1983,7 +1983,7 @@ Extra - asset_id: collision_camera_020
   * Power Beam Door to Phantom Cloak Tutorial/Door to Corpius Arena; Excluded from Dock Lock Rando
   * Extra - actor_name: Door054 (PW-PW)
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
-  * Extra - actor_layer: Boss
+  * Extra - actor_sublayer: Boss
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
@@ -4430,7 +4430,7 @@ Extra - asset_id: collision_camera_073
   * Power Beam Door to Corpius Arena/Door to Phantom Cloak Tutorial; Excluded from Dock Lock Rando
   * Extra - actor_name: Door054 (PW-PW)
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
-  * Extra - actor_layer: Boss
+  * Extra - actor_sublayer: Boss
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}

--- a/randovania/games/dread/logic_database/Ferenia.json
+++ b/randovania/games/dread/logic_database/Ferenia.json
@@ -11910,7 +11910,7 @@
                     "extra": {
                         "actor_name": "tunnelframe",
                         "actor_def": "actordef:actors/props/tunnelframe/charclasses/tunnelframe.bmsad",
-                        "actor_layer": "Emmy",
+                        "actor_sublayer": "Emmy",
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
@@ -12977,7 +12977,7 @@
                     "extra": {
                         "actor_name": "tunnelframe",
                         "actor_def": "actordef:actors/props/tunnelframe/charclasses/tunnelframe.bmsad",
-                        "actor_layer": "Emmy",
+                        "actor_sublayer": "Emmy",
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",

--- a/randovania/games/dread/logic_database/Ferenia.txt
+++ b/randovania/games/dread/logic_database/Ferenia.txt
@@ -2117,7 +2117,7 @@ Extra - asset_id: collision_camera_031
   * Morph Ball Tunnel to Purple EMMI Arena/Tunnel to Wave Beam Tutorial
   * Extra - actor_name: tunnelframe
   * Extra - actor_def: actordef:actors/props/tunnelframe/charclasses/tunnelframe.bmsad
-  * Extra - actor_layer: Emmy
+  * Extra - actor_sublayer: Emmy
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
@@ -2297,7 +2297,7 @@ Extra - asset_id: collision_camera_034
   * Morph Ball Tunnel to Wave Beam Tutorial/Tunnel to Purple EMMI Arena
   * Extra - actor_name: tunnelframe
   * Extra - actor_def: actordef:actors/props/tunnelframe/charclasses/tunnelframe.bmsad
-  * Extra - actor_layer: Emmy
+  * Extra - actor_sublayer: Emmy
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}

--- a/randovania/games/dread/logic_database/Ghavoran.json
+++ b/randovania/games/dread/logic_database/Ghavoran.json
@@ -12371,7 +12371,7 @@
                     "extra": {
                         "actor_name": "breakabletilegroup_011",
                         "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
+                        "actor_sublayer": "breakables",
                         "tile_types": [
                             "WEIGHT"
                         ]

--- a/randovania/games/dread/logic_database/Ghavoran.txt
+++ b/randovania/games/dread/logic_database/Ghavoran.txt
@@ -2087,7 +2087,7 @@ Extra - asset_id: collision_camera_026
   * Layers: default
   * Extra - actor_name: breakabletilegroup_011
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
+  * Extra - actor_sublayer: breakables
   * Extra - tile_types: ('WEIGHT',)
   > Event - Golzuna
       All of the following:

--- a/requirements.txt
+++ b/requirements.txt
@@ -150,7 +150,7 @@ markupsafe==3.0.2
     #   werkzeug
 matplotlib==3.9.2
     # via randovania (setup.py)
-mercury-engine-data-structures==0.31.1
+mercury-engine-data-structures==0.33.0
     # via
     #   open-dread-rando
     #   open-samus-returns-rando
@@ -177,7 +177,7 @@ oauthlib==3.2.2
     # via
     #   flask-discord
     #   requests-oauthlib
-open-dread-rando==2.13.1
+open-dread-rando==2.14.0
     # via randovania (setup.py)
 open-prime-rando==0.15.0
     # via randovania (setup.py)
@@ -343,5 +343,5 @@ wsproto==1.2.0
     # via simple-websocket
 yarl==1.15.4
     # via aiohttp
-zstd==1.5.5.1
+zstandard==0.23.0
     # via mercury-engine-data-structures

--- a/test/games/dread/exporter/test_dread_patch_data_factory.py
+++ b/test/games/dread/exporter/test_dread_patch_data_factory.py
@@ -124,11 +124,11 @@ def test_pickup_data_for_recolored_missiles(
         "pickup_type": "actor",
         "caption": "Missile Tank acquired.\nMissile capacity increased by 2.",
         "resources": [[{"item_id": "ITEM_WEAPON_MISSILE_MAX", "quantity": 2}]],
-        "pickup_actor": {"scenario": "s010_cave", "layer": "default", "actor": "ItemSphere_ChargeBeam"},
+        "pickup_actor": {"scenario": "s010_cave", "actor": "ItemSphere_ChargeBeam"},
         "model": ["item_missiletank_green"],
         "map_icon": {
             "icon_id": "item_missiletank",
-            "original_actor": {"actor": "powerup_chargebeam", "layer": "default", "scenario": "s010_cave"},
+            "original_actor": {"actor": "powerup_chargebeam", "scenario": "s010_cave"},
         },
     }
 
@@ -164,10 +164,10 @@ def test_pickup_data_for_a_major(dread_game_description: GameDescription, preset
         "pickup_type": "actor",
         "caption": "Speed Booster acquired.",
         "resources": [[{"item_id": "ITEM_SPEED_BOOSTER", "quantity": 1}]],
-        "pickup_actor": {"scenario": "s010_cave", "layer": "default", "actor": "ItemSphere_ChargeBeam"},
+        "pickup_actor": {"scenario": "s010_cave", "actor": "ItemSphere_ChargeBeam"},
         "model": ["powerup_speedbooster"],
         "map_icon": {
             "icon_id": "powerup_speedbooster",
-            "original_actor": {"actor": "powerup_chargebeam", "layer": "default", "scenario": "s010_cave"},
+            "original_actor": {"actor": "powerup_chargebeam", "scenario": "s010_cave"},
         },
     }

--- a/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
@@ -39,7 +39,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -49,7 +48,6 @@
                 "icon_id": "item_missiletankplus",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -67,7 +65,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -90,7 +87,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -113,7 +109,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -136,7 +131,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -159,7 +153,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -182,7 +175,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -205,7 +197,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -228,7 +219,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -251,7 +241,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -274,7 +263,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -297,7 +285,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -320,7 +307,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -343,7 +329,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -366,7 +351,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -389,7 +373,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -412,7 +395,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -435,7 +417,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -458,7 +439,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -482,7 +462,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -505,7 +484,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -528,7 +506,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -551,7 +528,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -574,7 +550,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -584,7 +559,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -602,7 +576,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -625,7 +598,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -635,7 +607,6 @@
                 "icon_id": "item_powerbombtank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -653,7 +624,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -676,7 +646,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -686,7 +655,6 @@
                 "icon_id": "item_powerbombtank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -704,7 +672,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -727,7 +694,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -750,7 +716,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -773,7 +738,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -797,7 +761,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -820,7 +783,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -843,7 +805,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -866,7 +827,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -876,7 +836,6 @@
                 "icon_id": "DNA_10",
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -894,7 +853,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -917,7 +875,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -940,7 +897,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -964,7 +920,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -987,7 +942,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1010,7 +964,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1039,7 +992,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1062,7 +1014,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1085,7 +1036,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1108,7 +1058,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1131,7 +1080,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1154,7 +1102,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1177,7 +1124,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1200,7 +1146,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1223,7 +1168,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1246,7 +1190,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1269,7 +1212,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1292,7 +1234,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1315,7 +1256,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1338,7 +1278,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1361,7 +1300,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1384,7 +1322,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1394,7 +1331,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1412,7 +1348,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1422,7 +1357,6 @@
                 "icon_id": "item_powerbombtank",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1440,7 +1374,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1463,7 +1396,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1486,7 +1418,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1509,7 +1440,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1532,7 +1462,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1555,7 +1484,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1578,7 +1506,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1601,7 +1528,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1625,7 +1551,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1654,7 +1579,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1677,7 +1601,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1700,7 +1623,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1723,7 +1645,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1746,7 +1667,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1770,7 +1690,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1793,7 +1712,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1816,7 +1734,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1839,7 +1756,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1862,7 +1778,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1886,7 +1801,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -1909,7 +1823,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -1919,7 +1832,6 @@
                 "icon_id": "item_missiletankplus",
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -1937,7 +1849,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1960,7 +1871,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1989,7 +1899,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2012,7 +1921,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2035,7 +1943,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2058,7 +1965,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2081,7 +1987,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2104,7 +2009,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2133,7 +2037,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2162,7 +2065,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2185,7 +2087,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2208,7 +2109,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2231,7 +2131,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2254,7 +2153,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2277,7 +2175,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2300,7 +2197,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2323,7 +2219,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2346,7 +2241,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2369,7 +2263,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2392,7 +2285,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2419,7 +2311,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2429,7 +2320,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2447,7 +2337,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2476,7 +2365,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2500,7 +2388,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2524,7 +2411,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2534,7 +2420,6 @@
                 "icon_id": "item_speedboostupgrade",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2552,7 +2437,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2575,7 +2459,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2598,7 +2481,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2621,7 +2503,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2644,7 +2525,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2667,7 +2547,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2690,7 +2569,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2713,7 +2591,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2736,7 +2613,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2759,7 +2635,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2782,7 +2657,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -2792,7 +2666,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -2810,7 +2683,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2833,7 +2705,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2856,7 +2727,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2885,7 +2755,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -2895,7 +2764,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -2913,7 +2781,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2936,7 +2803,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2959,7 +2825,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2982,7 +2847,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3005,7 +2869,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3028,7 +2891,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3051,7 +2913,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3074,7 +2935,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3097,7 +2957,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3120,7 +2979,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3143,7 +3001,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3166,7 +3023,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3189,7 +3045,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3212,7 +3067,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3235,7 +3089,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3258,7 +3111,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3281,7 +3133,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3518,7 +3369,6 @@
         {
             "teleporter": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "elevator_baselab_000"
             },
             "destination": {
@@ -3530,7 +3380,6 @@
         {
             "teleporter": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "LE_Elevator_FromMagma"
             },
             "destination": {
@@ -3542,7 +3391,6 @@
         {
             "teleporter": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "elevator_with_cutscene_aqua_000"
             },
             "destination": {
@@ -3554,7 +3402,6 @@
         {
             "teleporter": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "LE_Elevator_FromCave"
             },
             "destination": {
@@ -3566,7 +3413,6 @@
         {
             "teleporter": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "wagontrain_baselab_000"
             },
             "destination": {
@@ -3578,7 +3424,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "elevator_sanctuary_000"
             },
             "destination": {
@@ -3590,7 +3435,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "elevator_cave_000"
             },
             "destination": {
@@ -3602,7 +3446,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "elevator_sanctuary_001"
             },
             "destination": {
@@ -3614,7 +3457,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "wagontrain_magma_000"
             },
             "destination": {
@@ -3626,7 +3468,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "wagontrain_with_portal_aqua_001"
             },
             "destination": {
@@ -3638,7 +3479,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "wagontrain_aqua_000"
             },
             "destination": {
@@ -3650,7 +3490,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "elevator_forest_000"
             },
             "destination": {
@@ -3662,7 +3501,6 @@
         {
             "teleporter": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "wagontrain_baselab_000"
             },
             "destination": {
@@ -3674,7 +3512,6 @@
         {
             "teleporter": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "wagontrain_with_portal_baselab_001"
             },
             "destination": {
@@ -3686,7 +3523,6 @@
         {
             "teleporter": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "elevator_forest_000"
             },
             "destination": {
@@ -3698,7 +3534,6 @@
         {
             "teleporter": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "elevator_cave_000"
             },
             "destination": {
@@ -3710,7 +3545,6 @@
         {
             "teleporter": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "elevator_baselab_000"
             },
             "destination": {
@@ -3722,7 +3556,6 @@
         {
             "teleporter": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "elevator_baselab_001"
             },
             "destination": {
@@ -3734,7 +3567,6 @@
         {
             "teleporter": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "wagontrain_forest_000"
             },
             "destination": {
@@ -3746,7 +3578,6 @@
         {
             "teleporter": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "elevator_shipyard_000"
             },
             "destination": {
@@ -3758,7 +3589,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "elevator_aqua_000"
             },
             "destination": {
@@ -3770,7 +3600,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "wagontrain_sanctuary_000"
             },
             "destination": {
@@ -3782,7 +3611,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "wagontrain_shipyard_000"
             },
             "destination": {
@@ -3794,7 +3622,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "wagontrain_quarantine_with_cutscene_000"
             },
             "destination": {
@@ -3806,7 +3633,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "elevator_baselab_000"
             },
             "destination": {
@@ -3818,7 +3644,6 @@
         {
             "teleporter": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "wagontrain_forest_000"
             },
             "destination": {
@@ -3830,7 +3655,6 @@
         {
             "teleporter": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "elevator_sanctuary_000"
             },
             "destination": {
@@ -3842,7 +3666,6 @@
         {
             "teleporter": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "wagontrain_forest_000"
             },
             "destination": {
@@ -3854,7 +3677,6 @@
         {
             "teleporter": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "capsulelaunchershipyard_000"
             },
             "destination": {
@@ -3866,7 +3688,6 @@
         {
             "teleporter": {
                 "scenario": "s090_skybase",
-                "layer": "default",
                 "actor": "capsuleelevatorskybase_000"
             },
             "destination": {
@@ -3878,7 +3699,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "wagontrain_quarantine_000"
             },
             "destination": {
@@ -3892,7 +3712,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3901,7 +3720,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3910,7 +3728,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3919,7 +3736,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3928,7 +3744,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3937,7 +3752,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3946,7 +3760,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3955,7 +3768,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3964,7 +3776,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3973,7 +3784,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3982,7 +3792,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -4435,7 +4244,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door006 (CG-CG)"
             },
             "door_type": "power_bomb"
@@ -4443,7 +4251,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door009 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4451,7 +4258,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door002 (CG-CG)"
             },
             "door_type": "closed"
@@ -4459,7 +4265,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door006 (CG-CG)"
             },
             "door_type": "power_bomb"
@@ -4467,7 +4272,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door007 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4475,7 +4279,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door007 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4483,7 +4286,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door008 (PW-PW)"
             },
             "door_type": "missile"
@@ -4491,7 +4293,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door010 (CL-PW,OP)"
             },
             "door_type": "charge_beam"
@@ -4499,7 +4300,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door011 (CG-CG)"
             },
             "door_type": "charge_beam"
@@ -4507,7 +4307,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door012 (PW-PW, MISSILE)"
             },
             "door_type": "power_beam"
@@ -4515,7 +4314,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door055 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4523,7 +4321,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door011 (CG-CG)"
             },
             "door_type": "charge_beam"
@@ -4531,7 +4328,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door038 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4539,7 +4335,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door038 (PW-PW)_000"
             },
             "door_type": "super_missile"
@@ -4547,7 +4342,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door014 (CG-CG)"
             },
             "door_type": "super_missile"
@@ -4555,7 +4349,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door018 (CG-CL,OP)"
             },
             "door_type": "super_missile"
@@ -4563,7 +4356,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door062 (PW-PW, Special)"
             },
             "door_type": "power_beam"
@@ -4571,7 +4363,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door026 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4579,7 +4370,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door062 (PW-PW, Special)"
             },
             "door_type": "power_beam"
@@ -4587,7 +4377,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door020 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4595,7 +4384,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door026 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4603,7 +4391,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorPowerPower_001"
             },
             "door_type": "power_beam"
@@ -4611,7 +4398,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_015"
             },
             "door_type": "power_beam"
@@ -4619,7 +4405,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_016"
             },
             "door_type": "closed"
@@ -4627,7 +4412,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door028"
             },
             "door_type": "power_beam"
@@ -4635,7 +4419,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door020 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4643,7 +4426,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door025 (PW-PW)"
             },
             "door_type": "storm_missile"
@@ -4651,7 +4433,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door028"
             },
             "door_type": "power_beam"
@@ -4659,7 +4440,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_bomb"
@@ -4667,7 +4447,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_004"
             },
             "door_type": "bomb"
@@ -4675,7 +4454,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_005"
             },
             "door_type": "power_beam"
@@ -4683,7 +4461,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_006"
             },
             "door_type": "power_beam"
@@ -4691,7 +4468,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_007"
             },
             "door_type": "cross_bomb"
@@ -4699,7 +4475,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door024 (PW-PW)"
             },
             "door_type": "closed"
@@ -4707,7 +4482,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door054"
             },
             "door_type": "power_beam"
@@ -4715,7 +4489,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door056"
             },
             "door_type": "power_beam"
@@ -4723,7 +4496,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door023 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4731,7 +4503,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door024 (PW-PW)"
             },
             "door_type": "closed"
@@ -4739,7 +4510,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door001 (CG-CG)"
             },
             "door_type": "closed"
@@ -4747,7 +4517,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door002 (CG-CG)"
             },
             "door_type": "closed"
@@ -4755,7 +4524,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door003 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4763,7 +4531,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door004 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4771,7 +4538,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door001 (CG-CG)"
             },
             "door_type": "closed"
@@ -4779,7 +4545,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door016 (PW-PW)"
             },
             "door_type": "storm_missile"
@@ -4787,7 +4552,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_009"
             },
             "door_type": "power_beam"
@@ -4795,7 +4559,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_010"
             },
             "door_type": "super_missile"
@@ -4803,7 +4566,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_011"
             },
             "door_type": "power_beam"
@@ -4811,7 +4573,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_012"
             },
             "door_type": "power_beam"
@@ -4819,7 +4580,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door010 (CL-PW,OP)"
             },
             "door_type": "charge_beam"
@@ -4827,7 +4587,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door055 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4835,7 +4594,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door015 (CG-CG)"
             },
             "door_type": "plasma_beam"
@@ -4843,7 +4601,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door016 (PW-PW)"
             },
             "door_type": "storm_missile"
@@ -4851,7 +4608,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door018 (CG-CL,OP)"
             },
             "door_type": "super_missile"
@@ -4859,7 +4615,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door059 (CL-PW)"
             },
             "door_type": "charge_beam"
@@ -4867,7 +4622,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_009"
             },
             "door_type": "power_beam"
@@ -4875,7 +4629,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_010"
             },
             "door_type": "super_missile"
@@ -4883,7 +4636,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_011"
             },
             "door_type": "power_beam"
@@ -4891,7 +4643,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door014 (CG-CG)"
             },
             "door_type": "super_missile"
@@ -4899,7 +4650,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door029 (CG-CL,OP)"
             },
             "door_type": "power_beam"
@@ -4907,7 +4657,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorpresenceframe_000"
             },
             "door_type": "bomb"
@@ -4915,7 +4664,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door032 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4923,7 +4671,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door032 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4931,7 +4678,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door036 (PW-PW)"
             },
             "door_type": "missile"
@@ -4939,7 +4685,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door037 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4947,7 +4692,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door035 (PW-PW)"
             },
             "door_type": "super_missile"
@@ -4955,7 +4699,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door037 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4963,7 +4706,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door060"
             },
             "door_type": "power_beam"
@@ -4971,7 +4713,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorpresenceframe_001"
             },
             "door_type": "power_beam"
@@ -4979,7 +4720,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door036 (PW-PW)"
             },
             "door_type": "missile"
@@ -4987,7 +4727,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door034 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4995,7 +4734,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door035 (PW-PW)"
             },
             "door_type": "super_missile"
@@ -5003,7 +4741,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door053"
             },
             "door_type": "power_beam"
@@ -5011,7 +4748,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door055"
             },
             "door_type": "power_beam"
@@ -5019,7 +4755,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door055"
             },
             "door_type": "power_beam"
@@ -5027,7 +4762,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door056"
             },
             "door_type": "power_beam"
@@ -5035,7 +4769,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door058"
             },
             "door_type": "power_beam"
@@ -5043,7 +4776,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door059"
             },
             "door_type": "power_beam"
@@ -5051,7 +4783,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door058"
             },
             "door_type": "power_beam"
@@ -5059,7 +4790,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door059"
             },
             "door_type": "power_beam"
@@ -5067,7 +4797,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door065"
             },
             "door_type": "power_beam"
@@ -5075,7 +4804,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door066"
             },
             "door_type": "power_beam"
@@ -5083,7 +4811,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door067"
             },
             "door_type": "plasma_beam"
@@ -5091,7 +4818,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorclosedgrapple_000"
             },
             "door_type": "power_beam"
@@ -5099,7 +4825,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door069"
             },
             "door_type": "power_beam"
@@ -5107,7 +4832,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door066"
             },
             "door_type": "power_beam"
@@ -5115,7 +4839,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door005 (PW-PW)"
             },
             "door_type": "closed"
@@ -5123,7 +4846,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door025 (PW-PW)"
             },
             "door_type": "storm_missile"
@@ -5131,7 +4853,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_001"
             },
             "door_type": "missile"
@@ -5139,7 +4860,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door015 (CG-CG)"
             },
             "door_type": "plasma_beam"
@@ -5147,7 +4867,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door059 (CL-PW)"
             },
             "door_type": "charge_beam"
@@ -5155,7 +4874,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door030 (PW-PW)"
             },
             "door_type": "plasma_beam"
@@ -5163,7 +4881,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door049 (PR-PR)"
             },
             "door_type": "super_missile"
@@ -5171,7 +4888,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorpresenceframe_000"
             },
             "door_type": "bomb"
@@ -5179,7 +4895,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_bomb"
@@ -5187,7 +4902,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_001"
             },
             "door_type": "missile"
@@ -5195,7 +4909,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door005 (PW-PW)"
             },
             "door_type": "closed"
@@ -5203,7 +4916,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door053"
             },
             "door_type": "power_beam"
@@ -5211,7 +4923,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door054"
             },
             "door_type": "power_beam"
@@ -5219,7 +4930,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door022 (PW-PW) "
             },
             "door_type": "diffusion_beam"
@@ -5227,7 +4937,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door023 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -5235,7 +4944,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door022 (PW-PW) _000"
             },
             "door_type": "power_beam"
@@ -5243,7 +4951,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door074"
             },
             "door_type": "power_beam"
@@ -5251,7 +4958,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door076"
             },
             "door_type": "power_beam"
@@ -5259,7 +4965,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door021 (PW-PW)"
             },
             "door_type": "bomb"
@@ -5267,7 +4972,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door022 (PW-PW) "
             },
             "door_type": "diffusion_beam"
@@ -5275,7 +4979,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door021 (PW-PW)_000"
             },
             "door_type": "closed"
@@ -5283,7 +4986,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door022 (PW-PW) _000"
             },
             "door_type": "power_beam"
@@ -5291,7 +4993,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door021 (PW-PW)"
             },
             "door_type": "bomb"
@@ -5299,7 +5000,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door021 (PW-PW)_000"
             },
             "door_type": "closed"
@@ -5307,7 +5007,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door003 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -5315,7 +5014,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door004 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -5323,7 +5021,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door004 (PW-PW)_001"
             },
             "door_type": "power_beam"
@@ -5331,7 +5028,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door012 (PW-PW, MISSILE)"
             },
             "door_type": "power_beam"
@@ -5339,7 +5035,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door038 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -5347,7 +5042,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door029 (CG-CL,OP)"
             },
             "door_type": "power_beam"
@@ -5355,7 +5049,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door030 (PW-PW)"
             },
             "door_type": "plasma_beam"
@@ -5363,7 +5056,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door042 (PW-PW) "
             },
             "door_type": "cross_bomb"
@@ -5371,7 +5063,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door033 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -5379,7 +5070,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door034 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -5387,7 +5077,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door046 (PW-CL,OP)"
             },
             "door_type": "power_beam"
@@ -5395,7 +5084,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door033 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -5403,7 +5091,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door046 (PW-CL,OP)"
             },
             "door_type": "power_beam"
@@ -5411,7 +5098,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door008 (PW-PW)"
             },
             "door_type": "missile"
@@ -5419,7 +5105,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door009 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -5427,7 +5112,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_006"
             },
             "door_type": "power_beam"
@@ -5435,7 +5119,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_007"
             },
             "door_type": "cross_bomb"
@@ -5443,7 +5126,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_012"
             },
             "door_type": "power_beam"
@@ -5451,7 +5133,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door042 (PW-PW) "
             },
             "door_type": "cross_bomb"
@@ -5459,7 +5140,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorPowerPower_001"
             },
             "door_type": "power_beam"
@@ -5467,7 +5147,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_015"
             },
             "door_type": "power_beam"
@@ -5475,7 +5154,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_016"
             },
             "door_type": "closed"
@@ -5483,7 +5161,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door052"
             },
             "door_type": "closed"
@@ -5491,7 +5168,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door038 (PW-PW)_000"
             },
             "door_type": "super_missile"
@@ -5499,7 +5175,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door049 (PR-PR)"
             },
             "door_type": "super_missile"
@@ -5507,7 +5182,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door052"
             },
             "door_type": "closed"
@@ -5515,7 +5189,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_004"
             },
             "door_type": "bomb"
@@ -5523,7 +5196,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_005"
             },
             "door_type": "power_beam"
@@ -5531,7 +5203,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door064"
             },
             "door_type": "power_beam"
@@ -5539,7 +5210,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door065"
             },
             "door_type": "power_beam"
@@ -5547,7 +5217,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door062"
             },
             "door_type": "power_beam"
@@ -5555,7 +5224,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door063"
             },
             "door_type": "power_beam"
@@ -5563,7 +5231,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door060"
             },
             "door_type": "power_beam"
@@ -5571,7 +5238,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door062"
             },
             "door_type": "power_beam"
@@ -5579,7 +5245,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door063"
             },
             "door_type": "power_beam"
@@ -5587,7 +5252,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door070"
             },
             "door_type": "plasma_beam"
@@ -5595,7 +5259,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorgrapplegrapple"
             },
             "door_type": "power_beam"
@@ -5603,7 +5266,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door070"
             },
             "door_type": "plasma_beam"
@@ -5611,7 +5273,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door075"
             },
             "door_type": "power_beam"
@@ -5619,7 +5280,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door073"
             },
             "door_type": "power_beam"
@@ -5627,7 +5287,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorgrapplegrapple"
             },
             "door_type": "power_beam"
@@ -5635,7 +5294,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door075"
             },
             "door_type": "power_beam"
@@ -5643,7 +5301,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door077"
             },
             "door_type": "power_beam"
@@ -5651,7 +5308,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door076"
             },
             "door_type": "power_beam"
@@ -5659,7 +5315,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door073"
             },
             "door_type": "power_beam"
@@ -5667,7 +5322,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door074"
             },
             "door_type": "power_beam"
@@ -5675,7 +5329,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door004 (PW-PW)_001"
             },
             "door_type": "power_beam"
@@ -5683,7 +5336,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door078"
             },
             "door_type": "power_beam"
@@ -5691,7 +5343,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door064"
             },
             "door_type": "power_beam"
@@ -5699,7 +5350,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorclosedgrapple_000"
             },
             "door_type": "power_beam"
@@ -5707,7 +5357,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door069"
             },
             "door_type": "power_beam"
@@ -5715,7 +5364,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door067"
             },
             "door_type": "plasma_beam"
@@ -5723,7 +5371,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door077"
             },
             "door_type": "power_beam"
@@ -5731,7 +5378,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door078"
             },
             "door_type": "power_beam"
@@ -5739,7 +5385,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "cross_bomb"
@@ -5747,7 +5392,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "charge_beam"
@@ -5755,7 +5399,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "charge_beam"
@@ -5763,7 +5406,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "plasma_beam"
@@ -5771,7 +5413,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "plasma_beam"
@@ -5779,7 +5420,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -5787,7 +5427,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "cross_bomb"
@@ -5795,7 +5434,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_bomb"
@@ -5803,7 +5441,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_003"
             },
             "door_type": "power_beam"
@@ -5811,7 +5448,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -5819,7 +5455,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_007"
             },
             "door_type": "plasma_beam"
@@ -5827,7 +5462,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_026"
             },
             "door_type": "charge_beam"
@@ -5835,7 +5469,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -5843,7 +5476,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "power_beam"
@@ -5851,7 +5483,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "power_beam"
@@ -5859,7 +5490,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_002"
             },
             "door_type": "power_beam"
@@ -5867,7 +5497,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_003"
             },
             "door_type": "power_beam"
@@ -5875,7 +5504,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorframepresence_001"
             },
             "door_type": "bomb"
@@ -5883,7 +5511,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "power_beam"
@@ -5891,7 +5518,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "power_beam"
@@ -5899,7 +5525,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "power_beam"
@@ -5907,7 +5532,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "charge_beam"
@@ -5915,7 +5539,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "charge_beam"
@@ -5923,7 +5546,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpresenceframe_000"
             },
             "door_type": "power_beam"
@@ -5931,7 +5553,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -5939,7 +5560,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_bomb"
@@ -5947,7 +5567,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -5955,7 +5574,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_020"
             },
             "door_type": "power_beam"
@@ -5963,7 +5581,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "bomb"
@@ -5971,7 +5588,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge"
             },
             "door_type": "power_beam"
@@ -5979,7 +5595,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "charge_beam"
@@ -5987,7 +5602,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpresenceframe_000"
             },
             "door_type": "power_beam"
@@ -5995,7 +5609,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_005"
             },
             "door_type": "power_beam"
@@ -6003,7 +5616,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorframepresence"
             },
             "door_type": "power_beam"
@@ -6011,7 +5623,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_026"
             },
             "door_type": "charge_beam"
@@ -6019,7 +5630,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_029"
             },
             "door_type": "power_beam"
@@ -6027,7 +5637,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_028"
             },
             "door_type": "power_beam"
@@ -6035,7 +5644,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorframe"
             },
             "door_type": "diffusion_beam"
@@ -6043,7 +5651,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "storm_missile"
@@ -6051,7 +5658,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -6059,7 +5665,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "storm_missile"
@@ -6067,7 +5672,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "plasma_beam"
@@ -6075,7 +5679,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "plasma_beam"
@@ -6083,7 +5686,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "charge_beam"
@@ -6091,7 +5693,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "charge_beam"
@@ -6099,7 +5700,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "super_missile"
@@ -6107,7 +5707,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -6115,7 +5714,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "bomb"
@@ -6123,7 +5721,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge"
             },
             "door_type": "power_beam"
@@ -6131,7 +5728,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "power_beam"
@@ -6139,7 +5735,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "cross_bomb"
@@ -6147,7 +5742,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "bomb"
@@ -6155,7 +5749,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "cross_bomb"
@@ -6163,7 +5756,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_030"
             },
             "door_type": "bomb"
@@ -6171,7 +5763,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_030"
             },
             "door_type": "bomb"
@@ -6179,7 +5770,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "power_beam"
@@ -6187,7 +5777,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "power_beam"
@@ -6195,7 +5784,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_020"
             },
             "door_type": "power_beam"
@@ -6203,7 +5791,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge"
             },
             "door_type": "power_beam"
@@ -6211,7 +5798,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorframe"
             },
             "door_type": "diffusion_beam"
@@ -6219,7 +5805,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_029"
             },
             "door_type": "power_beam"
@@ -6227,7 +5812,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_bomb"
@@ -6235,7 +5819,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "charge_beam"
@@ -6243,7 +5826,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_002"
             },
             "door_type": "power_beam"
@@ -6251,7 +5833,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorframepresence_001"
             },
             "door_type": "bomb"
@@ -6259,7 +5840,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "super_missile"
@@ -6267,7 +5847,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_005"
             },
             "door_type": "power_beam"
@@ -6275,7 +5854,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "bomb"
@@ -6283,7 +5861,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge"
             },
             "door_type": "power_beam"
@@ -6291,7 +5868,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_007"
             },
             "door_type": "plasma_beam"
@@ -6299,7 +5875,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_bomb"
@@ -6307,7 +5882,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorgrapplegrapple"
             },
             "door_type": "missile"
@@ -6315,7 +5889,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "power_beam"
@@ -6323,7 +5896,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorgrapplegrapple"
             },
             "door_type": "missile"
@@ -6331,7 +5903,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "power_beam"
@@ -6339,7 +5910,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -6347,7 +5917,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "storm_missile"
@@ -6355,7 +5924,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "storm_missile"
@@ -6363,7 +5931,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_028"
             },
             "door_type": "power_beam"
@@ -6371,7 +5938,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "super_missile"
@@ -6379,7 +5945,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -6387,7 +5952,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "super_missile"
@@ -6395,7 +5959,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "diffusion_beam"
@@ -6403,7 +5966,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -6411,7 +5973,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "charge_beam"
@@ -6419,7 +5980,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargeclosed_000"
             },
             "door_type": "power_beam"
@@ -6427,7 +5987,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "charge_beam"
@@ -6435,7 +5994,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_002"
             },
             "door_type": "power_beam"
@@ -6443,7 +6001,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargeclosed_001"
             },
             "door_type": "power_beam"
@@ -6451,7 +6008,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargeclosed_001"
             },
             "door_type": "power_beam"
@@ -6459,7 +6015,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "power_beam"
@@ -6467,7 +6022,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_002"
             },
             "door_type": "power_beam"
@@ -6475,7 +6029,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -6483,7 +6036,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "power_beam"
@@ -6491,7 +6043,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -6499,7 +6050,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "power_beam"
@@ -6507,7 +6057,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -6515,7 +6064,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "power_beam"
@@ -6523,7 +6071,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargeclosed_000"
             },
             "door_type": "power_beam"
@@ -6531,7 +6078,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "power_beam"
@@ -6539,7 +6085,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "charge_beam"
@@ -6547,7 +6092,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "missile"
@@ -6555,7 +6099,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -6563,7 +6106,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_029"
             },
             "door_type": "closed"
@@ -6571,7 +6113,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "missile"
@@ -6579,7 +6120,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "cross_bomb"
@@ -6587,7 +6127,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_029"
             },
             "door_type": "closed"
@@ -6595,7 +6134,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorclosedcharge_000"
             },
             "door_type": "power_bomb"
@@ -6603,7 +6141,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorclosedcharge_000"
             },
             "door_type": "power_bomb"
@@ -6611,7 +6148,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "cross_bomb"
@@ -6619,7 +6155,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "missile"
@@ -6627,7 +6162,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -6635,7 +6169,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "missile"
@@ -6643,7 +6176,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -6651,7 +6183,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "diffusion_beam"
@@ -6659,7 +6190,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "power_beam"
@@ -6667,7 +6197,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "charge_beam"
@@ -6675,7 +6204,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -6683,7 +6211,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -6691,7 +6218,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -6699,7 +6225,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -6707,7 +6232,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "missile"
@@ -6715,7 +6239,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "closed"
@@ -6723,7 +6246,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -6731,7 +6253,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_bomb"
@@ -6739,7 +6260,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "missile"
@@ -6747,7 +6267,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -6755,7 +6274,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -6763,7 +6281,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_bomb"
@@ -6771,7 +6288,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -6779,7 +6295,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -6787,7 +6302,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_001"
             },
             "door_type": "power_beam"
@@ -6795,7 +6309,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_001"
             },
             "door_type": "power_beam"
@@ -6803,7 +6316,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "power_bomb"
@@ -6811,7 +6323,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -6819,7 +6330,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -6827,7 +6337,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "closed"
@@ -6835,7 +6344,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "power_bomb"
@@ -6843,7 +6351,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "charge_beam"
@@ -6851,7 +6358,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "power_beam"
@@ -6859,7 +6365,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "power_beam"
@@ -6867,7 +6372,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedpower"
             },
             "door_type": "power_beam"
@@ -6875,7 +6379,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "power_beam"
@@ -6883,7 +6386,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "power_beam"
@@ -6891,7 +6393,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "power_beam"
@@ -6899,7 +6400,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_024"
             },
             "door_type": "power_beam"
@@ -6907,7 +6407,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -6915,7 +6414,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "power_beam"
@@ -6923,7 +6421,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "power_beam"
@@ -6931,7 +6428,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "charge_beam"
@@ -6939,7 +6435,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_020"
             },
             "door_type": "power_beam"
@@ -6947,7 +6442,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "power_beam"
@@ -6955,7 +6449,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "power_beam"
@@ -6963,7 +6456,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedpower"
             },
             "door_type": "power_beam"
@@ -6971,7 +6463,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "charge_beam"
@@ -6979,7 +6470,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_beam"
@@ -6987,7 +6477,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "power_beam"
@@ -6995,7 +6484,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "power_beam"
@@ -7003,7 +6491,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_020"
             },
             "door_type": "power_beam"
@@ -7011,7 +6498,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "power_beam"
@@ -7019,7 +6505,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "power_beam"
@@ -7027,7 +6512,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_beam"
@@ -7035,7 +6519,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorframepresence"
             },
             "door_type": "power_beam"
@@ -7043,7 +6526,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -7051,7 +6533,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "charge_beam"
@@ -7059,7 +6540,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorframepresence"
             },
             "door_type": "power_beam"
@@ -7067,7 +6547,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorframepresence_000"
             },
             "door_type": "power_beam"
@@ -7075,7 +6554,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "power_beam"
@@ -7083,7 +6561,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -7091,7 +6568,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_024"
             },
             "door_type": "power_beam"
@@ -7099,7 +6575,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "power_beam"
@@ -7107,7 +6582,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "power_beam"
@@ -7115,7 +6589,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_beam"
@@ -7123,7 +6596,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_beam"
@@ -7131,7 +6603,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -7139,7 +6610,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_004"
             },
             "door_type": "power_beam"
@@ -7147,7 +6617,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -7155,7 +6624,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -7163,7 +6631,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "power_bomb"
@@ -7171,7 +6638,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -7179,7 +6645,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "diffusion_beam"
@@ -7187,7 +6652,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "closed"
@@ -7195,7 +6659,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -7203,7 +6666,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -7211,7 +6673,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "power_bomb"
@@ -7219,7 +6680,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "diffusion_beam"
@@ -7227,7 +6687,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -7235,7 +6694,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "cross_bomb"
@@ -7243,7 +6701,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "diffusion_beam"
@@ -7251,7 +6708,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -7259,7 +6715,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "storm_missile"
@@ -7267,7 +6722,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_000"
             },
             "door_type": "closed"
@@ -7275,7 +6729,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "diffusion_beam"
@@ -7283,7 +6736,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -7291,7 +6743,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "storm_missile"
@@ -7299,7 +6750,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "power_beam"
@@ -7307,7 +6757,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "cross_bomb"
@@ -7315,7 +6764,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "closed"
@@ -7323,7 +6771,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -7331,7 +6778,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "bomb"
@@ -7339,7 +6785,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "power_beam"
@@ -7347,7 +6792,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_000"
             },
             "door_type": "closed"
@@ -7355,7 +6799,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "bomb"
@@ -7363,7 +6806,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "power_beam"
@@ -7371,7 +6813,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "power_beam"
@@ -7379,7 +6820,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "power_beam"
@@ -7387,7 +6827,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -7395,7 +6834,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -7403,7 +6841,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "power_beam"
@@ -7411,7 +6848,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -7419,7 +6855,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_004"
             },
             "door_type": "power_beam"
@@ -7427,7 +6862,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "power_beam"
@@ -7435,7 +6869,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_beam"
@@ -7443,7 +6876,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "power_beam"
@@ -7451,7 +6883,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_024"
             },
             "door_type": "power_beam"
@@ -7459,7 +6890,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_beam"
@@ -7467,7 +6897,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_003"
             },
             "door_type": "power_beam"
@@ -7475,7 +6904,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "power_beam"
@@ -7483,7 +6911,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "power_beam"
@@ -7491,7 +6918,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "power_beam"
@@ -7499,7 +6925,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "power_beam"
@@ -7507,7 +6932,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "power_beam"
@@ -7515,7 +6939,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -7523,7 +6946,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "power_beam"
@@ -7531,7 +6953,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "power_beam"
@@ -7539,7 +6960,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -7547,7 +6967,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "power_bomb"
@@ -7555,7 +6974,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "power_beam"
@@ -7563,7 +6981,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -7571,7 +6988,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "power_bomb"
@@ -7579,7 +6995,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "power_beam"
@@ -7587,7 +7002,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "power_beam"
@@ -7595,7 +7009,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_024"
             },
             "door_type": "power_beam"
@@ -7603,7 +7016,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_003"
             },
             "door_type": "power_beam"
@@ -7611,7 +7023,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_bomb"
@@ -7619,7 +7030,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_001"
             },
             "door_type": "power_beam"
@@ -7627,7 +7037,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_beam"
@@ -7635,7 +7044,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "power_bomb"
@@ -7643,7 +7051,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "power_beam"
@@ -7651,7 +7058,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_001"
             },
             "door_type": "power_beam"
@@ -7659,7 +7065,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_beam"
@@ -7667,7 +7072,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -7675,7 +7079,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_bomb"
@@ -7683,7 +7086,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -7691,7 +7093,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "missile"
@@ -7699,7 +7100,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "power_beam"
@@ -7707,7 +7107,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "power_beam"
@@ -7715,7 +7114,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -7723,7 +7121,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -7731,7 +7128,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "charge_beam"
@@ -7739,7 +7135,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -7747,7 +7142,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -7755,7 +7149,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "power_beam"
@@ -7763,7 +7156,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -7771,7 +7163,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_bomb"
@@ -7779,7 +7170,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "power_beam"
@@ -7787,7 +7177,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "power_beam"
@@ -7795,7 +7184,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_bomb"
@@ -7803,7 +7191,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "missile"
@@ -7811,7 +7198,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorframe_000"
             },
             "door_type": "missile"
@@ -7819,7 +7205,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_006"
             },
             "door_type": "power_bomb"
@@ -7827,7 +7212,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -7835,7 +7219,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorframe_000"
             },
             "door_type": "missile"
@@ -7843,7 +7226,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "charge_beam"
@@ -7851,7 +7233,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_006"
             },
             "door_type": "power_bomb"
@@ -7859,7 +7240,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -7867,7 +7247,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "power_beam"
@@ -7875,7 +7254,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "charge_beam"
@@ -7883,7 +7261,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "closed"
@@ -7891,7 +7268,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "charge_beam"
@@ -7899,7 +7275,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "power_beam"
@@ -7907,7 +7282,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "charge_beam"
@@ -7915,7 +7289,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "closed"
@@ -7923,7 +7296,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrappleclosed_000"
             },
             "door_type": "power_beam"
@@ -7931,7 +7303,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "power_beam"
@@ -7939,7 +7310,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "power_beam"
@@ -7947,7 +7317,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "power_beam"
@@ -7955,7 +7324,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "power_beam"
@@ -7963,7 +7331,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_002"
             },
             "door_type": "power_beam"
@@ -7971,7 +7338,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -7979,7 +7345,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedcharge"
             },
             "door_type": "charge_beam"
@@ -7987,7 +7352,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "power_beam"
@@ -7995,7 +7359,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_002"
             },
             "door_type": "power_beam"
@@ -8003,7 +7366,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_002"
             },
             "door_type": "power_beam"
@@ -8011,7 +7373,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "power_beam"
@@ -8019,7 +7380,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_002"
             },
             "door_type": "power_beam"
@@ -8027,7 +7387,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_003"
             },
             "door_type": "power_beam"
@@ -8035,7 +7394,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "charge_beam"
@@ -8043,7 +7401,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_003"
             },
             "door_type": "power_bomb"
@@ -8051,7 +7408,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -8059,7 +7415,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_003"
             },
             "door_type": "power_beam"
@@ -8067,7 +7422,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_003"
             },
             "door_type": "power_beam"
@@ -8075,7 +7429,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -8083,7 +7436,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -8091,7 +7443,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "power_bomb"
@@ -8099,7 +7450,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_003"
             },
             "door_type": "power_beam"
@@ -8107,7 +7457,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_003"
             },
             "door_type": "power_bomb"
@@ -8115,7 +7464,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -8123,7 +7471,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrappleclosed_000"
             },
             "door_type": "power_beam"
@@ -8131,7 +7478,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedcharge"
             },
             "door_type": "charge_beam"
@@ -8139,7 +7485,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "storm_missile"
@@ -8147,7 +7492,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_beam"
@@ -8155,7 +7499,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_beam"
@@ -8163,7 +7506,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "charge_beam"
@@ -8171,7 +7513,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "missile"
@@ -8179,7 +7520,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "super_missile"
@@ -8187,7 +7527,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "power_beam"
@@ -8195,7 +7534,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "charge_beam"
@@ -8203,7 +7541,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "missile"
@@ -8211,7 +7548,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -8219,7 +7555,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -8227,7 +7562,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "super_missile"
@@ -8235,7 +7569,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "power_beam"
@@ -8243,7 +7576,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -8251,7 +7583,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -8259,7 +7590,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -8267,7 +7597,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -8275,7 +7604,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "storm_missile"
@@ -8283,7 +7611,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -8291,7 +7618,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_bomb"
@@ -8299,7 +7625,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -8307,7 +7632,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -8315,7 +7639,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "missile"
@@ -8323,7 +7646,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "missile"
@@ -8331,7 +7653,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_bomb"
@@ -8339,7 +7660,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -8347,7 +7667,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_bomb"
@@ -8355,7 +7674,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -8363,7 +7681,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "closed"
@@ -8371,7 +7688,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_bomb"
@@ -8379,7 +7695,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -8387,7 +7702,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "closed"
@@ -8395,7 +7709,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "missile"
@@ -8403,7 +7716,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "power_beam"
@@ -8411,7 +7723,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "power_beam"
@@ -8419,7 +7730,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "missile"
@@ -8427,7 +7737,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "power_beam"
@@ -8435,7 +7744,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "power_beam"
@@ -8443,7 +7751,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerclosed_001"
             },
             "door_type": "power_beam"
@@ -8451,7 +7758,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerclosed_001"
             },
             "door_type": "power_beam"
@@ -8461,7 +7767,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/dread/crazy_settings/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/crazy_settings/world_1.json
@@ -34,7 +34,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -45,7 +44,6 @@
                 "icon_id": "PROGRESSIVE_MISSILE",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -63,7 +61,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -86,7 +83,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -109,7 +105,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -136,7 +131,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -161,7 +155,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -184,7 +177,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -207,7 +199,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -238,7 +229,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -261,7 +251,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -284,7 +273,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -307,7 +295,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -330,7 +317,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -353,7 +339,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -376,7 +361,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -399,7 +383,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -422,7 +405,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -445,7 +427,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -468,7 +449,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -491,7 +471,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -514,7 +493,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -538,7 +516,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -567,7 +544,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -597,7 +573,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -607,7 +582,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -625,7 +599,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -648,7 +621,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -658,7 +630,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -676,7 +647,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -699,7 +669,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -710,7 +679,6 @@
                 "icon_id": "PROGRESSIVE_CHARGE",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -728,7 +696,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -751,7 +718,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -774,7 +740,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -797,7 +762,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -820,7 +784,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -843,7 +806,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -872,7 +834,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -895,7 +856,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -905,7 +865,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -923,7 +882,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -946,7 +904,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -969,7 +926,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -992,7 +948,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1015,7 +970,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1038,7 +992,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1061,7 +1014,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1084,7 +1036,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1107,7 +1058,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1130,7 +1080,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1153,7 +1102,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1182,7 +1130,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1205,7 +1152,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1228,7 +1174,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1251,7 +1196,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1274,7 +1218,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1297,7 +1240,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1320,7 +1262,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1343,7 +1284,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1366,7 +1306,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1389,7 +1328,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1413,7 +1351,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1423,7 +1360,6 @@
                 "icon_id": "item_flashshiftupgrade",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1441,7 +1377,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1451,7 +1386,6 @@
                 "icon_id": "item_speedboostupgrade",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1469,7 +1403,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1504,7 +1437,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1528,7 +1460,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1551,7 +1482,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1574,7 +1504,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1603,7 +1532,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1626,7 +1554,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1649,7 +1576,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1672,7 +1598,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1695,7 +1620,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1718,7 +1642,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1741,7 +1664,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1764,7 +1686,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1787,7 +1708,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1810,7 +1730,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1833,7 +1752,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1856,7 +1774,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1891,7 +1808,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1914,7 +1830,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1937,7 +1852,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -1960,7 +1874,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -1970,7 +1883,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -1988,7 +1900,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2011,7 +1922,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2034,7 +1944,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2058,7 +1967,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2081,7 +1989,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2104,7 +2011,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2127,7 +2033,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2156,7 +2061,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2179,7 +2083,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2202,7 +2105,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2225,7 +2127,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2249,7 +2150,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2273,7 +2173,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2296,7 +2195,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2319,7 +2217,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2342,7 +2239,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2371,7 +2267,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2394,7 +2289,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2417,7 +2311,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2440,7 +2333,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2463,7 +2355,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2473,7 +2364,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2491,7 +2381,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2514,7 +2403,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2537,7 +2425,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2560,7 +2447,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2570,7 +2456,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2588,7 +2473,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2611,7 +2495,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2634,7 +2517,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2657,7 +2539,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2680,7 +2561,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2703,7 +2583,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2726,7 +2605,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2749,7 +2627,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2772,7 +2649,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2797,7 +2673,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2820,7 +2695,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -2831,7 +2705,6 @@
                 "icon_id": "PROGRESSIVE_SPIN",
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -2849,7 +2722,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2872,7 +2744,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2895,7 +2766,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2918,7 +2788,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -2928,7 +2797,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -2952,7 +2820,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2975,7 +2842,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2998,7 +2864,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3021,7 +2886,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3044,7 +2908,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3067,7 +2930,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3090,7 +2952,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3113,7 +2974,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3136,7 +2996,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3165,7 +3024,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3188,7 +3046,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3211,7 +3068,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3234,7 +3090,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3257,7 +3112,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3280,7 +3134,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3303,7 +3156,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3326,7 +3178,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3580,7 +3431,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3589,7 +3439,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3598,7 +3447,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3607,7 +3455,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3616,7 +3463,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3625,7 +3471,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3634,7 +3479,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3643,7 +3487,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3652,7 +3495,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3661,7 +3503,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3670,7 +3511,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -3761,7 +3601,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door006 (CG-CG)"
             },
             "door_type": "charge_beam"
@@ -3769,7 +3608,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door009 (PW-PW)"
             },
             "door_type": "charge_beam"
@@ -3777,7 +3615,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door002 (CG-CG)"
             },
             "door_type": "wide_beam"
@@ -3785,7 +3622,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door006 (CG-CG)"
             },
             "door_type": "charge_beam"
@@ -3793,7 +3629,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door007 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -3801,7 +3636,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door007 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -3809,7 +3643,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door008 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -3817,7 +3650,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door010 (CL-PW,OP)"
             },
             "door_type": "wide_beam"
@@ -3825,7 +3657,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door011 (CG-CG)"
             },
             "door_type": "missile"
@@ -3833,7 +3664,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door012 (PW-PW, MISSILE)"
             },
             "door_type": "power_beam"
@@ -3841,7 +3671,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door055 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -3849,7 +3678,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door011 (CG-CG)"
             },
             "door_type": "missile"
@@ -3857,7 +3685,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door038 (PW-PW)"
             },
             "door_type": "missile"
@@ -3865,7 +3692,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door038 (PW-PW)_000"
             },
             "door_type": "wide_beam"
@@ -3873,7 +3699,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door014 (CG-CG)"
             },
             "door_type": "missile"
@@ -3881,7 +3706,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door018 (CG-CL,OP)"
             },
             "door_type": "charge_beam"
@@ -3889,7 +3713,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door062 (PW-PW, Special)"
             },
             "door_type": "power_beam"
@@ -3897,7 +3720,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door026 (PW-PW)"
             },
             "door_type": "wide_beam"
@@ -3905,7 +3727,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_014"
             },
             "door_type": "power_beam"
@@ -3913,7 +3734,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door062 (PW-PW, Special)"
             },
             "door_type": "power_beam"
@@ -3921,7 +3741,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door020 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -3929,7 +3748,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door026 (PW-PW)"
             },
             "door_type": "wide_beam"
@@ -3937,7 +3755,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorPowerPower_001"
             },
             "door_type": "charge_beam"
@@ -3945,7 +3762,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_015"
             },
             "door_type": "power_beam"
@@ -3953,7 +3769,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_016"
             },
             "door_type": "power_beam"
@@ -3961,7 +3776,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door028"
             },
             "door_type": "power_beam"
@@ -3969,7 +3783,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door020 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -3977,7 +3790,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door025 (PW-PW)"
             },
             "door_type": "wide_beam"
@@ -3985,7 +3797,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door028"
             },
             "door_type": "power_beam"
@@ -3993,7 +3804,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -4001,7 +3811,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_004"
             },
             "door_type": "power_beam"
@@ -4009,7 +3818,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_005"
             },
             "door_type": "power_beam"
@@ -4017,7 +3825,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_006"
             },
             "door_type": "power_beam"
@@ -4025,7 +3832,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_007"
             },
             "door_type": "charge_beam"
@@ -4033,7 +3839,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door024 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4041,7 +3846,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door054"
             },
             "door_type": "power_beam"
@@ -4049,7 +3853,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door056"
             },
             "door_type": "charge_beam"
@@ -4057,7 +3860,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door023 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4065,7 +3867,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door024 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4073,7 +3874,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door001 (CG-CG)"
             },
             "door_type": "wide_beam"
@@ -4081,7 +3881,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door002 (CG-CG)"
             },
             "door_type": "wide_beam"
@@ -4089,7 +3888,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door003 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4097,7 +3895,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door004 (PW-PW)"
             },
             "door_type": "charge_beam"
@@ -4105,7 +3902,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door001 (CG-CG)"
             },
             "door_type": "wide_beam"
@@ -4113,7 +3909,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door016 (PW-PW)"
             },
             "door_type": "missile"
@@ -4121,7 +3916,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_009"
             },
             "door_type": "power_beam"
@@ -4129,7 +3923,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_010"
             },
             "door_type": "wide_beam"
@@ -4137,7 +3930,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_011"
             },
             "door_type": "charge_beam"
@@ -4145,7 +3937,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_012"
             },
             "door_type": "power_beam"
@@ -4153,7 +3944,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door010 (CL-PW,OP)"
             },
             "door_type": "wide_beam"
@@ -4161,7 +3951,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door055 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4169,7 +3958,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door015 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4177,7 +3965,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door016 (PW-PW)"
             },
             "door_type": "missile"
@@ -4185,7 +3972,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door018 (CG-CL,OP)"
             },
             "door_type": "charge_beam"
@@ -4193,7 +3979,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door059 (CL-PW)"
             },
             "door_type": "wide_beam"
@@ -4201,7 +3986,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_009"
             },
             "door_type": "power_beam"
@@ -4209,7 +3993,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_010"
             },
             "door_type": "wide_beam"
@@ -4217,7 +4000,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_011"
             },
             "door_type": "charge_beam"
@@ -4225,7 +4007,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door014 (CG-CG)"
             },
             "door_type": "missile"
@@ -4233,7 +4014,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door029 (CG-CL,OP)"
             },
             "door_type": "power_beam"
@@ -4241,7 +4021,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door032 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4249,7 +4028,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door032 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4257,7 +4035,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door036 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4265,7 +4042,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door037 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4273,7 +4049,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door035 (PW-PW)"
             },
             "door_type": "missile"
@@ -4281,7 +4056,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door037 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4289,7 +4063,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door060"
             },
             "door_type": "charge_beam"
@@ -4297,7 +4070,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorpresenceframe_001"
             },
             "door_type": "power_beam"
@@ -4305,7 +4077,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door036 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4313,7 +4084,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door034 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4321,7 +4091,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door035 (PW-PW)"
             },
             "door_type": "missile"
@@ -4329,7 +4098,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door053"
             },
             "door_type": "power_beam"
@@ -4337,7 +4105,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door055"
             },
             "door_type": "power_beam"
@@ -4345,7 +4112,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door055"
             },
             "door_type": "power_beam"
@@ -4353,7 +4119,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door056"
             },
             "door_type": "charge_beam"
@@ -4361,7 +4126,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door058"
             },
             "door_type": "power_beam"
@@ -4369,7 +4133,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door059"
             },
             "door_type": "power_beam"
@@ -4377,7 +4140,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door058"
             },
             "door_type": "power_beam"
@@ -4385,7 +4147,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door059"
             },
             "door_type": "power_beam"
@@ -4393,7 +4154,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door065"
             },
             "door_type": "power_beam"
@@ -4401,7 +4161,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door066"
             },
             "door_type": "power_beam"
@@ -4409,7 +4168,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door067"
             },
             "door_type": "wide_beam"
@@ -4417,7 +4175,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorclosedgrapple_000"
             },
             "door_type": "power_beam"
@@ -4425,7 +4182,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door069"
             },
             "door_type": "power_beam"
@@ -4433,7 +4189,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door066"
             },
             "door_type": "power_beam"
@@ -4441,7 +4196,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door005 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4449,7 +4203,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door025 (PW-PW)"
             },
             "door_type": "wide_beam"
@@ -4457,7 +4210,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_001"
             },
             "door_type": "missile"
@@ -4465,7 +4217,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door015 (CG-CG)"
             },
             "door_type": "power_beam"
@@ -4473,7 +4224,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door059 (CL-PW)"
             },
             "door_type": "wide_beam"
@@ -4481,7 +4231,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door030 (PW-PW)"
             },
             "door_type": "charge_beam"
@@ -4489,7 +4238,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door049 (PR-PR)"
             },
             "door_type": "power_beam"
@@ -4497,7 +4245,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorpresenceframe_000"
             },
             "door_type": "power_beam"
@@ -4505,7 +4252,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -4513,7 +4259,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_001"
             },
             "door_type": "missile"
@@ -4521,7 +4266,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_014"
             },
             "door_type": "power_beam"
@@ -4529,7 +4273,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door005 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4537,7 +4280,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door053"
             },
             "door_type": "power_beam"
@@ -4545,7 +4287,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door054"
             },
             "door_type": "power_beam"
@@ -4553,7 +4294,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door022 (PW-PW) "
             },
             "door_type": "wide_beam"
@@ -4561,7 +4301,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door023 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4569,7 +4308,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door022 (PW-PW) _000"
             },
             "door_type": "power_beam"
@@ -4577,7 +4315,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door074"
             },
             "door_type": "power_beam"
@@ -4585,7 +4322,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door076"
             },
             "door_type": "power_beam"
@@ -4593,7 +4329,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door021 (PW-PW)"
             },
             "door_type": "wide_beam"
@@ -4601,7 +4336,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door022 (PW-PW) "
             },
             "door_type": "wide_beam"
@@ -4609,7 +4343,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door021 (PW-PW)_000"
             },
             "door_type": "power_beam"
@@ -4617,7 +4350,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door022 (PW-PW) _000"
             },
             "door_type": "power_beam"
@@ -4625,7 +4357,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door021 (PW-PW)"
             },
             "door_type": "wide_beam"
@@ -4633,7 +4364,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door021 (PW-PW)_000"
             },
             "door_type": "power_beam"
@@ -4641,7 +4371,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door003 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4649,7 +4378,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door004 (PW-PW)"
             },
             "door_type": "charge_beam"
@@ -4657,7 +4385,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door004 (PW-PW)_001"
             },
             "door_type": "wide_beam"
@@ -4665,7 +4392,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door012 (PW-PW, MISSILE)"
             },
             "door_type": "power_beam"
@@ -4673,7 +4399,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door038 (PW-PW)"
             },
             "door_type": "missile"
@@ -4681,7 +4406,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door029 (CG-CL,OP)"
             },
             "door_type": "power_beam"
@@ -4689,7 +4413,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door030 (PW-PW)"
             },
             "door_type": "charge_beam"
@@ -4697,7 +4420,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door042 (PW-PW) "
             },
             "door_type": "missile"
@@ -4705,7 +4427,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door033 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4713,7 +4434,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door034 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4721,7 +4441,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door046 (PW-CL,OP)"
             },
             "door_type": "power_beam"
@@ -4729,7 +4448,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door033 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4737,7 +4455,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door046 (PW-CL,OP)"
             },
             "door_type": "power_beam"
@@ -4745,7 +4462,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door008 (PW-PW)"
             },
             "door_type": "power_beam"
@@ -4753,7 +4469,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door009 (PW-PW)"
             },
             "door_type": "charge_beam"
@@ -4761,7 +4476,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_006"
             },
             "door_type": "power_beam"
@@ -4769,7 +4483,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_007"
             },
             "door_type": "charge_beam"
@@ -4777,7 +4490,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_012"
             },
             "door_type": "power_beam"
@@ -4785,7 +4497,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door042 (PW-PW) "
             },
             "door_type": "missile"
@@ -4793,7 +4504,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorPowerPower_001"
             },
             "door_type": "charge_beam"
@@ -4801,7 +4511,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_015"
             },
             "door_type": "power_beam"
@@ -4809,7 +4518,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_016"
             },
             "door_type": "power_beam"
@@ -4817,7 +4525,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door038 (PW-PW)_000"
             },
             "door_type": "wide_beam"
@@ -4825,7 +4532,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door049 (PR-PR)"
             },
             "door_type": "power_beam"
@@ -4833,7 +4539,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_004"
             },
             "door_type": "power_beam"
@@ -4841,7 +4546,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "DoorFrame_005"
             },
             "door_type": "power_beam"
@@ -4849,7 +4553,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door064"
             },
             "door_type": "power_beam"
@@ -4857,7 +4560,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door065"
             },
             "door_type": "power_beam"
@@ -4865,7 +4567,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door062"
             },
             "door_type": "power_beam"
@@ -4873,7 +4574,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door063"
             },
             "door_type": "missile"
@@ -4881,7 +4581,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door060"
             },
             "door_type": "charge_beam"
@@ -4889,7 +4588,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door062"
             },
             "door_type": "power_beam"
@@ -4897,7 +4595,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorpresenceframe_001"
             },
             "door_type": "power_beam"
@@ -4905,7 +4602,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door063"
             },
             "door_type": "missile"
@@ -4913,7 +4609,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door070"
             },
             "door_type": "power_beam"
@@ -4921,7 +4616,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorgrapplegrapple"
             },
             "door_type": "power_beam"
@@ -4929,7 +4623,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door070"
             },
             "door_type": "power_beam"
@@ -4937,7 +4630,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door075"
             },
             "door_type": "wide_beam"
@@ -4945,7 +4637,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door073"
             },
             "door_type": "power_beam"
@@ -4953,7 +4644,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorgrapplegrapple"
             },
             "door_type": "power_beam"
@@ -4961,7 +4651,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door075"
             },
             "door_type": "wide_beam"
@@ -4969,7 +4658,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door077"
             },
             "door_type": "ice_missile"
@@ -4977,7 +4665,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door076"
             },
             "door_type": "power_beam"
@@ -4985,7 +4672,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door073"
             },
             "door_type": "power_beam"
@@ -4993,7 +4679,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door074"
             },
             "door_type": "power_beam"
@@ -5001,7 +4686,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door004 (PW-PW)_001"
             },
             "door_type": "wide_beam"
@@ -5009,7 +4693,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door078"
             },
             "door_type": "power_beam"
@@ -5017,7 +4700,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door064"
             },
             "door_type": "power_beam"
@@ -5025,7 +4707,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "doorclosedgrapple_000"
             },
             "door_type": "power_beam"
@@ -5033,7 +4714,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door069"
             },
             "door_type": "power_beam"
@@ -5041,7 +4721,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door067"
             },
             "door_type": "wide_beam"
@@ -5049,7 +4728,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door077"
             },
             "door_type": "ice_missile"
@@ -5057,7 +4735,6 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Door078"
             },
             "door_type": "power_beam"
@@ -5065,7 +4742,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "power_beam"
@@ -5073,7 +4749,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -5081,7 +4756,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -5089,7 +4763,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "missile"
@@ -5097,7 +4770,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "missile"
@@ -5105,7 +4777,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -5113,7 +4784,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "power_beam"
@@ -5121,7 +4791,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "power_beam"
@@ -5129,7 +4798,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -5137,7 +4805,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_003"
             },
             "door_type": "charge_beam"
@@ -5145,7 +4812,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -5153,7 +4819,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "power_beam"
@@ -5161,7 +4826,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_007"
             },
             "door_type": "power_beam"
@@ -5169,7 +4833,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_026"
             },
             "door_type": "power_beam"
@@ -5177,7 +4840,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "wide_beam"
@@ -5185,7 +4847,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "power_beam"
@@ -5193,7 +4854,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "power_beam"
@@ -5201,7 +4861,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_002"
             },
             "door_type": "power_beam"
@@ -5209,7 +4868,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_003"
             },
             "door_type": "charge_beam"
@@ -5217,7 +4875,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "power_beam"
@@ -5225,7 +4882,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "power_beam"
@@ -5233,7 +4889,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "power_beam"
@@ -5241,7 +4896,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "charge_beam"
@@ -5249,7 +4903,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "wide_beam"
@@ -5257,7 +4910,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -5265,7 +4917,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -5273,7 +4924,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -5281,7 +4931,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_020"
             },
             "door_type": "missile"
@@ -5289,7 +4938,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_beam"
@@ -5297,7 +4945,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge"
             },
             "door_type": "power_beam"
@@ -5305,7 +4952,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "wide_beam"
@@ -5313,7 +4959,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_005"
             },
             "door_type": "missile"
@@ -5321,7 +4966,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorframepresence"
             },
             "door_type": "power_beam"
@@ -5329,7 +4973,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_026"
             },
             "door_type": "power_beam"
@@ -5337,7 +4980,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_029"
             },
             "door_type": "missile"
@@ -5345,7 +4987,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_028"
             },
             "door_type": "power_beam"
@@ -5353,7 +4994,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorframe"
             },
             "door_type": "power_beam"
@@ -5361,7 +5001,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -5369,7 +5008,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -5377,7 +5015,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "charge_beam"
@@ -5385,7 +5022,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "wide_beam"
@@ -5393,7 +5029,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "wide_beam"
@@ -5401,7 +5036,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "power_beam"
@@ -5409,7 +5043,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "power_beam"
@@ -5417,7 +5050,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "wide_beam"
@@ -5425,7 +5057,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "wide_beam"
@@ -5433,7 +5064,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "charge_beam"
@@ -5441,7 +5071,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge"
             },
             "door_type": "power_beam"
@@ -5449,7 +5078,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "power_beam"
@@ -5457,7 +5085,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -5465,7 +5092,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_beam"
@@ -5473,7 +5099,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -5481,7 +5106,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_030"
             },
             "door_type": "wide_beam"
@@ -5489,7 +5113,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_030"
             },
             "door_type": "wide_beam"
@@ -5497,7 +5120,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "power_beam"
@@ -5505,7 +5127,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "power_beam"
@@ -5513,7 +5134,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_020"
             },
             "door_type": "missile"
@@ -5521,7 +5141,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge"
             },
             "door_type": "power_beam"
@@ -5529,7 +5148,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorframe"
             },
             "door_type": "power_beam"
@@ -5537,7 +5155,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_029"
             },
             "door_type": "missile"
@@ -5545,7 +5162,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -5553,7 +5169,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "charge_beam"
@@ -5561,7 +5176,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_002"
             },
             "door_type": "power_beam"
@@ -5569,7 +5183,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorframepresence_001"
             },
             "door_type": "power_beam"
@@ -5577,7 +5190,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "wide_beam"
@@ -5585,7 +5197,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_005"
             },
             "door_type": "missile"
@@ -5593,7 +5204,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "charge_beam"
@@ -5601,7 +5211,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedcharge"
             },
             "door_type": "power_beam"
@@ -5609,7 +5218,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorchargecharge_007"
             },
             "door_type": "power_beam"
@@ -5617,7 +5225,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -5625,7 +5232,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorgrapplegrapple"
             },
             "door_type": "power_beam"
@@ -5633,7 +5239,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "wide_beam"
@@ -5641,7 +5246,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorgrapplegrapple"
             },
             "door_type": "power_beam"
@@ -5649,7 +5253,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "wide_beam"
@@ -5657,7 +5260,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -5665,7 +5267,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "charge_beam"
@@ -5673,7 +5274,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -5681,7 +5281,6 @@
         {
             "actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "doorpowerpower_028"
             },
             "door_type": "power_beam"
@@ -5689,7 +5288,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "grapple_beam"
@@ -5697,7 +5295,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -5705,7 +5302,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "grapple_beam"
@@ -5713,7 +5309,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "power_beam"
@@ -5721,7 +5316,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -5729,7 +5323,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "super_missile"
@@ -5737,7 +5330,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargeclosed_000"
             },
             "door_type": "power_beam"
@@ -5745,7 +5337,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "super_missile"
@@ -5753,7 +5344,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_002"
             },
             "door_type": "power_beam"
@@ -5761,7 +5351,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargeclosed_001"
             },
             "door_type": "wide_beam"
@@ -5769,7 +5358,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargeclosed_001"
             },
             "door_type": "wide_beam"
@@ -5777,7 +5365,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "power_beam"
@@ -5785,7 +5372,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_002"
             },
             "door_type": "power_beam"
@@ -5793,7 +5379,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -5801,7 +5386,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "power_beam"
@@ -5809,7 +5393,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -5817,7 +5400,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "plasma_beam"
@@ -5825,7 +5407,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -5833,7 +5414,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "plasma_beam"
@@ -5841,7 +5421,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargeclosed_000"
             },
             "door_type": "power_beam"
@@ -5849,7 +5428,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "wide_beam"
@@ -5857,7 +5435,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "power_beam"
@@ -5865,7 +5442,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "power_beam"
@@ -5873,7 +5449,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -5881,7 +5456,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_029"
             },
             "door_type": "power_beam"
@@ -5889,7 +5463,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "power_beam"
@@ -5897,7 +5470,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "wide_beam"
@@ -5905,7 +5477,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_029"
             },
             "door_type": "power_beam"
@@ -5913,7 +5484,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorclosedcharge_000"
             },
             "door_type": "super_missile"
@@ -5921,7 +5491,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorclosedcharge_000"
             },
             "door_type": "super_missile"
@@ -5929,7 +5498,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "wide_beam"
@@ -5937,7 +5505,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "plasma_beam"
@@ -5945,7 +5512,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -5953,7 +5519,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "plasma_beam"
@@ -5961,7 +5526,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "missile"
@@ -5969,7 +5533,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "power_beam"
@@ -5977,7 +5540,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "wide_beam"
@@ -5985,7 +5547,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "power_beam"
@@ -5993,7 +5554,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "missile"
@@ -6001,7 +5561,6 @@
         {
             "actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -6009,7 +5568,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "wide_beam"
@@ -6017,7 +5575,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -6025,7 +5582,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "charge_beam"
@@ -6033,7 +5589,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "plasma_beam"
@@ -6041,7 +5596,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "wide_beam"
@@ -6049,7 +5603,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_beam"
@@ -6057,7 +5610,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "charge_beam"
@@ -6065,7 +5617,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -6073,7 +5624,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "plasma_beam"
@@ -6081,7 +5631,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_beam"
@@ -6089,7 +5638,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "plasma_beam"
@@ -6097,7 +5645,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -6105,7 +5652,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_001"
             },
             "door_type": "ice_missile"
@@ -6113,7 +5659,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_001"
             },
             "door_type": "ice_missile"
@@ -6121,7 +5666,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "wide_beam"
@@ -6129,7 +5673,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -6137,7 +5680,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -6145,7 +5687,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "plasma_beam"
@@ -6153,7 +5694,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "wide_beam"
@@ -6161,7 +5701,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "plasma_beam"
@@ -6169,7 +5708,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "plasma_beam"
@@ -6177,7 +5715,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "wide_beam"
@@ -6185,7 +5722,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedpower"
             },
             "door_type": "power_beam"
@@ -6193,7 +5729,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "diffusion_beam"
@@ -6201,7 +5736,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "power_beam"
@@ -6209,7 +5743,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "plasma_beam"
@@ -6217,7 +5750,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_024"
             },
             "door_type": "power_beam"
@@ -6225,7 +5757,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -6233,7 +5764,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "plasma_beam"
@@ -6241,7 +5771,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "diffusion_beam"
@@ -6249,7 +5778,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "plasma_beam"
@@ -6257,7 +5785,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_020"
             },
             "door_type": "power_beam"
@@ -6265,7 +5792,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "diffusion_beam"
@@ -6273,7 +5799,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "wide_beam"
@@ -6281,7 +5806,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedpower"
             },
             "door_type": "power_beam"
@@ -6289,7 +5813,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "charge_beam"
@@ -6297,7 +5820,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "wave_beam"
@@ -6305,7 +5827,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "diffusion_beam"
@@ -6313,7 +5834,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "diffusion_beam"
@@ -6321,7 +5841,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_020"
             },
             "door_type": "power_beam"
@@ -6329,7 +5848,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "diffusion_beam"
@@ -6337,7 +5855,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "charge_beam"
@@ -6345,7 +5862,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "wave_beam"
@@ -6353,7 +5869,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -6361,7 +5876,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "charge_beam"
@@ -6369,7 +5883,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorframepresence_000"
             },
             "door_type": "power_beam"
@@ -6377,7 +5890,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "charge_beam"
@@ -6385,7 +5897,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "power_beam"
@@ -6393,7 +5904,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_024"
             },
             "door_type": "power_beam"
@@ -6401,7 +5911,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "power_beam"
@@ -6409,7 +5918,6 @@
         {
             "actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "plasma_beam"
@@ -6417,7 +5925,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "grapple_beam"
@@ -6425,7 +5932,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "grapple_beam"
@@ -6433,7 +5939,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "grapple_beam"
@@ -6441,7 +5946,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_004"
             },
             "door_type": "power_beam"
@@ -6449,7 +5953,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -6457,7 +5960,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -6465,7 +5967,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "wide_beam"
@@ -6473,7 +5974,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -6481,7 +5981,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "wide_beam"
@@ -6489,7 +5988,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -6497,7 +5995,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -6505,7 +6002,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -6513,7 +6009,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "wide_beam"
@@ -6521,7 +6016,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "wide_beam"
@@ -6529,7 +6023,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -6537,7 +6030,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "plasma_beam"
@@ -6545,7 +6037,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "power_beam"
@@ -6553,7 +6044,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -6561,7 +6051,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "power_beam"
@@ -6569,7 +6058,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_000"
             },
             "door_type": "plasma_beam"
@@ -6577,7 +6065,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "power_beam"
@@ -6585,7 +6072,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -6593,7 +6079,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "power_beam"
@@ -6601,7 +6086,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "power_beam"
@@ -6609,7 +6093,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "plasma_beam"
@@ -6617,7 +6100,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -6625,7 +6107,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -6633,7 +6114,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -6641,7 +6121,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "power_beam"
@@ -6649,7 +6128,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_000"
             },
             "door_type": "plasma_beam"
@@ -6657,7 +6135,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "power_beam"
@@ -6665,7 +6142,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "power_beam"
@@ -6673,7 +6149,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "super_missile"
@@ -6681,7 +6156,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "power_beam"
@@ -6689,7 +6163,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -6697,7 +6170,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -6705,7 +6177,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "power_beam"
@@ -6713,7 +6184,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_016"
             },
             "door_type": "grapple_beam"
@@ -6721,7 +6191,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_004"
             },
             "door_type": "power_beam"
@@ -6729,7 +6198,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "grapple_beam"
@@ -6737,7 +6205,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_beam"
@@ -6745,7 +6212,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "grapple_beam"
@@ -6753,7 +6219,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_024"
             },
             "door_type": "missile"
@@ -6761,7 +6226,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_beam"
@@ -6769,7 +6233,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_003"
             },
             "door_type": "power_beam"
@@ -6777,7 +6240,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_021"
             },
             "door_type": "power_beam"
@@ -6785,7 +6247,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "missile"
@@ -6793,7 +6254,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_022"
             },
             "door_type": "missile"
@@ -6801,7 +6261,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower"
             },
             "door_type": "super_missile"
@@ -6809,7 +6268,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "power_beam"
@@ -6817,7 +6275,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "power_beam"
@@ -6825,7 +6282,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "power_beam"
@@ -6833,7 +6289,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "super_missile"
@@ -6841,7 +6296,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -6849,7 +6303,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "power_beam"
@@ -6857,7 +6310,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_015"
             },
             "door_type": "power_beam"
@@ -6865,7 +6317,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -6873,7 +6324,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_001"
             },
             "door_type": "power_beam"
@@ -6881,7 +6331,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_002"
             },
             "door_type": "super_missile"
@@ -6889,7 +6338,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_023"
             },
             "door_type": "power_beam"
@@ -6897,7 +6345,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorpowerpower_024"
             },
             "door_type": "missile"
@@ -6905,7 +6352,6 @@
         {
             "actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "doorclosedcharge_003"
             },
             "door_type": "power_beam"
@@ -6913,7 +6359,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_beam"
@@ -6921,7 +6366,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_001"
             },
             "door_type": "plasma_beam"
@@ -6929,7 +6373,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "wide_beam"
@@ -6937,7 +6380,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "wide_beam"
@@ -6945,7 +6387,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "power_beam"
@@ -6953,7 +6394,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_001"
             },
             "door_type": "plasma_beam"
@@ -6961,7 +6401,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "wide_beam"
@@ -6969,7 +6408,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -6977,7 +6415,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_018"
             },
             "door_type": "power_beam"
@@ -6985,7 +6422,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_017"
             },
             "door_type": "power_beam"
@@ -6993,7 +6429,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "grapple_beam"
@@ -7001,7 +6436,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "diffusion_beam"
@@ -7009,7 +6443,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "diffusion_beam"
@@ -7017,7 +6450,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "diffusion_beam"
@@ -7025,7 +6457,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "diffusion_beam"
@@ -7033,7 +6464,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -7041,7 +6471,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "wide_beam"
@@ -7049,7 +6478,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "missile"
@@ -7057,7 +6485,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "plasma_beam"
@@ -7065,7 +6492,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "missile"
@@ -7073,7 +6499,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -7081,7 +6506,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_012"
             },
             "door_type": "power_beam"
@@ -7089,7 +6513,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "plasma_beam"
@@ -7097,7 +6520,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -7105,7 +6527,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "grapple_beam"
@@ -7113,7 +6534,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_006"
             },
             "door_type": "wide_beam"
@@ -7121,7 +6541,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "charge_beam"
@@ -7129,7 +6548,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "charge_beam"
@@ -7137,7 +6555,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_006"
             },
             "door_type": "wide_beam"
@@ -7145,7 +6562,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_009"
             },
             "door_type": "charge_beam"
@@ -7153,7 +6569,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "power_beam"
@@ -7161,7 +6576,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "power_beam"
@@ -7169,7 +6583,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "charge_beam"
@@ -7177,7 +6590,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorchargecharge_001"
             },
             "door_type": "charge_beam"
@@ -7185,7 +6597,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorchargecharge_000"
             },
             "door_type": "power_beam"
@@ -7193,7 +6604,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_010"
             },
             "door_type": "power_beam"
@@ -7201,7 +6611,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_011"
             },
             "door_type": "charge_beam"
@@ -7209,7 +6618,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrappleclosed_000"
             },
             "door_type": "power_beam"
@@ -7217,7 +6625,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "power_beam"
@@ -7225,7 +6632,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_019"
             },
             "door_type": "power_beam"
@@ -7233,7 +6639,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "power_beam"
@@ -7241,7 +6646,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_013"
             },
             "door_type": "power_beam"
@@ -7249,7 +6653,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_002"
             },
             "door_type": "power_beam"
@@ -7257,7 +6660,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "wide_beam"
@@ -7265,7 +6667,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedcharge"
             },
             "door_type": "power_beam"
@@ -7273,7 +6674,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "power_beam"
@@ -7281,7 +6681,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_002"
             },
             "door_type": "diffusion_beam"
@@ -7289,7 +6688,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_002"
             },
             "door_type": "power_beam"
@@ -7297,7 +6695,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_014"
             },
             "door_type": "power_beam"
@@ -7305,7 +6702,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_002"
             },
             "door_type": "diffusion_beam"
@@ -7313,7 +6709,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_003"
             },
             "door_type": "diffusion_beam"
@@ -7321,7 +6716,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -7329,7 +6723,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_003"
             },
             "door_type": "charge_beam"
@@ -7337,7 +6730,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_000"
             },
             "door_type": "wide_beam"
@@ -7345,7 +6737,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_003"
             },
             "door_type": "diffusion_beam"
@@ -7353,7 +6744,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_003"
             },
             "door_type": "charge_beam"
@@ -7361,7 +6751,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -7369,7 +6758,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -7377,7 +6765,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "wide_beam"
@@ -7385,7 +6772,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedpower_003"
             },
             "door_type": "charge_beam"
@@ -7393,7 +6779,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrapplegrapple_003"
             },
             "door_type": "charge_beam"
@@ -7401,7 +6786,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "wide_beam"
@@ -7409,7 +6793,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorgrappleclosed_000"
             },
             "door_type": "power_beam"
@@ -7417,7 +6800,6 @@
         {
             "actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "doorclosedcharge"
             },
             "door_type": "power_beam"
@@ -7425,7 +6807,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -7433,7 +6814,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_beam"
@@ -7441,7 +6821,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "power_beam"
@@ -7449,7 +6828,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -7457,7 +6835,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -7465,7 +6842,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "power_beam"
@@ -7473,7 +6849,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "missile"
@@ -7481,7 +6856,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -7489,7 +6863,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -7497,7 +6870,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -7505,7 +6877,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -7513,7 +6884,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_003"
             },
             "door_type": "power_beam"
@@ -7521,7 +6891,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "missile"
@@ -7529,7 +6898,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -7537,7 +6905,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -7545,7 +6912,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -7553,7 +6919,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_008"
             },
             "door_type": "power_beam"
@@ -7561,7 +6926,6 @@
         {
             "actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "power_beam"
@@ -7569,7 +6933,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "charge_beam"
@@ -7577,7 +6940,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "missile"
@@ -7585,7 +6947,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_004"
             },
             "door_type": "charge_beam"
@@ -7593,7 +6954,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -7601,7 +6961,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -7609,7 +6968,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -7617,7 +6975,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_000"
             },
             "door_type": "missile"
@@ -7625,7 +6982,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_001"
             },
             "door_type": "power_beam"
@@ -7633,7 +6989,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -7641,7 +6996,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -7649,7 +7003,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -7657,7 +7010,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -7665,7 +7017,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -7673,7 +7024,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_007"
             },
             "door_type": "power_beam"
@@ -7681,7 +7031,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_002"
             },
             "door_type": "power_beam"
@@ -7689,7 +7038,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "power_beam"
@@ -7697,7 +7045,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "charge_beam"
@@ -7705,7 +7052,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorclosedpower_000"
             },
             "door_type": "power_beam"
@@ -7713,7 +7059,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerclosed_000"
             },
             "door_type": "power_beam"
@@ -7721,7 +7066,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorclosedpower_001"
             },
             "door_type": "charge_beam"
@@ -7729,7 +7073,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerclosed_001"
             },
             "door_type": "charge_beam"
@@ -7737,7 +7080,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerclosed_001"
             },
             "door_type": "charge_beam"
@@ -7747,7 +7089,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/dread/custom_patcher_data/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/custom_patcher_data/world_1.json
@@ -43,7 +43,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -54,7 +53,6 @@
                 "icon_id": "PROGRESSIVE_SPIN",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -72,7 +70,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -95,7 +92,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -118,7 +114,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -141,7 +136,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -164,7 +158,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -187,7 +180,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -210,7 +202,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -233,7 +224,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -256,7 +246,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -279,7 +268,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -302,7 +290,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -325,7 +312,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -348,7 +334,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -371,7 +356,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -394,7 +378,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -423,7 +406,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -447,7 +429,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -474,7 +455,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -497,7 +477,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -520,7 +499,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -543,7 +521,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -566,7 +543,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -589,7 +565,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -599,7 +574,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -617,7 +591,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -640,7 +613,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -650,7 +622,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -668,7 +639,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -691,7 +661,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -701,7 +670,6 @@
                 "icon_id": "item_missiletankplus",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -719,7 +687,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -742,7 +709,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -765,7 +731,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -794,7 +759,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -818,7 +782,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -841,7 +804,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -870,7 +832,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -894,7 +855,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -904,7 +864,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -922,7 +881,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -945,7 +903,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -968,7 +925,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -991,7 +947,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1014,7 +969,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1037,7 +991,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1060,7 +1013,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1083,7 +1035,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1106,7 +1057,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1129,7 +1079,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1152,7 +1101,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1175,7 +1123,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1198,7 +1145,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1221,7 +1167,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1244,7 +1189,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1267,7 +1211,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1290,7 +1233,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1313,7 +1255,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1336,7 +1277,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1359,7 +1299,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1382,7 +1321,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1405,7 +1343,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1415,7 +1352,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1433,7 +1369,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1443,7 +1378,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1461,7 +1395,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1484,7 +1417,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1507,7 +1439,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1530,7 +1461,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1553,7 +1483,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1580,7 +1509,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1603,7 +1531,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1626,7 +1553,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1649,7 +1575,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1674,7 +1599,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1697,7 +1621,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1720,7 +1643,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1743,7 +1665,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1766,7 +1687,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1789,7 +1709,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1812,7 +1731,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1835,7 +1753,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1858,7 +1775,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1881,7 +1797,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1904,7 +1819,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -1927,7 +1841,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -1937,7 +1850,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -1955,7 +1867,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1978,7 +1889,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2001,7 +1911,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2024,7 +1933,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2047,7 +1955,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2070,7 +1977,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2093,7 +1999,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2116,7 +2021,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2139,7 +2043,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2162,7 +2065,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2185,7 +2087,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2208,7 +2109,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2231,7 +2131,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2254,7 +2153,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2277,7 +2175,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2300,7 +2197,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2323,7 +2219,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2346,7 +2241,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2369,7 +2263,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2392,7 +2285,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2415,7 +2307,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2425,7 +2316,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2443,7 +2333,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2466,7 +2355,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2489,7 +2377,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2512,7 +2399,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2522,7 +2408,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2540,7 +2425,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2563,7 +2447,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2586,7 +2469,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2609,7 +2491,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2638,7 +2519,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2668,7 +2548,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2692,7 +2571,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2715,7 +2593,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2738,7 +2615,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2761,7 +2637,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2784,7 +2659,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -2794,7 +2668,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -2812,7 +2685,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2835,7 +2707,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2858,7 +2729,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2881,7 +2751,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -2891,7 +2760,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -2909,7 +2777,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2932,7 +2799,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2955,7 +2821,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2978,7 +2843,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3001,7 +2865,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3024,7 +2887,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3047,7 +2909,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3070,7 +2931,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3093,7 +2953,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3116,7 +2975,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3139,7 +2997,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3162,7 +3019,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3185,7 +3041,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3208,7 +3063,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3231,7 +3085,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3254,7 +3107,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3277,7 +3129,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3527,7 +3378,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3536,7 +3386,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3545,7 +3394,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3554,7 +3402,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3563,7 +3410,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3572,7 +3418,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3581,7 +3426,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3590,7 +3434,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3599,7 +3442,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3608,7 +3450,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3617,7 +3458,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -3710,7 +3550,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -3718,7 +3557,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -3728,7 +3566,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/dread/custom_start/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/custom_start/world_1.json
@@ -35,7 +35,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -45,7 +44,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -63,7 +61,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -86,7 +83,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -121,7 +117,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -152,7 +147,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -176,7 +170,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -199,7 +192,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -222,7 +214,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -245,7 +236,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -268,7 +258,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -291,7 +280,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -314,7 +302,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -343,7 +330,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -367,7 +353,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -390,7 +375,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -415,7 +399,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -438,7 +421,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -461,7 +443,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -484,7 +465,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -507,7 +487,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -530,7 +509,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -553,7 +531,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -576,7 +553,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -599,7 +575,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -609,7 +584,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -627,7 +601,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -650,7 +623,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -660,7 +632,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -684,7 +655,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -708,7 +678,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -718,7 +687,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -736,7 +704,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -759,7 +726,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -782,7 +748,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -805,7 +770,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -828,7 +792,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -851,7 +814,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -874,7 +836,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -897,7 +858,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -907,7 +867,6 @@
                 "icon_id": "item_powerbombtank",
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -925,7 +884,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -954,7 +912,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -978,7 +935,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1001,7 +957,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1030,7 +985,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1054,7 +1008,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1077,7 +1030,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1100,7 +1052,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1123,7 +1074,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1146,7 +1096,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1169,7 +1118,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1204,7 +1152,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1229,7 +1176,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1252,7 +1198,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1279,7 +1224,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1302,7 +1246,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1325,7 +1268,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1348,7 +1290,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1371,7 +1312,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1394,7 +1334,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1417,7 +1356,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1446,7 +1384,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1457,7 +1394,6 @@
                 "icon_id": "PROGRESSIVE_SPIN",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1475,7 +1411,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1485,7 +1420,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1503,7 +1437,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1526,7 +1459,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1549,7 +1481,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1572,7 +1503,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1595,7 +1525,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1618,7 +1547,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1641,7 +1569,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1664,7 +1591,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1687,7 +1613,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1710,7 +1635,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1739,7 +1663,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1763,7 +1686,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1786,7 +1708,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1809,7 +1730,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1832,7 +1752,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1855,7 +1774,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1878,7 +1796,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1901,7 +1818,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1924,7 +1840,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1947,7 +1862,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -1970,7 +1884,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -1980,7 +1893,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -1998,7 +1910,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2021,7 +1932,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2044,7 +1954,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2067,7 +1976,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2090,7 +1998,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2113,7 +2020,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2136,7 +2042,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2165,7 +2070,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2189,7 +2093,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2212,7 +2115,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2235,7 +2137,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2258,7 +2159,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2281,7 +2181,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2304,7 +2203,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2327,7 +2225,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2350,7 +2247,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2373,7 +2269,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2396,7 +2291,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2419,7 +2313,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2442,7 +2335,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2465,7 +2357,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2475,7 +2366,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2493,7 +2383,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2516,7 +2405,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2539,7 +2427,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2562,7 +2449,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2572,7 +2458,6 @@
                 "icon_id": "powerup_stormmissile",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2590,7 +2475,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2625,7 +2509,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2650,7 +2533,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2673,7 +2555,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2696,7 +2577,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2719,7 +2599,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2742,7 +2621,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2765,7 +2643,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2788,7 +2665,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2811,7 +2687,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2834,7 +2709,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -2844,7 +2718,6 @@
                 "icon_id": "item_energytank",
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -2862,7 +2735,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2885,7 +2757,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2908,7 +2779,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2931,7 +2801,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -2941,7 +2810,6 @@
                 "icon_id": "item_energytank",
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -2959,7 +2827,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2982,7 +2849,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3005,7 +2871,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3028,7 +2893,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3057,7 +2921,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3081,7 +2944,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3104,7 +2966,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3127,7 +2988,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3150,7 +3010,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3173,7 +3032,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3202,7 +3060,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3226,7 +3083,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3249,7 +3105,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3272,7 +3127,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3295,7 +3149,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3318,7 +3171,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3341,7 +3193,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3583,7 +3434,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3592,7 +3442,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3601,7 +3450,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3610,7 +3458,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3619,7 +3466,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3628,7 +3474,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3637,7 +3482,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3646,7 +3490,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3655,7 +3498,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3664,7 +3506,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3673,7 +3514,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -3763,7 +3603,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -3771,7 +3610,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -3781,7 +3619,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_1.json
@@ -35,7 +35,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -45,7 +44,6 @@
                 "icon_id": "powerup_morphball",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -63,7 +61,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -89,7 +86,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -116,7 +112,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -139,7 +134,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -167,7 +161,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -190,7 +183,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -213,7 +205,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -236,7 +227,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -262,7 +252,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -285,7 +274,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -311,7 +299,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -337,7 +324,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -363,7 +349,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -389,7 +374,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -412,7 +396,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -435,7 +418,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -461,7 +443,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -484,7 +465,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -507,7 +487,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -533,7 +512,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -559,7 +537,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -588,7 +565,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -612,7 +588,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -622,7 +597,6 @@
                 "icon_id": "item_missiletankplus",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -640,7 +614,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -663,7 +636,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -676,7 +648,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -694,7 +665,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -717,7 +687,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -730,7 +699,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -748,7 +716,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -774,7 +741,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -801,7 +767,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -824,7 +789,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -847,7 +811,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -873,7 +836,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -899,7 +861,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -925,7 +886,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -938,7 +898,6 @@
                 },
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -956,7 +915,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -979,7 +937,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1002,7 +959,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1025,7 +981,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1048,7 +1003,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1074,7 +1028,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1100,7 +1053,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1126,7 +1078,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1152,7 +1103,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1178,7 +1128,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1204,7 +1153,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1230,7 +1178,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1253,7 +1200,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1276,7 +1222,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1299,7 +1244,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1325,7 +1269,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1348,7 +1291,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1371,7 +1313,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1397,7 +1338,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1420,7 +1360,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1446,7 +1385,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1469,7 +1407,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1482,7 +1419,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1500,7 +1436,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1513,7 +1448,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1531,7 +1465,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1557,7 +1490,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1580,7 +1512,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1606,7 +1537,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1632,7 +1562,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1658,7 +1587,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1681,7 +1609,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1704,7 +1631,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1730,7 +1656,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1756,7 +1681,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1782,7 +1706,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1808,7 +1731,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1834,7 +1756,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1860,7 +1781,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1886,7 +1806,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1909,7 +1828,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1935,7 +1853,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1958,7 +1875,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1981,7 +1897,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2007,7 +1922,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -2033,7 +1947,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -2043,7 +1956,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -2061,7 +1973,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2090,7 +2001,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2114,7 +2024,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2141,7 +2050,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2164,7 +2072,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2190,7 +2097,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2216,7 +2122,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2242,7 +2147,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2265,7 +2169,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2291,7 +2194,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2314,7 +2216,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2337,7 +2238,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2360,7 +2260,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2383,7 +2282,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2410,7 +2308,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2436,7 +2333,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2459,7 +2355,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2485,7 +2380,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2508,7 +2402,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2534,7 +2427,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2557,7 +2449,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2570,7 +2461,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2588,7 +2478,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2611,7 +2500,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2637,7 +2525,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2663,7 +2550,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2673,7 +2559,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2691,7 +2576,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2714,7 +2598,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2740,7 +2623,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2763,7 +2645,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2789,7 +2670,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2815,7 +2695,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2842,7 +2721,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2868,7 +2746,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2903,7 +2780,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2928,7 +2804,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2954,7 +2829,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -2964,7 +2838,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -2982,7 +2855,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3005,7 +2877,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3028,7 +2899,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3054,7 +2924,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -3067,7 +2936,6 @@
                 },
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -3085,7 +2953,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -3108,7 +2975,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3131,7 +2997,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3154,7 +3019,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3180,7 +3044,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3203,7 +3066,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3226,7 +3088,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3252,7 +3113,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3275,7 +3135,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3301,7 +3160,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3327,7 +3185,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3350,7 +3207,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3376,7 +3232,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3402,7 +3257,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3429,7 +3283,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3452,7 +3305,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3475,7 +3327,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3725,7 +3576,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3734,7 +3584,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3743,7 +3592,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3752,7 +3600,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3761,7 +3608,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3770,7 +3616,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3779,7 +3624,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3788,7 +3632,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3797,7 +3640,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3806,7 +3648,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3815,7 +3656,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -4255,7 +4095,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -4263,7 +4102,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -4273,7 +4111,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_2.json
+++ b/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_2.json
@@ -35,7 +35,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -48,7 +47,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -66,7 +64,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -89,7 +86,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -115,7 +111,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -141,7 +136,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -167,7 +161,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -199,7 +192,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -223,7 +215,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -249,7 +240,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -287,7 +277,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -312,7 +301,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -338,7 +326,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -364,7 +351,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -391,7 +377,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -417,7 +402,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -443,7 +427,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -466,7 +449,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -489,7 +471,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -515,7 +496,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -541,7 +521,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -567,7 +546,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -590,7 +568,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -616,7 +593,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -642,7 +618,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -655,7 +630,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -673,7 +647,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -699,7 +672,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -709,7 +681,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -727,7 +698,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -750,7 +720,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -763,7 +732,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -781,7 +749,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -807,7 +774,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -833,7 +799,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -859,7 +824,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -886,7 +850,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -912,7 +875,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -937,7 +899,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -963,7 +924,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -973,7 +933,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -991,7 +950,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1017,7 +975,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1040,7 +997,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1066,7 +1022,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1092,7 +1047,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1121,7 +1075,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1145,7 +1098,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1168,7 +1120,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1194,7 +1145,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1226,7 +1176,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1250,7 +1199,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1290,7 +1238,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1315,7 +1262,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1338,7 +1284,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1365,7 +1310,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1392,7 +1336,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1418,7 +1361,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1444,7 +1386,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1467,7 +1408,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1490,7 +1430,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1516,7 +1455,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1539,7 +1477,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1549,7 +1486,6 @@
                 "icon_id": "item_missiletankplus",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1567,7 +1503,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1577,7 +1512,6 @@
                 "icon_id": "item_missiletankplus",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1595,7 +1529,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1621,7 +1554,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1647,7 +1579,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1674,7 +1605,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1697,7 +1627,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1723,7 +1652,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1746,7 +1674,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1772,7 +1699,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1795,7 +1721,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1821,7 +1746,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1844,7 +1768,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1867,7 +1790,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1890,7 +1812,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1913,7 +1834,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1936,7 +1856,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1959,7 +1878,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1985,7 +1903,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2008,7 +1925,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2031,7 +1947,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2057,7 +1972,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -2080,7 +1994,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -2093,7 +2006,6 @@
                 },
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -2111,7 +2023,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2137,7 +2048,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2160,7 +2070,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2186,7 +2095,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2219,7 +2127,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2243,7 +2150,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2266,7 +2172,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2289,7 +2194,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2312,7 +2216,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2335,7 +2238,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2358,7 +2260,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2381,7 +2282,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2404,7 +2304,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2427,7 +2326,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2453,7 +2351,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2479,7 +2376,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2505,7 +2401,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2531,7 +2426,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2557,7 +2451,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2583,7 +2476,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2606,7 +2498,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2616,7 +2507,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2634,7 +2524,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2660,7 +2549,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2683,7 +2571,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2709,7 +2596,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2719,7 +2605,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2737,7 +2622,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2760,7 +2644,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2786,7 +2669,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2809,7 +2691,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2832,7 +2713,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2858,7 +2738,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2885,7 +2764,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2908,7 +2786,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2931,7 +2808,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2954,7 +2830,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2977,7 +2852,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -2990,7 +2864,6 @@
                 },
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -3008,7 +2881,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3031,7 +2903,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3057,7 +2928,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3083,7 +2953,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -3093,7 +2962,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -3111,7 +2979,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -3134,7 +3001,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3157,7 +3023,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3183,7 +3048,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3210,7 +3074,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3233,7 +3096,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3259,7 +3121,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3282,7 +3143,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3311,7 +3171,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3335,7 +3194,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3358,7 +3216,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3381,7 +3238,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3407,7 +3263,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3430,7 +3285,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3455,7 +3309,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3478,7 +3331,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3504,7 +3356,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3745,7 +3596,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3754,7 +3604,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3763,7 +3612,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3772,7 +3620,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3781,7 +3628,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3790,7 +3636,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3799,7 +3644,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3808,7 +3652,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3817,7 +3660,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3826,7 +3668,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3835,7 +3676,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -4275,7 +4115,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -4283,7 +4122,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -4293,7 +4131,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/dread/elevator_rando/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/elevator_rando/world_1.json
@@ -39,7 +39,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -49,7 +48,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -67,7 +65,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -90,7 +87,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -113,7 +109,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -136,7 +131,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -159,7 +153,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -182,7 +175,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -205,7 +197,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -228,7 +219,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -257,7 +247,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -293,7 +282,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -318,7 +306,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -341,7 +328,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -364,7 +350,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -387,7 +372,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -410,7 +394,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -433,7 +416,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -456,7 +438,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -479,7 +460,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -514,7 +494,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -539,7 +518,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -562,7 +540,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -585,7 +562,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -608,7 +584,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -618,7 +593,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -636,7 +610,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -659,7 +632,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -669,7 +641,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -687,7 +658,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -712,7 +682,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -722,7 +691,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -740,7 +708,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -763,7 +730,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -786,7 +752,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -809,7 +774,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -832,7 +796,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -855,7 +818,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -878,7 +840,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -901,7 +862,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -911,7 +871,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -929,7 +888,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -952,7 +910,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -975,7 +932,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -998,7 +954,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1021,7 +976,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1048,7 +1002,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1071,7 +1024,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1094,7 +1046,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1117,7 +1068,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1140,7 +1090,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1163,7 +1112,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1186,7 +1134,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1209,7 +1156,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1232,7 +1178,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1255,7 +1200,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1278,7 +1222,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1301,7 +1244,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1324,7 +1266,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1347,7 +1288,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1370,7 +1310,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1395,7 +1334,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1418,7 +1356,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1428,7 +1365,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1452,7 +1388,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1463,7 +1398,6 @@
                 "icon_id": "PROGRESSIVE_MISSILE",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1481,7 +1415,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1504,7 +1437,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1527,7 +1459,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1550,7 +1481,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1573,7 +1503,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1596,7 +1525,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1619,7 +1547,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1642,7 +1569,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1665,7 +1591,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1688,7 +1613,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1717,7 +1641,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1747,7 +1670,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1771,7 +1693,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1794,7 +1715,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1817,7 +1737,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1840,7 +1759,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1863,7 +1781,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1886,7 +1803,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1909,7 +1825,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1932,7 +1847,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -1955,7 +1869,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -1965,7 +1878,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -1983,7 +1895,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2006,7 +1917,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2029,7 +1939,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2052,7 +1961,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2075,7 +1983,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2098,7 +2005,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2121,7 +2027,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2144,7 +2049,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2167,7 +2071,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2190,7 +2093,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2213,7 +2115,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2236,7 +2137,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2259,7 +2159,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2282,7 +2181,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2305,7 +2203,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2328,7 +2225,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2351,7 +2247,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2374,7 +2269,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2397,7 +2291,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2420,7 +2313,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2443,7 +2335,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2453,7 +2344,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2471,7 +2361,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2494,7 +2383,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2517,7 +2405,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2540,7 +2427,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2550,7 +2436,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2568,7 +2453,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2591,7 +2475,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2614,7 +2497,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2641,7 +2523,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2664,7 +2545,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2687,7 +2567,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2710,7 +2589,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2745,7 +2623,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2770,7 +2647,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2793,7 +2669,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2816,7 +2691,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -2826,7 +2700,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -2844,7 +2717,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2867,7 +2739,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2890,7 +2761,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2913,7 +2783,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -2923,7 +2792,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -2947,7 +2815,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2971,7 +2838,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2994,7 +2860,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3017,7 +2882,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3040,7 +2904,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3063,7 +2926,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3088,7 +2950,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3111,7 +2972,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3134,7 +2994,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3159,7 +3018,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3182,7 +3040,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3205,7 +3062,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3228,7 +3084,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3251,7 +3106,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3274,7 +3128,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3297,7 +3150,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3320,7 +3172,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3563,7 +3414,6 @@
         {
             "teleporter": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "elevator_baselab_000"
             },
             "destination": {
@@ -3575,7 +3425,6 @@
         {
             "teleporter": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "LE_Elevator_FromMagma"
             },
             "destination": {
@@ -3587,7 +3436,6 @@
         {
             "teleporter": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "elevator_with_cutscene_aqua_000"
             },
             "destination": {
@@ -3599,7 +3447,6 @@
         {
             "teleporter": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "LE_Elevator_FromCave"
             },
             "destination": {
@@ -3611,7 +3458,6 @@
         {
             "teleporter": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "wagontrain_baselab_000"
             },
             "destination": {
@@ -3623,7 +3469,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "elevator_sanctuary_000"
             },
             "destination": {
@@ -3635,7 +3480,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "elevator_cave_000"
             },
             "destination": {
@@ -3647,7 +3491,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "elevator_sanctuary_001"
             },
             "destination": {
@@ -3659,7 +3502,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "wagontrain_magma_000"
             },
             "destination": {
@@ -3671,7 +3513,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "wagontrain_with_portal_aqua_001"
             },
             "destination": {
@@ -3683,7 +3524,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "wagontrain_aqua_000"
             },
             "destination": {
@@ -3695,7 +3535,6 @@
         {
             "teleporter": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "elevator_forest_000"
             },
             "destination": {
@@ -3707,7 +3546,6 @@
         {
             "teleporter": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "wagontrain_baselab_000"
             },
             "destination": {
@@ -3719,7 +3557,6 @@
         {
             "teleporter": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "wagontrain_with_portal_baselab_001"
             },
             "destination": {
@@ -3731,7 +3568,6 @@
         {
             "teleporter": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "elevator_forest_000"
             },
             "destination": {
@@ -3743,7 +3579,6 @@
         {
             "teleporter": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "elevator_cave_000"
             },
             "destination": {
@@ -3755,7 +3590,6 @@
         {
             "teleporter": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "elevator_baselab_000"
             },
             "destination": {
@@ -3767,7 +3601,6 @@
         {
             "teleporter": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "elevator_baselab_001"
             },
             "destination": {
@@ -3779,7 +3612,6 @@
         {
             "teleporter": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "wagontrain_forest_000"
             },
             "destination": {
@@ -3791,7 +3623,6 @@
         {
             "teleporter": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "elevator_shipyard_000"
             },
             "destination": {
@@ -3803,7 +3634,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "elevator_aqua_000"
             },
             "destination": {
@@ -3815,7 +3645,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "wagontrain_sanctuary_000"
             },
             "destination": {
@@ -3827,7 +3656,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "wagontrain_shipyard_000"
             },
             "destination": {
@@ -3839,7 +3667,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "wagontrain_quarantine_with_cutscene_000"
             },
             "destination": {
@@ -3851,7 +3678,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "elevator_baselab_000"
             },
             "destination": {
@@ -3863,7 +3689,6 @@
         {
             "teleporter": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "wagontrain_forest_000"
             },
             "destination": {
@@ -3875,7 +3700,6 @@
         {
             "teleporter": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "elevator_sanctuary_000"
             },
             "destination": {
@@ -3887,7 +3711,6 @@
         {
             "teleporter": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "wagontrain_forest_000"
             },
             "destination": {
@@ -3899,7 +3722,6 @@
         {
             "teleporter": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "capsulelaunchershipyard_000"
             },
             "destination": {
@@ -3911,7 +3733,6 @@
         {
             "teleporter": {
                 "scenario": "s090_skybase",
-                "layer": "default",
                 "actor": "capsuleelevatorskybase_000"
             },
             "destination": {
@@ -3923,7 +3744,6 @@
         {
             "teleporter": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "wagontrain_quarantine_000"
             },
             "destination": {
@@ -3937,7 +3757,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3946,7 +3765,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3955,7 +3773,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3964,7 +3781,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3973,7 +3789,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3982,7 +3797,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3991,7 +3805,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -4000,7 +3813,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -4009,7 +3821,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -4018,7 +3829,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -4027,7 +3837,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -4165,7 +3974,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -4173,7 +3981,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -4183,7 +3990,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/dread/hide_all_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/hide_all_with_nothing/world_1.json
@@ -35,7 +35,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -47,7 +46,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -65,7 +63,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -90,7 +87,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -115,7 +111,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -140,7 +135,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -165,7 +159,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -190,7 +183,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -215,7 +207,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -240,7 +231,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -271,7 +261,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -296,7 +285,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -321,7 +309,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -346,7 +333,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -371,7 +357,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -396,7 +381,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -421,7 +405,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -446,7 +429,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -471,7 +453,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -496,7 +477,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -521,7 +501,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -546,7 +525,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -571,7 +549,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -596,7 +573,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -621,7 +597,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -633,7 +608,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -651,7 +625,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -682,7 +655,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -694,7 +666,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -712,7 +683,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -737,7 +707,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -749,7 +718,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -767,7 +735,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -792,7 +759,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -817,7 +783,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -848,7 +813,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -873,7 +837,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -898,7 +861,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -923,7 +885,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -948,7 +909,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -960,7 +920,6 @@
                 },
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -978,7 +937,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1003,7 +961,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1028,7 +985,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1053,7 +1009,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1078,7 +1033,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1103,7 +1057,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1128,7 +1081,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1153,7 +1105,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1178,7 +1129,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1203,7 +1153,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1228,7 +1177,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1253,7 +1201,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1278,7 +1225,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1303,7 +1249,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1328,7 +1273,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1353,7 +1297,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1378,7 +1321,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1403,7 +1345,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1428,7 +1369,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1453,7 +1393,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1478,7 +1417,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1509,7 +1447,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1521,7 +1458,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1539,7 +1475,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1551,7 +1486,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1569,7 +1503,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1594,7 +1527,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1619,7 +1551,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1644,7 +1575,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1669,7 +1599,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1694,7 +1623,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1719,7 +1647,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1744,7 +1671,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1769,7 +1695,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1794,7 +1719,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1819,7 +1743,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1844,7 +1767,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1875,7 +1797,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1900,7 +1821,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1925,7 +1845,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1950,7 +1869,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1975,7 +1893,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2000,7 +1917,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2025,7 +1941,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2050,7 +1965,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -2081,7 +1995,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -2093,7 +2006,6 @@
                 },
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -2117,7 +2029,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2142,7 +2053,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2167,7 +2077,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2192,7 +2101,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2217,7 +2125,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2242,7 +2149,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2267,7 +2173,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2292,7 +2197,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2317,7 +2221,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2342,7 +2245,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2373,7 +2275,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2398,7 +2299,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2423,7 +2323,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2448,7 +2347,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2473,7 +2371,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2498,7 +2395,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2523,7 +2419,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2548,7 +2443,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2573,7 +2467,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2598,7 +2491,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2623,7 +2515,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2635,7 +2526,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2653,7 +2543,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2678,7 +2567,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2703,7 +2591,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2728,7 +2615,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2740,7 +2626,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2758,7 +2643,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2787,7 +2671,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2812,7 +2695,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2837,7 +2719,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2862,7 +2743,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2887,7 +2767,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2912,7 +2791,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2941,7 +2819,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2966,7 +2843,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2991,7 +2867,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -3016,7 +2891,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -3028,7 +2902,6 @@
                 },
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -3046,7 +2919,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3071,7 +2943,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3096,7 +2967,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3121,7 +2991,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -3133,7 +3002,6 @@
                 },
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -3151,7 +3019,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -3176,7 +3043,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3201,7 +3067,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3226,7 +3091,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3251,7 +3115,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3276,7 +3139,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3301,7 +3163,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3326,7 +3187,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3351,7 +3211,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3376,7 +3235,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3401,7 +3259,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3426,7 +3283,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3451,7 +3307,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3476,7 +3331,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3501,7 +3355,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3526,7 +3379,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3551,7 +3403,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3791,7 +3642,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3800,7 +3650,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3809,7 +3658,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3818,7 +3666,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3827,7 +3674,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3836,7 +3682,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3845,7 +3690,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3854,7 +3698,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3863,7 +3706,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3872,7 +3714,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3881,7 +3722,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -3974,7 +3814,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -3982,7 +3821,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -3992,7 +3830,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/dread/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/starter_preset/world_1.json
@@ -26,7 +26,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -36,7 +35,6 @@
                 "icon_id": "powerup_speedbooster",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -54,7 +52,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -77,7 +74,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -100,7 +96,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -123,7 +118,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -146,7 +140,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -175,7 +168,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -199,7 +191,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -222,7 +213,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -245,7 +235,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -268,7 +257,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -291,7 +279,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -314,7 +301,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -337,7 +323,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -360,7 +345,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -383,7 +367,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -406,7 +389,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -441,7 +423,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -466,7 +447,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -489,7 +469,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -512,7 +491,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -535,7 +513,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -564,7 +541,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -588,7 +564,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -598,7 +573,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -616,7 +590,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -639,7 +612,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -649,7 +621,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -667,7 +638,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -690,7 +660,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -700,7 +669,6 @@
                 "icon_id": "item_missiletankplus",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -718,7 +686,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -741,7 +708,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -764,7 +730,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -787,7 +752,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -810,7 +774,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -833,7 +796,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -856,7 +818,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -879,7 +840,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -889,7 +849,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -907,7 +866,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -930,7 +888,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -953,7 +910,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -976,7 +932,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -999,7 +954,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1022,7 +976,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1045,7 +998,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1072,7 +1024,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1095,7 +1046,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1118,7 +1068,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1141,7 +1090,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1170,7 +1118,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1194,7 +1141,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1217,7 +1163,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1240,7 +1185,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1263,7 +1207,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1286,7 +1229,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1309,7 +1251,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1332,7 +1273,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1355,7 +1295,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1378,7 +1317,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1407,7 +1345,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1418,7 +1355,6 @@
                 "icon_id": "PROGRESSIVE_SPIN",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1436,7 +1372,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1446,7 +1381,6 @@
                 "icon_id": "item_missiletankplus",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1470,7 +1404,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1494,7 +1427,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1517,7 +1449,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1540,7 +1471,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1563,7 +1493,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1586,7 +1515,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1609,7 +1537,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1632,7 +1559,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1655,7 +1581,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1678,7 +1603,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1701,7 +1625,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1724,7 +1647,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1747,7 +1669,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1770,7 +1691,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1793,7 +1713,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1816,7 +1735,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1839,7 +1757,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1862,7 +1779,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1885,7 +1801,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1908,7 +1823,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -1943,7 +1857,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -1955,7 +1868,6 @@
                 "icon_id": "PROGRESSIVE_BEAM",
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -1973,7 +1885,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1996,7 +1907,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2025,7 +1935,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2049,7 +1958,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2072,7 +1980,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2095,7 +2002,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2118,7 +2024,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2141,7 +2046,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2164,7 +2068,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2187,7 +2090,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2210,7 +2112,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2233,7 +2134,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2256,7 +2156,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2279,7 +2178,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2302,7 +2200,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2325,7 +2222,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2354,7 +2250,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2378,7 +2273,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2401,7 +2295,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2426,7 +2319,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2449,7 +2341,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2459,7 +2350,6 @@
                 "icon_id": "item_powerbombtank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2477,7 +2367,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2502,7 +2391,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2525,7 +2413,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2548,7 +2435,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2558,7 +2444,6 @@
                 "icon_id": "item_powerbombtank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2576,7 +2461,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2599,7 +2483,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2622,7 +2505,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2645,7 +2527,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2668,7 +2549,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2691,7 +2571,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2714,7 +2593,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2737,7 +2615,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2760,7 +2637,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2783,7 +2659,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2806,7 +2681,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -2816,7 +2690,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -2834,7 +2707,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2857,7 +2729,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2880,7 +2751,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2903,7 +2773,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -2913,7 +2782,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -2931,7 +2799,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2954,7 +2821,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2977,7 +2843,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3000,7 +2865,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3023,7 +2887,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3046,7 +2909,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3069,7 +2931,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3092,7 +2953,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3115,7 +2975,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3150,7 +3009,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3179,7 +3037,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3202,7 +3059,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3225,7 +3081,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3248,7 +3103,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3277,7 +3131,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3300,7 +3153,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3323,7 +3175,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3561,7 +3412,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3570,7 +3420,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3579,7 +3428,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3588,7 +3436,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3597,7 +3444,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3606,7 +3452,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3615,7 +3460,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3624,7 +3468,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3633,7 +3476,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3642,7 +3484,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3651,7 +3492,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -3739,7 +3579,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -3747,7 +3586,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -3757,7 +3595,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/dread_prime1_multiworld/world_1.json
+++ b/test/test_files/patcher_data/dread/dread_prime1_multiworld/world_1.json
@@ -41,7 +41,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -52,7 +51,6 @@
                 "icon_id": "PROGRESSIVE_CHARGE",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -70,7 +68,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -96,7 +93,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -119,7 +115,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -142,7 +137,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -168,7 +162,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -191,7 +184,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -214,7 +206,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -240,7 +231,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -266,7 +256,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -289,7 +278,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -312,7 +300,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -341,7 +328,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -365,7 +351,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -388,7 +373,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -411,7 +395,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -434,7 +417,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -460,7 +442,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -498,7 +479,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -523,7 +503,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -546,7 +525,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -569,7 +547,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -595,7 +572,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -618,7 +594,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -628,7 +603,6 @@
                 "icon_id": "item_missiletankplus",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -646,7 +620,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -672,7 +645,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -685,7 +657,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -703,7 +674,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -726,7 +696,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -736,7 +705,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -754,7 +722,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -780,7 +747,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -806,7 +772,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -829,7 +794,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -855,7 +819,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -880,7 +843,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -903,7 +865,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -929,7 +890,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -942,7 +902,6 @@
                 },
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -960,7 +919,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -986,7 +944,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1009,7 +966,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1035,7 +991,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1058,7 +1013,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1084,7 +1038,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1110,7 +1063,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1133,7 +1085,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1159,7 +1110,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1188,7 +1138,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1212,7 +1161,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1235,7 +1183,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1258,7 +1205,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1281,7 +1227,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1307,7 +1252,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1333,7 +1277,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1356,7 +1299,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1382,7 +1324,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1408,7 +1349,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1431,7 +1371,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1457,7 +1396,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1483,7 +1421,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1493,7 +1430,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1511,7 +1447,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1524,7 +1459,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1542,7 +1476,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1565,7 +1498,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1591,7 +1523,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1614,7 +1545,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1637,7 +1567,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1660,7 +1589,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1683,7 +1611,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1706,7 +1633,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1729,7 +1655,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1755,7 +1680,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1781,7 +1705,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1804,7 +1727,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1827,7 +1749,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1859,7 +1780,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1883,7 +1803,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1909,7 +1828,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1935,7 +1853,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1961,7 +1878,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1984,7 +1900,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2007,7 +1922,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -2030,7 +1944,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -2040,7 +1953,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -2058,7 +1970,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2081,7 +1992,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2106,7 +2016,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2129,7 +2038,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2152,7 +2060,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2184,7 +2091,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2208,7 +2114,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2231,7 +2136,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2254,7 +2158,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2283,7 +2186,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2307,7 +2209,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2333,7 +2234,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2356,7 +2256,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2379,7 +2278,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2402,7 +2300,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2428,7 +2325,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2454,7 +2350,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2480,7 +2375,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2503,7 +2397,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2526,7 +2419,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2549,7 +2441,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2561,7 +2452,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2579,7 +2469,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2605,7 +2494,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2631,7 +2519,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2654,7 +2541,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2667,7 +2553,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2685,7 +2570,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2710,7 +2594,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2733,7 +2616,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2759,7 +2641,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2785,7 +2666,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2811,7 +2691,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2837,7 +2716,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2866,7 +2744,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2890,7 +2767,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2913,7 +2789,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2936,7 +2811,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -2946,7 +2820,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -2964,7 +2837,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2987,7 +2859,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3010,7 +2881,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3033,7 +2903,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -3046,7 +2915,6 @@
                 },
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -3064,7 +2932,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -3093,7 +2960,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3117,7 +2983,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3140,7 +3005,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3166,7 +3030,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3189,7 +3052,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3212,7 +3074,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3235,7 +3096,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3258,7 +3118,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3284,7 +3143,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3307,7 +3165,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3330,7 +3187,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3356,7 +3212,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3379,7 +3234,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3405,7 +3259,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3428,7 +3281,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3451,7 +3303,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3704,7 +3555,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3713,7 +3563,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3722,7 +3571,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3731,7 +3579,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3740,7 +3587,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3749,7 +3595,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3758,7 +3603,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3767,7 +3611,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3776,7 +3619,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3785,7 +3627,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3794,7 +3635,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -3884,7 +3724,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -3892,7 +3731,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -3902,7 +3740,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2+msr/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2+msr/world_4.json
@@ -35,7 +35,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -48,7 +47,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -66,7 +64,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -98,7 +95,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -122,7 +118,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -147,7 +142,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -172,7 +166,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -198,7 +191,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -224,7 +216,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -250,7 +241,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -276,7 +266,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -302,7 +291,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -328,7 +316,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -354,7 +341,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -380,7 +366,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -403,7 +388,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -429,7 +413,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -452,7 +435,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -478,7 +460,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -504,7 +485,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -530,7 +510,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -556,7 +535,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -582,7 +560,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -608,7 +585,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -631,7 +607,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -644,7 +619,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -662,7 +636,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -688,7 +661,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -701,7 +673,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -719,7 +690,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -745,7 +715,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -755,7 +724,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -773,7 +741,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -799,7 +766,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -825,7 +791,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -850,7 +815,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -876,7 +840,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -902,7 +865,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -925,7 +887,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -951,7 +912,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -961,7 +921,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -979,7 +938,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1005,7 +963,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1031,7 +988,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1057,7 +1013,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1083,7 +1038,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1109,7 +1063,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1132,7 +1085,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1155,7 +1107,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1181,7 +1132,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1207,7 +1157,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1230,7 +1179,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1256,7 +1204,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1282,7 +1229,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1308,7 +1254,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1340,7 +1285,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1364,7 +1308,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1387,7 +1330,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1413,7 +1355,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1439,7 +1380,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1462,7 +1402,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1488,7 +1427,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1514,7 +1452,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1527,7 +1464,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1545,7 +1481,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1557,7 +1492,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1575,7 +1509,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1598,7 +1531,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1624,7 +1556,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1650,7 +1581,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1676,7 +1606,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1702,7 +1631,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1728,7 +1656,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1753,7 +1680,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1776,7 +1702,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1802,7 +1727,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1828,7 +1752,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1854,7 +1777,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1877,7 +1799,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1903,7 +1824,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1929,7 +1849,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1954,7 +1873,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1980,7 +1898,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2006,7 +1923,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2032,7 +1948,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2058,7 +1973,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -2084,7 +1998,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -2097,7 +2010,6 @@
                 },
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -2115,7 +2027,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2141,7 +2052,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2167,7 +2077,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2193,7 +2102,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2219,7 +2127,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2245,7 +2152,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2271,7 +2177,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2297,7 +2202,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2323,7 +2227,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2349,7 +2252,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2375,7 +2277,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2398,7 +2299,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2424,7 +2324,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2450,7 +2349,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2476,7 +2374,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2502,7 +2399,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2528,7 +2424,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2554,7 +2449,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2580,7 +2474,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2606,7 +2499,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2632,7 +2524,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2645,7 +2536,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2663,7 +2553,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2689,7 +2578,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2712,7 +2600,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2738,7 +2625,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2751,7 +2637,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2769,7 +2654,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2792,7 +2676,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2818,7 +2701,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2844,7 +2726,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2870,7 +2751,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2896,7 +2776,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2922,7 +2801,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2948,7 +2826,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2973,7 +2850,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2999,7 +2875,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -3025,7 +2900,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -3038,7 +2912,6 @@
                 },
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -3056,7 +2929,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3081,7 +2953,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3107,7 +2978,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3133,7 +3003,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -3143,7 +3012,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -3161,7 +3029,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -3187,7 +3054,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3210,7 +3076,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3236,7 +3101,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3261,7 +3125,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3287,7 +3150,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3313,7 +3175,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3339,7 +3200,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3365,7 +3225,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3391,7 +3250,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3417,7 +3275,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3440,7 +3297,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3466,7 +3322,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3492,7 +3347,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3518,7 +3372,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3544,7 +3397,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3570,7 +3422,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3811,7 +3662,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3820,7 +3670,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3829,7 +3678,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3838,7 +3686,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3847,7 +3694,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3856,7 +3702,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3865,7 +3710,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3874,7 +3718,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3883,7 +3726,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3892,7 +3734,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3901,7 +3742,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -3994,7 +3834,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -4002,7 +3841,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -4012,7 +3850,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_4.json
@@ -33,7 +33,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -46,7 +45,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -64,7 +62,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -90,7 +87,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -116,7 +112,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -142,7 +137,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -168,7 +162,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -191,7 +184,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -217,7 +209,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -240,7 +231,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -265,7 +255,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -291,7 +280,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -314,7 +302,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -339,7 +326,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -364,7 +350,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -390,7 +375,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -416,7 +400,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -442,7 +425,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -468,7 +450,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -491,7 +472,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -514,7 +494,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -537,7 +516,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -563,7 +541,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -589,7 +566,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -614,7 +590,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -624,7 +599,6 @@
                 "icon_id": "item_powerbombtank",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -642,7 +616,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -668,7 +641,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -681,7 +653,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -699,7 +670,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -722,7 +692,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -732,7 +701,6 @@
                 "icon_id": "item_flashshiftupgrade",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -750,7 +718,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -776,7 +743,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -802,7 +768,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -828,7 +793,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -854,7 +818,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -880,7 +843,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -906,7 +868,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -931,7 +892,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -944,7 +904,6 @@
                 },
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -962,7 +921,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -988,7 +946,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1013,7 +970,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1039,7 +995,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1065,7 +1020,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1090,7 +1044,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1115,7 +1068,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1138,7 +1090,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1164,7 +1115,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1190,7 +1140,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1216,7 +1165,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1242,7 +1190,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1268,7 +1215,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1294,7 +1240,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1319,7 +1264,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1345,7 +1289,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1368,7 +1311,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1394,7 +1336,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1420,7 +1361,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1446,7 +1386,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1469,7 +1408,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1495,7 +1433,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1508,7 +1445,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1526,7 +1462,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1539,7 +1474,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1557,7 +1491,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1582,7 +1515,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1608,7 +1540,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1634,7 +1565,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1663,7 +1593,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1687,7 +1616,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1712,7 +1640,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1738,7 +1665,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1764,7 +1690,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1787,7 +1712,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1813,7 +1737,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1836,7 +1759,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1861,7 +1783,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1887,7 +1808,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1913,7 +1833,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1939,7 +1858,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1964,7 +1882,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1987,7 +1904,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2013,7 +1929,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2036,7 +1951,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -2062,7 +1976,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -2074,7 +1987,6 @@
                 },
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -2092,7 +2004,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2118,7 +2029,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2144,7 +2054,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2170,7 +2079,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2195,7 +2103,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2218,7 +2125,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2244,7 +2150,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2270,7 +2175,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2302,7 +2206,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2326,7 +2229,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2352,7 +2254,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2378,7 +2279,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2404,7 +2304,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2430,7 +2329,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2456,7 +2354,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2482,7 +2379,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2505,7 +2401,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2528,7 +2423,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2554,7 +2448,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2580,7 +2473,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2605,7 +2497,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2618,7 +2509,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2636,7 +2526,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2662,7 +2551,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2687,7 +2575,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2713,7 +2600,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2726,7 +2612,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2744,7 +2629,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2770,7 +2654,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2793,7 +2676,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2818,7 +2700,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2844,7 +2725,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2870,7 +2750,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2896,7 +2775,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2921,7 +2799,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2944,7 +2821,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2970,7 +2846,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2996,7 +2871,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -3009,7 +2883,6 @@
                 },
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -3027,7 +2900,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3053,7 +2925,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3078,7 +2949,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3104,7 +2974,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -3114,7 +2983,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -3132,7 +3000,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -3158,7 +3025,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3184,7 +3050,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3207,7 +3072,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3232,7 +3096,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3258,7 +3121,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3283,7 +3145,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3309,7 +3170,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3335,7 +3195,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3361,7 +3220,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3386,7 +3244,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3412,7 +3269,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3438,7 +3294,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3463,7 +3318,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3488,7 +3342,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3514,7 +3367,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3537,7 +3389,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3778,7 +3629,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3787,7 +3637,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3796,7 +3645,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3805,7 +3653,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3814,7 +3661,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3823,7 +3669,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3832,7 +3677,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3841,7 +3685,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3850,7 +3693,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3859,7 +3701,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3868,7 +3709,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -3966,7 +3806,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -3974,7 +3813,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -3984,7 +3822,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_4.json
@@ -35,7 +35,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -48,7 +47,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -72,7 +70,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -96,7 +93,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -122,7 +118,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -148,7 +143,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -174,7 +168,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -200,7 +193,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -223,7 +215,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -246,7 +237,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -271,7 +261,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -303,7 +292,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -327,7 +315,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -353,7 +340,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -379,7 +365,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -405,7 +390,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -431,7 +415,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -454,7 +437,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -480,7 +462,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -506,7 +487,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -532,7 +512,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -558,7 +537,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -581,7 +559,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -604,7 +581,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -630,7 +606,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -643,7 +618,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -661,7 +635,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -687,7 +660,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -700,7 +672,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -718,7 +689,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -741,7 +711,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -754,7 +723,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -772,7 +740,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -795,7 +762,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -821,7 +787,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -847,7 +812,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -873,7 +837,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -899,7 +862,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -925,7 +887,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -951,7 +912,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -961,7 +921,6 @@
                 "icon_id": "powerup_widebeam",
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -979,7 +938,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1002,7 +960,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1028,7 +985,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1051,7 +1007,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1077,7 +1032,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1103,7 +1057,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1129,7 +1082,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1155,7 +1107,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1181,7 +1132,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1207,7 +1157,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1233,7 +1182,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1259,7 +1207,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1285,7 +1232,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1308,7 +1254,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1338,7 +1283,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1361,7 +1305,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1387,7 +1330,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1413,7 +1355,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1439,7 +1380,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1465,7 +1405,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1491,7 +1430,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1523,7 +1461,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1534,7 +1471,6 @@
                 "icon_id": "PROGRESSIVE_SUIT",
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1552,7 +1488,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1565,7 +1500,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1583,7 +1517,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1609,7 +1542,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1635,7 +1567,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1661,7 +1592,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1684,7 +1614,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1710,7 +1639,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1733,7 +1661,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1759,7 +1686,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1785,7 +1711,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1808,7 +1733,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1834,7 +1758,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1860,7 +1783,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1886,7 +1808,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1912,7 +1833,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1938,7 +1858,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1964,7 +1883,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1990,7 +1908,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2016,7 +1933,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2042,7 +1958,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2068,7 +1983,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -2094,7 +2008,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -2107,7 +2020,6 @@
                 },
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -2125,7 +2037,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2151,7 +2062,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2177,7 +2087,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2203,7 +2112,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2229,7 +2137,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2256,7 +2163,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2282,7 +2188,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2308,7 +2213,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2334,7 +2238,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2360,7 +2263,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2386,7 +2288,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2412,7 +2313,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2435,7 +2335,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2461,7 +2360,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2487,7 +2385,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2513,7 +2410,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2539,7 +2435,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2562,7 +2457,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2588,7 +2482,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2614,7 +2507,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2637,7 +2529,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2647,7 +2538,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2665,7 +2555,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2691,7 +2580,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2717,7 +2605,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2743,7 +2630,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2756,7 +2642,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2774,7 +2659,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2800,7 +2684,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2826,7 +2709,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2852,7 +2734,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2878,7 +2759,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2901,7 +2781,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2927,7 +2806,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2953,7 +2831,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2979,7 +2856,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3005,7 +2881,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -3028,7 +2903,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -3041,7 +2915,6 @@
                 },
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -3059,7 +2932,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3082,7 +2954,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3108,7 +2979,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3134,7 +3004,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -3147,7 +3016,6 @@
                 },
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -3165,7 +3033,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -3191,7 +3058,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3217,7 +3083,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3243,7 +3108,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3269,7 +3133,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3295,7 +3158,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3318,7 +3180,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3341,7 +3202,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3367,7 +3227,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3393,7 +3252,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3419,7 +3277,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3445,7 +3302,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3471,7 +3327,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3497,7 +3352,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3523,7 +3377,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3549,7 +3402,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3572,7 +3424,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3813,7 +3664,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3822,7 +3672,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3831,7 +3680,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3840,7 +3688,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3849,7 +3696,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3858,7 +3704,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3867,7 +3712,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3876,7 +3720,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3885,7 +3728,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3894,7 +3736,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3903,7 +3744,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -3996,7 +3836,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -4004,7 +3843,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -4014,7 +3852,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"

--- a/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_8.json
+++ b/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_8.json
@@ -41,7 +41,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ChargeBeam"
             },
             "model": [
@@ -51,7 +50,6 @@
                 "icon_id": "item_energyfragment",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_chargebeam"
                 }
             }
@@ -69,7 +67,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank011"
             },
             "model": [
@@ -95,7 +92,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank012"
             },
             "model": [
@@ -121,7 +117,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_EnergyTank001"
             },
             "model": [
@@ -147,7 +142,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank001"
             },
             "model": [
@@ -173,7 +167,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank002"
             },
             "model": [
@@ -200,7 +193,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -223,7 +215,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003"
             },
             "model": [
@@ -246,7 +237,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank004"
             },
             "model": [
@@ -272,7 +262,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank005"
             },
             "model": [
@@ -298,7 +287,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank006"
             },
             "model": [
@@ -324,7 +312,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank007"
             },
             "model": [
@@ -347,7 +334,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
@@ -373,7 +359,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank009"
             },
             "model": [
@@ -396,7 +381,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -419,7 +403,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -445,7 +428,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -471,7 +453,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -497,7 +478,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -520,7 +500,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -546,7 +525,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -572,7 +550,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -598,7 +575,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank010"
             },
             "model": [
@@ -625,7 +601,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "IT_VARIA_GEN_001"
             },
             "model": [
@@ -635,7 +610,6 @@
                 "icon_id": "offworld",
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_variasuit"
                 }
             }
@@ -653,7 +627,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -679,7 +652,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
@@ -692,7 +664,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_grapplebeam"
                 }
             }
@@ -710,7 +681,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank014"
             },
             "model": [
@@ -736,7 +706,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
@@ -749,7 +718,6 @@
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
-                    "layer": "default",
                     "actor": "powerup_screwattack"
                 }
             }
@@ -767,7 +735,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank015"
             },
             "model": [
@@ -794,7 +761,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "Item_MissileTank016"
             },
             "model": [
@@ -820,7 +786,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -843,7 +808,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -869,7 +833,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -895,7 +858,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -921,7 +883,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_012"
             },
             "model": [
@@ -947,7 +908,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
@@ -960,7 +920,6 @@
                 },
                 "original_actor": {
                     "scenario": "s020_magma",
-                    "layer": "default",
                     "actor": "powerup_diffusionbeam"
                 }
             }
@@ -984,7 +943,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1007,7 +965,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1033,7 +990,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1059,7 +1015,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1085,7 +1040,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1111,7 +1065,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -1137,7 +1090,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1164,7 +1116,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1187,7 +1138,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1213,7 +1163,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -1239,7 +1188,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1262,7 +1210,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_011"
             },
             "model": [
@@ -1289,7 +1236,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1315,7 +1261,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -1338,7 +1283,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1364,7 +1308,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1390,7 +1333,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1416,7 +1358,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -1442,7 +1383,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1468,7 +1408,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -1494,7 +1433,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -1520,7 +1458,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_widebeam"
             },
             "model": [
@@ -1533,7 +1470,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_widebeam"
                 }
             }
@@ -1551,7 +1487,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "itemsphere_bomb"
             },
             "model": [
@@ -1564,7 +1499,6 @@
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
-                    "layer": "default",
                     "actor": "powerup_bomb"
                 }
             }
@@ -1582,7 +1516,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -1608,7 +1541,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -1631,7 +1563,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -1657,7 +1588,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -1683,7 +1613,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -1709,7 +1638,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -1735,7 +1663,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -1761,7 +1688,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -1787,7 +1713,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_008"
             },
             "model": [
@@ -1813,7 +1738,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -1839,7 +1763,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_010"
             },
             "model": [
@@ -1862,7 +1785,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -1888,7 +1810,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -1914,7 +1835,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_energyfragment_003"
             },
             "model": [
@@ -1940,7 +1860,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_powerbombtank_002"
             },
             "model": [
@@ -1963,7 +1882,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -1989,7 +1907,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2015,7 +1932,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2041,7 +1957,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -2067,7 +1982,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "powerup_ghostaura"
             },
             "model": [
@@ -2093,7 +2007,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "itemsphere_gravitysuit"
             },
             "model": [
@@ -2106,7 +2019,6 @@
                 },
                 "original_actor": {
                     "scenario": "s040_aqua",
-                    "layer": "default",
                     "actor": "powerup_gravitysuit"
                 }
             }
@@ -2124,7 +2036,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2150,7 +2061,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2176,7 +2086,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2202,7 +2111,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2228,7 +2136,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2254,7 +2161,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2280,7 +2186,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -2306,7 +2211,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_002"
             },
             "model": [
@@ -2332,7 +2236,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus"
             },
             "model": [
@@ -2358,7 +2261,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -2384,7 +2286,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2407,7 +2308,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2433,7 +2333,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2459,7 +2358,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2485,7 +2383,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2511,7 +2408,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "item_energytank"
             },
             "model": [
@@ -2537,7 +2433,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -2563,7 +2458,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -2586,7 +2480,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -2612,7 +2505,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -2635,7 +2527,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_supermissile"
             },
             "model": [
@@ -2648,7 +2539,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_supermissile"
                 }
             }
@@ -2666,7 +2556,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -2692,7 +2581,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -2718,7 +2606,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -2744,7 +2631,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "itemsphere_doublejump"
             },
             "model": [
@@ -2757,7 +2643,6 @@
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
-                    "layer": "default",
                     "actor": "powerup_doublejump"
                 }
             }
@@ -2775,7 +2660,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -2801,7 +2685,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_006"
             },
             "model": [
@@ -2827,7 +2710,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_007"
             },
             "model": [
@@ -2853,7 +2735,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -2879,7 +2760,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -2905,7 +2785,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "powerup_sonar"
             },
             "model": [
@@ -2928,7 +2807,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank_009"
             },
             "model": [
@@ -2954,7 +2832,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -2980,7 +2857,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3006,7 +2882,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_energytank_000"
             },
             "model": [
@@ -3032,7 +2907,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "itemsphere_plasmabeam_000"
             },
             "model": [
@@ -3045,7 +2919,6 @@
                 },
                 "original_actor": {
                     "scenario": "s060_quarantine",
-                    "layer": "default",
                     "actor": "powerup_plasmabeam"
                 }
             }
@@ -3063,7 +2936,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3089,7 +2961,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3112,7 +2983,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s060_quarantine",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3135,7 +3005,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "itemsphere_spacejump"
             },
             "model": [
@@ -3145,7 +3014,6 @@
                 "icon_id": "item_missiletank",
                 "original_actor": {
                     "scenario": "s070_basesanc",
-                    "layer": "default",
                     "actor": "powerup_spacejump"
                 }
             }
@@ -3163,7 +3031,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_001"
             },
             "model": [
@@ -3186,7 +3053,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3212,7 +3078,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_004"
             },
             "model": [
@@ -3238,7 +3103,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_002"
             },
             "model": [
@@ -3264,7 +3128,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_001"
             },
             "model": [
@@ -3290,7 +3153,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_003"
             },
             "model": [
@@ -3316,7 +3178,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_001"
             },
             "model": [
@@ -3342,7 +3203,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3368,7 +3228,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_001"
             },
             "model": [
@@ -3394,7 +3253,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_002"
             },
             "model": [
@@ -3420,7 +3278,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletankplus_000"
             },
             "model": [
@@ -3443,7 +3300,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment_000"
             },
             "model": [
@@ -3469,7 +3325,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_missiletank_005"
             },
             "model": [
@@ -3495,7 +3350,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "item_energyfragment"
             },
             "model": [
@@ -3521,7 +3375,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank_000"
             },
             "model": [
@@ -3547,7 +3400,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_powerbombtank_000"
             },
             "model": [
@@ -3573,7 +3425,6 @@
             ],
             "pickup_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "item_missiletank"
             },
             "model": [
@@ -3814,7 +3665,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint002"
             },
             "hint_id": "CAVE_2",
@@ -3823,7 +3673,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s010_cave",
-                "layer": "default",
                 "actor": "PRP_CV_AccessPoint001"
             },
             "hint_id": "CAVE_1",
@@ -3832,7 +3681,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint"
             },
             "hint_id": "MAGMA_1",
@@ -3841,7 +3689,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s020_magma",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "MAGMA_2",
@@ -3850,7 +3697,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "LAB_1",
@@ -3859,7 +3705,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s030_baselab",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "LAB_2",
@@ -3868,7 +3713,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "AQUA_1",
@@ -3877,7 +3721,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s040_aqua",
-                "layer": "default",
                 "actor": "accesspoint_001"
             },
             "hint_id": "AQUA_2",
@@ -3886,7 +3729,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s070_basesanc",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SANC_1",
@@ -3895,7 +3737,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s050_forest",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "FOREST_1",
@@ -3904,7 +3745,6 @@
         {
             "accesspoint_actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "accesspoint_000"
             },
             "hint_id": "SHIP_1",
@@ -3997,7 +3837,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_005"
             },
             "door_type": "power_beam"
@@ -4005,7 +3844,6 @@
         {
             "actor": {
                 "scenario": "s080_shipyard",
-                "layer": "default",
                 "actor": "doorpowerpower_006"
             },
             "door_type": "power_beam"
@@ -4015,7 +3853,7 @@
         {
             "actor": {
                 "scenario": "s010_cave",
-                "layer": "breakables",
+                "sublayer": "breakables",
                 "actor": "breakabletilegroup_060"
             },
             "tiletype": "SPEEDBOOST"


### PR DESCRIPTION
Since `layer` is now deprecated in ODR, `sublayer` should be used instead. This is a draft PR until ODR gets a release, but this PR has been tested with my ODR PR (https://github.com/randovania/open-dread-rando/pull/369) and the code should be ready for review.