### PR TITLE
Adding multiworld support for custom Prime 1 items

### DIFF
--- a/randovania/game_connection/connector/prime1_remote_connector.py
+++ b/randovania/game_connection/connector/prime1_remote_connector.py
@@ -63,7 +63,7 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
         """Fetches the inventory represented by the given game memory."""
 
         memory_ops = await self._memory_op_for_items(
-            [item for item in self.game.resource_database.item if not item.extra.get("exclude_from_remote_connector")]
+            [item for item in self.game.resource_database.item if item.extra["item_id"] < 1000]
         )
         ops_result = await self.executor.perform_memory_operations(memory_ops)
 

--- a/randovania/game_connection/connector/prime1_remote_connector.py
+++ b/randovania/game_connection/connector/prime1_remote_connector.py
@@ -63,11 +63,7 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
         """Fetches the inventory represented by the given game memory."""
 
         memory_ops = await self._memory_op_for_items(
-            [
-                item
-                for item in self.game.resource_database.item
-                if not item.extra.get("exclude_from_remote_connector")
-            ]
+            [item for item in self.game.resource_database.item if not item.extra.get("exclude_from_remote_connector")]
         )
         ops_result = await self.executor.perform_memory_operations(memory_ops)
 

--- a/randovania/game_connection/connector/prime1_remote_connector.py
+++ b/randovania/game_connection/connector/prime1_remote_connector.py
@@ -66,7 +66,7 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
             [
                 item
                 for item in self.game.resource_database.item
-                if item.extra["item_id"] < 1000 and not item.extra.get("exclude_from_remote_connector")
+                if not item.extra.get("exclude_from_remote_connector")
             ]
         )
         ops_result = await self.executor.perform_memory_operations(memory_ops)
@@ -79,10 +79,10 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
             inventory[item] = inv
 
         for item in self.game.resource_database.item:
-            if item.extra.get("custom_value"):
+            if item.extra.get("unk2_bitmask_value"):
                 unknown2 = inventory.get(self.game.resource_database.get_item("Unknown2"))
                 if unknown2:
-                    item_value = (unknown2.capacity & item.extra["custom_value"]) >= 1
+                    item_value = (unknown2.capacity & item.extra["unk2_bitmask_value"]) >= 1
                     new_item = InventoryItem(item_value, item_value)
                     inventory[item] = new_item
 
@@ -147,13 +147,13 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
             if delta == 0:
                 continue
 
-            if item.extra.get("custom_value"):
+            if item.extra.get("unk2_bitmask_value"):
                 patches.append(
                     all_prime_dol_patches.adjust_item_amount_and_capacity_patch(
                         self.version.powerup_functions,
                         self.version.game,
                         self.game.resource_database.get_item("Unknown2").extra["item_id"],
-                        item.extra["custom_value"],
+                        (item.extra["item_id"] - 1000),
                     )
                 )
 

--- a/randovania/game_connection/connector/prime1_remote_connector.py
+++ b/randovania/game_connection/connector/prime1_remote_connector.py
@@ -7,7 +7,12 @@ from open_prime_rando.dol_patching import all_prime_dol_patches
 from open_prime_rando.dol_patching.prime1 import dol_patches
 
 from randovania.game_connection.connector.prime_remote_connector import PrimeRemoteConnector
-from randovania.game_connection.executor.memory_operation import MemoryOperation, MemoryOperationExecutor
+from randovania.game_connection.executor.memory_operation import (
+    MemoryOperation,
+    MemoryOperationException,
+    MemoryOperationExecutor,
+)
+from randovania.game_description.resources.inventory import Inventory, InventoryItem
 from randovania.games.prime1.patcher import prime_items
 
 if TYPE_CHECKING:
@@ -16,7 +21,6 @@ if TYPE_CHECKING:
 
     from randovania.game_description.db.region import Region
     from randovania.game_description.pickup.pickup_entry import PickupEntry
-    from randovania.game_description.resources.inventory import Inventory
     from randovania.game_description.resources.item_resource_info import ItemResourceInfo
 
 
@@ -54,6 +58,35 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
     @property
     def multiworld_magic_item(self) -> ItemResourceInfo:
         return self.game.resource_database.get_item(prime_items.MULTIWORLD_ITEM)
+
+    async def get_inventory(self) -> Inventory:
+        """Fetches the inventory represented by the given game memory."""
+
+        memory_ops = await self._memory_op_for_items(
+            [
+                item
+                for item in self.game.resource_database.item
+                if item.extra["item_id"] < 1000 and not item.extra.get("exclude_from_remote_connector")
+            ]
+        )
+        ops_result = await self.executor.perform_memory_operations(memory_ops)
+
+        inventory = {}
+        for item, memory_op in zip(self.game.resource_database.item, memory_ops):
+            inv = InventoryItem(*struct.unpack(">II", ops_result[memory_op]))
+            if (inv.amount > inv.capacity or inv.capacity > item.max_capacity) and (item != self.multiworld_magic_item):
+                raise MemoryOperationException(f"Received {inv} for {item.long_name}, which is an invalid state.")
+            inventory[item] = inv
+
+        for item in self.game.resource_database.item:
+            if item.extra.get("custom_value"):
+                unknown2 = inventory.get(self.game.resource_database.get_item("Unknown2"))
+                if unknown2:
+                    item_value = (unknown2.capacity & item.extra["custom_value"]) >= 1
+                    new_item = InventoryItem(item_value, item_value)
+                    inventory[item] = new_item
+
+        return Inventory(inventory)
 
     async def current_game_status(self) -> tuple[bool, Region | None]:
         """
@@ -113,6 +146,16 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
         for item, delta in resources_to_give.as_resource_gain():
             if delta == 0:
                 continue
+
+            if item.extra.get("custom_value"):
+                patches.append(
+                    all_prime_dol_patches.adjust_item_amount_and_capacity_patch(
+                        self.version.powerup_functions,
+                        self.version.game,
+                        self.game.resource_database.get_item("Unknown2").extra["item_id"],
+                        item.extra["custom_value"],
+                    )
+                )
 
             if item.short_name not in prime_items.ARTIFACT_ITEMS:
                 if item.extra.get("max_increase", None) == 0:

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -42,6 +42,8 @@ _STARTING_ITEM_NAME_TO_INDEX = {
     "wave": "Wave",
     "plasma": "Plasma",
     "missiles": "Missile",
+    "missileLauncher": "MissileLauncher",
+    "unlimitedMissiles": "UnlimitedMissiles",
     "scanVisor": "Scan",
     "bombs": "Bombs",
     "powerBombs": "PowerBomb",
@@ -124,12 +126,15 @@ def prime1_pickup_details_to_patcher(
                 count = quantity
                 max_count = 0
                 break
+            elif resource.extra.get("launcher_type"):
+                pickup_type = resource.long_name
+                break
             # Regular items
             elif resource.extra["item_id"] < 1000:
                 pickup_type = resource.long_name
                 count = quantity
                 max_count = count
-                break
+                # break
 
     if (
         model["name"] == "Missile"
@@ -141,6 +146,8 @@ def prime1_pickup_details_to_patcher(
         collection_text = collection_text.replace("Missile Expansion", "Shiny Missile Expansion")
         name = name.replace("Missile Expansion", "Shiny Missile Expansion")
         original_model = model
+
+    # if (model["name"] == "UnlimitedMissiles"):
 
     result = {
         "type": pickup_type,

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -47,6 +47,8 @@ _STARTING_ITEM_NAME_TO_INDEX = {
     "scanVisor": "Scan",
     "bombs": "Bombs",
     "powerBombs": "PowerBomb",
+    "powerBombLauncher": "MainPB",
+    "unlimitedPowerBombs": "UnlimitedPowerBombs",
     "flamethrower": "Flamethrower",
     "thermalVisor": "Thermal",
     "charge": "Charge",
@@ -126,7 +128,7 @@ def prime1_pickup_details_to_patcher(
                 count = quantity
                 max_count = 0
                 break
-            elif resource.extra.get("launcher_type"):
+            elif resource.extra.get("custom_value"):
                 pickup_type = resource.long_name
                 break
             # Regular items
@@ -134,7 +136,6 @@ def prime1_pickup_details_to_patcher(
                 pickup_type = resource.long_name
                 count = quantity
                 max_count = count
-                # break
 
     if (
         model["name"] == "Missile"
@@ -147,7 +148,7 @@ def prime1_pickup_details_to_patcher(
         name = name.replace("Missile Expansion", "Shiny Missile Expansion")
         original_model = model
 
-    # if (model["name"] == "UnlimitedMissiles"):
+    # TODO: Model for custom items.
 
     result = {
         "type": pickup_type,
@@ -657,18 +658,6 @@ class PrimePatchDataFactory(PatchDataFactory):
         db = self.game
         namer = PrimeHintNamer(self.description.all_patches, self.players_config)
 
-        ammo_with_mains = [
-            ammo.name
-            for ammo, state in self.configuration.ammo_pickup_configuration.pickups_state.items()
-            if state.requires_main_item
-        ]
-        if ammo_with_mains:
-            raise ValueError(
-                "Preset has {} with required mains enabled. This is currently not supported.".format(
-                    " and ".join(ammo_with_mains)
-                )
-            )
-
         scan_visor = self.game.resource_database.get_item_by_name("Scan Visor")
         pickup_list = self.export_pickup_list()
         modal_hud_override = _create_locations_with_modal_hud_memo(pickup_list)
@@ -896,12 +885,14 @@ class PrimePatchDataFactory(PatchDataFactory):
             for name, index in _STARTING_ITEM_NAME_TO_INDEX.items()
         }
 
-        # Check if mains are required. If not, force Missile Launcher to be a starting item. Right?
+        # Check if mains are required. If not, force Missile Launcher or Main Power Bombs to be a starting item.
         for ammo, state in self.configuration.ammo_pickup_configuration.pickups_state.items():
             if ammo.name == "Missile Expansion":
                 if not state.requires_main_item:
                     starting_items["missileLauncher"] = True
-                break
+            elif ammo.name == "Power Bomb Expansion":
+                if not state.requires_main_item:
+                    starting_items["powerBombLauncher"] = True
 
         if not self.configuration.legacy_mode:
             idrone_config = {

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -896,6 +896,13 @@ class PrimePatchDataFactory(PatchDataFactory):
             for name, index in _STARTING_ITEM_NAME_TO_INDEX.items()
         }
 
+        # Check if mains are required. If not, force Missile Launcher to be a starting item. Right?
+        for ammo, state in self.configuration.ammo_pickup_configuration.pickups_state.items():
+            if ammo.name == "Missile Expansion":
+                if not state.requires_main_item:
+                    starting_items["missileLauncher"] = True
+                break
+
         if not self.configuration.legacy_mode:
             idrone_config = {
                 "eyeWaitInitialRandomTime": 0.0,

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -128,7 +128,7 @@ def prime1_pickup_details_to_patcher(
                 count = quantity
                 max_count = 0
                 break
-            elif resource.extra.get("custom_value"):
+            elif resource.extra.get("unk2_bitmask_value"):
                 pickup_type = resource.long_name
                 break
             # Regular items
@@ -885,7 +885,7 @@ class PrimePatchDataFactory(PatchDataFactory):
             for name, index in _STARTING_ITEM_NAME_TO_INDEX.items()
         }
 
-        # Check if mains are required. If not, force Missile Launcher or Main Power Bombs to be a starting item.
+        # Check if mains are required. If not, force the respective main to be a starting item.
         for ammo, state in self.configuration.ammo_pickup_configuration.pickups_state.items():
             if ammo.name == "Missile Expansion":
                 if not state.requires_main_item:

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -294,7 +294,8 @@
                 "long_name": "Main Power Bomb",
                 "max_capacity": 1,
                 "extra": {
-                    "item_id": 1005
+                    "item_id": 44,
+                    "launcher_type": "Main Power Bomb"
                 }
             },
             "LockedPB": {
@@ -308,7 +309,8 @@
                 "long_name": "Missile Launcher",
                 "max_capacity": 1,
                 "extra": {
-                    "item_id": 1007
+                    "item_id": 43,
+                    "launcher_type": "Missile Launcher"
                 }
             },
             "LockedMissile": {

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -295,7 +295,6 @@
                 "max_capacity": 1,
                 "extra": {
                     "item_id": 1041,
-                    "exclude_from_remote_connector": true,
                     "unk2_bitmask_value": 1
                 }
             },
@@ -304,7 +303,6 @@
                 "max_capacity": 1,
                 "extra": {
                     "item_id": 1042,
-                    "exclude_from_remote_connector": true,
                     "unk2_bitmask_value": 2
                 }
             },
@@ -313,7 +311,6 @@
                 "max_capacity": 1,
                 "extra": {
                     "item_id": 1043,
-                    "exclude_from_remote_connector": true,
                     "unk2_bitmask_value": 4
                 }
             },
@@ -322,7 +319,6 @@
                 "max_capacity": 1,
                 "extra": {
                     "item_id": 1044,
-                    "exclude_from_remote_connector": true,
                     "unk2_bitmask_value": 8
                 }
             },

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -290,19 +290,22 @@
                     "item_id": 1004
                 }
             },
-            "MainPB": {
-                "long_name": "Main Power Bomb",
+            "UnlimitedMissiles": {
+                "long_name": "Unlimited Missiles",
                 "max_capacity": 1,
                 "extra": {
-                    "item_id": 44,
-                    "launcher_type": "Main Power Bomb"
+                    "item_id": 41,
+                    "exclude_from_remote_connector": true,
+                    "custom_value": 1
                 }
             },
-            "LockedPB": {
-                "long_name": "Locked Power Bomb",
-                "max_capacity": 99,
+            "UnlimitedPowerBombs": {
+                "long_name": "Unlimited Power Bombs",
+                "max_capacity": 1,
                 "extra": {
-                    "item_id": 1006
+                    "item_id": 42,
+                    "exclude_from_remote_connector": true,
+                    "custom_value": 2
                 }
             },
             "MissileLauncher": {
@@ -310,7 +313,26 @@
                 "max_capacity": 1,
                 "extra": {
                     "item_id": 43,
-                    "launcher_type": "Missile Launcher"
+                    "launcher_type": "Missile Launcher",
+                    "exclude_from_remote_connector": true,
+                    "custom_value": 4
+                }
+            },
+            "MainPB": {
+                "long_name": "Main Power Bomb",
+                "max_capacity": 1,
+                "extra": {
+                    "item_id": 44,
+                    "launcher_type": "Main Power Bomb",
+                    "exclude_from_remote_connector": true,
+                    "custom_value": 8
+                }
+            },
+            "LockedPB": {
+                "long_name": "Locked Power Bomb",
+                "max_capacity": 99,
+                "extra": {
+                    "item_id": 1006
                 }
             },
             "LockedMissile": {
@@ -351,20 +373,6 @@
                     "max_increase": 0,
                     "is_refill": true,
                     "refill_id": 7
-                }
-            },
-            "UnlimitedMissiles": {
-                "long_name": "Unlimited Missiles",
-                "max_capacity": 1,
-                "extra": {
-                    "item_id": 41
-                }
-            },
-            "UnlimitedPowerBombs": {
-                "long_name": "Unlimited Power Bombs",
-                "max_capacity": 1,
-                "extra": {
-                    "item_id": 42
                 }
             }
         },

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -296,7 +296,7 @@
                 "extra": {
                     "item_id": 1041,
                     "exclude_from_remote_connector": true,
-                    "custom_value": 1
+                    "unk2_bitmask_value": 1
                 }
             },
             "UnlimitedPowerBombs": {
@@ -305,7 +305,7 @@
                 "extra": {
                     "item_id": 1042,
                     "exclude_from_remote_connector": true,
-                    "custom_value": 2
+                    "unk2_bitmask_value": 2
                 }
             },
             "MissileLauncher": {
@@ -314,7 +314,7 @@
                 "extra": {
                     "item_id": 1043,
                     "exclude_from_remote_connector": true,
-                    "custom_value": 4
+                    "unk2_bitmask_value": 4
                 }
             },
             "MainPB": {
@@ -323,7 +323,7 @@
                 "extra": {
                     "item_id": 1044,
                     "exclude_from_remote_connector": true,
-                    "custom_value": 8
+                    "unk2_bitmask_value": 8
                 }
             },
             "LockedPB": {

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -350,6 +350,20 @@
                     "is_refill": true,
                     "refill_id": 7
                 }
+            },
+            "UnlimitedMissiles": {
+                "long_name": "Unlimited Missiles",
+                "max_capacity": 1,
+                "extra": {
+                    "item_id": 41
+                }
+            },
+            "UnlimitedPowerBombs": {
+                "long_name": "Unlimited Power Bombs",
+                "max_capacity": 1,
+                "extra": {
+                    "item_id": 42
+                }
             }
         },
         "events": {

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -294,7 +294,7 @@
                 "long_name": "Unlimited Missiles",
                 "max_capacity": 1,
                 "extra": {
-                    "item_id": 41,
+                    "item_id": 1041,
                     "exclude_from_remote_connector": true,
                     "custom_value": 1
                 }
@@ -303,7 +303,7 @@
                 "long_name": "Unlimited Power Bombs",
                 "max_capacity": 1,
                 "extra": {
-                    "item_id": 42,
+                    "item_id": 1042,
                     "exclude_from_remote_connector": true,
                     "custom_value": 2
                 }
@@ -312,8 +312,7 @@
                 "long_name": "Missile Launcher",
                 "max_capacity": 1,
                 "extra": {
-                    "item_id": 43,
-                    "launcher_type": "Missile Launcher",
+                    "item_id": 1043,
                     "exclude_from_remote_connector": true,
                     "custom_value": 4
                 }
@@ -322,8 +321,7 @@
                 "long_name": "Main Power Bomb",
                 "max_capacity": 1,
                 "extra": {
-                    "item_id": 44,
-                    "launcher_type": "Main Power Bomb",
+                    "item_id": 1044,
                     "exclude_from_remote_connector": true,
                     "custom_value": 8
                 }

--- a/randovania/games/prime1/pickup_database/pickup-database.json
+++ b/randovania/games/prime1/pickup_database/pickup-database.json
@@ -217,7 +217,7 @@
         "Unlimited Missiles": {
             "pickup_category": "missile",
             "broad_category": "missile_related",
-            "model_name": "UnlimitedMissiles",
+            "model_name": "Cog",
             "offworld_models": {},
             "progression": [
                 "UnlimitedMissiles"

--- a/randovania/games/prime1/pickup_database/pickup-database.json
+++ b/randovania/games/prime1/pickup_database/pickup-database.json
@@ -214,6 +214,17 @@
                 19
             ]
         },
+        "Unlimited Missiles": {
+            "pickup_category": "missile",
+            "broad_category": "missile_related",
+            "model_name": "UnlimitedMissiles",
+            "offworld_models": {},
+            "progression": [
+                "UnlimitedMissiles"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "missing"
+        },
         "Grapple Beam": {
             "pickup_category": "movement",
             "broad_category": "movement",
@@ -425,6 +436,17 @@
             "original_locations": [
                 84
             ]
+        },
+        "Unlimited Power Bombs": {
+            "pickup_category": "morph_ball",
+            "broad_category": "morph_ball_related",
+            "model_name": "UnlimitedPowerBombs",
+            "offworld_models": {},
+            "progression": [
+                "UnlimitedPowerBombs"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "missing"
         },
         "Power Suit": {
             "pickup_category": "suit",

--- a/randovania/games/prime1/pickup_database/pickup-database.json
+++ b/randovania/games/prime1/pickup_database/pickup-database.json
@@ -440,7 +440,7 @@
         "Unlimited Power Bombs": {
             "pickup_category": "morph_ball",
             "broad_category": "morph_ball_related",
-            "model_name": "UnlimitedPowerBombs",
+            "model_name": "Cog",
             "offworld_models": {},
             "progression": [
                 "UnlimitedPowerBombs"

--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -9,7 +9,6 @@ from PySide6 import QtCore, QtWidgets
 
 import randovania.gui.lib.signal_handling
 from randovania.exporter import item_names
-from randovania.game.game_enum import RandovaniaGame
 from randovania.game_description import default_database
 from randovania.game_description.resources.resource_type import ResourceType
 from randovania.generator.pickup_pool import pool_creator
@@ -26,6 +25,7 @@ from randovania.layout.base.standard_pickup_state import StandardPickupState
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
+    from randovania.game.game_enum import RandovaniaGame
     from randovania.game_description.game_description import GameDescription
     from randovania.game_description.pickup.ammo_pickup import AmmoPickupDefinition
     from randovania.game_description.pickup.pickup_category import PickupCategory
@@ -169,8 +169,6 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
 
             if widgets.require_main_item_check is not None:
                 widgets.require_main_item_check.setChecked(state.requires_main_item)
-                if self.game == RandovaniaGame.METROID_PRIME:
-                    widgets.require_main_item_check.setChecked(False)
 
             self_counts = []
             for ammo_index, count in enumerate(state.ammo_count):
@@ -394,13 +392,10 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
             add_column(pickup_spinbox)
             current_row += 1
 
-            # FIXME: hardcoded check to hide required mains for Prime 1
             if ammo.temporary:
                 require_main_item_check = QtWidgets.QCheckBox(pickup_box)
                 require_main_item_check.setText("Requires the main item to work?")
                 require_main_item_check.stateChanged.connect(partial(self._on_update_ammo_require_main_item, ammo))
-                if self.game == RandovaniaGame.METROID_PRIME:
-                    require_main_item_check.setVisible(False)
                 layout.addWidget(require_main_item_check, current_row, 0, 1, -1)
                 current_row += 1
             else:

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1210,6 +1210,15 @@ def _migrate_v90(preset: dict) -> dict:
     return preset
 
 
+def _migrate_v91(preset: dict) -> dict:
+    if preset["game"] == "prime1":
+        items = ["Unlimited Missiles", "Unlimited Power Bombs"]
+        for i in items:
+            preset["configuration"]["standard_pickup_configuration"]["pickups_state"][i] = {}
+
+    return preset
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -1301,6 +1310,7 @@ _MIGRATIONS = [
     _migrate_v88,  # dread freesink
     _migrate_v89,  # msr configurable required dna
     _migrate_v90,  # msr configurable final boss
+    _migrate_v91,
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/test/test_files/log_files/prime1_crazy_seed.rdvgame
+++ b/test/test_files/log_files/prime1_crazy_seed.rdvgame
@@ -1114,6 +1114,9 @@
                                     5
                                 ]
                             },
+                            "Unlimited Missiles": {
+                                "num_included_in_starting_pickups": 1
+                            },
                             "Grapple Beam": {
                                 "num_shuffled_pickups": 1
                             },
@@ -1152,6 +1155,9 @@
                                 "included_ammo": [
                                     8
                                 ]
+                            },
+                            "Unlimited Power Bombs": {
+                                "num_included_in_starting_pickups": 1
                             },
                             "Power Suit": {
                                 "num_included_in_starting_items": 1
@@ -1314,9 +1320,11 @@
             "starting_location": "Magmoor Caverns/Shore Tunnel",
             "starting_items": {
                 "Power Beam": 1,
+                "Unlimited Missiles": 1,
                 "Scan Visor": 1,
                 "Morph Ball": 1,
                 "Morph Ball Bomb": 1,
+                "Unlimited Power Bombs": 1,
                 "Power Suit": 1,
                 "Artifact of World": 1,
                 "Artifact of Spirit": 1,

--- a/test/test_files/log_files/prime1_refills.rdvgame
+++ b/test/test_files/log_files/prime1_refills.rdvgame
@@ -55,6 +55,9 @@
                                     5
                                 ]
                             },
+                            "Unlimited Missiles": {
+                                "num_shuffled_pickups": 1
+                            },
                             "Grapple Beam": {
                                 "num_shuffled_pickups": 1
                             },
@@ -94,6 +97,9 @@
                                     4
                                 ]
                             },
+                            "Unlimited Power Bombs": {
+                                "num_shuffled_pickups": 1
+                            },
                             "Power Suit": {
                                 "num_included_in_starting_pickups": 1
                             },
@@ -130,14 +136,14 @@
                                     5
                                 ],
                                 "pickup_count": 41,
-                                "requires_main_item": false
+                                "requires_main_item": true
                             },
                             "Power Bomb Expansion": {
                                 "ammo_count": [
                                     1
                                 ],
                                 "pickup_count": 4,
-                                "requires_main_item": false
+                                "requires_main_item": true
                             },
                             "Energy Refill": {
                                 "ammo_count": [

--- a/test/test_files/patcher_data/prime1/dread_prime1_multiworld/world_2.json
+++ b/test/test_files/patcher_data/prime1/dread_prime1_multiworld/world_2.json
@@ -74,6 +74,8 @@
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,
+            "powerBombLauncher": true,
+            "unlimitedPowerBombs": false,
             "flamethrower": false,
             "thermalVisor": false,
             "charge": false,

--- a/test/test_files/patcher_data/prime1/dread_prime1_multiworld/world_2.json
+++ b/test/test_files/patcher_data/prime1/dread_prime1_multiworld/world_2.json
@@ -69,6 +69,8 @@
             "wave": false,
             "plasma": false,
             "missiles": 0,
+            "missileLauncher": true,
+            "unlimitedMissiles": false,
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,
@@ -348,7 +350,7 @@
                 "Phendrana Canyon": {
                     "pickups": [
                         {
-                            "type": "Power Bomb",
+                            "type": "Main Power Bomb",
                             "model": {
                                 "game": "prime1",
                                 "name": "Power Bomb"

--- a/test/test_files/patcher_data/prime1/multi-am2r+cs+dread+prime1+prime2+msr/world_3.json
+++ b/test/test_files/patcher_data/prime1/multi-am2r+cs+dread+prime1+prime2+msr/world_3.json
@@ -70,6 +70,8 @@
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,
+            "powerBombLauncher": true,
+            "unlimitedPowerBombs": false,
             "flamethrower": false,
             "thermalVisor": false,
             "charge": false,

--- a/test/test_files/patcher_data/prime1/multi-am2r+cs+dread+prime1+prime2+msr/world_3.json
+++ b/test/test_files/patcher_data/prime1/multi-am2r+cs+dread+prime1+prime2+msr/world_3.json
@@ -65,6 +65,8 @@
             "wave": false,
             "plasma": false,
             "missiles": 0,
+            "missileLauncher": true,
+            "unlimitedMissiles": false,
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,

--- a/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_2.json
+++ b/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_2.json
@@ -70,6 +70,8 @@
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,
+            "powerBombLauncher": true,
+            "unlimitedPowerBombs": false,
             "flamethrower": false,
             "thermalVisor": false,
             "charge": false,

--- a/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_2.json
+++ b/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_2.json
@@ -65,6 +65,8 @@
             "wave": false,
             "plasma": false,
             "missiles": 0,
+            "missileLauncher": true,
+            "unlimitedMissiles": false,
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,

--- a/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_6.json
+++ b/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_6.json
@@ -70,6 +70,8 @@
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,
+            "powerBombLauncher": true,
+            "unlimitedPowerBombs": false,
             "flamethrower": false,
             "thermalVisor": false,
             "charge": false,

--- a/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_6.json
+++ b/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_6.json
@@ -65,6 +65,8 @@
             "wave": false,
             "plasma": false,
             "missiles": 0,
+            "missileLauncher": true,
+            "unlimitedMissiles": false,
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,
@@ -2118,7 +2120,7 @@
                 "Hive Totem": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Missile Launcher",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"

--- a/test/test_files/patcher_data/prime1/prime1_and_2_multi/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_and_2_multi/world_1.json
@@ -74,6 +74,8 @@
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,
+            "powerBombLauncher": true,
+            "unlimitedPowerBombs": false,
             "flamethrower": false,
             "thermalVisor": false,
             "charge": false,

--- a/test/test_files/patcher_data/prime1/prime1_and_2_multi/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_and_2_multi/world_1.json
@@ -69,6 +69,8 @@
             "wave": false,
             "plasma": false,
             "missiles": 5,
+            "missileLauncher": true,
+            "unlimitedMissiles": false,
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,
@@ -1587,7 +1589,7 @@
                             "showIcon": true
                         },
                         {
-                            "type": "Power Bomb",
+                            "type": "Main Power Bomb",
                             "model": {
                                 "game": "prime1",
                                 "name": "Power Bomb"

--- a/test/test_files/patcher_data/prime1/prime1_crazy_seed/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_crazy_seed/world_1.json
@@ -74,6 +74,8 @@
             "scanVisor": true,
             "bombs": true,
             "powerBombs": 0,
+            "powerBombLauncher": true,
+            "unlimitedPowerBombs": false,
             "flamethrower": false,
             "thermalVisor": false,
             "charge": false,

--- a/test/test_files/patcher_data/prime1/prime1_crazy_seed/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_crazy_seed/world_1.json
@@ -70,12 +70,12 @@
             "plasma": false,
             "missiles": 0,
             "missileLauncher": true,
-            "unlimitedMissiles": false,
+            "unlimitedMissiles": true,
             "scanVisor": true,
             "bombs": true,
             "powerBombs": 0,
             "powerBombLauncher": true,
-            "unlimitedPowerBombs": false,
+            "unlimitedPowerBombs": true,
             "flamethrower": false,
             "thermalVisor": false,
             "charge": false,
@@ -143,7 +143,7 @@
             "Artifact of Newborn": false
         },
         "requiredArtifactCount": 12,
-        "startingMemo": "Varia Suit"
+        "startingMemo": "Unlimited Missiles, Unlimited Power Bombs, Varia Suit"
     },
     "tweaks": {
         "playerSize": 0.3,

--- a/test/test_files/patcher_data/prime1/prime1_crazy_seed/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_crazy_seed/world_1.json
@@ -69,6 +69,8 @@
             "wave": false,
             "plasma": false,
             "missiles": 0,
+            "missileLauncher": true,
+            "unlimitedMissiles": false,
             "scanVisor": true,
             "bombs": true,
             "powerBombs": 0,
@@ -4756,7 +4758,7 @@
                 "Transport Tunnel A": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Missile Launcher",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -9508,7 +9510,7 @@
                             "jumboScan": true
                         },
                         {
-                            "type": "Power Bomb",
+                            "type": "Main Power Bomb",
                             "model": {
                                 "game": "prime1",
                                 "name": "Power Bomb"

--- a/test/test_files/patcher_data/prime1/prime1_crazy_seed_one_way_door/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_crazy_seed_one_way_door/world_1.json
@@ -74,6 +74,8 @@
             "wave": false,
             "plasma": false,
             "missiles": 0,
+            "missileLauncher": true,
+            "unlimitedMissiles": false,
             "scanVisor": true,
             "bombs": true,
             "powerBombs": 0,
@@ -7620,7 +7622,7 @@
                 "Alcove": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Missile Launcher",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -10811,7 +10813,7 @@
                 "Transport Access North": {
                     "pickups": [
                         {
-                            "type": "Power Bomb",
+                            "type": "Main Power Bomb",
                             "model": {
                                 "game": "prime1",
                                 "name": "Power Bomb"

--- a/test/test_files/patcher_data/prime1/prime1_crazy_seed_one_way_door/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_crazy_seed_one_way_door/world_1.json
@@ -79,6 +79,8 @@
             "scanVisor": true,
             "bombs": true,
             "powerBombs": 0,
+            "powerBombLauncher": true,
+            "unlimitedPowerBombs": false,
             "flamethrower": false,
             "thermalVisor": false,
             "charge": false,

--- a/test/test_files/patcher_data/prime1/prime1_refills/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_refills/world_1.json
@@ -70,6 +70,8 @@
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,
+            "powerBombLauncher": true,
+            "unlimitedPowerBombs": false,
             "flamethrower": false,
             "thermalVisor": false,
             "charge": false,

--- a/test/test_files/patcher_data/prime1/prime1_refills/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_refills/world_1.json
@@ -65,12 +65,12 @@
             "wave": false,
             "plasma": false,
             "missiles": 0,
-            "missileLauncher": true,
+            "missileLauncher": false,
             "unlimitedMissiles": false,
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,
-            "powerBombLauncher": true,
+            "powerBombLauncher": false,
             "unlimitedPowerBombs": false,
             "flamethrower": false,
             "thermalVisor": false,
@@ -176,7 +176,7 @@
                 "Phendrana Shorelines": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -186,9 +186,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         },
@@ -228,7 +228,7 @@
                 "Chozo Ice Temple": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -238,9 +238,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -270,7 +270,7 @@
                 "Ice Ruins East": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -280,9 +280,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         },
@@ -308,7 +308,7 @@
                 "Chapel of the Elders": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -318,9 +318,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -385,7 +385,7 @@
                 "Quarantine Cave": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -395,9 +395,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -448,7 +448,7 @@
                 "Observatory": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -458,9 +458,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -504,7 +504,7 @@
                 "Control Tower": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -514,9 +514,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -525,7 +525,7 @@
                 "Research Core": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -535,9 +535,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -546,7 +546,7 @@
                 "Frost Cave": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -556,9 +556,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -598,7 +598,7 @@
                             "showIcon": true
                         },
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -608,9 +608,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -636,7 +636,7 @@
                             "showIcon": true
                         },
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -646,9 +646,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -657,7 +657,7 @@
                 "Storage Cave": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -667,9 +667,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -678,7 +678,7 @@
                 "Security Cave": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -688,9 +688,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -753,7 +753,7 @@
                 "Triclops Pit": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -763,9 +763,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -795,7 +795,7 @@
                 "Transport Tunnel A": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -805,9 +805,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -816,7 +816,7 @@
                 "Warrior Shrine": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -826,9 +826,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -858,7 +858,7 @@
                 "Fiery Shores": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -868,14 +868,14 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         },
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -885,9 +885,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -962,7 +962,7 @@
                 "Main Quarry": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -972,9 +972,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -997,7 +997,7 @@
                 "Security Access A": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1007,9 +1007,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1018,7 +1018,7 @@
                 "Storage Depot B": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1028,9 +1028,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1039,7 +1039,7 @@
                 "Storage Depot A": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1049,9 +1049,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1060,7 +1060,7 @@
                 "Elite Research": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1070,9 +1070,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         },
@@ -1098,7 +1098,7 @@
                 "Elite Control Access": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1108,9 +1108,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1119,7 +1119,7 @@
                 "Ventilation Shaft": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1129,9 +1129,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1265,7 +1265,7 @@
                 "Metroid Quarantine A": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1275,9 +1275,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1411,7 +1411,7 @@
                 "Frigate Crash Site": {
                     "pickups": [
                         {
-                            "type": "Power Bomb",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
@@ -1421,9 +1421,9 @@
                                 "name": "Power Bomb Expansion"
                             },
                             "scanText": "Power Bomb Expansion. Provides 1 Power Bomb.",
-                            "hudmemoText": "Power Bomb Expansion acquired!",
-                            "currIncrease": 1,
-                            "maxIncrease": 1,
+                            "hudmemoText": "Locked Power Bomb Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1516,7 +1516,7 @@
                 "Arbor Chamber": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1526,9 +1526,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1545,7 +1545,7 @@
                 "Cargo Freight Lift to Deck Gamma": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1555,9 +1555,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1574,7 +1574,7 @@
                 "Biohazard Containment": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1584,9 +1584,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1595,7 +1595,7 @@
                 "Hydro Access Tunnel": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1605,9 +1605,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1723,7 +1723,7 @@
                             "showIcon": true
                         },
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1733,9 +1733,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         },
@@ -1839,7 +1839,7 @@
                             "showIcon": true
                         },
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1849,9 +1849,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1902,7 +1902,7 @@
                 "Ruined Nursery": {
                     "pickups": [
                         {
-                            "type": "Power Bomb",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
@@ -1912,9 +1912,9 @@
                                 "name": "Power Bomb Expansion"
                             },
                             "scanText": "Power Bomb Expansion. Provides 1 Power Bomb.",
-                            "hudmemoText": "Power Bomb Expansion acquired!",
-                            "currIncrease": 1,
-                            "maxIncrease": 1,
+                            "hudmemoText": "Locked Power Bomb Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -1950,7 +1950,7 @@
                 "Magma Pool": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -1960,9 +1960,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -2000,7 +2000,7 @@
                 "Tower Chamber": {
                     "pickups": [
                         {
-                            "type": "Power Bomb",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
@@ -2010,9 +2010,9 @@
                                 "name": "Power Bomb Expansion"
                             },
                             "scanText": "Power Bomb Expansion. Provides 1 Power Bomb.",
-                            "hudmemoText": "Power Bomb Expansion acquired!",
-                            "currIncrease": 1,
-                            "maxIncrease": 1,
+                            "hudmemoText": "Locked Power Bomb Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -2021,7 +2021,7 @@
                 "Ruined Gallery": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -2031,14 +2031,14 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         },
                         {
-                            "type": "Power Bomb",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
@@ -2048,9 +2048,9 @@
                                 "name": "Power Bomb Expansion"
                             },
                             "scanText": "Power Bomb Expansion. Provides 1 Power Bomb.",
-                            "hudmemoText": "Power Bomb Expansion acquired!",
-                            "currIncrease": 1,
-                            "maxIncrease": 1,
+                            "hudmemoText": "Locked Power Bomb Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -2145,7 +2145,7 @@
                             "showIcon": true
                         },
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -2155,9 +2155,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -2166,7 +2166,7 @@
                 "Watery Hall Access": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -2176,9 +2176,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -2326,7 +2326,7 @@
                             "showIcon": true
                         },
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -2336,9 +2336,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -2347,7 +2347,7 @@
                 "Hall of the Elders": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -2357,9 +2357,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -2368,7 +2368,7 @@
                 "Crossway": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -2378,9 +2378,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -2389,7 +2389,7 @@
                 "Elder Chamber": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -2399,9 +2399,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -2410,7 +2410,7 @@
                 "Antechamber": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Nothing",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"
@@ -2420,9 +2420,9 @@
                                 "name": "Missile"
                             },
                             "scanText": "Missile Expansion. Provides 5 Missiles.",
-                            "hudmemoText": "Missile Expansion acquired!",
-                            "currIncrease": 5,
-                            "maxIncrease": 5,
+                            "hudmemoText": "Locked Missile Expansion acquired!",
+                            "currIncrease": 0,
+                            "maxIncrease": 0,
                             "respawn": false,
                             "showIcon": true
                         }
@@ -2453,6 +2453,6 @@
         0
     ],
     "_randovania_meta": {
-        "layout_was_user_modified": false
+        "layout_was_user_modified": true
     }
 }

--- a/test/test_files/patcher_data/prime1/prime1_refills/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_refills/world_1.json
@@ -65,6 +65,8 @@
             "wave": false,
             "plasma": false,
             "missiles": 0,
+            "missileLauncher": true,
+            "unlimitedMissiles": false,
             "scanVisor": true,
             "bombs": false,
             "powerBombs": 0,
@@ -1365,7 +1367,7 @@
                 "Landing Site": {
                     "pickups": [
                         {
-                            "type": "Power Bomb",
+                            "type": "Main Power Bomb",
                             "model": {
                                 "game": "prime1",
                                 "name": "Power Bomb"
@@ -1386,7 +1388,7 @@
                 "Alcove": {
                     "pickups": [
                         {
-                            "type": "Missile",
+                            "type": "Missile Launcher",
                             "model": {
                                 "game": "prime1",
                                 "name": "Missile"


### PR DESCRIPTION
Added support for custom Prime 1 items in multiworld sessions. As they work together with "Unknown Item 2" in Prime 1 sending and receiving items were adjusted to properly handle the items.