### PR TITLE
Fusion: Readjust kago freezing

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -7657,8 +7657,42 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Freeze Enemies With Any Weapon"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Get over Kago by freezing it",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Freeze Enemies With Any Weapon"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Hi-Jump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "StandOnFrozenEnemies",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1201,7 +1201,11 @@ Extra - room_id: [33]
   * Extra - door_idx: (73,)
   > Beside Pickup
       Any of the following:
-          Screw Attack or Space Jump or Can Freeze Enemies With Any Weapon
+          Screw Attack or Space Jump
+          All of the following:
+              # Get over Kago by freezing it
+              Can Freeze Enemies With Any Weapon
+              Hi-Jump or Stand On Frozen Enemies (Beginner)
           All of the following:
               # Jump over the Kago with HJ
               Hi-Jump


### PR DESCRIPTION
Reasoning for making HJless behind a trick:
The game doesn't teach you anywhere to bait reos into swooping down and freezing them in mid air. The game does teach you on freezing and standing on kagos though, hence why HJ is trickless.