### PR TITLE
Co op: make clearer why check is disabled during/after gen

### DIFF
--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -360,6 +360,8 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         self.advanced_options_tool.setEnabled(session.users[self.network_client.current_user.id].admin)
         # self.customize_user_preferences_button.setEnabled(self.current_player_game is not None)
 
+        not_genned_yet = self._session.game_details is None and self._session.generation_in_progress is None
+
         self.setWindowTitle(f"Multiworld Session: {self._session.name}")
         self.users_widget.update_state(self._session)
         self.sync_background_process_to_session()
@@ -370,10 +372,9 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         self.everyone_can_claim_check.setChecked(session.allow_everyone_claim_world)
         self.everyone_can_claim_check.setEnabled(self.users_widget.is_admin())
         self.allow_coop_check.setChecked(session.allow_coop)
-        self.allow_coop_check.setEnabled(
-            self.users_widget.is_admin()
-            and self._session.game_details is None
-            and self._session.generation_in_progress is None
+        self.allow_coop_check.setEnabled(self.users_widget.is_admin() and not_genned_yet)
+        self.allow_coop_check.setText(
+            "Enable Co-Op" + ("" if not_genned_yet else " (can only be changed before generation)")
         )
         self.allow_coop_check.setVisible(not randovania.is_frozen())
 


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/678f316c-4d61-496c-bae1-2a8e656459a2)
![grafik](https://github.com/user-attachments/assets/178eeb26-1d0a-4aea-9caa-712c55494b70)
