### PR TITLE
Fixed connection for auto tracker

### DIFF
--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -145,7 +145,7 @@
             },
             "PowerSuit": {
                 "long_name": "Power Suit",
-                "max_capacity": 1,
+                "max_capacity": 2147483647,
                 "extra": {
                     "item_id": 20
                 }
@@ -187,7 +187,7 @@
             },
             "Unknown2": {
                 "long_name": "Unknown Item 2",
-                "max_capacity": 1,
+                "max_capacity": 2147483647,
                 "extra": {
                     "item_id": 27
                 }


### PR DESCRIPTION
The auto tracker was switching between being in-game and on the title screen because of incorrect settings for specific item IDs (in this case "Unknown Item 2" and "Power Suit"). Adjusted their max_capacity in the database and now it should work fine again.