### PR TITLE
Properly introduce PickupIndex age v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: When editing the preset description after another change in a preset, the cursor position is now retained.
 - Added: Show confirmation dialog when closing the main window or multiplayer session window while generation is in progress.
 - Fixed: Closing the multiplayer session window while generation is in progress will now abort the generation.
+- Changed: Ammo pickups now have a smaller impact in generator.
 
 ### Door Lock Randomizer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: When editing the preset description after another change in a preset, the cursor position is now retained.
 - Added: Show confirmation dialog when closing the main window or multiplayer session window while generation is in progress.
 - Fixed: Closing the multiplayer session window while generation is in progress will now abort the generation.
-- Changed: Ammo pickups now have a smaller impact in generator.
 
 ### Door Lock Randomizer
 

--- a/randovania/game_description/pickup/ammo_pickup.py
+++ b/randovania/game_description/pickup/ammo_pickup.py
@@ -39,6 +39,9 @@ class AmmoPickupDefinition(JsonDataclass):
     mention_limit: bool = dataclasses.field(default=True, metadata=EXCLUDE_DEFAULT)
     extra: frozendict = dataclasses.field(default_factory=frozendict, metadata=EXCLUDE_DEFAULT)
 
+    index_age_impact: float = dataclasses.field(default=1.0, metadata=EXCLUDE_DEFAULT)
+    # TODO: docstring
+
     def __post_init__(self) -> None:
         if self.temporary is not None:
             if self.unlocked_by is None:

--- a/randovania/game_description/pickup/ammo_pickup.py
+++ b/randovania/game_description/pickup/ammo_pickup.py
@@ -20,6 +20,7 @@ EXCLUDE_DEFAULT = {"exclude_if_default": True}
 
 @dataclass(frozen=True, order=True)
 class AmmoPickupDefinition(JsonDataclass):
+    # TODO: docstrings
     game: RandovaniaGame = dataclasses.field(metadata={"init_from_extra": True})
     name: str = dataclasses.field(metadata={"init_from_extra": True})
     model_name: str
@@ -38,9 +39,7 @@ class AmmoPickupDefinition(JsonDataclass):
     explain_other_sources: bool = dataclasses.field(default=True, metadata=EXCLUDE_DEFAULT)
     mention_limit: bool = dataclasses.field(default=True, metadata=EXCLUDE_DEFAULT)
     extra: frozendict = dataclasses.field(default_factory=frozendict, metadata=EXCLUDE_DEFAULT)
-
     index_age_impact: float = dataclasses.field(default=1.0, metadata=EXCLUDE_DEFAULT)
-    # TODO: docstring
 
     def __post_init__(self) -> None:
         if self.temporary is not None:

--- a/randovania/game_description/pickup/ammo_pickup.py
+++ b/randovania/game_description/pickup/ammo_pickup.py
@@ -39,6 +39,8 @@ class AmmoPickupDefinition(JsonDataclass):
     explain_other_sources: bool = dataclasses.field(default=True, metadata=EXCLUDE_DEFAULT)
     mention_limit: bool = dataclasses.field(default=True, metadata=EXCLUDE_DEFAULT)
     extra: frozendict = dataclasses.field(default_factory=frozendict, metadata=EXCLUDE_DEFAULT)
+
+    # TODO: change later to lower number after more experimentation and adjust in test_pickup_creator
     index_age_impact: float = dataclasses.field(default=1.0, metadata=EXCLUDE_DEFAULT)
 
     def __post_init__(self) -> None:

--- a/randovania/game_description/pickup/pickup_entry.py
+++ b/randovania/game_description/pickup/pickup_entry.py
@@ -67,7 +67,7 @@ class PickupGeneratorParams:
     probability_offset: float = 0.0
     probability_multiplier: float = 1.0
     required_progression: int = 0
-    index_age_impact: float = 1.0  # by how much the PickupIndex's age is incremented when this pickup is placed
+    index_age_impact: float = 1.0  # By how much the PickupIndex's age is incremented when this pickup is placed
 
 
 @dataclass(frozen=True)

--- a/randovania/game_description/pickup/pickup_entry.py
+++ b/randovania/game_description/pickup/pickup_entry.py
@@ -67,6 +67,7 @@ class PickupGeneratorParams:
     probability_offset: float = 0.0
     probability_multiplier: float = 1.0
     required_progression: int = 0
+    index_age_impact: float = 1.0  # by how much the PickupIndex's age is incremented when this pickup is placed
 
 
 @dataclass(frozen=True)

--- a/randovania/game_description/pickup/standard_pickup.py
+++ b/randovania/game_description/pickup/standard_pickup.py
@@ -92,6 +92,9 @@ class StandardPickupDefinition(JsonDataclass, DataclassPostInitTypeCheck):
     it's set to be at the original location.
     """
 
+    index_age_impact: float = dataclasses.field(default=1.0, metadata=EXCLUDE_DEFAULT)
+    # TODO: docstring
+
     probability_offset: float = dataclasses.field(default=0.0, metadata=EXCLUDE_DEFAULT)
     """During generation, determines how much the weight when placing the pickup will be offset."""
 

--- a/randovania/game_description/pickup/standard_pickup.py
+++ b/randovania/game_description/pickup/standard_pickup.py
@@ -93,7 +93,10 @@ class StandardPickupDefinition(JsonDataclass, DataclassPostInitTypeCheck):
     """
 
     index_age_impact: float = dataclasses.field(default=1.0, metadata=EXCLUDE_DEFAULT)
-    # TODO: docstring
+    """
+    During generation, determines by how much to increase all reachable location's age before this pickup is placed.
+    The older a location is, the less likely it is for future pickups to be placed there.
+    """
 
     probability_offset: float = dataclasses.field(default=0.0, metadata=EXCLUDE_DEFAULT)
     """During generation, determines how much the weight when placing the pickup will be offset."""

--- a/randovania/generator/filler/player_state.py
+++ b/randovania/generator/filler/player_state.py
@@ -40,7 +40,7 @@ class PlayerState:
     game: GameDescription
     pickups_left: list[PickupEntry]
     configuration: FillerConfiguration
-    pickup_index_age: collections.defaultdict[PickupIndex, float]
+    pickup_index_ages: collections.defaultdict[PickupIndex, float]
     hint_seen_count: collections.defaultdict[NodeIdentifier, int]
     hint_initial_pickups: dict[NodeIdentifier, frozenset[PickupIndex]]
     event_seen_count: dict[ResourceInfo, int]
@@ -67,7 +67,7 @@ class PlayerState:
         self.pickups_left = pickups_left
         self.configuration = configuration
 
-        self.pickup_index_age = collections.defaultdict(float)
+        self.pickup_index_ages = collections.defaultdict(float)
         self.hint_seen_count = collections.defaultdict(int)
         self.event_seen_count = collections.defaultdict(int)
         self.hint_initial_pickups = {}
@@ -104,8 +104,8 @@ class PlayerState:
 
     def _log_new_pickup_index(self) -> None:
         for index in self.reach.state.collected_pickup_indices:
-            if index not in self.pickup_index_age:
-                self.pickup_index_age[index] = 0.0
+            if index not in self.pickup_index_ages:
+                self.pickup_index_ages[index] = 0.0
                 filler_logging.print_new_pickup_index(self, index)
 
     def _calculate_potential_actions(self) -> None:

--- a/randovania/generator/filler/player_state.py
+++ b/randovania/generator/filler/player_state.py
@@ -40,7 +40,7 @@ class PlayerState:
     game: GameDescription
     pickups_left: list[PickupEntry]
     configuration: FillerConfiguration
-    pickup_index_considered_count: collections.defaultdict[PickupIndex, int]
+    pickup_index_age: collections.defaultdict[PickupIndex, float]
     hint_seen_count: collections.defaultdict[NodeIdentifier, int]
     hint_initial_pickups: dict[NodeIdentifier, frozenset[PickupIndex]]
     event_seen_count: dict[ResourceInfo, int]
@@ -67,7 +67,7 @@ class PlayerState:
         self.pickups_left = pickups_left
         self.configuration = configuration
 
-        self.pickup_index_considered_count = collections.defaultdict(int)
+        self.pickup_index_age = collections.defaultdict(float)
         self.hint_seen_count = collections.defaultdict(int)
         self.event_seen_count = collections.defaultdict(int)
         self.hint_initial_pickups = {}
@@ -104,8 +104,8 @@ class PlayerState:
 
     def _log_new_pickup_index(self) -> None:
         for index in self.reach.state.collected_pickup_indices:
-            if index not in self.pickup_index_considered_count:
-                self.pickup_index_considered_count[index] = 0
+            if index not in self.pickup_index_age:
+                self.pickup_index_age[index] = 0.0
                 filler_logging.print_new_pickup_index(self, index)
 
     def _calculate_potential_actions(self) -> None:

--- a/randovania/generator/filler/retcon.py
+++ b/randovania/generator/filler/retcon.py
@@ -182,10 +182,10 @@ def increment_index_age(locations_weighted: WeightedLocations, increment: float)
     Increments the pickup index's age for every already collected index.
     """
     for player, location, _ in locations_weighted.all_items():
-        was_present = location in player.pickup_index_age
-        player.pickup_index_age[location] += increment
+        was_present = location in player.pickup_index_ages
+        player.pickup_index_ages[location] += increment
         if not was_present:
-            # if it wasn't present, thenwe get to log!
+            # if it wasn't present, then we get to log!
             filler_logging.print_new_pickup_index(player, location)
 
 
@@ -423,7 +423,7 @@ def _calculate_all_pickup_indices_weight(player_states: list[PlayerState]) -> We
         pickup_index_weights = _calculate_uncollected_index_weights(
             player_state.all_indices & UncollectedState.from_reach(player_state.reach).indices,
             set(player_state.reach.state.patches.pickup_assignment),
-            player_state.pickup_index_age,
+            player_state.pickup_index_ages,
             player_state.indices_groups,
         )
         for pickup_index, weight in pickup_index_weights.items():

--- a/randovania/generator/filler/retcon.py
+++ b/randovania/generator/filler/retcon.py
@@ -49,9 +49,9 @@ def _calculate_uncollected_index_weights(
         weight_from_collected_indices = math.sqrt(len(indices) / ((1 + len(assigned_indices & indices)) ** 2))
 
         for index in sorted(uncollected_indices & indices):
-            weight_from_considered_count = min(10.0, index_age[index] + 1.0) ** -2
-            result[index] = weight_from_collected_indices * weight_from_considered_count
-            # print(f"## {index} : {weight_from_collected_indices} ___ {weight_from_considered_count}")
+            weight_from_index_age = min(10.0, index_age[index] + 1.0) ** -2
+            result[index] = weight_from_collected_indices * weight_from_index_age
+            # print(f"## {index} : {weight_from_collected_indices} ___ {weight_from_index_age}")
 
     return result
 

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -102,7 +102,7 @@ def create_ammo_pickup(
             preferred_location_category=ammo.preferred_location_category,
             probability_offset=ammo.probability_offset,
             probability_multiplier=ammo.probability_multiplier,
-            index_age_impact=0.25,
+            index_age_impact=ammo.index_age_impact,
         ),
     )
 

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -63,6 +63,7 @@ def create_standard_pickup(
             preferred_location_category=pickup.preferred_location_category,
             probability_offset=pickup.probability_offset,
             probability_multiplier=pickup.probability_multiplier * state.priority,
+            index_age_impact=pickup.index_age_impact,
         ),
     )
 
@@ -101,6 +102,7 @@ def create_ammo_pickup(
             preferred_location_category=ammo.preferred_location_category,
             probability_offset=ammo.probability_offset,
             probability_multiplier=ammo.probability_multiplier,
+            index_age_impact=0.25,
         ),
     )
 

--- a/test/generator/pickup_pool/test_pickup_creator.py
+++ b/test/generator/pickup_pool/test_pickup_creator.py
@@ -231,6 +231,7 @@ def test_create_ammo_expansion(requires_main_item: bool, echoes_pickup_database,
             preferred_location_category=LocationCategory.MINOR,
             probability_offset=0.0,
             probability_multiplier=2.0,
+            index_age_impact=0.25,
         ),
     )
 

--- a/test/generator/pickup_pool/test_pickup_creator.py
+++ b/test/generator/pickup_pool/test_pickup_creator.py
@@ -231,7 +231,7 @@ def test_create_ammo_expansion(requires_main_item: bool, echoes_pickup_database,
             preferred_location_category=LocationCategory.MINOR,
             probability_offset=0.0,
             probability_multiplier=2.0,
-            index_age_impact=0.25,
+            index_age_impact=1.0,
         ),
     )
 


### PR DESCRIPTION
Recontinuation of #6607 

Pickups have an impact in the age when they're assigned. The weight of an index depends on it's age, where younger age = more likely

This PR does introduce an option, but it is currently off for all games.
In future PRs, I want to do a bit more analysis on nicer values (especially for Prime)

Fixes https://github.com/randovania/randovania/issues/4496