### PR TITLE
Fix: Generator now has proper starting energy based on items that increase it.

### DIFF
--- a/randovania/resolver/bootstrap.py
+++ b/randovania/resolver/bootstrap.py
@@ -129,7 +129,9 @@ class Bootstrap:
         starting_state = State(
             initial_resources,
             (),
-            self.create_damage_state(game, configuration),
+            self.create_damage_state(game, configuration).apply_collected_resource_difference(
+                initial_resources, ResourceCollection()
+            ),
             starting_node,
             patches,
             None,


### PR DESCRIPTION
Fixes #7667

Another way to fix it would be to provide a ResourceCollection to `create_damage_state` which each implementation then uses to calculate the proper starting energy. 
But this feels cleaner to me.