### PR TITLE
minimize unnecessary use of type: ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,17 +289,36 @@ files = [
 follow_imports = "silent"
 disallow_untyped_defs = true
 local_partial_types = true
+warn_unused_ignores = true
+enable_error_code = [
+    "ignore-without-code",
+]
 
 [[tool.mypy.overrides]]
 module = "test.*"
 disallow_untyped_defs = false
 check_untyped_defs = true
-disable_error_code = "method-assign"
+disable_error_code = [
+    "method-assign",
+]
 
 [[tool.mypy.overrides]]
-module = "randovania.games.*.gui.generated.*"
+module = "randovania.*.gui.generated.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = "randovania.gui.generated.*"
-disallow_untyped_defs = false
+# any dependencies which we do not control but are missing types go here
+# not too much can be done about these, so they're not the end of the world
+# dependencies we DO control should use `type: ignore[import-untyped]`
+module = [
+    "bitstruct.*",
+    "construct.*",
+    "graphviz.*",
+    "htmlmin.*",
+    "json_delta.*",
+    "networkx.*",
+    "pytest_localftpserver.*",
+    "pytestqt.*",
+    "qasync.*",
+]
+ignore_missing_imports = true

--- a/pyuic.json
+++ b/pyuic.json
@@ -57,5 +57,5 @@
     "pyrcc": "pyside6-rcc",
     "pyrcc_options": "",
     "pyuic": "pyside6-uic",
-    "pyuic_options": "--star-imports"
+    "pyuic_options": "--absolute-imports"
 }

--- a/randovania/bitpacking/bitpacking.py
+++ b/randovania/bitpacking/bitpacking.py
@@ -7,7 +7,7 @@ import typing
 from enum import Enum
 from typing import TYPE_CHECKING, TypeVar
 
-import bitstruct  # type: ignore
+import bitstruct
 
 from randovania.lib import type_lib
 

--- a/randovania/bitpacking/construct_pack.py
+++ b/randovania/bitpacking/construct_pack.py
@@ -8,7 +8,7 @@ import typing
 import uuid
 from enum import Enum
 
-import construct  # type: ignore[import-untyped]
+import construct
 from frozendict import frozendict
 
 from randovania.lib import construct_lib, type_lib

--- a/randovania/cli/__init__.py
+++ b/randovania/cli/__init__.py
@@ -56,7 +56,7 @@ def _run_args(parser: ArgumentParser, args: Namespace) -> int:
 def run_pytest(argv: list[str]) -> None:
     import pytest
     import pytest_asyncio.plugin
-    import pytest_localftpserver.plugin  # type: ignore[import-untyped]
+    import pytest_localftpserver.plugin
     import pytest_mock.plugin
 
     sys.exit(pytest.main(argv[2:], plugins=[pytest_asyncio.plugin, pytest_mock.plugin, pytest_localftpserver.plugin]))

--- a/randovania/cli/commands/export_db_videos.py
+++ b/randovania/cli/commands/export_db_videos.py
@@ -300,7 +300,7 @@ def generate_region_html(name: str, areas: dict[str, AreaVideos]) -> str:
 
     html = header + toc + body + HTML_FOOTER
 
-    from htmlmin import minify  # type: ignore
+    from htmlmin import minify
 
     return minify(html, remove_comments=True, remove_all_empty_space=True)
 

--- a/randovania/cli/commands/render_regions.py
+++ b/randovania/cli/commands/render_regions.py
@@ -12,7 +12,7 @@ def render_region_graph_logic(args: Namespace) -> None:
     import hashlib
     import re
 
-    import graphviz  # type: ignore
+    import graphviz
 
     from randovania.game.game_enum import RandovaniaGame
     from randovania.game_description import default_database

--- a/randovania/exporter/patch_data_factory.py
+++ b/randovania/exporter/patch_data_factory.py
@@ -4,7 +4,7 @@ import typing
 from random import Random
 from typing import TYPE_CHECKING
 
-import json_delta  # type: ignore
+import json_delta
 
 from randovania.exporter import pickup_exporter
 from randovania.game_description import default_database

--- a/randovania/game_connection/connector/dread_remote_connector.py
+++ b/randovania/game_connection/connector/dread_remote_connector.py
@@ -31,7 +31,7 @@ class DreadRemoteConnector(MercuryConnector):
         remote_pickups = self.remote_pickups
         num_pickups = self.received_pickups
 
-        from open_dread_rando.misc_patches.lua_util import lua_convert  # type: ignore
+        from open_dread_rando.misc_patches.lua_util import lua_convert  # type: ignore[import-untyped]
 
         progression_as_lua = lua_convert(items_list, True)
         message = self.format_received_item(item_name, provider_name)
@@ -39,7 +39,7 @@ class DreadRemoteConnector(MercuryConnector):
         self.logger.info("%d permanent pickups, magic %d. Next pickup: %s", len(remote_pickups), num_pickups, message)
 
         main_item_id = items_list[0][0]["item_id"]
-        from open_dread_rando.pickups.lua_editor import LuaEditor  # type: ignore
+        from open_dread_rando.pickups.lua_editor import LuaEditor  # type: ignore[import-untyped]
 
         # use any none 0 quantity
         parent = LuaEditor.get_parent_for(None, main_item_id, 1)

--- a/randovania/game_connection/connector/mercury_remote_connector.py
+++ b/randovania/game_connection/connector/mercury_remote_connector.py
@@ -6,7 +6,7 @@ import typing
 import uuid
 from typing import TYPE_CHECKING
 
-from qasync import asyncSlot  # type: ignore
+from qasync import asyncSlot
 
 from randovania.exporter.pickup_exporter import _conditional_resources_for_pickup
 from randovania.game_connection.connector.remote_connector import (

--- a/randovania/game_connection/executor/dread_executor.py
+++ b/randovania/game_connection/executor/dread_executor.py
@@ -51,7 +51,7 @@ class ClientInterests(IntEnum):
 # FIXME: This is a copy of ODR's implementation just that the first param is a path instead of a name
 # for a file within ODR's template folder
 def replace_lua_template(file: Path, replacement: dict[str, Any], wrap_strings: bool = False) -> str:
-    from open_dread_rando.misc_patches.lua_util import lua_convert  # type: ignore
+    from open_dread_rando.misc_patches.lua_util import lua_convert  # type: ignore[import-untyped]
 
     code = file.read_text()
     for key, content in replacement.items():

--- a/randovania/game_connection/executor/msr_executor.py
+++ b/randovania/game_connection/executor/msr_executor.py
@@ -50,7 +50,7 @@ class ClientInterests(IntEnum):
 # FIXME: This is a copy of ODR's implementation just that the first param is a path instead of a name
 # for a file within ODR's template folder
 def replace_lua_template(file: Path, replacement: dict[str, Any], wrap_strings: bool = False) -> str:
-    from open_samus_returns_rando.misc_patches.lua_util import lua_convert  # type: ignore
+    from open_samus_returns_rando.misc_patches.lua_util import lua_convert
 
     code = file.read_text()
     for key, content in replacement.items():

--- a/randovania/game_description/db/dock_lock_node.py
+++ b/randovania/game_description/db/dock_lock_node.py
@@ -58,7 +58,7 @@ class DockLockNode(ResourceNode):
     def should_collect(self, context: NodeContext) -> bool:
         dock = self.dock
 
-        patches: GamePatches = context.patches  # type: ignore
+        patches: GamePatches = context.patches  # type: ignore[assignment]
         front_weak = patches.get_dock_weakness_for(dock)
         if not context.has_resource(self.resource(context)):
             if front_weak.lock is not None:
@@ -79,7 +79,7 @@ class DockLockNode(ResourceNode):
         dock_resource = self.resource(context)
         target_resource = NodeResourceInfo.from_node(dock.get_target_node(context), context)
 
-        patches: GamePatches = context.patches  # type: ignore
+        patches: GamePatches = context.patches  # type: ignore[assignment]
         front_weak = patches.get_dock_weakness_for(dock)
         if not context.has_resource(dock_resource) and front_weak.lock is not None:
             yield dock_resource, 1

--- a/randovania/game_description/db/dock_node.py
+++ b/randovania/game_description/db/dock_node.py
@@ -19,7 +19,7 @@ if typing.TYPE_CHECKING:
 
 def _requirement_from_back(context: NodeContext, target_node: Node) -> ResourceRequirement | None:
     if isinstance(target_node, DockNode):
-        patches: GamePatches = context.patches  # type: ignore
+        patches: GamePatches = context.patches  # type: ignore[assignment]
         weak = patches.get_dock_weakness_for(target_node)
         if weak.lock is not None:
             return ResourceRequirement.simple(NodeResourceInfo.from_node(target_node, context))
@@ -56,7 +56,7 @@ class DockNode(Node):
         return f"DockNode({self.name!r} -> {self.default_connection})"
 
     def get_back_weakness(self, context: NodeContext) -> DockWeakness | None:
-        patches: GamePatches = context.patches  # type: ignore
+        patches: GamePatches = context.patches  # type: ignore[assignment]
         target_node = patches.get_dock_connection_for(self)
         if isinstance(target_node, DockNode):
             return patches.get_dock_weakness_for(target_node)
@@ -80,7 +80,7 @@ class DockNode(Node):
         context: NodeContext,
         target_node: Node,
     ) -> tuple[Node, Requirement]:
-        patches: GamePatches = context.patches  # type: ignore
+        patches: GamePatches = context.patches  # type: ignore[assignment]
         forward_weakness = patches.get_dock_weakness_for(self)
 
         reqs: list[Requirement] = [self._get_open_requirement(context, forward_weakness)]
@@ -104,7 +104,7 @@ class DockNode(Node):
     def _lock_connection(self, context: NodeContext) -> tuple[Node, Requirement] | None:
         requirement = Requirement.trivial()
 
-        patches: GamePatches = context.patches  # type: ignore
+        patches: GamePatches = context.patches  # type: ignore[assignment]
         forward_weakness = patches.get_dock_weakness_for(self)
         forward_lock = forward_weakness.lock
 
@@ -125,11 +125,11 @@ class DockNode(Node):
         return self.lock_node, requirement
 
     def get_target_node(self, context: NodeContext) -> Node:
-        patches: GamePatches = context.patches  # type: ignore
+        patches: GamePatches = context.patches  # type: ignore[assignment]
         return patches.get_dock_connection_for(self)
 
     def connections_from(self, context: NodeContext) -> Iterator[tuple[Node, Requirement]]:
-        patches: GamePatches = context.patches  # type: ignore
+        patches: GamePatches = context.patches  # type: ignore[assignment]
         result: Iterable[tuple[Node, Requirement]] | None = patches.get_cached_dock_connections_from(self)
         if result is None:
             connections = []

--- a/randovania/game_description/integrity_check.py
+++ b/randovania/game_description/integrity_check.py
@@ -194,7 +194,7 @@ def find_region_errors(game: GameDescription, region: Region) -> Iterator[str]:
 
 
 def find_invalid_strongly_connected_components(game: GameDescription) -> Iterator[str]:
-    import networkx  # type: ignore
+    import networkx
 
     graph = networkx.DiGraph()
 

--- a/randovania/game_description/node_search.py
+++ b/randovania/game_description/node_search.py
@@ -32,7 +32,7 @@ def distances_to_node(
     :param patches:
     :return: Dict keyed by area to shortest distance to starting_node.
     """
-    import networkx  # type: ignore
+    import networkx
 
     g = networkx.DiGraph()
 

--- a/randovania/games/samus_returns/gui/dialog/game_export_dialog.py
+++ b/randovania/games/samus_returns/gui/dialog/game_export_dialog.py
@@ -6,7 +6,7 @@ import platform
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from construct import StreamError  # type: ignore
+from construct import StreamError
 from PySide6 import QtGui, QtWidgets
 
 from randovania.game.game_enum import RandovaniaGame

--- a/randovania/generator/old_generator_reach.py
+++ b/randovania/generator/old_generator_reach.py
@@ -266,9 +266,7 @@ class OldGeneratorReach(GeneratorReach):
     def nodes(self) -> Iterator[Node]:
         for i, node in enumerate(typing.cast(tuple[Node, ...], self.all_nodes)):
             if i in self._digraph:
-                # entries in all_nodes can be None, but never for an index that's in _digraph
-                # We'd do `assert node is not None`, but we're skipping that here for speed
-                yield node  # type: ignore
+                yield node
 
     @property
     def safe_nodes(self) -> Iterator[Node]:
@@ -277,8 +275,7 @@ class OldGeneratorReach(GeneratorReach):
 
         all_nodes = typing.cast(tuple[Node, ...], self.all_nodes)
         for i in self._safe_nodes.as_list:
-            # safe disclaimer as `nodes`
-            yield all_nodes[i]  # type: ignore
+            yield all_nodes[i]
 
     def is_safe_node(self, node: Node) -> bool:
         node_index = node.node_index

--- a/randovania/gui/data_editor.py
+++ b/randovania/gui/data_editor.py
@@ -10,7 +10,7 @@ import frozendict
 from PySide6 import QtGui, QtWidgets
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QDialog, QFileDialog, QInputDialog, QMainWindow, QMessageBox, QRadioButton
-from qasync import asyncSlot  # type: ignore
+from qasync import asyncSlot
 
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_description import (
@@ -111,7 +111,7 @@ class DataEditorWindow(QMainWindow, Ui_DataEditorWindow):
         self.edit_mode = edit_mode
         self.radio_button_to_node = {}
 
-        self.setCentralWidget(None)  # type: ignore
+        self.setCentralWidget(None)  # type: ignore[arg-type]
         # self.points_of_interest_dock.hide()
         # self.node_info_dock.hide()
         self.splitDockWidget(self.points_of_interest_dock, self.area_view_dock, Qt.Orientation.Horizontal)

--- a/randovania/gui/dialog/base_cosmetic_patches_dialog.py
+++ b/randovania/gui/dialog/base_cosmetic_patches_dialog.py
@@ -33,7 +33,7 @@ class BaseCosmeticPatchesDialog(QtWidgets.QDialog):
         def persist_field(value: bool) -> None:
             self._cosmetic_patches = dataclasses.replace(
                 self._cosmetic_patches,
-                **{attribute_name: value},  # type: ignore[arg-type]
+                **{attribute_name: value},
             )
 
         signal_handling.on_checked(check, persist_field)

--- a/randovania/gui/widgets/game_connection_window.py
+++ b/randovania/gui/widgets/game_connection_window.py
@@ -4,10 +4,10 @@ import collections
 import functools
 from typing import TYPE_CHECKING
 
-import wiiload  # type: ignore
+import wiiload  # type: ignore[import-untyped]
 from PySide6 import QtCore, QtGui, QtWidgets
 from PySide6.QtCore import Qt
-from qasync import asyncSlot  # type: ignore
+from qasync import asyncSlot
 
 import randovania
 from randovania.game.game_enum import RandovaniaGame

--- a/randovania/layout/layout_description.py
+++ b/randovania/layout/layout_description.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from random import Random
 
-import construct  # type: ignore[import-untyped]
+import construct
 
 import randovania
 from randovania.game.game_enum import RandovaniaGame

--- a/randovania/layout/permalink.py
+++ b/randovania/layout/permalink.py
@@ -9,7 +9,7 @@ import operator
 from typing import TYPE_CHECKING
 
 import bitstruct
-import construct  # type: ignore[import-untyped]
+import construct
 
 import randovania
 from randovania.bitpacking.bitpacking import single_byte_hash

--- a/randovania/layout/versioned_preset.py
+++ b/randovania/layout/versioned_preset.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import aiofiles
-import construct  # type: ignore[import-untyped]
+import construct
 import slugify
 
 from randovania.game.game_enum import RandovaniaGame

--- a/randovania/lib/construct_lib.py
+++ b/randovania/lib/construct_lib.py
@@ -4,7 +4,7 @@ import json
 import typing
 from typing import Any
 
-import construct  # type: ignore[import-untyped]
+import construct
 from construct import CString, Flag, If, PascalString, PrefixedArray, Rebuild, Struct, VarInt
 
 if typing.TYPE_CHECKING:
@@ -14,11 +14,11 @@ String = PascalString(VarInt, "utf-8")
 
 
 def add_emit_build(con: construct.Construct, emit: typing.Callable[[CodeGen], str]) -> None:
-    con._emitbuild = emit  # type: ignore[attr-defined]
+    con._emitbuild = emit
 
 
 def compile_build_struct(con: construct.Construct, code: CodeGen) -> str:
-    return con._compilebuild(code)  # type: ignore[attr-defined]
+    return con._compilebuild(code)
 
 
 def varint_emitbuild(code: CodeGen) -> str:

--- a/randovania/lib/obfuscator.py
+++ b/randovania/lib/obfuscator.py
@@ -6,7 +6,7 @@ import cryptography
 from cryptography.fernet import Fernet
 
 try:
-    from randovania.lib.obfuscator_secret import secret as _secret  # type: ignore
+    from randovania.lib.obfuscator_secret import secret as _secret  # type: ignore[import-not-found]
 except ImportError:
     _secret = None
 

--- a/randovania/network_client/network_client.py
+++ b/randovania/network_client/network_client.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import aiofiles
 import aiohttp
-import construct  # type: ignore[import-untyped]
+import construct
 import sentry_sdk
 import socketio
 import socketio.exceptions

--- a/randovania/network_common/remote_inventory.py
+++ b/randovania/network_common/remote_inventory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import construct  # type: ignore[import-untyped]
+import construct
 
 from randovania.bitpacking import construct_pack
 from randovania.game_description.resources.inventory import Inventory, InventoryItem

--- a/test/games/blank/gui/dialog/test_blank_cosmetic_patches_dialog.py
+++ b/test/games/blank/gui/dialog/test_blank_cosmetic_patches_dialog.py
@@ -6,7 +6,7 @@ from randovania.games.blank.gui.dialog.cosmetic_patches_dialog import BlankCosme
 from randovania.games.blank.layout import BlankCosmeticPatches
 
 if TYPE_CHECKING:
-    import pytestqt.qtbot  # type: ignore[import]
+    import pytestqt.qtbot
 
 
 def test_reset(skip_qtbot: pytestqt.qtbot.QtBot) -> None:

--- a/test/games/cave_story/gui/test_cs_cosmetic_patches_dialog.py
+++ b/test/games/cave_story/gui/test_cs_cosmetic_patches_dialog.py
@@ -14,7 +14,7 @@ from randovania.games.cave_story.layout.cs_cosmetic_patches import (
 )
 
 if TYPE_CHECKING:
-    import pytestqt.qtbot  # type: ignore[import]
+    import pytestqt.qtbot
 
 
 def test_change_mychar(skip_qtbot: pytestqt.qtbot.QtBot) -> None:

--- a/test/games/dread/gui/test_dread_cosmetic_patches_dialog.py
+++ b/test/games/dread/gui/test_dread_cosmetic_patches_dialog.py
@@ -15,7 +15,7 @@ from randovania.games.dread.layout.dread_cosmetic_patches import (
 from randovania.gui.lib.signal_handling import set_combo_with_value
 
 if TYPE_CHECKING:
-    import pytestqt.qtbot  # type: ignore[import]
+    import pytestqt.qtbot
 
 
 @pytest.mark.parametrize(

--- a/test/games/prime1/gui/dialog/test_prime_cosmetic_patches_dialog.py
+++ b/test/games/prime1/gui/dialog/test_prime_cosmetic_patches_dialog.py
@@ -11,7 +11,7 @@ from randovania.games.prime1.gui.dialog.prime_cosmetic_patches_dialog import (
 from randovania.games.prime1.layout.prime_cosmetic_patches import PrimeCosmeticPatches
 
 if TYPE_CHECKING:
-    import pytestqt.qtbot  # type: ignore[import]
+    import pytestqt.qtbot
 
 
 def test_open_map(skip_qtbot: pytestqt.qtbot.QtBot) -> None:

--- a/test/games/prime2/gui/dialog/test_echoes_cosmetic_patches_dialog.py
+++ b/test/games/prime2/gui/dialog/test_echoes_cosmetic_patches_dialog.py
@@ -9,7 +9,7 @@ from randovania.games.prime2.layout.echoes_cosmetic_patches import EchoesCosmeti
 from randovania.games.prime2.layout.echoes_user_preferences import EchoesUserPreferences, SoundMode
 
 if TYPE_CHECKING:
-    import pytestqt.qtbot  # type: ignore[import]
+    import pytestqt.qtbot
 
 
 def test_suit_cosmetics(skip_qtbot: pytestqt.qtbot.QtBot) -> None:

--- a/test/games/prime3/gui/dialog/test_corruption_cosmetic_patches_dialog.py
+++ b/test/games/prime3/gui/dialog/test_corruption_cosmetic_patches_dialog.py
@@ -9,7 +9,7 @@ from randovania.games.prime3.layout.corruption_cosmetic_patches import Corruptio
 from randovania.gui.lib.signal_handling import set_combo_with_value
 
 if TYPE_CHECKING:
-    import pytestqt.qtbot  # type: ignore[import]
+    import pytestqt.qtbot
 
 
 def test_random_welding_colors(skip_qtbot: pytestqt.qtbot.QtBot) -> None:

--- a/test/games/samus_returns/gui/dialog/test_msr_cosmetic_patches_dialog.py
+++ b/test/games/samus_returns/gui/dialog/test_msr_cosmetic_patches_dialog.py
@@ -10,7 +10,7 @@ from randovania.games.samus_returns.layout.msr_cosmetic_patches import MSRCosmet
 from randovania.gui.lib.signal_handling import set_combo_with_value
 
 if TYPE_CHECKING:
-    import pytestqt.qtbot  # type: ignore[import]
+    import pytestqt.qtbot
 
 
 @pytest.mark.parametrize(

--- a/test/games/super_metroid/gui/dialog/test_super_cosmetic_patches_dialog.py
+++ b/test/games/super_metroid/gui/dialog/test_super_cosmetic_patches_dialog.py
@@ -8,7 +8,7 @@ from randovania.games.super_metroid.gui.dialog.super_cosmetic_patches_dialog imp
 from randovania.games.super_metroid.layout.super_metroid_cosmetic_patches import SuperMetroidCosmeticPatches
 
 if typing.TYPE_CHECKING:
-    import pytestqt.qtbot  # type: ignore[import]
+    import pytestqt.qtbot
 
 
 def test_dialog_checkboxes(skip_qtbot: pytestqt.qtbot.QtBot) -> None:

--- a/test/gui/dialog/test_connections_editor.py
+++ b/test/gui/dialog/test_connections_editor.py
@@ -18,7 +18,7 @@ from randovania.gui.dialog import connections_editor
 from randovania.gui.lib import signal_handling
 
 if TYPE_CHECKING:
-    import pytestqt.qtbot  # type: ignore[import-untyped]
+    import pytestqt.qtbot
 
     from randovania.game_description.game_description import GameDescription
 

--- a/test/gui/widgets/test_node_selector_widget.py
+++ b/test/gui/widgets/test_node_selector_widget.py
@@ -6,7 +6,7 @@ from randovania.game_description.db.node_identifier import NodeIdentifier
 from randovania.gui.widgets.node_selector_widget import NodeSelectorWidget
 
 if TYPE_CHECKING:
-    import pytestqt.qtbot  # type: ignore[import-untyped]
+    import pytestqt.qtbot
 
     from randovania.game_description.game_description import GameDescription
 


### PR DESCRIPTION
mypy now errors on redundant ignores, as well as ignores without a specific error code declared. this makes sure we avoid ignoring unless we absolutely have to

also, external libraries without type stubs are now ignored in pyproject.toml instead of inline ignore comments. this helps make it clear that they're not our responsibility to fix and again keeps ignore comments to the absolute minimum necessary