### PR TITLE
Implemented the Remove Bars Feature

### DIFF
--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -733,6 +733,15 @@ class PrimePatchDataFactory(PatchDataFactory):
                 }
             ]
 
+        # Remove Bars in Great Tree Hall
+        if self.configuration.remove_bars_great_tree_hall:
+            level_data["Tallon Overworld"]["rooms"]["Great Tree Hall"]["deleteIds"] = [
+                2359733,
+                2359744,
+                2359830,
+                2359829,
+            ]
+
         # serialize room modifications
         if self.configuration.superheated_probability != 0:
             probability = self.configuration.superheated_probability / 1000.0

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -736,10 +736,10 @@ class PrimePatchDataFactory(PatchDataFactory):
         # Remove Bars in Great Tree Hall
         if self.configuration.remove_bars_great_tree_hall:
             level_data["Tallon Overworld"]["rooms"]["Great Tree Hall"]["deleteIds"] = [
-                2359733,
-                2359744,
-                2359830,
-                2359829,
+                2359733,  # 0x002401B5 - bar
+                2359744,  # 0x002401C0 - spinner auto-enable timer
+                2359830,  # 0x00240216 - scan front
+                2359829,  # 0x00240215 - scan back
             ]
 
         # serialize room modifications

--- a/randovania/games/prime1/generator/bootstrap.py
+++ b/randovania/games/prime1/generator/bootstrap.py
@@ -40,6 +40,7 @@ class PrimeBootstrap(MetroidBootstrap):
             "no_doors": "no_doors",
             "superheated_probability": "superheated_probability",
             "submerged_probability": "submerged_probability",
+            "remove_bars_great_tree_hall": "remove_bars_great_tree_hall",
         }
         for name, index in logical_patches.items():
             if getattr(configuration, name):

--- a/randovania/games/prime1/gui/preset_settings/prime_patches_qol.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_patches_qol.py
@@ -25,6 +25,7 @@ _FIELDS = [
     "backwards_lower_mines",
     "phazon_elite_without_dynamo",
     "spring_ball",
+    "remove_bars_great_tree_hall",
 ]
 
 

--- a/randovania/games/prime1/gui/ui_files/preset_prime_qol.ui
+++ b/randovania/games/prime1/gui/ui_files/preset_prime_qol.ui
@@ -42,9 +42,9 @@
        <property name="geometry">
         <rect>
          <x>0</x>
-         <y>-276</y>
+         <y>-420</y>
          <width>487</width>
-         <height>1182</height>
+         <height>1200</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="scroll_layout">
@@ -278,7 +278,10 @@
            <item>
             <widget class="QLabel" name="remove_bars_great_tree_hall_label">
              <property name="text">
-              <string>Removes the boost ball bars obstacle in Tallon Overworld Great Tree Hall</string>
+              <string>Removes the Boost Ball bars obstacle in Tallon Overworld's Great Tree Hall allowing free movement between the lower and upper levels of the room</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>

--- a/randovania/games/prime1/gui/ui_files/preset_prime_qol.ui
+++ b/randovania/games/prime1/gui/ui_files/preset_prime_qol.ui
@@ -42,9 +42,9 @@
        <property name="geometry">
         <rect>
          <x>0</x>
-         <y>0</y>
-         <width>482</width>
-         <height>1110</height>
+         <y>-276</y>
+         <width>487</width>
+         <height>1182</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="scroll_layout">
@@ -63,10 +63,10 @@
         <item>
          <spacer name="top_spacer">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
+           <enum>QSizePolicy::Policy::Fixed</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -139,7 +139,7 @@
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These quality of life options affect the game world and therefore might affect the logical path the generator expects the player to traverse.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
              </property>
              <property name="wordWrap">
               <bool>true</bool>
@@ -265,6 +265,20 @@
              </property>
              <property name="wordWrap">
               <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="remove_bars_great_tree_hall_check">
+             <property name="text">
+              <string>Remove Bars in Great Tree Hall</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="remove_bars_great_tree_hall_label">
+             <property name="text">
+              <string>Removes the boost ball bars obstacle in Tallon Overworld Great Tree Hall</string>
              </property>
             </widget>
            </item>

--- a/randovania/games/prime1/gui/ui_files/preset_prime_qol.ui
+++ b/randovania/games/prime1/gui/ui_files/preset_prime_qol.ui
@@ -42,7 +42,7 @@
        <property name="geometry">
         <rect>
          <x>0</x>
-         <y>-420</y>
+         <y>-358</y>
          <width>487</width>
          <height>1200</height>
         </rect>
@@ -218,6 +218,23 @@
             </widget>
            </item>
            <item>
+            <widget class="QCheckBox" name="remove_bars_great_tree_hall_check">
+             <property name="text">
+              <string>Remove Bars in Great Tree Hall</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="remove_bars_great_tree_hall_label">
+             <property name="text">
+              <string>Removes the Boost Ball bars obstacle in Tallon Overworld's Great Tree Hall allowing free movement between the lower and upper levels of the room</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QCheckBox" name="backwards_upper_mines_check">
              <property name="text">
               <string>Backwards Upper Mines</string>
@@ -262,23 +279,6 @@
             <widget class="QLabel" name="phazon_elite_without_dynamo_label">
              <property name="text">
               <string>Removes the Central Dynamo item requirement for activating the Phazon Elite boss fight</string>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="remove_bars_great_tree_hall_check">
-             <property name="text">
-              <string>Remove Bars in Great Tree Hall</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="remove_bars_great_tree_hall_label">
-             <property name="text">
-              <string>Removes the Boost Ball bars obstacle in Tallon Overworld's Great Tree Hall allowing free movement between the lower and upper levels of the room</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>

--- a/randovania/games/prime1/layout/prime_configuration.py
+++ b/randovania/games/prime1/layout/prime_configuration.py
@@ -116,6 +116,7 @@ class PrimeConfiguration(BaseConfiguration):
     backwards_upper_mines: bool
     backwards_lower_mines: bool
     phazon_elite_without_dynamo: bool
+    remove_bars_great_tree_hall: bool
 
     legacy_mode: bool
     qol_cutscenes: LayoutCutsceneMode

--- a/randovania/games/prime1/logic_database/Tallon Overworld.json
+++ b/randovania/games/prime1/logic_database/Tallon Overworld.json
@@ -10072,6 +10072,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "remove_bars_great_tree_hall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/prime1/logic_database/Tallon Overworld.json
+++ b/randovania/games/prime1/logic_database/Tallon Overworld.json
@@ -9668,6 +9668,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "remove_bars_great_tree_hall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/prime1/logic_database/Tallon Overworld.txt
+++ b/randovania/games/prime1/logic_database/Tallon Overworld.txt
@@ -1465,7 +1465,7 @@ Extra - aabb: [-36.58473, 104.77827, -72.26208, 52.718994, 189.0148, 72.021576]
                   Morph Ball Bomb and Bomb Jump (Hypermode) and Complex Bomb Jump (Hypermode) and Combat/Scan Dash (Expert) and Movement (Hypermode) and Standable Terrain (Expert)
   > Next to Spinner
       Any of the following:
-          After Great Tree Hall Bars Unlocked
+          After Great Tree Hall Bars Unlocked or Enabled Remove Bars in Great Tree Hall
           # https://www.youtube.com/watch?v=8RA6ZOd5RSo
           Morph Ball Bomb and Morph Ball and Bomb Jump (Advanced)
 

--- a/randovania/games/prime1/logic_database/Tallon Overworld.txt
+++ b/randovania/games/prime1/logic_database/Tallon Overworld.txt
@@ -1514,7 +1514,7 @@ Extra - aabb: [-36.58473, 104.77827, -72.26208, 52.718994, 189.0148, 72.021576]
   * Layers: default
   > Door to Transport Tunnel D
       Any of the following:
-          After Great Tree Hall Bars Unlocked
+          After Great Tree Hall Bars Unlocked or Enabled Remove Bars in Great Tree Hall
           # https://www.youtube.com/watch?v=8RA6ZOd5RSo
           Morph Ball Bomb and Morph Ball and Bomb Jump (Advanced)
   > Door to Transport Tunnel E

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -800,6 +800,10 @@
             "room_rando": {
                 "long_name": "Entrance Rando",
                 "extra": {}
+            },
+            "remove_bars_great_tree_hall": {
+                "long_name": "Remove Bars in Great Tree Hall",
+                "extra": {}
             }
         },
         "requirement_template": {

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1216,6 +1216,12 @@ def _migrate_v91(preset: dict) -> dict:
     return preset
 
 
+def _migrate_v92(preset: dict) -> dict:
+    preset["configuration"]["remove_bars_great_tree_hall"] = False
+
+    return preset
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -1308,6 +1314,7 @@ _MIGRATIONS = [
     _migrate_v89,  # msr configurable required dna
     _migrate_v90,  # msr configurable final boss
     _migrate_v91,  # two sided door search
+    _migrate_v92,  # remove bars great tree hall
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1217,7 +1217,8 @@ def _migrate_v91(preset: dict) -> dict:
 
 
 def _migrate_v92(preset: dict) -> dict:
-    preset["configuration"]["remove_bars_great_tree_hall"] = False
+    if preset["game"] == "prime1":
+        preset["configuration"]["remove_bars_great_tree_hall"] = False
 
     return preset
 

--- a/test/test_files/log_files/prime1_refills.rdvgame
+++ b/test/test_files/log_files/prime1_refills.rdvgame
@@ -10,7 +10,7 @@
         "word_hash": "Shriekbat Ice Glider",
         "presets": [
             {
-                "schema_version": 87,
+                "schema_version": 93,
                 "base_preset_uuid": null,
                 "name": "Starter Preset Copy",
                 "uuid": "822da6c2-65ad-4da5-a9ce-11a70a80f994",
@@ -167,6 +167,7 @@
                     "pickup_model_data_source": "etm",
                     "logical_resource_action": "randomly",
                     "first_progression_must_be_local": false,
+                    "two_sided_door_lock_search": false,
                     "minimum_available_locations_for_hint_placement": 0,
                     "minimum_location_weight_for_hint_placement": 0.0,
                     "dock_rando": {
@@ -251,6 +252,7 @@
                     "backwards_upper_mines": true,
                     "backwards_lower_mines": false,
                     "phazon_elite_without_dynamo": true,
+                    "remove_bars_great_tree_hall": true,
                     "legacy_mode": false,
                     "qol_cutscenes": "Skippable",
                     "ingame_difficulty": "Normal",

--- a/test/test_files/patcher_data/prime1/prime1_refills/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_refills/world_1.json
@@ -1609,6 +1609,14 @@
                         }
                     ]
                 },
+                "Great Tree Hall": {
+                    "deleteIds": [
+                        2359733,
+                        2359744,
+                        2359830,
+                        2359829
+                    ]
+                },
                 "Great Tree Chamber": {
                     "pickups": [
                         {
@@ -2443,6 +2451,6 @@
         0
     ],
     "_randovania_meta": {
-        "layout_was_user_modified": false
+        "layout_was_user_modified": true
     }
 }


### PR DESCRIPTION
Discussion from the Community: The idea behind removing bars was to open up mines from the front without needing to go through frigate in beginner logic. There was also an argument that it gives ice more utility since reverse frigate can be a thing before wave beam.

This feature will be disabled by default

Details of Changes

- Added a boolean to the prime configuration
- Added a checkbox to the UI that toggles that configuration value
- Wrote a preset migration to write the default value for older presets migrating
- Edited the patch data factory to tell the patcher to remove specific objects in Great Tree Hall.
- Added Misc Resource to the Logic DB for this new feature
- Edited the correct node in Great Tree Hall to be able to use the Misc Resource
- Edited the bootstrap for the feature toggle

Tests

- All objects dealing with bars seems to be removed

```
0x002401B5 - bar
0x002401C0 - spinner auto-enable timer
0x00240216 - scan front
0x00240215 - scan back
```

- Boost Ball slot behaves as intended (Just pushes you out, is scan-able, seemingly has no issues)
- Music in room and transitioning to other surrounding rooms music seems fine
- Transitioned between all surrounding rooms and elevators.
- Enemies still chilling and spiking around, could kill them and the gravity sharks and the plants
- Water still good and slow in it without grav etc
- X ray platform still there
- Picked up an randomized item in Great Tree Chamber
- Spider Track still functional
- Switched between all visors and beams
- Did the stand-able trick up to Life Grove Tunnel

Maybe potential future cleanup needed

- One member of the community expressed the following during the implementation: Solved bars are by default disabled. Unsolved bars are on Gate Solved layer which gets removed if you disable the layer or remove the object. Might need to change 0x2401f6 for solved gate to re enable if any weirdness\issues are discovered.
