### PR TITLE
Fusion: Fix 1st action giving items to unlock hints only

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -1145,6 +1145,15 @@
                                         "amount": 1,
                                         "negate": false
                                     }
+                                },
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "events",
+                                        "name": "MainDeckHubVisited",
+                                        "amount": 1,
+                                        "negate": false
+                                    }
                                 }
                             ]
                         }
@@ -3009,6 +3018,15 @@
                                         "amount": 1,
                                         "negate": false
                                     }
+                                },
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "events",
+                                        "name": "MainDeckHubVisited",
+                                        "amount": 1,
+                                        "negate": false
+                                    }
                                 }
                             ]
                         }
@@ -4813,6 +4831,13 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Event - Sector Hub visited": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -4886,6 +4911,31 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
+                    "connections": {
+                        "Elevator to Main Elevator Shaft": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Sector Hub visited": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 274.92,
+                        "y": 161.27,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "MainDeckHubVisited",
                     "connections": {
                         "Elevator to Main Elevator Shaft": {
                             "type": "and",

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -756,6 +756,8 @@ Extra - room_id: [24]
       Trivial
   > Door to Elevator to Sector 1 (SRX)
       Trivial
+  > Event - Sector Hub visited
+      Trivial
 
 > Door to Elevator to Sector 2 (TRO); Heals? False
   * Layers: default
@@ -768,6 +770,12 @@ Extra - room_id: [24]
   * Layers: default
   * L0 Hatch to Elevator to Sector 1 (SRX)/Door to Sector Hub
   * Extra - door_idx: (57,)
+  > Elevator to Main Elevator Shaft
+      Trivial
+
+> Event - Sector Hub visited; Heals? False
+  * Layers: default
+  * Event Main Deck Hub Visited
   > Elevator to Main Elevator Shaft
       Trivial
 

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -609,6 +609,10 @@
             "AnimorphsOpen": {
                 "long_name": "Sector 1 Animorphs Entrance Uncovered",
                 "extra": {}
+            },
+            "MainDeckHubVisited": {
+                "long_name": "Main Deck Hub Visited",
+                "extra": {}
             }
         },
         "tricks": {


### PR DESCRIPTION
```
[P: Missile Launcher Data] - 1.75
[P: Morph Ball] - 1.75
[P: Level 2 Locks] - 0.0
[P: Level 4 Locks] - 0.0
```