### PR TITLE
Add pickup index and provider uuid to remote pickups

### DIFF
--- a/randovania/game_connection/connector/am2r_remote_connector.py
+++ b/randovania/game_connection/connector/am2r_remote_connector.py
@@ -8,7 +8,6 @@ from randovania.game.game_enum import RandovaniaGame
 from randovania.game_connection.connector.remote_connector import (
     PlayerLocationEvent,
     RemoteConnector,
-    RemotePickupTuple,
 )
 from randovania.game_connection.executor.am2r_executor import AM2RExecutor
 from randovania.game_description import default_database
@@ -16,6 +15,7 @@ from randovania.game_description.db.region import Region
 from randovania.game_description.resources.inventory import Inventory, InventoryItem
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.games.am2r.layout import progressive_items
+from randovania.network_common.remote_pickup import RemotePickup
 
 
 class AM2RRemoteConnector(RemoteConnector):
@@ -57,7 +57,7 @@ class AM2RRemoteConnector(RemoteConnector):
 
     # Reset all values on init, disconnect or after switching back to main menu
     def reset_values(self) -> None:
-        self.remote_pickups: tuple[RemotePickupTuple, ...] = ()
+        self.remote_pickups: tuple[RemotePickup, ...] = ()
         self.last_inventory = Inventory.empty()
         self.in_cooldown = True
         self.received_pickups: int | None = None
@@ -221,7 +221,7 @@ class AM2RRemoteConnector(RemoteConnector):
         self.received_pickups = new_recv_as_int
         await self.receive_remote_pickups()
 
-    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickupTuple, ...]) -> None:
+    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickup, ...]) -> None:
         self.remote_pickups = remote_pickups
         await self.receive_remote_pickups()
 
@@ -242,7 +242,7 @@ class AM2RRemoteConnector(RemoteConnector):
 
         # Mark as cooldown, and send provider, item name, model name and quantity to game
         self.in_cooldown = True
-        provider_name, pickup, location, provider_uuid = remote_pickups[num_pickups]
+        provider_name, pickup, pickup_index, is_coop = remote_pickups[num_pickups]
         name, model = pickup.name, pickup.model.name
         # For some reason, the resources here are sorted differently to the patch data factory.
         # There we want the first entry, here we want the last.

--- a/randovania/game_connection/connector/am2r_remote_connector.py
+++ b/randovania/game_connection/connector/am2r_remote_connector.py
@@ -1,15 +1,14 @@
 import logging
 import uuid
 from collections import defaultdict
-from typing import TYPE_CHECKING
 
 from qasync import asyncSlot
 
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_connection.connector.remote_connector import (
-    PickupEntryWithOwner,
     PlayerLocationEvent,
     RemoteConnector,
+    RemotePickupTuple,
 )
 from randovania.game_connection.executor.am2r_executor import AM2RExecutor
 from randovania.game_description import default_database
@@ -17,9 +16,6 @@ from randovania.game_description.db.region import Region
 from randovania.game_description.resources.inventory import Inventory, InventoryItem
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.games.am2r.layout import progressive_items
-
-if TYPE_CHECKING:
-    from randovania.game_description.pickup.pickup_entry import PickupEntry
 
 
 class AM2RRemoteConnector(RemoteConnector):
@@ -61,7 +57,7 @@ class AM2RRemoteConnector(RemoteConnector):
 
     # Reset all values on init, disconnect or after switching back to main menu
     def reset_values(self) -> None:
-        self.remote_pickups: tuple[tuple[str, PickupEntry], ...] = ()
+        self.remote_pickups: tuple[RemotePickupTuple, ...] = ()
         self.last_inventory = Inventory.empty()
         self.in_cooldown = True
         self.received_pickups: int | None = None
@@ -225,7 +221,7 @@ class AM2RRemoteConnector(RemoteConnector):
         self.received_pickups = new_recv_as_int
         await self.receive_remote_pickups()
 
-    async def set_remote_pickups(self, remote_pickups: tuple[PickupEntryWithOwner, ...]) -> None:
+    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickupTuple, ...]) -> None:
         self.remote_pickups = remote_pickups
         await self.receive_remote_pickups()
 
@@ -246,7 +242,7 @@ class AM2RRemoteConnector(RemoteConnector):
 
         # Mark as cooldown, and send provider, item name, model name and quantity to game
         self.in_cooldown = True
-        provider_name, pickup = remote_pickups[num_pickups]
+        provider_name, pickup, location, provider_uuid = remote_pickups[num_pickups]
         name, model = pickup.name, pickup.model.name
         # For some reason, the resources here are sorted differently to the patch data factory.
         # There we want the first entry, here we want the last.

--- a/randovania/game_connection/connector/am2r_remote_connector.py
+++ b/randovania/game_connection/connector/am2r_remote_connector.py
@@ -250,7 +250,7 @@ class AM2RRemoteConnector(RemoteConnector):
 
         # Mark as cooldown, and send provider, item name, model name and quantity to game
         self.in_cooldown = True
-        provider_name, pickup, pickup_index, is_coop = remote_pickups[num_pickups]
+        provider_name, pickup, coop_location = remote_pickups[num_pickups]
         name, model = pickup.name, pickup.model.name
         # For some reason, the resources here are sorted differently to the patch data factory.
         # There we want the first entry, here we want the last.

--- a/randovania/game_connection/connector/corruption_remote_connector.py
+++ b/randovania/game_connection/connector/corruption_remote_connector.py
@@ -12,10 +12,10 @@ from randovania.game_description.resources.inventory import Inventory, Inventory
 if TYPE_CHECKING:
     from open_prime_rando.dol_patching.corruption.dol_patches import CorruptionDolVersion
 
-    from randovania.game_connection.connector.remote_connector import RemotePickupTuple
     from randovania.game_description.db.region import Region
     from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.game_description.resources.item_resource_info import ItemResourceInfo
+    from randovania.network_common.remote_pickup import RemotePickup
 
 
 def format_received_item(item_name: str, player_name: str) -> str:
@@ -134,7 +134,7 @@ class CorruptionRemoteConnector(PrimeRemoteConnector):
     async def receive_remote_pickups(
         self,
         inventory: Inventory,
-        remote_pickups: tuple[RemotePickupTuple, ...],
+        remote_pickups: tuple[RemotePickup, ...],
     ) -> bool:
         # Not yet implemented
         return False

--- a/randovania/game_connection/connector/corruption_remote_connector.py
+++ b/randovania/game_connection/connector/corruption_remote_connector.py
@@ -12,7 +12,7 @@ from randovania.game_description.resources.inventory import Inventory, Inventory
 if TYPE_CHECKING:
     from open_prime_rando.dol_patching.corruption.dol_patches import CorruptionDolVersion
 
-    from randovania.game_connection.connector.remote_connector import PickupEntryWithOwner
+    from randovania.game_connection.connector.remote_connector import RemotePickupTuple
     from randovania.game_description.db.region import Region
     from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.game_description.resources.item_resource_info import ItemResourceInfo
@@ -134,7 +134,7 @@ class CorruptionRemoteConnector(PrimeRemoteConnector):
     async def receive_remote_pickups(
         self,
         inventory: Inventory,
-        remote_pickups: tuple[PickupEntryWithOwner, ...],
+        remote_pickups: tuple[RemotePickupTuple, ...],
     ) -> bool:
         # Not yet implemented
         return False

--- a/randovania/game_connection/connector/cs_remote_connector.py
+++ b/randovania/game_connection/connector/cs_remote_connector.py
@@ -5,9 +5,9 @@ from caver.patcher import wrap_msg_text
 
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_connection.connector.remote_connector import (
-    PickupEntryWithOwner,
     PlayerLocationEvent,
     RemoteConnector,
+    RemotePickupTuple,
 )
 from randovania.game_connection.executor.cs_executor import CSExecutor, GameState, TSCError
 from randovania.game_description import default_database
@@ -26,7 +26,7 @@ ITEM_RECEIVED_FLAG = 7411
 class CSRemoteConnector(RemoteConnector):
     game_state: GameState
     last_inventory: Inventory
-    remote_pickups: tuple[PickupEntryWithOwner, ...]
+    remote_pickups: tuple[RemotePickupTuple, ...]
     current_map: PlayerLocationEvent
 
     _dt: float = 1.0
@@ -194,7 +194,7 @@ class CSRemoteConnector(RemoteConnector):
         # no pending pickups, and pickups to send:
         # send the next pickup!
         await self.executor.set_flag(ITEM_SENT_FLAG, True)
-        provider_name, pickup = self.remote_pickups[num_pickups]
+        provider_name, pickup, location, provider_uuid = self.remote_pickups[num_pickups]
 
         message = f"Received item from ={provider_name}=!"
         message = wrap_msg_text(message, False)
@@ -210,5 +210,5 @@ class CSRemoteConnector(RemoteConnector):
         script = f"<MSG{text}<WAI0500<END"
         await self.executor.exec_script(script)
 
-    async def set_remote_pickups(self, remote_pickups: tuple[PickupEntryWithOwner, ...]) -> None:
+    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickupTuple, ...]) -> None:
         self.remote_pickups = remote_pickups

--- a/randovania/game_connection/connector/cs_remote_connector.py
+++ b/randovania/game_connection/connector/cs_remote_connector.py
@@ -194,7 +194,7 @@ class CSRemoteConnector(RemoteConnector):
         # no pending pickups, and pickups to send:
         # send the next pickup!
         await self.executor.set_flag(ITEM_SENT_FLAG, True)
-        provider_name, pickup, pickup_index, is_coop = self.remote_pickups[num_pickups]
+        provider_name, pickup, coop_location = self.remote_pickups[num_pickups]
 
         message = f"Received item from ={provider_name}=!"
         message = wrap_msg_text(message, False)

--- a/randovania/game_connection/connector/cs_remote_connector.py
+++ b/randovania/game_connection/connector/cs_remote_connector.py
@@ -7,13 +7,13 @@ from randovania.game.game_enum import RandovaniaGame
 from randovania.game_connection.connector.remote_connector import (
     PlayerLocationEvent,
     RemoteConnector,
-    RemotePickupTuple,
 )
 from randovania.game_connection.executor.cs_executor import CSExecutor, GameState, TSCError
 from randovania.game_description import default_database
 from randovania.game_description.resources.inventory import Inventory, InventoryItem
 from randovania.games.cave_story.exporter.patch_data_factory import NOTHING_ITEM_SCRIPT
 from randovania.lib.infinite_timer import InfiniteTimer
+from randovania.network_common.remote_pickup import RemotePickup
 
 INDICES_FLAGS_START = 7300
 PUPPIES_FLAGS = tuple(range(5001, 5006))
@@ -26,7 +26,7 @@ ITEM_RECEIVED_FLAG = 7411
 class CSRemoteConnector(RemoteConnector):
     game_state: GameState
     last_inventory: Inventory
-    remote_pickups: tuple[RemotePickupTuple, ...]
+    remote_pickups: tuple[RemotePickup, ...]
     current_map: PlayerLocationEvent
 
     _dt: float = 1.0
@@ -194,7 +194,7 @@ class CSRemoteConnector(RemoteConnector):
         # no pending pickups, and pickups to send:
         # send the next pickup!
         await self.executor.set_flag(ITEM_SENT_FLAG, True)
-        provider_name, pickup, location, provider_uuid = self.remote_pickups[num_pickups]
+        provider_name, pickup, pickup_index, is_coop = self.remote_pickups[num_pickups]
 
         message = f"Received item from ={provider_name}=!"
         message = wrap_msg_text(message, False)
@@ -210,5 +210,5 @@ class CSRemoteConnector(RemoteConnector):
         script = f"<MSG{text}<WAI0500<END"
         await self.executor.exec_script(script)
 
-    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickupTuple, ...]) -> None:
+    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickup, ...]) -> None:
         self.remote_pickups = remote_pickups

--- a/randovania/game_connection/connector/debug_remote_connector.py
+++ b/randovania/game_connection/connector/debug_remote_connector.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from PySide6.QtCore import Signal
 
-from randovania.game_connection.connector.remote_connector import RemoteConnector, RemotePickupTuple
+from randovania.game_connection.connector.remote_connector import RemoteConnector
 from randovania.game_description import default_database
 from randovania.game_description.resources.inventory import Inventory, InventoryItem
 from randovania.game_description.resources.resource_collection import ResourceCollection
@@ -13,11 +13,12 @@ if TYPE_CHECKING:
     import uuid
 
     from randovania.game.game_enum import RandovaniaGame
+    from randovania.network_common.remote_pickup import RemotePickup
 
 
 class DebugRemoteConnector(RemoteConnector):
     messages: list[str]
-    remote_pickups: tuple[RemotePickupTuple, ...] = ()
+    remote_pickups: tuple[RemotePickup, ...] = ()
     _finished: bool = False
     _last_inventory_event: Inventory
     item_collection: ResourceCollection
@@ -46,7 +47,7 @@ class DebugRemoteConnector(RemoteConnector):
         self.messages.append(message)
         self.MessagesUpdated.emit()
 
-    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickupTuple, ...]):
+    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickup, ...]):
         self.remote_pickups = remote_pickups
 
         for remote_pickup in remote_pickups[self._last_remote_pickup :]:

--- a/randovania/game_connection/connector/debug_remote_connector.py
+++ b/randovania/game_connection/connector/debug_remote_connector.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from PySide6.QtCore import Signal
 
-from randovania.game_connection.connector.remote_connector import PickupEntryWithOwner, RemoteConnector
+from randovania.game_connection.connector.remote_connector import RemoteConnector, RemotePickupTuple
 from randovania.game_description import default_database
 from randovania.game_description.resources.inventory import Inventory, InventoryItem
 from randovania.game_description.resources.resource_collection import ResourceCollection
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 class DebugRemoteConnector(RemoteConnector):
     messages: list[str]
-    remote_pickups: tuple[PickupEntryWithOwner, ...] = ()
+    remote_pickups: tuple[RemotePickupTuple, ...] = ()
     _finished: bool = False
     _last_inventory_event: Inventory
     item_collection: ResourceCollection
@@ -46,7 +46,7 @@ class DebugRemoteConnector(RemoteConnector):
         self.messages.append(message)
         self.MessagesUpdated.emit()
 
-    async def set_remote_pickups(self, remote_pickups: tuple[PickupEntryWithOwner, ...]):
+    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickupTuple, ...]):
         self.remote_pickups = remote_pickups
 
         for remote_pickup in remote_pickups[self._last_remote_pickup :]:

--- a/randovania/game_connection/connector/dread_remote_connector.py
+++ b/randovania/game_connection/connector/dread_remote_connector.py
@@ -26,7 +26,7 @@ class DreadRemoteConnector(MercuryConnector):
         return get_resources_for_details(pickup, conditional_resources, other_player)
 
     async def game_specific_execute(
-        self, item_name: str, items_list: list, provider_name: str, region_name: str, is_coop: bool
+        self, item_name: str, items_list: list, provider_name: str, scenario_id: str
     ) -> None:
         remote_pickups = self.remote_pickups
         num_pickups = self.received_pickups

--- a/randovania/game_connection/connector/dread_remote_connector.py
+++ b/randovania/game_connection/connector/dread_remote_connector.py
@@ -7,8 +7,6 @@ from randovania.game_connection.connector.mercury_remote_connector import Mercur
 from randovania.games.dread.exporter.patch_data_factory import get_resources_for_details
 
 if TYPE_CHECKING:
-    import uuid
-
     from randovania.game_connection.executor.dread_executor import DreadExecutor
     from randovania.game_description.pickup.pickup_entry import ConditionalResources, PickupEntry
 
@@ -28,7 +26,7 @@ class DreadRemoteConnector(MercuryConnector):
         return get_resources_for_details(pickup, conditional_resources, other_player)
 
     async def game_specific_execute(
-        self, item_name: str, items_list: list, provider_name: str, region_name: str, provider_uuid: uuid.UUID
+        self, item_name: str, items_list: list, provider_name: str, region_name: str, is_coop: bool
     ) -> None:
         remote_pickups = self.remote_pickups
         num_pickups = self.received_pickups

--- a/randovania/game_connection/connector/dread_remote_connector.py
+++ b/randovania/game_connection/connector/dread_remote_connector.py
@@ -25,7 +25,9 @@ class DreadRemoteConnector(MercuryConnector):
     ) -> list:
         return get_resources_for_details(pickup, conditional_resources, other_player)
 
-    async def game_specific_execute(self, item_name: str, items_list: list, provider_name: str) -> None:
+    async def game_specific_execute(
+        self, item_name: str, items_list: list, provider_name: str, region_name: str, provider_uuid: str
+    ) -> None:
         remote_pickups = self.remote_pickups
         num_pickups = self.received_pickups
 

--- a/randovania/game_connection/connector/dread_remote_connector.py
+++ b/randovania/game_connection/connector/dread_remote_connector.py
@@ -7,6 +7,8 @@ from randovania.game_connection.connector.mercury_remote_connector import Mercur
 from randovania.games.dread.exporter.patch_data_factory import get_resources_for_details
 
 if TYPE_CHECKING:
+    import uuid
+
     from randovania.game_connection.executor.dread_executor import DreadExecutor
     from randovania.game_description.pickup.pickup_entry import ConditionalResources, PickupEntry
 
@@ -26,7 +28,7 @@ class DreadRemoteConnector(MercuryConnector):
         return get_resources_for_details(pickup, conditional_resources, other_player)
 
     async def game_specific_execute(
-        self, item_name: str, items_list: list, provider_name: str, region_name: str, provider_uuid: str
+        self, item_name: str, items_list: list, provider_name: str, region_name: str, provider_uuid: uuid.UUID
     ) -> None:
         remote_pickups = self.remote_pickups
         num_pickups = self.received_pickups

--- a/randovania/game_connection/connector/mercury_remote_connector.py
+++ b/randovania/game_connection/connector/mercury_remote_connector.py
@@ -142,12 +142,12 @@ class MercuryConnector(RemoteConnector):
 
         self.in_cooldown = True
 
-        provider_name, pickup, pickup_index, is_coop = remote_pickups[num_pickups]
+        provider_name, pickup, coop_location = remote_pickups[num_pickups]
         item_name, items_list = self.resources_to_give_for_pickup(self.game.resource_database, pickup, inventory)
 
         scenario_id = ""
-        if is_coop:
-            location_node = self.game.region_list.node_from_pickup_index(pickup_index)
+        if coop_location is not None:
+            location_node = self.game.region_list.node_from_pickup_index(coop_location)
             scenario_id = self.game.region_list.nodes_to_region(location_node).extra["scenario_id"]
 
         self.logger.debug("Resource changes for %s from %s", pickup.name, provider_name)

--- a/randovania/game_connection/connector/mercury_remote_connector.py
+++ b/randovania/game_connection/connector/mercury_remote_connector.py
@@ -151,7 +151,7 @@ class MercuryConnector(RemoteConnector):
         await self.game_specific_execute(item_name, items_list, provider_name, region_name, provider_uuid)
 
     async def game_specific_execute(
-        self, item_name: str, items_list: list, provider_name: str, region_name: str, provider_uuid: str
+        self, item_name: str, items_list: list, provider_name: str, region_name: str, provider_uuid: uuid.UUID
     ) -> None:
         raise NotImplementedError
 

--- a/randovania/game_connection/connector/mercury_remote_connector.py
+++ b/randovania/game_connection/connector/mercury_remote_connector.py
@@ -144,15 +144,18 @@ class MercuryConnector(RemoteConnector):
 
         provider_name, pickup, pickup_index, is_coop = remote_pickups[num_pickups]
         item_name, items_list = self.resources_to_give_for_pickup(self.game.resource_database, pickup, inventory)
-        location_node = self.game.region_list.node_from_pickup_index(pickup_index)
-        region_name = self.game.region_list.nodes_to_region(location_node).extra.get("scenario_id", "")
+
+        scenario_id = ""
+        if is_coop:
+            location_node = self.game.region_list.node_from_pickup_index(pickup_index)
+            scenario_id = self.game.region_list.nodes_to_region(location_node).extra["scenario_id"]
 
         self.logger.debug("Resource changes for %s from %s", pickup.name, provider_name)
 
-        await self.game_specific_execute(item_name, items_list, provider_name, region_name, is_coop)
+        await self.game_specific_execute(item_name, items_list, provider_name, scenario_id)
 
     async def game_specific_execute(
-        self, item_name: str, items_list: list, provider_name: str, region_name: str, is_coop: bool
+        self, item_name: str, items_list: list, provider_name: str, scenario_id: str
     ) -> None:
         raise NotImplementedError
 

--- a/randovania/game_connection/connector/mercury_remote_connector.py
+++ b/randovania/game_connection/connector/mercury_remote_connector.py
@@ -12,7 +12,6 @@ from randovania.exporter.pickup_exporter import _conditional_resources_for_picku
 from randovania.game_connection.connector.remote_connector import (
     PlayerLocationEvent,
     RemoteConnector,
-    RemotePickupTuple,
 )
 from randovania.game_description import default_database
 from randovania.game_description.resources.inventory import Inventory, InventoryItem
@@ -24,6 +23,7 @@ if TYPE_CHECKING:
     from randovania.game_description.db.region import Region
     from randovania.game_description.pickup.pickup_entry import ConditionalResources, PickupEntry
     from randovania.game_description.resources.resource_database import ResourceDatabase
+    from randovania.network_common.remote_pickup import RemotePickup
 
 
 class MercuryConnector(RemoteConnector):
@@ -63,7 +63,7 @@ class MercuryConnector(RemoteConnector):
 
     # reset all values on init, disconnect or after switching back to main menu
     def reset_values(self) -> None:
-        self.remote_pickups: tuple[RemotePickupTuple, ...] = ()
+        self.remote_pickups: tuple[RemotePickup, ...] = ()
         self.last_inventory = Inventory.empty()
         self.in_cooldown = True
         self.received_pickups: int | None = None
@@ -122,7 +122,7 @@ class MercuryConnector(RemoteConnector):
         self.received_pickups = new_recv_as_int
         await self.receive_remote_pickups()
 
-    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickupTuple, ...]) -> None:
+    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickup, ...]) -> None:
         self.remote_pickups = remote_pickups
         await self.receive_remote_pickups()
 
@@ -141,17 +141,17 @@ class MercuryConnector(RemoteConnector):
 
         self.in_cooldown = True
 
-        provider_name, pickup, location, provider_uuid = remote_pickups[num_pickups]
+        provider_name, pickup, pickup_index, is_coop = remote_pickups[num_pickups]
         item_name, items_list = self.resources_to_give_for_pickup(self.game.resource_database, pickup, inventory)
-        location_node = self.game.region_list.node_from_pickup_index(location)
+        location_node = self.game.region_list.node_from_pickup_index(pickup_index)
         region_name = self.game.region_list.nodes_to_region(location_node).extra.get("scenario_id", "")
 
         self.logger.debug("Resource changes for %s from %s", pickup.name, provider_name)
 
-        await self.game_specific_execute(item_name, items_list, provider_name, region_name, provider_uuid)
+        await self.game_specific_execute(item_name, items_list, provider_name, region_name, is_coop)
 
     async def game_specific_execute(
-        self, item_name: str, items_list: list, provider_name: str, region_name: str, provider_uuid: uuid.UUID
+        self, item_name: str, items_list: list, provider_name: str, region_name: str, is_coop: bool
     ) -> None:
         raise NotImplementedError
 

--- a/randovania/game_connection/connector/msr_remote_connector.py
+++ b/randovania/game_connection/connector/msr_remote_connector.py
@@ -25,7 +25,9 @@ class MSRRemoteConnector(MercuryConnector):
     ) -> list:
         return get_resources_for_details(pickup, conditional_resources, other_player)
 
-    async def game_specific_execute(self, item_name: str, items_list: list, provider_name: str) -> None:
+    async def game_specific_execute(
+        self, item_name: str, items_list: list, provider_name: str, region_name: str, provider_uuid: str
+    ) -> None:
         remote_pickups = self.remote_pickups
         num_pickups = self.received_pickups
         message = self.format_received_item(item_name, provider_name)

--- a/randovania/game_connection/connector/msr_remote_connector.py
+++ b/randovania/game_connection/connector/msr_remote_connector.py
@@ -7,6 +7,8 @@ from randovania.game_connection.connector.mercury_remote_connector import Mercur
 from randovania.games.samus_returns.exporter.patch_data_factory import get_resources_for_details
 
 if TYPE_CHECKING:
+    import uuid
+
     from randovania.game_connection.executor.msr_executor import MSRExecutor
     from randovania.game_description.pickup.pickup_entry import ConditionalResources, PickupEntry
 
@@ -26,7 +28,7 @@ class MSRRemoteConnector(MercuryConnector):
         return get_resources_for_details(pickup, conditional_resources, other_player)
 
     async def game_specific_execute(
-        self, item_name: str, items_list: list, provider_name: str, region_name: str, provider_uuid: str
+        self, item_name: str, items_list: list, provider_name: str, region_name: str, provider_uuid: uuid.UUID
     ) -> None:
         remote_pickups = self.remote_pickups
         num_pickups = self.received_pickups

--- a/randovania/game_connection/connector/msr_remote_connector.py
+++ b/randovania/game_connection/connector/msr_remote_connector.py
@@ -26,7 +26,7 @@ class MSRRemoteConnector(MercuryConnector):
         return get_resources_for_details(pickup, conditional_resources, other_player)
 
     async def game_specific_execute(
-        self, item_name: str, items_list: list, provider_name: str, region_name: str, is_coop: bool
+        self, item_name: str, items_list: list, provider_name: str, scenario_id: str
     ) -> None:
         remote_pickups = self.remote_pickups
         num_pickups = self.received_pickups

--- a/randovania/game_connection/connector/msr_remote_connector.py
+++ b/randovania/game_connection/connector/msr_remote_connector.py
@@ -7,8 +7,6 @@ from randovania.game_connection.connector.mercury_remote_connector import Mercur
 from randovania.games.samus_returns.exporter.patch_data_factory import get_resources_for_details
 
 if TYPE_CHECKING:
-    import uuid
-
     from randovania.game_connection.executor.msr_executor import MSRExecutor
     from randovania.game_description.pickup.pickup_entry import ConditionalResources, PickupEntry
 
@@ -28,7 +26,7 @@ class MSRRemoteConnector(MercuryConnector):
         return get_resources_for_details(pickup, conditional_resources, other_player)
 
     async def game_specific_execute(
-        self, item_name: str, items_list: list, provider_name: str, region_name: str, provider_uuid: uuid.UUID
+        self, item_name: str, items_list: list, provider_name: str, region_name: str, is_coop: bool
     ) -> None:
         remote_pickups = self.remote_pickups
         num_pickups = self.received_pickups

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -203,7 +203,7 @@ class PrimeRemoteConnector(RemoteConnector):
         if magic_inv is None or magic_inv.amount > 0 or magic_inv.capacity >= len(remote_pickups) or in_cooldown:
             return False
 
-        provider_name, pickup, pickup_index, is_coop = remote_pickups[magic_inv.capacity]
+        provider_name, pickup, coop_location = remote_pickups[magic_inv.capacity]
         item_patches, message = await self._patches_for_pickup(provider_name, pickup, inventory)
         self.logger.info(f"{len(remote_pickups)} permanent pickups, magic {magic_inv.capacity}. Next pickup: {message}")
 

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -11,9 +11,9 @@ from retro_data_structures.game_check import Game as RDSGame
 
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_connection.connector.remote_connector import (
-    PickupEntryWithOwner,
     PlayerLocationEvent,
     RemoteConnector,
+    RemotePickupTuple,
 )
 from randovania.game_connection.executor.dolphin_executor import DolphinExecutor
 from randovania.game_connection.executor.memory_operation import (
@@ -56,7 +56,7 @@ class PrimeRemoteConnector(RemoteConnector):
     _last_message_size: int = 0
     _last_emitted_region: Region | None = None
     executor: MemoryOperationExecutor
-    remote_pickups: tuple[PickupEntryWithOwner, ...]
+    remote_pickups: tuple[RemotePickupTuple, ...]
     message_cooldown: float = 0.0
     last_inventory: Inventory = {}
     _dt: float = 2.5
@@ -193,7 +193,7 @@ class PrimeRemoteConnector(RemoteConnector):
     async def receive_remote_pickups(
         self,
         inventory: Inventory,
-        remote_pickups: tuple[PickupEntryWithOwner, ...],
+        remote_pickups: tuple[RemotePickupTuple, ...],
     ) -> bool:
         """Returns true if an operation was sent."""
 
@@ -203,7 +203,7 @@ class PrimeRemoteConnector(RemoteConnector):
         if magic_inv is None or magic_inv.amount > 0 or magic_inv.capacity >= len(remote_pickups) or in_cooldown:
             return False
 
-        provider_name, pickup = remote_pickups[magic_inv.capacity]
+        provider_name, pickup, location, provider_uuid = remote_pickups[magic_inv.capacity]
         item_patches, message = await self._patches_for_pickup(provider_name, pickup, inventory)
         self.logger.info(f"{len(remote_pickups)} permanent pickups, magic {magic_inv.capacity}. Next pickup: {message}")
 
@@ -373,7 +373,7 @@ class PrimeRemoteConnector(RemoteConnector):
     async def display_arbitrary_message(self, message: str):
         self.pending_messages.append(message)
 
-    async def set_remote_pickups(self, remote_pickups: tuple[PickupEntryWithOwner, ...]):
+    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickupTuple, ...]):
         """
         Sets the list of remote pickups that must be sent to the game.
         :param remote_pickups: Ordered list of pickups sent from other players, with the name of the player.

--- a/randovania/game_connection/connector/remote_connector.py
+++ b/randovania/game_connection/connector/remote_connector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import enum
 import typing
+import uuid
 
 from PySide6 import QtCore
 
@@ -11,14 +12,12 @@ from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.lib import enum_lib
 
 if typing.TYPE_CHECKING:
-    import uuid
-
     from randovania.game.game_enum import RandovaniaGame
     from randovania.game_description.db.area import Area
     from randovania.game_description.db.region import Region
 
 # provider_name, PickupEntry, PickupIndex, provider_uuid
-RemotePickupTuple = tuple[str, PickupEntry, PickupIndex, str]
+RemotePickupTuple = tuple[str, PickupEntry, PickupIndex, uuid.UUID]
 
 
 class PlayerLocationEvent(typing.NamedTuple):

--- a/randovania/game_connection/connector/remote_connector.py
+++ b/randovania/game_connection/connector/remote_connector.py
@@ -2,22 +2,20 @@ from __future__ import annotations
 
 import enum
 import typing
-import uuid
 
 from PySide6 import QtCore
 
-from randovania.game_description.pickup.pickup_entry import PickupEntry
 from randovania.game_description.resources.inventory import Inventory
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.lib import enum_lib
 
 if typing.TYPE_CHECKING:
+    import uuid
+
     from randovania.game.game_enum import RandovaniaGame
     from randovania.game_description.db.area import Area
     from randovania.game_description.db.region import Region
-
-# provider_name, PickupEntry, PickupIndex, provider_uuid
-RemotePickupTuple = tuple[str, PickupEntry, PickupIndex, uuid.UUID]
+    from randovania.network_common.remote_pickup import RemotePickup
 
 
 class PlayerLocationEvent(typing.NamedTuple):
@@ -82,7 +80,7 @@ class RemoteConnector(QtCore.QObject):
         """
         raise NotImplementedError
 
-    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickupTuple, ...]):
+    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickup, ...]):
         """
         Sets the list of remote pickups that must be sent to the game.
         :param remote_pickups: Ordered list of pickups sent from other players, with the name of the player.

--- a/randovania/game_connection/connector/remote_connector.py
+++ b/randovania/game_connection/connector/remote_connector.py
@@ -17,7 +17,8 @@ if typing.TYPE_CHECKING:
     from randovania.game_description.db.area import Area
     from randovania.game_description.db.region import Region
 
-PickupEntryWithOwner = tuple[str, PickupEntry]
+# provider_name, PickupEntry, PickupIndex, provider_uuid
+RemotePickupTuple = tuple[str, PickupEntry, PickupIndex, str]
 
 
 class PlayerLocationEvent(typing.NamedTuple):
@@ -82,7 +83,7 @@ class RemoteConnector(QtCore.QObject):
         """
         raise NotImplementedError
 
-    async def set_remote_pickups(self, remote_pickups: tuple[PickupEntryWithOwner, ...]):
+    async def set_remote_pickups(self, remote_pickups: tuple[RemotePickupTuple, ...]):
         """
         Sets the list of remote pickups that must be sent to the game.
         :param remote_pickups: Ordered list of pickups sent from other players, with the name of the player.

--- a/randovania/network_client/network_client.py
+++ b/randovania/network_client/network_client.py
@@ -380,7 +380,7 @@ class NetworkClient:
                         item["provider_name"],
                         _decode_pickup(item["pickup"], resource_database),
                         PickupIndex(item["location"]),
-                        item["provider_uuid"],
+                        uuid.UUID(item["provider_uuid"]),
                     )
                     for item in data["pickups"]
                 ),

--- a/randovania/network_client/network_client.py
+++ b/randovania/network_client/network_client.py
@@ -22,6 +22,7 @@ import randovania
 from randovania.bitpacking import bitpacking, construct_pack
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_description import default_database
+from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.lib import container_lib
 from randovania.network_common import (
     admin_actions,
@@ -375,7 +376,12 @@ class NetworkClient:
                 world_id=uuid.UUID(data["world"]),
                 game=game,
                 pickups=tuple(
-                    (item["provider_name"], _decode_pickup(item["pickup"], resource_database))
+                    (
+                        item["provider_name"],
+                        _decode_pickup(item["pickup"], resource_database),
+                        PickupIndex(item["location"]),
+                        item["provider_uuid"],
+                    )
                     for item in data["pickups"]
                 ),
             )

--- a/randovania/network_client/network_client.py
+++ b/randovania/network_client/network_client.py
@@ -380,8 +380,7 @@ class NetworkClient:
                     RemotePickup(
                         item["provider_name"],
                         _decode_pickup(item["pickup"], resource_database),
-                        PickupIndex(item["location"]),
-                        item["is_coop"],
+                        PickupIndex(item["coop_location"]) if item["coop_location"] is not None else None,
                     )
                     for item in data["pickups"]
                 ),

--- a/randovania/network_client/network_client.py
+++ b/randovania/network_client/network_client.py
@@ -42,6 +42,7 @@ from randovania.network_common.multiplayer_session import (
     User,
     WorldUserInventory,
 )
+from randovania.network_common.remote_pickup import RemotePickup
 from randovania.network_common.world_sync import ServerSyncRequest, ServerSyncResponse
 
 if TYPE_CHECKING:
@@ -376,11 +377,11 @@ class NetworkClient:
                 world_id=uuid.UUID(data["world"]),
                 game=game,
                 pickups=tuple(
-                    (
+                    RemotePickup(
                         item["provider_name"],
                         _decode_pickup(item["pickup"], resource_database),
                         PickupIndex(item["location"]),
-                        uuid.UUID(item["provider_uuid"]),
+                        item["is_coop"],
                     )
                     for item in data["pickups"]
                 ),

--- a/randovania/network_common/__init__.py
+++ b/randovania/network_common/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import randovania
 
-SERVER_API_VERSION = 16
+SERVER_API_VERSION = 17
 
 
 def connection_headers():

--- a/randovania/network_common/multiplayer_session.py
+++ b/randovania/network_common/multiplayer_session.py
@@ -15,8 +15,8 @@ from randovania.network_common.game_connection_status import GameConnectionStatu
 from randovania.network_common.session_visibility import MultiplayerSessionVisibility
 
 if TYPE_CHECKING:
-    from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.network_common.remote_inventory import RemoteInventory
+    from randovania.network_common.remote_pickup import RemotePickup
 
 MAX_SESSION_NAME_LENGTH = 50
 MAX_WORLD_NAME_LENGTH = 30
@@ -75,7 +75,7 @@ class MultiplayerWorld(JsonDataclass):
 class MultiplayerWorldPickups:
     world_id: uuid.UUID
     game: RandovaniaGame
-    pickups: tuple[tuple[str, PickupEntry, PickupIndex, uuid.UUID], ...]
+    pickups: tuple[RemotePickup, ...]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/randovania/network_common/multiplayer_session.py
+++ b/randovania/network_common/multiplayer_session.py
@@ -75,7 +75,7 @@ class MultiplayerWorld(JsonDataclass):
 class MultiplayerWorldPickups:
     world_id: uuid.UUID
     game: RandovaniaGame
-    pickups: tuple[tuple[str, PickupEntry], ...]
+    pickups: tuple[tuple[str, PickupEntry, PickupIndex, str], ...]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/randovania/network_common/multiplayer_session.py
+++ b/randovania/network_common/multiplayer_session.py
@@ -75,7 +75,7 @@ class MultiplayerWorld(JsonDataclass):
 class MultiplayerWorldPickups:
     world_id: uuid.UUID
     game: RandovaniaGame
-    pickups: tuple[tuple[str, PickupEntry, PickupIndex, str], ...]
+    pickups: tuple[tuple[str, PickupEntry, PickupIndex, uuid.UUID], ...]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/randovania/network_common/remote_pickup.py
+++ b/randovania/network_common/remote_pickup.py
@@ -1,0 +1,11 @@
+from typing import NamedTuple
+
+from randovania.game_description.pickup.pickup_entry import PickupEntry
+from randovania.game_description.resources.pickup_index import PickupIndex
+
+
+class RemotePickup(NamedTuple):
+    provider_name: str
+    pickup_entry: PickupEntry
+    pickup_index: PickupIndex
+    is_coop: bool

--- a/randovania/network_common/remote_pickup.py
+++ b/randovania/network_common/remote_pickup.py
@@ -7,5 +7,4 @@ from randovania.game_description.resources.pickup_index import PickupIndex
 class RemotePickup(NamedTuple):
     provider_name: str
     pickup_entry: PickupEntry
-    pickup_index: PickupIndex
-    is_coop: bool
+    coop_location: PickupIndex | None

--- a/randovania/server/multiplayer/world_api.py
+++ b/randovania/server/multiplayer/world_api.py
@@ -334,6 +334,7 @@ def emit_world_pickups_update(sa: ServerApp, world: World):
             WorldAction.location,
             World.order,
             World.name,
+            World.uuid,
         )
         .join(World, on=WorldAction.provider)
         .where(WorldAction.receiver == world)
@@ -350,6 +351,8 @@ def emit_world_pickups_update(sa: ServerApp, world: World):
                 {
                     "provider_name": action.provider.name,
                     "pickup": _base64_encode_pickup(pickup_target.pickup, resource_database),
+                    "provider_uuid": str(action.provider.uuid),
+                    "location": action.location,
                 }
             )
 

--- a/randovania/server/multiplayer/world_api.py
+++ b/randovania/server/multiplayer/world_api.py
@@ -351,8 +351,7 @@ def emit_world_pickups_update(sa: ServerApp, world: World):
                 {
                     "provider_name": action.provider.name,
                     "pickup": _base64_encode_pickup(pickup_target.pickup, resource_database),
-                    "location": action.location,
-                    "is_coop": action.provider.uuid == world.uuid,
+                    "coop_location": action.location if action.provider.uuid == world.uuid else None,
                 }
             )
 

--- a/randovania/server/multiplayer/world_api.py
+++ b/randovania/server/multiplayer/world_api.py
@@ -351,8 +351,8 @@ def emit_world_pickups_update(sa: ServerApp, world: World):
                 {
                     "provider_name": action.provider.name,
                     "pickup": _base64_encode_pickup(pickup_target.pickup, resource_database),
-                    "provider_uuid": str(action.provider.uuid),
                     "location": action.location,
+                    "is_coop": action.provider.uuid == world.uuid,
                 }
             )
 

--- a/test/game_connection/connector/test_am2r_remote_connector.py
+++ b/test/game_connection/connector/test_am2r_remote_connector.py
@@ -113,16 +113,22 @@ async def test_new_received_pickups_received(connector: AM2RRemoteConnector):
 
 async def test_set_remote_pickups(connector: AM2RRemoteConnector, am2r_varia_pickup):
     connector.receive_remote_pickups = AsyncMock()
-    pickup_entry_with_owner = (("Dummy 1", am2r_varia_pickup), ("Dummy 2", am2r_varia_pickup))
-    await connector.set_remote_pickups(pickup_entry_with_owner)
-    assert connector.remote_pickups == pickup_entry_with_owner
+    remote_pickups = (
+        ("Dummy 1", am2r_varia_pickup, MagicMock(), MagicMock()),
+        ("Dummy 2", am2r_varia_pickup, MagicMock(), MagicMock()),
+    )
+    await connector.set_remote_pickups(remote_pickups)
+    assert connector.remote_pickups == remote_pickups
 
 
 async def test_receive_remote_pickups(connector: AM2RRemoteConnector, am2r_varia_pickup):
     connector.in_cooldown = False
     connector.current_region = Region(name="Golden Temple", areas=[], extra={})
-    pickup_entry_with_owner = (("Dummy 1", am2r_varia_pickup), ("Dummy 2", am2r_varia_pickup))
-    connector.remote_pickups = pickup_entry_with_owner
+    remote_pickups = (
+        ("Dummy 1", am2r_varia_pickup, MagicMock(), MagicMock()),
+        ("Dummy 2", am2r_varia_pickup, MagicMock(), MagicMock()),
+    )
+    connector.remote_pickups = remote_pickups
 
     connector.received_pickups = None
     await connector.receive_remote_pickups()

--- a/test/game_connection/connector/test_am2r_remote_connector.py
+++ b/test/game_connection/connector/test_am2r_remote_connector.py
@@ -117,8 +117,8 @@ async def test_new_received_pickups_received(connector: AM2RRemoteConnector):
 async def test_set_remote_pickups(connector: AM2RRemoteConnector, am2r_varia_pickup):
     connector.receive_remote_pickups = AsyncMock()
     remote_pickups = (
-        ("Dummy 1", am2r_varia_pickup, MagicMock(), MagicMock()),
-        ("Dummy 2", am2r_varia_pickup, MagicMock(), MagicMock()),
+        ("Dummy 1", am2r_varia_pickup, None),
+        ("Dummy 2", am2r_varia_pickup, None),
     )
     await connector.set_remote_pickups(remote_pickups)
     assert connector.remote_pickups == remote_pickups
@@ -128,8 +128,8 @@ async def test_receive_remote_pickups(connector: AM2RRemoteConnector, am2r_varia
     connector.in_cooldown = False
     connector.current_region = Region(name="Golden Temple", areas=[], extra={})
     remote_pickups = (
-        ("Dummy 1", am2r_varia_pickup, MagicMock(), MagicMock()),
-        ("Dummy 2", am2r_varia_pickup, MagicMock(), MagicMock()),
+        ("Dummy 1", am2r_varia_pickup, None),
+        ("Dummy 2", am2r_varia_pickup, None),
     )
     connector.remote_pickups = remote_pickups
 

--- a/test/game_connection/connector/test_cs_remote_connector.py
+++ b/test/game_connection/connector/test_cs_remote_connector.py
@@ -142,8 +142,8 @@ async def test_set_remote_pickups(connector: CSRemoteConnector, cs_panties_picku
     assert isinstance(connector.executor, MagicMock)
 
     remote_pickups = (
-        ("Dummy 1", cs_panties_pickup, MagicMock(), MagicMock()),
-        ("Dummy 2", cs_panties_pickup, MagicMock(), MagicMock()),
+        ("Dummy 1", cs_panties_pickup, None),
+        ("Dummy 2", cs_panties_pickup, None),
     )
     await connector.set_remote_pickups(remote_pickups)
     assert connector.remote_pickups == remote_pickups
@@ -179,8 +179,8 @@ async def test_receive_items(connector: CSRemoteConnector, cs_panties_pickup):
     connector.executor.exec_script.assert_not_awaited()
 
     remote_pickups = (
-        ("Dummy 1", cs_panties_pickup, MagicMock(), MagicMock()),
-        ("Dummy 2", cs_panties_pickup, MagicMock(), MagicMock()),
+        ("Dummy 1", cs_panties_pickup, None),
+        ("Dummy 2", cs_panties_pickup, None),
     )
     connector.remote_pickups = remote_pickups
 

--- a/test/game_connection/connector/test_cs_remote_connector.py
+++ b/test/game_connection/connector/test_cs_remote_connector.py
@@ -141,9 +141,12 @@ async def test_update_inventory(connector: CSRemoteConnector, has_item: bool, ha
 async def test_set_remote_pickups(connector: CSRemoteConnector, cs_panties_pickup):
     assert isinstance(connector.executor, MagicMock)
 
-    pickup_entry_with_owner = (("Dummy 1", cs_panties_pickup), ("Dummy 2", cs_panties_pickup))
-    await connector.set_remote_pickups(pickup_entry_with_owner)
-    assert connector.remote_pickups == pickup_entry_with_owner
+    remote_pickups = (
+        ("Dummy 1", cs_panties_pickup, MagicMock(), MagicMock()),
+        ("Dummy 2", cs_panties_pickup, MagicMock(), MagicMock()),
+    )
+    await connector.set_remote_pickups(remote_pickups)
+    assert connector.remote_pickups == remote_pickups
 
 
 async def test_receive_items(connector: CSRemoteConnector, cs_panties_pickup):
@@ -175,8 +178,11 @@ async def test_receive_items(connector: CSRemoteConnector, cs_panties_pickup):
     await connector._receive_items()
     connector.executor.exec_script.assert_not_awaited()
 
-    pickup_entry_with_owner = (("Dummy 1", cs_panties_pickup), ("Dummy 2", cs_panties_pickup))
-    connector.remote_pickups = pickup_entry_with_owner
+    remote_pickups = (
+        ("Dummy 1", cs_panties_pickup, MagicMock(), MagicMock()),
+        ("Dummy 2", cs_panties_pickup, MagicMock(), MagicMock()),
+    )
+    connector.remote_pickups = remote_pickups
 
     # send first item
     await connector._receive_items()

--- a/test/game_connection/connector/test_dread_remote_connector.py
+++ b/test/game_connection/connector/test_dread_remote_connector.py
@@ -99,15 +99,21 @@ async def test_new_received_pickups_received(connector: DreadRemoteConnector):
 
 async def test_set_remote_pickups(connector: DreadRemoteConnector, dread_spider_pickup):
     connector.receive_remote_pickups = AsyncMock()
-    pickup_entry_with_owner = (("Dummy 1", dread_spider_pickup), ("Dummy 2", dread_spider_pickup))
-    await connector.set_remote_pickups(pickup_entry_with_owner)
-    assert connector.remote_pickups == pickup_entry_with_owner
+    remote_pickup = (
+        ("Dummy 1", dread_spider_pickup, PickupIndex(1), MagicMock()),
+        ("Dummy 2", dread_spider_pickup, PickupIndex(2), MagicMock()),
+    )
+    await connector.set_remote_pickups(remote_pickup)
+    assert connector.remote_pickups == remote_pickup
 
 
 async def test_receive_remote_pickups(connector: DreadRemoteConnector, dread_spider_pickup):
     connector.in_cooldown = False
-    pickup_entry_with_owner = (("Dummy 1", dread_spider_pickup), ("Dummy 2", dread_spider_pickup))
-    connector.remote_pickups = pickup_entry_with_owner
+    remote_pickup = (
+        ("Dummy 1", dread_spider_pickup, PickupIndex(1), MagicMock()),
+        ("Dummy 2", dread_spider_pickup, PickupIndex(2), MagicMock()),
+    )
+    connector.remote_pickups = remote_pickup
     connector.executor.run_lua_code = AsyncMock()
 
     connector.received_pickups = None

--- a/test/game_connection/connector/test_dread_remote_connector.py
+++ b/test/game_connection/connector/test_dread_remote_connector.py
@@ -100,8 +100,8 @@ async def test_new_received_pickups_received(connector: DreadRemoteConnector):
 async def test_set_remote_pickups(connector: DreadRemoteConnector, dread_spider_pickup):
     connector.receive_remote_pickups = AsyncMock()
     remote_pickup = (
-        ("Dummy 1", dread_spider_pickup, PickupIndex(1), MagicMock()),
-        ("Dummy 2", dread_spider_pickup, PickupIndex(2), MagicMock()),
+        ("Dummy 1", dread_spider_pickup, None),
+        ("Dummy 2", dread_spider_pickup, None),
     )
     await connector.set_remote_pickups(remote_pickup)
     assert connector.remote_pickups == remote_pickup
@@ -110,8 +110,8 @@ async def test_set_remote_pickups(connector: DreadRemoteConnector, dread_spider_
 async def test_receive_remote_pickups(connector: DreadRemoteConnector, dread_spider_pickup):
     connector.in_cooldown = False
     remote_pickup = (
-        ("Dummy 1", dread_spider_pickup, PickupIndex(1), MagicMock()),
-        ("Dummy 2", dread_spider_pickup, PickupIndex(2), MagicMock()),
+        ("Dummy 1", dread_spider_pickup, None),
+        ("Dummy 2", dread_spider_pickup, None),
     )
     connector.remote_pickups = remote_pickup
     connector.executor.run_lua_code = AsyncMock()

--- a/test/game_connection/connector/test_echoes_remote_connector.py
+++ b/test/game_connection/connector/test_echoes_remote_connector.py
@@ -215,8 +215,8 @@ async def test_receive_remote_pickups_give_pickup(
 
     inventory = {connector.multiworld_magic_item: InventoryItem(0, 0)}
     permanent_pickups = (
-        ("A", MagicMock()),
-        ("B", MagicMock()),
+        ("A", MagicMock(), MagicMock(), MagicMock()),
+        ("B", MagicMock(), MagicMock(), MagicMock()),
     )
 
     # Run
@@ -370,7 +370,7 @@ async def test_receive_required_missile_launcher(
     )
 
     connector.execute_remote_patches = AsyncMock()
-    permanent_pickups = (("Received Missile Launcher from Someone Else", pickup),)
+    permanent_pickups = (("Received Missile Launcher from Someone Else", pickup, MagicMock(), MagicMock()),)
 
     inventory = Inventory(
         {

--- a/test/game_connection/connector/test_echoes_remote_connector.py
+++ b/test/game_connection/connector/test_echoes_remote_connector.py
@@ -215,8 +215,8 @@ async def test_receive_remote_pickups_give_pickup(
 
     inventory = {connector.multiworld_magic_item: InventoryItem(0, 0)}
     permanent_pickups = (
-        ("A", MagicMock(), MagicMock(), MagicMock()),
-        ("B", MagicMock(), MagicMock(), MagicMock()),
+        ("A", MagicMock(), None),
+        ("B", MagicMock(), None),
     )
 
     # Run
@@ -370,7 +370,7 @@ async def test_receive_required_missile_launcher(
     )
 
     connector.execute_remote_patches = AsyncMock()
-    permanent_pickups = (("Received Missile Launcher from Someone Else", pickup, MagicMock(), MagicMock()),)
+    permanent_pickups = (("Received Missile Launcher from Someone Else", pickup, None),)
 
     inventory = Inventory(
         {

--- a/test/game_connection/connector/test_msr_remote_connector.py
+++ b/test/game_connection/connector/test_msr_remote_connector.py
@@ -99,15 +99,21 @@ async def test_new_received_pickups_received(connector: MSRRemoteConnector):
 
 async def test_set_remote_pickups(connector: MSRRemoteConnector, msr_ice_beam_pickup):
     connector.receive_remote_pickups = AsyncMock()
-    pickup_entry_with_owner = (("Dummy 1", msr_ice_beam_pickup), ("Dummy 2", msr_ice_beam_pickup))
-    await connector.set_remote_pickups(pickup_entry_with_owner)
-    assert connector.remote_pickups == pickup_entry_with_owner
+    remote_pickup = (
+        ("Dummy 1", msr_ice_beam_pickup, PickupIndex(1), MagicMock()),
+        ("Dummy 2", msr_ice_beam_pickup, PickupIndex(2), MagicMock()),
+    )
+    await connector.set_remote_pickups(remote_pickup)
+    assert connector.remote_pickups == remote_pickup
 
 
 async def test_receive_remote_pickups(connector: MSRRemoteConnector, msr_ice_beam_pickup):
     connector.in_cooldown = False
-    pickup_entry_with_owner = (("Dummy 1", msr_ice_beam_pickup), ("Dummy 2", msr_ice_beam_pickup))
-    connector.remote_pickups = pickup_entry_with_owner
+    remote_pickup = (
+        ("Dummy 1", msr_ice_beam_pickup, PickupIndex(1), MagicMock()),
+        ("Dummy 2", msr_ice_beam_pickup, PickupIndex(2), MagicMock()),
+    )
+    connector.remote_pickups = remote_pickup
     connector.executor.run_lua_code = AsyncMock()
 
     connector.received_pickups = None

--- a/test/game_connection/connector/test_msr_remote_connector.py
+++ b/test/game_connection/connector/test_msr_remote_connector.py
@@ -104,8 +104,8 @@ async def test_new_received_pickups_received(connector: MSRRemoteConnector):
 async def test_set_remote_pickups(connector: MSRRemoteConnector, msr_ice_beam_pickup):
     connector.receive_remote_pickups = AsyncMock()
     remote_pickup = (
-        ("Dummy 1", msr_ice_beam_pickup, PickupIndex(1), MagicMock()),
-        ("Dummy 2", msr_ice_beam_pickup, PickupIndex(2), MagicMock()),
+        ("Dummy 1", msr_ice_beam_pickup, None),
+        ("Dummy 2", msr_ice_beam_pickup, None),
     )
     await connector.set_remote_pickups(remote_pickup)
     assert connector.remote_pickups == remote_pickup
@@ -114,8 +114,8 @@ async def test_set_remote_pickups(connector: MSRRemoteConnector, msr_ice_beam_pi
 async def test_receive_remote_pickups(connector: MSRRemoteConnector, msr_ice_beam_pickup):
     connector.in_cooldown = False
     remote_pickup = (
-        ("Dummy 1", msr_ice_beam_pickup, PickupIndex(1), MagicMock()),
-        ("Dummy 2", msr_ice_beam_pickup, PickupIndex(2), MagicMock()),
+        ("Dummy 1", msr_ice_beam_pickup, None),
+        ("Dummy 2", msr_ice_beam_pickup, None),
     )
     connector.remote_pickups = remote_pickup
     connector.executor.run_lua_code = AsyncMock()
@@ -157,7 +157,7 @@ async def test_receive_remote_pickups(connector: MSRRemoteConnector, msr_ice_bea
 @pytest.mark.parametrize("is_coop", [False, True])
 async def test_receive_remote_pickups_coop_logic(connector: MSRRemoteConnector, msr_ice_beam_pickup, is_coop: bool):
     connector.in_cooldown = False
-    remote_pickup = (("Dummy 1", msr_ice_beam_pickup, PickupIndex(69), is_coop),)
+    remote_pickup = (("Dummy 1", msr_ice_beam_pickup, PickupIndex(69) if is_coop else None),)
     connector.remote_pickups = remote_pickup
     connector.game_specific_execute = AsyncMock()
 

--- a/test/game_connection/connector/test_prime1_remote_connector.py
+++ b/test/game_connection/connector/test_prime1_remote_connector.py
@@ -113,7 +113,7 @@ async def test_multiworld_interaction_missing_remote_pickups(has_cooldown: bool,
     inventory.get = MagicMock()
     inventory.get.return_value = magic_item
 
-    remote_pickups = [("", MagicMock())] if has_patches else []
+    remote_pickups = [("", MagicMock(), MagicMock(), MagicMock())] if has_patches else []
 
     # Run
     await connector.receive_remote_pickups(inventory, remote_pickups)

--- a/test/game_connection/connector/test_prime1_remote_connector.py
+++ b/test/game_connection/connector/test_prime1_remote_connector.py
@@ -113,7 +113,7 @@ async def test_multiworld_interaction_missing_remote_pickups(has_cooldown: bool,
     inventory.get = MagicMock()
     inventory.get.return_value = magic_item
 
-    remote_pickups = [("", MagicMock(), MagicMock(), MagicMock())] if has_patches else []
+    remote_pickups = [("", MagicMock(), None)] if has_patches else []
 
     # Run
     await connector.receive_remote_pickups(inventory, remote_pickups)

--- a/test/network_client/test_network_client.py
+++ b/test/network_client/test_network_client.py
@@ -287,9 +287,9 @@ async def test_refresh_received_pickups(client: NetworkClient, corruption_game_d
             world_id=uuid.UUID("00000000-0000-1111-0000-000000000000"),
             game=RandovaniaGame.METROID_PRIME_CORRUPTION,
             pickups=(
-                ("Message A", pickups[0], PickupIndex(1), "00000000-0000-1111-0000-000000000000"),
-                ("Message B", pickups[1], PickupIndex(2), "00000000-0000-1111-0000-000000000000"),
-                ("Message C", pickups[2], PickupIndex(3), "00000000-0000-1111-0000-000000000000"),
+                ("Message A", pickups[0], PickupIndex(1), uuid.UUID("00000000-0000-1111-0000-000000000000")),
+                ("Message B", pickups[1], PickupIndex(2), uuid.UUID("00000000-0000-1111-0000-000000000000")),
+                ("Message C", pickups[2], PickupIndex(3), uuid.UUID("00000000-0000-1111-0000-000000000000")),
             ),
         )
     )

--- a/test/network_client/test_network_client.py
+++ b/test/network_client/test_network_client.py
@@ -256,20 +256,17 @@ async def test_refresh_received_pickups(client: NetworkClient, corruption_game_d
             {
                 "provider_name": "Message A",
                 "pickup": "VtI6Bb3p",
-                "location": 1,
-                "is_coop": False,
+                "coop_location": None,
             },
             {
                 "provider_name": "Message B",
                 "pickup": "VtI6Bb3y",
-                "location": 2,
-                "is_coop": False,
+                "coop_location": None,
             },
             {
                 "provider_name": "Message C",
                 "pickup": "VtI6Bb3*",
-                "location": 3,
-                "is_coop": True,
+                "coop_location": 3,
             },
         ],
     }
@@ -288,9 +285,9 @@ async def test_refresh_received_pickups(client: NetworkClient, corruption_game_d
             world_id=uuid.UUID("00000000-0000-1111-0000-000000000000"),
             game=RandovaniaGame.METROID_PRIME_CORRUPTION,
             pickups=(
-                RemotePickup("Message A", pickups[0], PickupIndex(1), False),
-                RemotePickup("Message B", pickups[1], PickupIndex(2), False),
-                RemotePickup("Message C", pickups[2], PickupIndex(3), True),
+                RemotePickup("Message A", pickups[0], None),
+                RemotePickup("Message B", pickups[1], None),
+                RemotePickup("Message C", pickups[2], PickupIndex(3)),
             ),
         )
     )

--- a/test/network_client/test_network_client.py
+++ b/test/network_client/test_network_client.py
@@ -20,6 +20,7 @@ from randovania.network_common import connection_headers, remote_inventory
 from randovania.network_common.admin_actions import SessionAdminGlobalAction
 from randovania.network_common.error import InvalidSessionError, RequestTimeoutError, ServerError
 from randovania.network_common.multiplayer_session import MultiplayerWorldPickups, WorldUserInventory
+from randovania.network_common.remote_pickup import RemotePickup
 
 if TYPE_CHECKING:
     import pytest_mock
@@ -256,19 +257,19 @@ async def test_refresh_received_pickups(client: NetworkClient, corruption_game_d
                 "provider_name": "Message A",
                 "pickup": "VtI6Bb3p",
                 "location": 1,
-                "provider_uuid": "00000000-0000-1111-0000-000000000000",
+                "is_coop": False,
             },
             {
                 "provider_name": "Message B",
                 "pickup": "VtI6Bb3y",
                 "location": 2,
-                "provider_uuid": "00000000-0000-1111-0000-000000000000",
+                "is_coop": False,
             },
             {
                 "provider_name": "Message C",
                 "pickup": "VtI6Bb3*",
                 "location": 3,
-                "provider_uuid": "00000000-0000-1111-0000-000000000000",
+                "is_coop": True,
             },
         ],
     }
@@ -287,9 +288,9 @@ async def test_refresh_received_pickups(client: NetworkClient, corruption_game_d
             world_id=uuid.UUID("00000000-0000-1111-0000-000000000000"),
             game=RandovaniaGame.METROID_PRIME_CORRUPTION,
             pickups=(
-                ("Message A", pickups[0], PickupIndex(1), uuid.UUID("00000000-0000-1111-0000-000000000000")),
-                ("Message B", pickups[1], PickupIndex(2), uuid.UUID("00000000-0000-1111-0000-000000000000")),
-                ("Message C", pickups[2], PickupIndex(3), uuid.UUID("00000000-0000-1111-0000-000000000000")),
+                RemotePickup("Message A", pickups[0], PickupIndex(1), False),
+                RemotePickup("Message B", pickups[1], PickupIndex(2), False),
+                RemotePickup("Message C", pickups[2], PickupIndex(3), True),
             ),
         )
     )

--- a/test/network_client/test_network_client.py
+++ b/test/network_client/test_network_client.py
@@ -14,6 +14,7 @@ from randovania.game.game_enum import RandovaniaGame
 from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupModel
 from randovania.game_description.resources.inventory import Inventory, InventoryItem
 from randovania.game_description.resources.item_resource_info import ItemResourceInfo
+from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.network_client.network_client import ConnectionState, NetworkClient, UnableToConnect, _decode_pickup
 from randovania.network_common import connection_headers, remote_inventory
 from randovania.network_common.admin_actions import SessionAdminGlobalAction
@@ -251,9 +252,24 @@ async def test_refresh_received_pickups(client: NetworkClient, corruption_game_d
         "world": "00000000-0000-1111-0000-000000000000",
         "game": RandovaniaGame.METROID_PRIME_CORRUPTION.value,
         "pickups": [
-            {"provider_name": "Message A", "pickup": "VtI6Bb3p"},
-            {"provider_name": "Message B", "pickup": "VtI6Bb3y"},
-            {"provider_name": "Message C", "pickup": "VtI6Bb3*"},
+            {
+                "provider_name": "Message A",
+                "pickup": "VtI6Bb3p",
+                "location": 1,
+                "provider_uuid": "00000000-0000-1111-0000-000000000000",
+            },
+            {
+                "provider_name": "Message B",
+                "pickup": "VtI6Bb3y",
+                "location": 2,
+                "provider_uuid": "00000000-0000-1111-0000-000000000000",
+            },
+            {
+                "provider_name": "Message C",
+                "pickup": "VtI6Bb3*",
+                "location": 3,
+                "provider_uuid": "00000000-0000-1111-0000-000000000000",
+            },
         ],
     }
 
@@ -271,9 +287,9 @@ async def test_refresh_received_pickups(client: NetworkClient, corruption_game_d
             world_id=uuid.UUID("00000000-0000-1111-0000-000000000000"),
             game=RandovaniaGame.METROID_PRIME_CORRUPTION,
             pickups=(
-                ("Message A", pickups[0]),
-                ("Message B", pickups[1]),
-                ("Message C", pickups[2]),
+                ("Message A", pickups[0], PickupIndex(1), "00000000-0000-1111-0000-000000000000"),
+                ("Message B", pickups[1], PickupIndex(2), "00000000-0000-1111-0000-000000000000"),
+                ("Message C", pickups[2], PickupIndex(3), "00000000-0000-1111-0000-000000000000"),
             ),
         )
     )

--- a/test/server/multiplayer/test_world_api.py
+++ b/test/server/multiplayer/test_world_api.py
@@ -109,7 +109,14 @@ def test_emit_world_pickups_update_one_action(
         "world_pickups_update",
         {
             "game": "prime2",
-            "pickups": [{"provider_name": "World 2", "pickup": result}],
+            "pickups": [
+                {
+                    "provider_name": "World 2",
+                    "pickup": result,
+                    "provider_uuid": "6b5ac1a1-d250-4f05-a5fb-ae37e8a92165",
+                    "location": 0,
+                }
+            ],
             "world": "1179c986-758a-4170-9b07-fe4541d78db0",
         },
         room="world-1179c986-758a-4170-9b07-fe4541d78db0",

--- a/test/server/multiplayer/test_world_api.py
+++ b/test/server/multiplayer/test_world_api.py
@@ -113,8 +113,8 @@ def test_emit_world_pickups_update_one_action(
                 {
                     "provider_name": "World 2",
                     "pickup": result,
-                    "provider_uuid": "6b5ac1a1-d250-4f05-a5fb-ae37e8a92165",
                     "location": 0,
+                    "is_coop": False,
                 }
             ],
             "world": "1179c986-758a-4170-9b07-fe4541d78db0",

--- a/test/server/multiplayer/test_world_api.py
+++ b/test/server/multiplayer/test_world_api.py
@@ -113,8 +113,7 @@ def test_emit_world_pickups_update_one_action(
                 {
                     "provider_name": "World 2",
                     "pickup": result,
-                    "location": 0,
-                    "is_coop": False,
+                    "coop_location": None,
                 }
             ],
             "world": "1179c986-758a-4170-9b07-fe4541d78db0",


### PR DESCRIPTION
Need this to fix MSR DNA counter in coop.
Provider UUID to compare to remote connector UUID. If it's the same, it's a coop item.
Pickup index to find the region of the pickup for the coop world.