### PR TITLE
Prime 1 Remove Superheat Option in Twin Fires Tunnel

### DIFF
--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -740,6 +740,19 @@ class PrimePatchDataFactory(PatchDataFactory):
             ]
 
         # serialize room modifications
+        if self.configuration.remove_superheat_twin_fires_tunnel:
+            magmoor_region = level_data["Magmoor Caverns"]["rooms"]
+            magmoor_region["Twin Fires Tunnel"]["superheated"] = False
+            magmoor_region["Transport to Tallon Overworld West"]["deleteIds"] = [
+                1048683,  # 0x0010006B - Timer for Varia Check
+                1048684,  # 0x0010006C - Function for Varia Check
+                1048682,  # 0x0010006A - Hud Memo Trigger for Heat
+                1048686,  # 0x0010006E - Hud Memo for Heat
+                1048685,  # 0x0010006D - Hud Memo Timer for Heat
+                1048681,  # 0x00100069 - Steam Effect
+                1048687,  # 0x0010006F - Lava that was meant to trigger "Warning" and Heat Glow Effect
+            ]
+
         if self.configuration.superheated_probability != 0:
             probability = self.configuration.superheated_probability / 1000.0
             for region in regions:

--- a/randovania/games/prime1/generator/bootstrap.py
+++ b/randovania/games/prime1/generator/bootstrap.py
@@ -40,6 +40,7 @@ class PrimeBootstrap(MetroidBootstrap):
             "superheated_probability": "superheated_probability",
             "submerged_probability": "submerged_probability",
             "remove_bars_great_tree_hall": "remove_bars_great_tree_hall",
+            "remove_superheat_twin_fires_tunnel": "remove_superheat_twin_fires_tunnel",
         }
         for name, index in logical_patches.items():
             if getattr(configuration, name):

--- a/randovania/games/prime1/gui/preset_settings/prime_patches_qol.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_patches_qol.py
@@ -26,6 +26,7 @@ _FIELDS = [
     "phazon_elite_without_dynamo",
     "spring_ball",
     "remove_bars_great_tree_hall",
+    "remove_superheat_twin_fires_tunnel",
 ]
 
 

--- a/randovania/games/prime1/gui/ui_files/preset_prime_qol.ui
+++ b/randovania/games/prime1/gui/ui_files/preset_prime_qol.ui
@@ -42,9 +42,9 @@
        <property name="geometry">
         <rect>
          <x>0</x>
-         <y>-358</y>
+         <y>-143</y>
          <width>487</width>
-         <height>1200</height>
+         <height>1272</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="scroll_layout">
@@ -211,6 +211,23 @@
             <widget class="QLabel" name="backwards_labs_label">
              <property name="text">
               <string>Scan through barrier of Research Lab Hydra when approached from deep labs</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="remove_superheat_twin_fires_tunnel_check">
+             <property name="text">
+              <string>Remove Superheat in Twin Fires Tunnel</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="remove_superheat_twin_fires_tunnel_label">
+             <property name="text">
+              <string>Removes the Superheat in Magmoor's Twin Fires Tunnel to eliminate the need for Varia Suit to access the unheated rooms past Twin Fires Tunnel</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>

--- a/randovania/games/prime1/layout/prime_configuration.py
+++ b/randovania/games/prime1/layout/prime_configuration.py
@@ -117,6 +117,7 @@ class PrimeConfiguration(BaseConfiguration):
     backwards_lower_mines: bool
     phazon_elite_without_dynamo: bool
     remove_bars_great_tree_hall: bool
+    remove_superheat_twin_fires_tunnel: bool
 
     legacy_mode: bool
     qol_cutscenes: LayoutCutsceneMode

--- a/randovania/games/prime1/logic_database/Magmoor Caverns.json
+++ b/randovania/games/prime1/logic_database/Magmoor Caverns.json
@@ -12992,6 +12992,15 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "remove_superheat_twin_fires_tunnel",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -13049,8 +13058,33 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Heat-Resisting Suit"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Heat-Resisting Suit"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "remove_superheat_twin_fires_tunnel",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -13156,6 +13190,15 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "remove_superheat_twin_fires_tunnel",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -13254,6 +13297,15 @@
                                                                             }
                                                                         }
                                                                     ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "remove_superheat_twin_fires_tunnel",
+                                                                    "amount": 1,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -13354,6 +13406,15 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "remove_superheat_twin_fires_tunnel",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -13426,6 +13487,15 @@
                                                                             }
                                                                         }
                                                                     ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "remove_superheat_twin_fires_tunnel",
+                                                                    "amount": 1,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -13508,8 +13578,33 @@
                                                                             }
                                                                         },
                                                                         {
-                                                                            "type": "template",
-                                                                            "data": "Heat-Resisting Suit"
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "or",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "template",
+                                                                                                    "data": "Heat-Resisting Suit"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "misc",
+                                                                                                        "name": "remove_superheat_twin_fires_tunnel",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
                                                                         }
                                                                     ]
                                                                 }
@@ -13625,6 +13720,15 @@
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "misc",
+                                                                                                                    "name": "remove_superheat_twin_fires_tunnel",
+                                                                                                                    "amount": 1,
+                                                                                                                    "negate": false
+                                                                                                                }
                                                                                                             }
                                                                                                         ]
                                                                                                     }
@@ -13714,6 +13818,15 @@
                                                                                                                             }
                                                                                                                         }
                                                                                                                     ]
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "misc",
+                                                                                                                    "name": "remove_superheat_twin_fires_tunnel",
+                                                                                                                    "amount": 1,
+                                                                                                                    "negate": false
                                                                                                                 }
                                                                                                             }
                                                                                                         ]
@@ -13825,6 +13938,15 @@
                                                                             }
                                                                         }
                                                                     ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "remove_superheat_twin_fires_tunnel",
+                                                                    "amount": 1,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -13987,6 +14109,15 @@
                                                                                                 }
                                                                                             ]
                                                                                         }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "misc",
+                                                                                            "name": "remove_superheat_twin_fires_tunnel",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
                                                                                     }
                                                                                 ]
                                                                             }
@@ -14076,6 +14207,15 @@
                                                                                                     }
                                                                                                 }
                                                                                             ]
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "misc",
+                                                                                            "name": "remove_superheat_twin_fires_tunnel",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
                                                                                         }
                                                                                     }
                                                                                 ]

--- a/randovania/games/prime1/logic_database/Magmoor Caverns.txt
+++ b/randovania/games/prime1/logic_database/Magmoor Caverns.txt
@@ -1339,34 +1339,36 @@ Extra - aabb: [299.85785, -645.52344, 22.734497, 367.19962, -567.72406, 82.52421
           All of the following:
               Space Jump Boots
               Any of the following:
-                  Heat-Resisting Suit
+                  Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
                   Heat Runs (Beginner) and Heated Rooms Damage ≥ 100
                   Heat Runs (Intermediate) and Heated Rooms Damage ≥ 65
               L-Jump (Intermediate) or Lava Damage ≥ 50
-          Morph Ball and Spider Ball and Heat-Resisting Suit
+          All of the following:
+              Morph Ball and Spider Ball
+              Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
           All of the following:
               Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner) and Gravityless Underwater Movement (Beginner) and Lava Damage ≥ 60
               Any of the following:
-                  Heat-Resisting Suit
+                  Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
                   Heat Runs (Beginner) and Heated Rooms Damage ≥ 185
                   Heat Runs (Intermediate) and Heated Rooms Damage ≥ 85
           All of the following:
               Combat/Scan Dash (Expert) and Standable Terrain (Advanced) and Disabled Dock Rando
               Any of the following:
-                  Heat-Resisting Suit
+                  Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
                   Heat Runs (Advanced) and Heated Rooms Damage ≥ 160
                   Heat Runs (Expert) and Heated Rooms Damage ≥ 80
           All of the following:
               Gravity Suit and Lava Damage ≥ 40
               Any of the following:
-                  Heat-Resisting Suit
+                  Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
                   Heat Runs (Beginner) and Heated Rooms Damage ≥ 120
                   Heat Runs (Intermediate) and Heated Rooms Damage ≥ 70
           All of the following:
               # https://youtu.be/9jk5s2W6yhY
               Movement (Expert) and Standable Terrain (Intermediate) and Lava Damage ≥ 10
               Any of the following:
-                  Heat-Resisting Suit
+                  Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
                   Heat Runs (Advanced) and Heated Rooms Damage ≥ 110
 
 > Door to Transport to Tallon Overworld West; Heals? False
@@ -1379,26 +1381,28 @@ Extra - aabb: [299.85785, -645.52344, 22.734497, 367.19962, -567.72406, 82.52421
           All of the following:
               Morph Ball
               Any of the following:
-                  Spider Ball and Heat-Resisting Suit
+                  All of the following:
+                      Spider Ball
+                      Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
                   All of the following:
                       Morph Ball Bomb
                       Any of the following:
                           All of the following:
                               Gravity Suit and Bomb Jump (Intermediate) and Lava Damage ≥ 95
                               Any of the following:
-                                  Heat-Resisting Suit
+                                  Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
                                   Heat Runs (Beginner) and Heated Rooms Damage ≥ 125
                                   Heat Runs (Intermediate) and Heated Rooms Damage ≥ 75
                           All of the following:
                               Bomb Jump (Expert) and L-Jump (Advanced) and Gravityless Underwater Movement (Advanced) and Lava Damage ≥ 200
                               Any of the following:
-                                  Heat-Resisting Suit
+                                  Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
                                   Heat Runs (Advanced) and Heated Rooms Damage ≥ 150
                                   Heat Runs (Expert) and Heated Rooms Damage ≥ 99
           All of the following:
               Space Jump Boots
               Any of the following:
-                  Heat-Resisting Suit
+                  Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
                   Heat Runs (Beginner) and Heated Rooms Damage ≥ 125
                   Heat Runs (Intermediate) and Heated Rooms Damage ≥ 85
               Any of the following:
@@ -1412,14 +1416,14 @@ Extra - aabb: [299.85785, -645.52344, 22.734497, 367.19962, -567.72406, 82.52421
                       # https://youtu.be/OK3lSWvTKKU
                       Space Jump Boots and Combat/Scan Dash (Advanced) and Standable Terrain (Intermediate)
                       Any of the following:
-                          Heat-Resisting Suit
+                          Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
                           Heat Runs (Intermediate) and Heated Rooms Damage ≥ 135
                           Heat Runs (Advanced) and Heated Rooms Damage ≥ 85
                   All of the following:
                       # https://youtu.be/Ue9T-9SY0o4
                       Combat/Scan Dash (Expert) and Standable Terrain (Advanced)
                       Any of the following:
-                          Heat-Resisting Suit
+                          Enabled Remove Superheat Twin Fires Tunnel or Heat-Resisting Suit
                           Heat Runs (Advanced) and Heated Rooms Damage ≥ 145
                           Heat Runs (Expert) and Heated Rooms Damage ≥ 95
 

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -808,6 +808,10 @@
             "vanilla_heat": {
                 "long_name": "Vanilla Heat Resistance",
                 "extra": {}
+            },
+            "remove_superheat_twin_fires_tunnel": {
+                "long_name": "Remove Superheat Twin Fires Tunnel",
+                "extra": {}
             }
         },
         "requirement_template": {

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1233,6 +1233,13 @@ def _migrate_v93(preset: dict) -> dict:
     return preset
 
 
+def _migrate_v94(preset: dict) -> dict:
+    if preset["game"] == "prime1":
+        preset["configuration"]["remove_superheat_twin_fires_tunnel"] = False
+
+    return preset
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -1327,6 +1334,7 @@ _MIGRATIONS = [
     _migrate_v91,  # two sided door search
     _migrate_v92,  # remove bars great tree hall
     _migrate_v93,  # update default dock_rando in Prime 1 to use RP Blast Shield Change
+    _migrate_v94,  # remove superheat twin fire tunnels option
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 


### PR DESCRIPTION
Idea from Amojini, Baja also thought it could be a _cool_ idea.

> Ideas for opening up prime progression for cgc was removing superheated from twin fires tunnel. Allows phen and maybe mines without Varia, maybe makes gravity more important logically

Since this change seemed like the remove bars feature, I thought I could implement it in a similar fashion. 

- Added option "Remove Superheat in Twin Fires Tunnel" and it is disabled by default
- Removed out HUD Heat Notifications and similar Items in Transport to Tallon Overworld West to remove confusion while entering the room

Tested

- Verified removed objects in Transport to Tallon Overworld West and no crashes/weirdness
- Forced Starting Location to Twin Fires tunnel to test Logic and Generator
- Made sure room was not superheated and tried the spider ball track etc

I believe I did the logic edits correctly, but would like a triple check since I am new at it.

If I need to edit one of the testing rdv files like the remove bars feature implementation, please let me know. I can do the refills one again or whatever you all decide is best. 