### PR TITLE
Spider method of crossing mining facility alpha nest access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: Wording on the Door Locks preset tab to be clearer.
 
+### AM2R
+
+#### Logic Database
+
+##### Main Caves
+
+- Added: Mining Facility Alpha Nest Access now has a Spider Ball method of crossing the room from either side.
+
 ## [8.8.0] - 2025-01-02
 
 - Added: Experimental preset option to place all majors or pickups logically. This makes sure pickups that are not required can be collected.

--- a/randovania/games/am2r/logic_database/Main Caves.json
+++ b/randovania/games/am2r/logic_database/Main Caves.json
@@ -11371,6 +11371,68 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Spider Ball along the ceiling",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Spider Ball"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Reach the ceiling in morph",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Spring Ball"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "MidAirMorph",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Use Bombs"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "EntranceRando",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -11491,6 +11553,68 @@
                                                         "name": "EntranceRando",
                                                         "amount": 1,
                                                         "negate": true
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Spider Ball along the ceiling",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Spider Ball"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Reach the ceiling in morph",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "MidAirMorph",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Spring Ball"
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Use Bombs"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "EntranceRando",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/am2r/logic_database/Main Caves.txt
+++ b/randovania/games/am2r/logic_database/Main Caves.txt
@@ -1804,6 +1804,11 @@ Extra - liquid_info: {'liquid_type': 1, 'liquid_level': 176}
                   Damage Boost (Beginner) and Lava Damage ≥ 35
           # Shinespark
           Speed Booster and Shinesparking Tricks (Beginner) and Disabled Entrance Rando
+          All of the following:
+              # Spider Ball along the ceiling
+              Can Use Spider Ball
+              # Reach the ceiling in morph
+              Mid-Air Morph (Intermediate) or Disabled Entrance Rando or Can Use Bombs or Can Use Spring Ball
 
 > Horizontal Dock to Mining Facility Alpha Nest; Heals? False
   * Layers: default
@@ -1817,6 +1822,11 @@ Extra - liquid_info: {'liquid_type': 1, 'liquid_level': 176}
               Damage Boost (Beginner) and Lava Damage ≥ 35
           # Shinespark
           Speed Booster and Shinesparking Tricks (Beginner) and Disabled Entrance Rando
+          All of the following:
+              # Spider Ball along the ceiling
+              Can Use Spider Ball
+              # Reach the ceiling in morph
+              Mid-Air Morph (Intermediate) or Disabled Entrance Rando or Can Use Bombs or Can Use Spring Ball
 
 ----------------
 Mining Facility Alpha Nest


### PR DESCRIPTION
Added spider method along the ceiling to both horizontal docks in mining facility alpha nest access making sure you can reach the ceiling as a ball first

Intermediate mid-air morph since the short height means you have to do the jump > morph > aim inputs in fairly quick succession

A single bomb jump inside the doorways lets you reach the ceiling

Plus disabled entrance rando since you can roll in from the adjacent rooms

I was unsure about adding CBJ, I think it might be redundant since the CBJ template also has "can use bombs" 