### PR TITLE
Prime 1: use misc resource for vanilla heat reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Damage Reduction for Starter Preset and Moderate Challenge is now Additive.
 - Fixed: Setting Screen Brightness in the cosmetic settings mismatching with what appears in-game.
 
+#### Logic Database
+
+- Changed: The Varia-only heat reduction is now done via a miscellaneous resource rather than being patched at runtime.
+
 ### Metroid Prime 2: Echoes
 
 #### Logic Database

--- a/randovania/games/prime1/generator/bootstrap.py
+++ b/randovania/games/prime1/generator/bootstrap.py
@@ -4,7 +4,6 @@ import copy
 import dataclasses
 from typing import TYPE_CHECKING
 
-from randovania.game_description.requirements.resource_requirement import ResourceRequirement
 from randovania.game_description.resources.damage_reduction import DamageReduction
 from randovania.game_description.resources.resource_type import ResourceType
 from randovania.games.prime1.layout.prime_configuration import DamageReduction as DamageReductionConfig
@@ -51,6 +50,9 @@ class PrimeBootstrap(MetroidBootstrap):
 
         if configuration.ingame_difficulty == IngameDifficulty.HARD:
             enabled_resources.add("hard_mode")
+
+        if configuration.legacy_mode:
+            enabled_resources.add("vanilla_heat")
 
         return enabled_resources
 
@@ -112,12 +114,7 @@ class PrimeBootstrap(MetroidBootstrap):
         requirement_template = copy.copy(db.requirement_template)
 
         suits = [db.get_item_by_name("Varia Suit")]
-        if not configuration.legacy_mode:
-            requirement_template["Heat-Resisting Suit"] = dataclasses.replace(
-                requirement_template["Heat-Resisting Suit"],
-                requirement=ResourceRequirement.simple(db.get_item_by_name("Varia Suit")),
-            )
-        else:
+        if configuration.legacy_mode:
             suits.extend([db.get_item_by_name("Gravity Suit"), db.get_item_by_name("Phazon Suit")])
 
         reductions = [DamageReduction(None, configuration.heat_damage / 10.0)]

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -804,6 +804,10 @@
             "remove_bars_great_tree_hall": {
                 "long_name": "Remove Bars in Great Tree Hall",
                 "extra": {}
+            },
+            "vanilla_heat": {
+                "long_name": "Vanilla Heat Resistance",
+                "extra": {}
             }
         },
         "requirement_template": {
@@ -908,12 +912,46 @@
                         "comment": null,
                         "items": [
                             {
-                                "type": "resource",
+                                "type": "and",
                                 "data": {
-                                    "type": "items",
-                                    "name": "GravitySuit",
-                                    "amount": 1,
-                                    "negate": false
+                                    "comment": null,
+                                    "items": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": "misc",
+                                                "name": "vanilla_heat",
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": {
+                                                "comment": null,
+                                                "items": [
+                                                    {
+                                                        "type": "resource",
+                                                        "data": {
+                                                            "type": "items",
+                                                            "name": "GravitySuit",
+                                                            "amount": 1,
+                                                            "negate": false
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "resource",
+                                                        "data": {
+                                                            "type": "items",
+                                                            "name": "PhazonSuit",
+                                                            "amount": 1,
+                                                            "negate": false
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
                                 }
                             },
                             {
@@ -921,15 +959,6 @@
                                 "data": {
                                     "type": "items",
                                     "name": "VariaSuit",
-                                    "amount": 1,
-                                    "negate": false
-                                }
-                            },
-                            {
-                                "type": "resource",
-                                "data": {
-                                    "type": "items",
-                                    "name": "PhazonSuit",
                                     "amount": 1,
                                     "negate": false
                                 }

--- a/randovania/games/prime1/logic_database/header.txt
+++ b/randovania/games/prime1/logic_database/header.txt
@@ -8,7 +8,11 @@ Templates
       Ice Beam and Plasma Beam and Power Beam and Wave Beam and Can Use Arm Cannon
 
 * Heat-Resisting Suit:
-      Gravity Suit or Phazon Suit or Varia Suit
+      Any of the following:
+          Varia Suit
+          All of the following:
+              Enabled Vanilla Heat Resistance
+              Gravity Suit or Phazon Suit
 
 * Can Use Arm Cannon:
       Combat Visor or Thermal Visor or X-Ray Visor


### PR DESCRIPTION
This makes it possible to understand for users how heat reduction is handled without needing to know that its a thing that can be patched at runtime by bootstrap.

Alternatively we could also say, legacy mode isn't logical and remove the branch entirely :upside_down_face: 