### PR TITLE
Fix Seeker Door Overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: Experimental option that changes Door Lock Rando so that when determining which types a door can be randomized into, the algorithm searches for either side of the door using the resolver. This means some doors are more likely to have locks on them. Generation will also be faster.  
 
+### Metroid Prime 2: Echoes
+
+#### Logic Database
+
+- Fixed: All Seeker Doors without Seekers tricks have been moved into the dock override section thus allowing the corresponding doors to get shuffled in door type rando. To find the requirements of a seeker skip, look in the description of the corresponding dock node in the data visualiser.
+ 
 ### Metroid Dread
 
 #### Logic Database

--- a/randovania/games/prime2/logic_database/Agon Wastes.json
+++ b/randovania/games/prime2/logic_database/Agon Wastes.json
@@ -2156,7 +2156,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://www.youtube.com/watch?v=-LZluWe8QvM&list=PLevfta9o_QKWuQNXAnmBXtzW4nmU5VLyN&index=46",
+                    "description": "<https://youtu.be/Myr8MRM5ZDc&t=88>",
                     "layers": [
                         "default"
                     ],
@@ -3332,7 +3332,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://www.youtube.com/watch?v=yZIy4aLaKNU&list=PLZkUEWCHwYRyXIU-to88js2M6mEOBoHUy&index=83",
+                    "description": "<https://www.youtube.com/watch?v=yZIy4aLaKNU>",
                     "layers": [
                         "default"
                     ],
@@ -5910,7 +5910,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=76",
+                    "description": "<https://youtu.be/Myr8MRM5ZDc&t=76>",
                     "layers": [
                         "default"
                     ],
@@ -7271,7 +7271,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://www.youtube.com/watch?v=xjfVuXDROz0",
+                    "description": "<https://youtu.be/Myr8MRM5ZDc&t=115>",
                     "layers": [
                         "default"
                     ],
@@ -7312,7 +7312,7 @@
                                                 "data": {
                                                     "type": "items",
                                                     "name": "Missile",
-                                                    "amount": 1,
+                                                    "amount": 2,
                                                     "negate": false
                                                 }
                                             },

--- a/randovania/games/prime2/logic_database/Agon Wastes.txt
+++ b/randovania/games/prime2/logic_database/Agon Wastes.txt
@@ -337,7 +337,7 @@ Extra - in_dark_aether: False
 > Door to Mine Shaft; Heals? False
   * Layers: default
   * Seeker Launcher Blast Shield to Mine Shaft/Door to Mining Station B
-  * https://www.youtube.com/watch?v=-LZluWe8QvM&list=PLevfta9o_QKWuQNXAnmBXtzW4nmU5VLyN&index=46
+  * <https://youtu.be/Myr8MRM5ZDc&t=88>
   * Extra - dock_name: East
   * Override default lock requirement:
     Any of the following:
@@ -468,7 +468,7 @@ Extra - in_dark_aether: False
 > Door to Transport to Torvus Bog; Heals? False
   * Layers: default
   * Seeker Launcher Blast Shield to Transport to Torvus Bog/Door to Transport Center
-  * https://www.youtube.com/watch?v=yZIy4aLaKNU&list=PLZkUEWCHwYRyXIU-to88js2M6mEOBoHUy&index=83
+  * <https://www.youtube.com/watch?v=yZIy4aLaKNU>
   * Extra - dock_name: South
   * Override default lock requirement:
     Any of the following:
@@ -831,7 +831,7 @@ Extra - in_dark_aether: False
 > Door to Mining Station B; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Seeker Launcher Blast Shield to Mining Station B/Door to Mine Shaft
-  * https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=76
+  * <https://youtu.be/Myr8MRM5ZDc&t=76>
   * Extra - dock_name: West
   * Override default lock requirement:
     Any of the following:
@@ -992,12 +992,12 @@ Extra - in_dark_aether: False
 > Door to Transport Center; Heals? False
   * Layers: default
   * Seeker Launcher Blast Shield to Transport Center/Door to Transport to Torvus Bog
-  * https://www.youtube.com/watch?v=xjfVuXDROz0
+  * <https://youtu.be/Myr8MRM5ZDc&t=115>
   * Extra - dock_name: Dock - North
   * Override default lock requirement:
     Any of the following:
         Destroy Seeker Locks
-        Missile and Seeker Locks without Seeker Missiles (Hypermode) and Use Screw Attack (Space Jump)
+        Missile ≥ 2 and Seeker Locks without Seeker Missiles (Hypermode) and Use Screw Attack (Space Jump)
 
   > Elevator to Torvus Bog
       Scan Visor

--- a/randovania/games/prime2/logic_database/Temple Grounds.json
+++ b/randovania/games/prime2/logic_database/Temple Grounds.json
@@ -1559,7 +1559,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=24",
+                    "description": "<https://youtu.be/Myr8MRM5ZDc&t=24>",
                     "layers": [
                         "default"
                     ],
@@ -2496,7 +2496,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://www.youtube.com/watch?v=Tb0XJ6Y5WH4&list=PLevfta9o_QKWuQNXAnmBXtzW4nmU5VLyN&index=32",
+                    "description": "https://www.youtube.com/watch?v=Tb0XJ6Y5WH4",
                     "layers": [
                         "default"
                     ],
@@ -8974,7 +8974,7 @@
                     "node_type": "dock",
                     "heal": true,
                     "coordinates": null,
-                    "description": "https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=62",
+                    "description": "<https://www.youtube.com/watch?v=6Ks1mKF1Jgw>",
                     "layers": [
                         "default"
                     ],
@@ -8993,39 +8993,85 @@
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": {
-                        "type": "or",
+                        "type": "and",
                         "data": {
                             "comment": null,
                             "items": [
                                 {
-                                    "type": "template",
-                                    "data": "Destroy Seeker Locks"
-                                },
-                                {
-                                    "type": "and",
+                                    "type": "or",
                                     "data": {
                                         "comment": null,
                                         "items": [
                                             {
                                                 "type": "template",
-                                                "data": "Use Screw Attack (Space Jump)"
+                                                "data": "Destroy Seeker Locks"
                                             },
+                                            {
+                                                "type": "and",
+                                                "data": {
+                                                    "comment": null,
+                                                    "items": [
+                                                        {
+                                                            "type": "template",
+                                                            "data": "Use Screw Attack (Space Jump)"
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "items",
+                                                                "name": "Missile",
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "tricks",
+                                                                "name": "SeekerlessLocks",
+                                                                "amount": 4,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "or",
+                                    "data": {
+                                        "comment": null,
+                                        "items": [
                                             {
                                                 "type": "resource",
                                                 "data": {
-                                                    "type": "items",
-                                                    "name": "Missile",
-                                                    "amount": 2,
+                                                    "type": "damage",
+                                                    "name": "DarkWorld1",
+                                                    "amount": 75,
                                                     "negate": false
                                                 }
                                             },
                                             {
-                                                "type": "resource",
+                                                "type": "and",
                                                 "data": {
-                                                    "type": "tricks",
-                                                    "name": "SeekerlessLocks",
-                                                    "amount": 5,
-                                                    "negate": false
+                                                    "comment": null,
+                                                    "items": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "damage",
+                                                                "name": "DarkWorld1",
+                                                                "amount": 60,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "template",
+                                                            "data": "Activate Safe Zone"
+                                                        }
+                                                    ]
                                                 }
                                             }
                                         ]
@@ -9249,70 +9295,6 @@
                                                         "name": "DarkWorld1",
                                                         "amount": 25,
                                                         "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": "https://www.youtube.com/watch?v=4eNjVcIpQHA",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "SeekerlessLocks",
-                                                        "amount": 4,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "misc",
-                                                        "name": "DoorRando",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "DarkWorld1",
-                                                                    "amount": 75,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "template",
-                                                                            "data": "Activate Safe Zone"
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "DarkWorld1",
-                                                                                "amount": 60,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
                                                     }
                                                 }
                                             ]
@@ -11120,7 +11102,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://www.youtube.com/watch?v=_mSQ-ckqaA8&list=PLZkUEWCHwYRyXIU-to88js2M6mEOBoHUy&index=62",
+                    "description": "<https://youtu.be/_mSQ-ckqaA8>",
                     "layers": [
                         "default"
                     ],
@@ -11139,42 +11121,59 @@
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": {
-                        "type": "or",
+                        "type": "and",
                         "data": {
                             "comment": null,
                             "items": [
                                 {
-                                    "type": "template",
-                                    "data": "Destroy Seeker Locks"
-                                },
-                                {
-                                    "type": "and",
+                                    "type": "or",
                                     "data": {
                                         "comment": null,
                                         "items": [
                                             {
                                                 "type": "template",
-                                                "data": "Use Screw Attack (Space Jump)"
+                                                "data": "Destroy Seeker Locks"
                                             },
                                             {
-                                                "type": "resource",
+                                                "type": "and",
                                                 "data": {
-                                                    "type": "items",
-                                                    "name": "Missile",
-                                                    "amount": 1,
-                                                    "negate": false
-                                                }
-                                            },
-                                            {
-                                                "type": "resource",
-                                                "data": {
-                                                    "type": "tricks",
-                                                    "name": "SeekerlessLocks",
-                                                    "amount": 4,
-                                                    "negate": false
+                                                    "comment": null,
+                                                    "items": [
+                                                        {
+                                                            "type": "template",
+                                                            "data": "Use Screw Attack (Space Jump)"
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "items",
+                                                                "name": "Missile",
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "tricks",
+                                                                "name": "SeekerlessLocks",
+                                                                "amount": 4,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
                                                 }
                                             }
                                         ]
+                                    }
+                                },
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "damage",
+                                        "name": "DarkWorld1",
+                                        "amount": 40,
+                                        "negate": false
                                     }
                                 }
                             ]
@@ -11230,41 +11229,6 @@
                                             "name": "DarkWorld1",
                                             "amount": 10,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": "https://www.youtube.com/watch?v=kkEVvbdof8U",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "SeekerlessLocks",
-                                                        "amount": 4,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "DarkWorld1",
-                                                        "amount": 40,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "misc",
-                                                        "name": "DoorRando",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                }
-                                            ]
                                         }
                                     }
                                 ]
@@ -18011,41 +17975,6 @@
                                             "amount": 60,
                                             "negate": false
                                         }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": "https://www.youtube.com/watch?v=cqF7NN7d5h0",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "SeekerlessLocks",
-                                                        "amount": 4,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "DarkWorld1",
-                                                        "amount": 90,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "misc",
-                                                        "name": "DoorRando",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                }
-                                            ]
-                                        }
                                     }
                                 ]
                             }
@@ -18324,7 +18253,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://www.youtube.com/watch?v=_ZB9NSBnIrs&list=PLZkUEWCHwYRyXIU-to88js2M6mEOBoHUy&index=2",
+                    "description": "<https://youtu.be/_ZB9NSBnIrs>",
                     "layers": [
                         "default"
                     ],
@@ -18343,42 +18272,59 @@
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": {
-                        "type": "or",
+                        "type": "and",
                         "data": {
                             "comment": null,
                             "items": [
                                 {
-                                    "type": "template",
-                                    "data": "Destroy Seeker Locks"
-                                },
-                                {
-                                    "type": "and",
+                                    "type": "or",
                                     "data": {
                                         "comment": null,
                                         "items": [
                                             {
                                                 "type": "template",
-                                                "data": "Use Screw Attack (Space Jump)"
+                                                "data": "Destroy Seeker Locks"
                                             },
                                             {
-                                                "type": "resource",
+                                                "type": "and",
                                                 "data": {
-                                                    "type": "items",
-                                                    "name": "Missile",
-                                                    "amount": 2,
-                                                    "negate": false
-                                                }
-                                            },
-                                            {
-                                                "type": "resource",
-                                                "data": {
-                                                    "type": "tricks",
-                                                    "name": "SeekerlessLocks",
-                                                    "amount": 4,
-                                                    "negate": false
+                                                    "comment": null,
+                                                    "items": [
+                                                        {
+                                                            "type": "template",
+                                                            "data": "Use Screw Attack (Space Jump)"
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "items",
+                                                                "name": "Missile",
+                                                                "amount": 2,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "tricks",
+                                                                "name": "SeekerlessLocks",
+                                                                "amount": 4,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
                                                 }
                                             }
                                         ]
+                                    }
+                                },
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "damage",
+                                        "name": "DarkWorld1",
+                                        "amount": 90,
+                                        "negate": false
                                     }
                                 }
                             ]
@@ -18833,7 +18779,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://www.youtube.com/watch?v=L0ULmh5YmFg",
+                    "description": "<https://www.youtube.com/watch?v=L0ULmh5YmFg>",
                     "layers": [
                         "default"
                     ],
@@ -18852,42 +18798,59 @@
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": {
-                        "type": "or",
+                        "type": "and",
                         "data": {
                             "comment": null,
                             "items": [
                                 {
-                                    "type": "template",
-                                    "data": "Destroy Seeker Locks"
-                                },
-                                {
-                                    "type": "and",
+                                    "type": "or",
                                     "data": {
                                         "comment": null,
                                         "items": [
                                             {
                                                 "type": "template",
-                                                "data": "Use Screw Attack (Space Jump)"
+                                                "data": "Destroy Seeker Locks"
                                             },
                                             {
-                                                "type": "resource",
+                                                "type": "and",
                                                 "data": {
-                                                    "type": "items",
-                                                    "name": "Missile",
-                                                    "amount": 1,
-                                                    "negate": false
-                                                }
-                                            },
-                                            {
-                                                "type": "resource",
-                                                "data": {
-                                                    "type": "tricks",
-                                                    "name": "SeekerlessLocks",
-                                                    "amount": 4,
-                                                    "negate": false
+                                                    "comment": null,
+                                                    "items": [
+                                                        {
+                                                            "type": "template",
+                                                            "data": "Use Screw Attack (Space Jump)"
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "items",
+                                                                "name": "Missile",
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "tricks",
+                                                                "name": "SeekerlessLocks",
+                                                                "amount": 4,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
                                                 }
                                             }
                                         ]
+                                    }
+                                },
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": "damage",
+                                        "name": "DarkWorld1",
+                                        "amount": 40,
+                                        "negate": false
                                     }
                                 }
                             ]
@@ -18912,7 +18875,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=RfWnxL7HI1Y&list=PLx6vT1x-80zuA1vUepQUSqYOQeHiRNbt5&index=24",
+                                            "comment": "https://youtu.be/RfWnxL7HI1Y",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -19123,7 +19086,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=RfWnxL7HI1Y",
+                                            "comment": "https://youtu.be/RfWnxL7HI1Y",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -19137,7 +19100,7 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Energy for Ingstorm",
                                                         "items": [
                                                             {
                                                                 "type": "and",
@@ -19287,7 +19250,7 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Energy for area before Ingstorm",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -19296,41 +19259,6 @@
                                                                     "name": "DarkWorld1",
                                                                     "amount": 20,
                                                                     "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": "https://www.youtube.com/watch?v=L0ULmh5YmFg",
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "SeekerlessLocks",
-                                                                                "amount": 4,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "DarkWorld1",
-                                                                                "amount": 40,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "misc",
-                                                                                "name": "DoorRando",
-                                                                                "amount": 1,
-                                                                                "negate": true
-                                                                            }
-                                                                        }
-                                                                    ]
                                                                 }
                                                             }
                                                         ]

--- a/randovania/games/prime2/logic_database/Temple Grounds.txt
+++ b/randovania/games/prime2/logic_database/Temple Grounds.txt
@@ -228,7 +228,7 @@ Extra - in_dark_aether: False
 > Door to Hall of Honored Dead; Heals? False
   * Layers: default
   * Seeker Launcher Blast Shield to Hall of Honored Dead/Door to Path of Honor
-  * https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=24
+  * <https://youtu.be/Myr8MRM5ZDc&t=24>
   * Extra - dock_name: North
   * Override default lock requirement:
     Any of the following:
@@ -412,7 +412,7 @@ Extra - in_dark_aether: False
 > Door to Path of Honor; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Seeker Launcher Blast Shield to Path of Honor/Door to Hall of Honored Dead
-  * https://www.youtube.com/watch?v=Tb0XJ6Y5WH4&list=PLevfta9o_QKWuQNXAnmBXtzW4nmU5VLyN&index=32
+  * https://www.youtube.com/watch?v=Tb0XJ6Y5WH4
   * Extra - dock_name: South
   * Override default lock requirement:
     Any of the following:
@@ -1339,12 +1339,16 @@ Extra - in_dark_aether: True
 > Door to Gateway Access; Heals? True
   * Layers: default
   * Seeker Launcher Blast Shield to Gateway Access/Door to Shrine Access
-  * https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=62
+  * <https://www.youtube.com/watch?v=6Ks1mKF1Jgw>
   * Extra - dock_name: East
   * Override default lock requirement:
-    Any of the following:
-        Destroy Seeker Locks
-        Missile ≥ 2 and Seeker Locks without Seeker Missiles (Hypermode) and Use Screw Attack (Space Jump)
+    All of the following:
+        Any of the following:
+            Destroy Seeker Locks
+            Missile and Seeker Locks without Seeker Missiles (Expert) and Use Screw Attack (Space Jump)
+        Any of the following:
+            Dark World Damage ≥ 75
+            Dark World Damage ≥ 60 and Activate Safe Zone
 
   > Safe Zone
       Dark World Damage ≥ 15
@@ -1367,12 +1371,6 @@ Extra - in_dark_aether: True
       Any of the following:
           Dark World Damage ≥ 60
           Dark World Damage ≥ 25 and Activate Safe Zone
-          All of the following:
-              # https://www.youtube.com/watch?v=4eNjVcIpQHA
-              Seeker Locks without Seeker Missiles (Expert) and Disabled Door Randomizer
-              Any of the following:
-                  Dark World Damage ≥ 75
-                  Dark World Damage ≥ 60 and Activate Safe Zone
 
 ----------------
 Grand Windchamber
@@ -1597,12 +1595,14 @@ Extra - in_dark_aether: True
 > Door to Lake Access; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Seeker Launcher Blast Shield to Lake Access/Door to Plain of Dark Worship
-  * https://www.youtube.com/watch?v=_mSQ-ckqaA8&list=PLZkUEWCHwYRyXIU-to88js2M6mEOBoHUy&index=62
+  * <https://youtu.be/_mSQ-ckqaA8>
   * Extra - dock_name: South
   * Override default lock requirement:
-    Any of the following:
-        Destroy Seeker Locks
-        Missile and Seeker Locks without Seeker Missiles (Expert) and Use Screw Attack (Space Jump)
+    All of the following:
+        Dark World Damage ≥ 40
+        Any of the following:
+            Destroy Seeker Locks
+            Missile and Seeker Locks without Seeker Missiles (Expert) and Use Screw Attack (Space Jump)
 
   > Portal to Temple Assembly Site
       Dark World Damage ≥ 10
@@ -1612,10 +1612,7 @@ Extra - in_dark_aether: True
   * Light Portal to Temple Assembly Site/Portal to Plain of Dark Worship
   * Extra - dock_name: VirtualNorth
   > Door to Lake Access
-      Any of the following:
-          Dark World Damage ≥ 10
-          # https://www.youtube.com/watch?v=kkEVvbdof8U
-          Seeker Locks without Seeker Missiles (Expert) and Dark World Damage ≥ 40 and Disabled Door Randomizer
+      Dark World Damage ≥ 10
   > Pickup (Missile)
       Any of the following:
           Dark World Damage ≥ 15 and Has Suit
@@ -2444,10 +2441,7 @@ Extra - in_dark_aether: True
   * Normal Door to Phazon Pit/Door to Phazon Grounds
   * Extra - dock_name: WestTop
   > Door to Reliquary Access
-      Any of the following:
-          Dark World Damage ≥ 60
-          # https://www.youtube.com/watch?v=cqF7NN7d5h0
-          Seeker Locks without Seeker Missiles (Expert) and Dark World Damage ≥ 90 and Disabled Door Randomizer
+      Dark World Damage ≥ 60
   > Pickup (Missile)
       Any of the following:
           All of the following:
@@ -2468,12 +2462,14 @@ Extra - in_dark_aether: True
 > Door to Reliquary Access; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Seeker Launcher Blast Shield to Reliquary Access/Door to Phazon Grounds
-  * https://www.youtube.com/watch?v=_ZB9NSBnIrs&list=PLZkUEWCHwYRyXIU-to88js2M6mEOBoHUy&index=2
+  * <https://youtu.be/_ZB9NSBnIrs>
   * Extra - dock_name: East
   * Override default lock requirement:
-    Any of the following:
-        Destroy Seeker Locks
-        Missile ≥ 2 and Seeker Locks without Seeker Missiles (Expert) and Use Screw Attack (Space Jump)
+    All of the following:
+        Dark World Damage ≥ 90
+        Any of the following:
+            Destroy Seeker Locks
+            Missile ≥ 2 and Seeker Locks without Seeker Missiles (Expert) and Use Screw Attack (Space Jump)
 
   > Door to Phazon Pit
       Any of the following:
@@ -2512,18 +2508,20 @@ Extra - in_dark_aether: True
 > Door to Phazon Grounds; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Seeker Launcher Blast Shield to Phazon Grounds/Door to Reliquary Access
-  * https://www.youtube.com/watch?v=L0ULmh5YmFg
+  * <https://www.youtube.com/watch?v=L0ULmh5YmFg>
   * Extra - dock_name: West
   * Override default lock requirement:
-    Any of the following:
-        Destroy Seeker Locks
-        Missile and Seeker Locks without Seeker Missiles (Expert) and Use Screw Attack (Space Jump)
+    All of the following:
+        Dark World Damage ≥ 40
+        Any of the following:
+            Destroy Seeker Locks
+            Missile and Seeker Locks without Seeker Missiles (Expert) and Use Screw Attack (Space Jump)
 
   > Door to Reliquary Grounds
       Any of the following:
           Light Suit
           All of the following:
-              # https://www.youtube.com/watch?v=RfWnxL7HI1Y&list=PLx6vT1x-80zuA1vUepQUSqYOQeHiRNbt5&index=24
+              # https://youtu.be/RfWnxL7HI1Y
               Suitless Dark Aether (Advanced)
               Any of the following:
                   Dark World Damage ≥ 40 and Ingstorm Damage ≥ 100 and Use Screw Attack (Space Jump)
@@ -2542,9 +2540,10 @@ Extra - in_dark_aether: True
       Any of the following:
           Light Suit
           All of the following:
-              # https://www.youtube.com/watch?v=RfWnxL7HI1Y
+              # https://youtu.be/RfWnxL7HI1Y
               Suitless Dark Aether (Advanced)
               Any of the following:
+                  # Energy for Ingstorm
                   Dark World Damage ≥ 60 and Ingstorm Damage ≥ 100 and Use Screw Attack (Space Jump)
                   Dark World Damage ≥ 70 and Ingstorm Damage ≥ 220
                   All of the following:
@@ -2552,10 +2551,8 @@ Extra - in_dark_aether: True
                       Any of the following:
                           Dark World Damage ≥ 65 and Ingstorm Damage ≥ 160
                           Boost Ball and Dark World Damage ≥ 40 and Ingstorm Damage ≥ 140
-              Any of the following:
-                  Dark World Damage ≥ 20
-                  # https://www.youtube.com/watch?v=L0ULmh5YmFg
-                  Seeker Locks without Seeker Missiles (Expert) and Dark World Damage ≥ 40 and Disabled Door Randomizer
+              # Energy for area before Ingstorm
+              Dark World Damage ≥ 20
 
 ----------------
 Reliquary Grounds

--- a/randovania/games/prime2/logic_database/Torvus Bog.json
+++ b/randovania/games/prime2/logic_database/Torvus Bog.json
@@ -8060,7 +8060,7 @@
                     "node_type": "dock",
                     "heal": true,
                     "coordinates": null,
-                    "description": "https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=182",
+                    "description": "https://youtu.be/Myr8MRM5ZDc&t=182",
                     "layers": [
                         "default"
                     ],
@@ -14795,7 +14795,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://www.youtube.com/watch?v=WNMbKEZjDz0&list=PLZkUEWCHwYRyXIU-to88js2M6mEOBoHUy&index=33",
+                    "description": "<https://youtu.be/WNMbKEZjDz0>",
                     "layers": [
                         "default"
                     ],
@@ -18211,7 +18211,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://www.youtube.com/watch?v=Fup9-vStwKI&list=PLevfta9o_QKWuQNXAnmBXtzW4nmU5VLyN&index=65",
+                    "description": "<https://youtu.be/Myr8MRM5ZDc&t=153>",
                     "layers": [
                         "default"
                     ],
@@ -19805,7 +19805,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "<https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=134>",
+                    "description": "<https://youtu.be/Myr8MRM5ZDc&t=134>",
                     "layers": [
                         "default"
                     ],

--- a/randovania/games/prime2/logic_database/Torvus Bog.txt
+++ b/randovania/games/prime2/logic_database/Torvus Bog.txt
@@ -1007,7 +1007,7 @@ Extra - in_dark_aether: True
 > Door to Cache A; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Seeker Launcher Blast Shield to Cache A/Door to Poisoned Bog
-  * https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=182
+  * https://youtu.be/Myr8MRM5ZDc&t=182
   * Extra - dock_name: South
   * Override default lock requirement:
     Any of the following:
@@ -1696,7 +1696,7 @@ Extra - low_memory_mode: True
 > Door to Transport to Agon Wastes; Heals? False
   * Layers: default
   * Seeker Launcher Blast Shield to Transport to Agon Wastes/Door to Torvus Temple
-  * https://www.youtube.com/watch?v=WNMbKEZjDz0&list=PLZkUEWCHwYRyXIU-to88js2M6mEOBoHUy&index=33
+  * <https://youtu.be/WNMbKEZjDz0>
   * Extra - dock_name: South
   * Override default lock requirement:
     Any of the following:
@@ -2092,7 +2092,7 @@ Extra - in_dark_aether: False
 > Door to Torvus Temple; Heals? False
   * Layers: default
   * Seeker Launcher Blast Shield to Torvus Temple/Door to Transport to Agon Wastes
-  * https://www.youtube.com/watch?v=Fup9-vStwKI&list=PLevfta9o_QKWuQNXAnmBXtzW4nmU5VLyN&index=65
+  * <https://youtu.be/Myr8MRM5ZDc&t=153>
   * Extra - dock_name: North
   * Override default lock requirement:
     Any of the following:
@@ -2315,7 +2315,7 @@ Extra - in_dark_aether: False
 > Door to Training Access; Heals? False
   * Layers: default
   * Seeker Launcher Blast Shield to Training Access/Door to Hydrodynamo Station; Dock Lock Rando incompatible with: Screw Attack Blast Shield
-  * <https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=134>
+  * <https://youtu.be/Myr8MRM5ZDc&t=134>
   * Extra - dock_name: North_OK
   * Override default lock requirement:
     Any of the following:


### PR DESCRIPTION
Moves all dark world damage requirements out of the door connection and into the dock override.
Updated videos for Seeker skips
Also truncated some links here and there.

fixes #6608