### PR TITLE
Ensure that inventory only contains ints and no floats

### DIFF
--- a/randovania/game_connection/connector/mercury_remote_connector.py
+++ b/randovania/game_connection/connector/mercury_remote_connector.py
@@ -101,7 +101,8 @@ class MercuryConnector(RemoteConnector):
         try:
             inventory_json = json.loads(json_string)
             self.inventory_index = inventory_json["index"]
-            inventory_ints: list[int] = inventory_json["inventory"]
+            # just round the values to ints because aeion can be a float in MSR
+            inventory_ints: list[int] = [round(inv_float) for inv_float in inventory_json["inventory"]]
         except Exception as e:
             self.logger.error("Unknown response: %s (got %s)", json_string, e)
             return

--- a/test/game_connection/connector/test_msr_remote_connector.py
+++ b/test/game_connection/connector/test_msr_remote_connector.py
@@ -70,20 +70,24 @@ async def test_new_inventory_received(connector: MSRRemoteConnector):
     inventory_updated.assert_not_called()
 
     assert connector.inventory_index is None
-    connector.new_inventory_received('{"index": 69, "inventory": [0,1,0,1]}')
+    connector.new_inventory_received('{"index": 69, "inventory": [0,1,0,1,275.323]}')
     assert connector.inventory_index == 69
 
     # check ice beam
-    plasma_beam = connector.game.resource_database.get_item_by_name("Ice Beam")
-    assert connector.last_inventory[plasma_beam].capacity == 1
+    ice_beam = connector.game.resource_database.get_item_by_name("Ice Beam")
+    assert connector.last_inventory[ice_beam].capacity == 1
 
     # check wave beam
-    plasma_beam = connector.game.resource_database.get_item_by_name("Wave Beam")
-    assert connector.last_inventory[plasma_beam].capacity == 0
+    wave_beam = connector.game.resource_database.get_item_by_name("Wave Beam")
+    assert connector.last_inventory[wave_beam].capacity == 0
 
     # check spazer beam
     spazer_beam = connector.game.resource_database.get_item_by_name("Spazer Beam")
     assert connector.last_inventory[spazer_beam].capacity == 1
+
+    # check rounding floats to ints via plasma beam item
+    plasma_beam = connector.game.resource_database.get_item_by_name("Plasma Beam")
+    assert connector.last_inventory[plasma_beam].capacity == 275
 
     inventory_updated.assert_called_once()
 


### PR DESCRIPTION
Fixes #6961

That should do the trick if I understand correctly.

Afaik this was catched in the source and only shown in the console. Was there anything else which the user experienced that it would be worth a changelog entry?