### PR TITLE
Revert "Fixes needed for running with Python 3.13"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ gui = [
     "async-wiiload",
     "dolphin-memory-engine>=1.0.2",
     "pid>=3.0.0",
-    "packaging",  # for Version
 ]
 
 server = [
@@ -126,10 +125,8 @@ server = [
     "peewee",
     "requests-oauthlib",
     "cachetools",  # for TTLCache
-    "packaging",  # for Version
 
     "py-cord>=2.3.1",  # for randovania/server/discord; 2.3.1+ is needed for Python 3.11
-    "audioop-lts; python_version>='3.13'",  # for py-cord
     "Pillow>=9.0.0",  # for randovania/server/discord/database_command
     "graphviz",  # for randovania/server/discord/database_command
 ]
@@ -151,7 +148,7 @@ typing = [
 ]
 
 website = [
-    "htmlmin2",
+    "htmlmin",
     "ruamel.yaml",
 ]
 

--- a/randovania/bitpacking/construct_pack.py
+++ b/randovania/bitpacking/construct_pack.py
@@ -180,7 +180,7 @@ def construct_for_type(type_: type) -> construct.Construct:
     if type_ in _direct_mapping:
         return _direct_mapping[type_]
 
-    if isinstance(type_, type) and issubclass(type_, Enum):
+    if issubclass(type_, Enum):
         enum_arr = list(type_)
         return construct.ExprAdapter(
             construct.VarInt,

--- a/randovania/cli/commands/export_game.py
+++ b/randovania/cli/commands/export_game.py
@@ -29,7 +29,7 @@ def _add_parser_arguments_for(
             arg_kwargs["action"] = "store_true"
             arg_kwargs["required"] = False
 
-        elif isinstance(type_, type) and issubclass(type_, enum.Enum):
+        elif issubclass(type_, enum.Enum):
             arg_kwargs["type"] = type_
             arg_kwargs["required"] = not is_optional
             arg_kwargs["action"] = EnumAction

--- a/randovania/interface_common/options.py
+++ b/randovania/interface_common/options.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import dataclasses
 import json
 import uuid
+from distutils.version import StrictVersion
 from enum import Enum
 from typing import TYPE_CHECKING, Any, TypeVar
-
-from packaging.version import Version
 
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_connection.builder.connector_builder_option import ConnectorBuilderOption
@@ -386,11 +385,11 @@ class Options:
 
     # Access to Direct fields
     @property
-    def last_changelog_displayed(self) -> Version:
-        return Version(self._last_changelog_displayed)
+    def last_changelog_displayed(self) -> StrictVersion:
+        return StrictVersion(self._last_changelog_displayed)
 
     @last_changelog_displayed.setter
-    def last_changelog_displayed(self, value: Version):
+    def last_changelog_displayed(self, value: StrictVersion):
         if value != self.last_changelog_displayed:
             self._check_editable_and_mark_dirty()
             self._last_changelog_displayed = str(value)

--- a/randovania/interface_common/update_checker.py
+++ b/randovania/interface_common/update_checker.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime
+from distutils.version import StrictVersion
 from typing import NamedTuple
-
-from packaging.version import Version
 
 from randovania import VERSION
 
@@ -24,21 +23,21 @@ class VersionDescription(NamedTuple):
     html_url: str
 
     @property
-    def as_strict_version(self) -> Version:
-        return Version(self.tag_name[1:])
+    def as_strict_version(self) -> StrictVersion:
+        return StrictVersion(self.tag_name[1:])
 
 
-def strict_version_for_version_string(version_name: str) -> Version:
+def strict_version_for_version_string(version_name: str) -> StrictVersion:
     version_name = version_name.replace("-dirty", "")
     try:
-        return Version(version_name)
+        return StrictVersion(version_name)
     except ValueError:
         if ".dev" not in version_name:
             raise
-        return Version(version_name.split(".dev")[0])
+        return StrictVersion(version_name.split(".dev")[0])
 
 
-def strict_current_version() -> Version:
+def strict_current_version() -> StrictVersion:
     return strict_version_for_version_string(VERSION)
 
 
@@ -75,8 +74,8 @@ def _get_major_entries(log: str) -> str:
 
 
 def versions_to_display_for_releases(
-    current_version: Version,
-    last_changelog_version: Version,
+    current_version: StrictVersion,
+    last_changelog_version: StrictVersion,
     releases: list[dict],
 ) -> tuple[dict[str, str], list[str], VersionDescription | None]:
     all_change_logs = {}

--- a/randovania/server/client_check.py
+++ b/randovania/server/client_check.py
@@ -1,6 +1,5 @@
+from distutils.version import StrictVersion
 from enum import Enum
-
-from packaging.version import Version
 
 import randovania
 
@@ -17,12 +16,11 @@ def check_client_version(version_checking: ClientVersionCheck, client_version: s
             return f"Incompatible client version '{client_version}', expected '{server_version}'"
 
     elif version_checking == ClientVersionCheck.MATCH_MAJOR_MINOR:
-        server = Version(server_version)
-        client = Version(client_version)
-
-        if server.release[:2] != client.release[:2]:
-            shorter_client = "{}.{}".format(*client.release[:2])
-            shorter_server = "{}.{}".format(*server.release[:2])
+        server = StrictVersion(server_version.split(".dev")[0])
+        client = StrictVersion(client_version.split(".dev")[0])
+        if server.version[:2] != client.version[:2]:
+            shorter_client = "{}.{}".format(*client.version[:2])
+            shorter_server = "{}.{}".format(*server.version[:2])
             return f"Incompatible client version '{shorter_client}', expected '{shorter_server}'"
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,7 +111,7 @@ greenlet==3.1.1
     # via eventlet
 h11==0.14.0
     # via wsproto
-htmlmin2==0.1.13
+htmlmin==0.1.12
     # via randovania (setup.py)
 idna==3.10
     # via
@@ -186,7 +186,6 @@ packaging==24.2
     # via
     #   matplotlib
     #   pytest
-    #   randovania (setup.py)
 peewee==3.17.8
     # via randovania (setup.py)
 pid==3.0.4

--- a/test/interface_common/test_update_checker.py
+++ b/test/interface_common/test_update_checker.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime
+from distutils.version import StrictVersion
 
 import pytest
-from packaging.version import Version
 
 from randovania.interface_common import update_checker
 from randovania.interface_common.update_checker import ChangeLogDetails, VersionDescription
@@ -59,7 +59,7 @@ def test_versions_to_display_for_releases(
         change_logs,
         version_to_display,
     ) = update_checker.versions_to_display_for_releases(
-        Version(f"0.{current_version}.0"), Version(f"0.{last_changelog_version}.0"), releases
+        StrictVersion(f"0.{current_version}.0"), StrictVersion(f"0.{last_changelog_version}.0"), releases
     )
 
     # Assert

--- a/test/server/test_client_check.py
+++ b/test/server/test_client_check.py
@@ -61,8 +61,6 @@ def test_check_client_headers_wrong_value(expected_headers):
         (client_check.ClientVersionCheck.STRICT, "1.0", "1.1", False),
         (client_check.ClientVersionCheck.MATCH_MAJOR_MINOR, "1.0", "1.0", True),
         (client_check.ClientVersionCheck.MATCH_MAJOR_MINOR, "1.0", "1.0.1", True),
-        (client_check.ClientVersionCheck.MATCH_MAJOR_MINOR, "1.0.0.dev5", "1.0.1", True),
-        (client_check.ClientVersionCheck.MATCH_MAJOR_MINOR, "1.0", "1.0.1.dev35", True),
         (client_check.ClientVersionCheck.MATCH_MAJOR_MINOR, "1.0", "1.1", False),
         (client_check.ClientVersionCheck.IGNORE, "1.0", "1.0", True),
         (client_check.ClientVersionCheck.IGNORE, "1.0", "1.0.1", True),


### PR DESCRIPTION
Reverts randovania/randovania#7563

For some reason, this breaks stable for new users. They are not able to use the application at all, and instead just get an error message and the application immediately closing afterwards.

I don't want to try to find the proper solution for now, so full on revert it is (it's not like we're testing python 3.13 right now anyway)