### PR TITLE
Revised welcome page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.9.x] - 2025-02-??
 
 - Added: It is now possible to focus the game images in the "Games" tab via a Keyboard.
+- Changed: Revised the welcome page.
+- Changed: The Multiworld-Tab and the "Import Game"-Tab have switched positions.
 - Changed: Wording on the Door Locks preset tab to be clearer.
 - Changed: The highlighted button in the cosmetic options is now `Accept` instead of `Reset to Defaults`.
 

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -837,17 +837,6 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
         self.intro_label.setText(self.intro_label.text().format(version=VERSION))
 
         welcome = get_readme_section("WELCOME")
-        supported = get_readme_section("SUPPORTED")
-        experimental = get_readme_section("EXPERIMENTAL")
-
-        self.games_supported_label.setText(supported)
-        if randovania.is_dev_version():
-            self.intro_games_experimental_foldable.setVisible(True)
-            self.games_experimental_label.setText(experimental)
-        else:
-            self.intro_games_experimental_foldable.setVisible(False)
-            self.games_experimental_label.setText("Foobar")
-
         self.intro_welcome_label.setText(welcome)
 
     def _create_generic_window(self, widget: QtWidgets.QWidget, title: str | None = None) -> QtWidgets.QMainWindow:

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -834,8 +834,6 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
         )
 
     def setup_welcome_text(self):
-        self.intro_label.setText(self.intro_label.text().format(version=VERSION))
-
         welcome = get_readme_section("WELCOME")
         self.intro_welcome_label.setText(welcome)
 

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -177,6 +177,7 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
         self.intro_play_solo_button.clicked.connect(partial(self._set_main_tab, self.tab_game_list))
         self.intro_play_multiworld_button.clicked.connect(partial(self._set_main_tab, self.tab_multiworld))
         self.intro_play_existing_button.clicked.connect(partial(self._set_main_tab, self.tab_play_existing))
+        self.intro_item_tracker_button.clicked.connect(self._open_auto_tracker)
         self.intro_about_button.clicked.connect(self._on_menu_action_about)
         self.intro_changelog_button.clicked.connect(self._on_menu_action_changelog)
         self.intro_help_button.clicked.connect(self._on_menu_action_help)

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -175,8 +175,11 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
         self.main_tab_widget.currentChanged.connect(self._on_main_tab_changed)
 
         self.intro_play_solo_button.clicked.connect(partial(self._set_main_tab, self.tab_game_list))
-        self.intro_play_existing_button.clicked.connect(partial(self._set_main_tab, self.tab_play_existing))
         self.intro_play_multiworld_button.clicked.connect(partial(self._set_main_tab, self.tab_multiworld))
+        self.intro_play_existing_button.clicked.connect(partial(self._set_main_tab, self.tab_play_existing))
+        self.intro_about_button.clicked.connect(self._on_menu_action_about)
+        self.intro_changelog_button.clicked.connect(self._on_menu_action_changelog)
+        self.intro_help_button.clicked.connect(self._on_menu_action_help)
 
         self.import_permalink_button.clicked.connect(self._import_permalink)
         self.import_game_file_button.clicked.connect(self._import_spoiler_log)
@@ -838,7 +841,13 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
         experimental = get_readme_section("EXPERIMENTAL")
 
         self.games_supported_label.setText(supported)
-        self.games_experimental_label.setText(experimental if randovania.is_dev_version() else "")
+        if randovania.is_dev_version():
+            self.intro_games_experimental_foldable.setVisible(True)
+            self.games_experimental_label.setText(experimental)
+        else:
+            self.intro_games_experimental_foldable.setVisible(False)
+            self.games_experimental_label.setText("Foobar")
+
         self.intro_welcome_label.setText(welcome)
 
     def _create_generic_window(self, widget: QtWidgets.QWidget, title: str | None = None) -> QtWidgets.QMainWindow:

--- a/randovania/gui/ui_files/main_window.ui
+++ b/randovania/gui/ui_files/main_window.ui
@@ -32,6 +32,9 @@
       <property name="currentIndex">
        <number>0</number>
       </property>
+      <property name="documentMode">
+       <bool>false</bool>
+      </property>
       <widget class="QWidget" name="tab_welcome">
        <attribute name="title">
         <string>Welcome</string>
@@ -236,6 +239,47 @@
              </spacer>
             </item>
             <item>
+             <widget class="QPushButton" name="intro_help_button">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Help</string>
+              </property>
+              <property name="autoDefault">
+               <bool>true</bool>
+              </property>
+              <property name="default">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="button_vertical_spacer_small">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Policy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
              <widget class="QPushButton" name="intro_about_button">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -279,47 +323,6 @@
               </property>
              </widget>
             </item>
-            <item>
-             <spacer name="button_vertical_spacer_small">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="intro_help_button">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>140</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Help</string>
-              </property>
-              <property name="autoDefault">
-               <bool>true</bool>
-              </property>
-              <property name="default">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
            </layout>
           </item>
          </layout>
@@ -338,8 +341,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>674</width>
-          <height>401</height>
+          <width>678</width>
+          <height>403</height>
          </rect>
         </property>
        </widget>

--- a/randovania/gui/ui_files/main_window.ui
+++ b/randovania/gui/ui_files/main_window.ui
@@ -349,70 +349,6 @@
         <string>Games</string>
        </attribute>
       </widget>
-      <widget class="QWidget" name="tab_play_existing">
-       <attribute name="title">
-        <string>Import Game</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="play_existing_layout">
-        <item>
-         <widget class="QLabel" name="import_permalink_label">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Are you playing with others?&lt;/p&gt;&lt;p&gt;Ask them for a permalink and import it here. You'll create the same game as them.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="import_permalink_button">
-          <property name="text">
-           <string>Import permalink</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="browse_racetime_label">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Are you joining a race hosted in &lt;a href=&quot;https://racetime.gg/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;racetime.gg&lt;/span&gt;&lt;/a&gt;?&lt;/p&gt;&lt;p&gt;Select the race from Randovania and automatically import the permalink!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::TextFormat::AutoText</enum>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="browse_racetime_button">
-          <property name="text">
-           <string>Browse races in racetime.gg</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="import_game_file_label">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If they've shared a spoiler file instead, you can import it directly. This skips the generation step. You can also drag and drop the file into Randovania.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="import_game_file_button">
-          <property name="text">
-           <string>Import game file</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
       <widget class="QWidget" name="tab_multiworld">
        <attribute name="title">
         <string>Multiworld</string>
@@ -492,6 +428,70 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
          <widget class="QPushButton" name="game_connection_button">
           <property name="text">
            <string>Connect to games</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab_play_existing">
+       <attribute name="title">
+        <string>Import Game</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="play_existing_layout">
+        <item>
+         <widget class="QLabel" name="import_permalink_label">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Are you playing with others?&lt;/p&gt;&lt;p&gt;Ask them for a permalink and import it here. You'll create the same game as them.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="import_permalink_button">
+          <property name="text">
+           <string>Import permalink</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="browse_racetime_label">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Are you joining a race hosted in &lt;a href=&quot;https://racetime.gg/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;racetime.gg&lt;/span&gt;&lt;/a&gt;?&lt;/p&gt;&lt;p&gt;Select the race from Randovania and automatically import the permalink!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::TextFormat::AutoText</enum>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="browse_racetime_button">
+          <property name="text">
+           <string>Browse races in racetime.gg</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="import_game_file_label">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If they've shared a spoiler file instead, you can import it directly. This skips the generation step. You can also drag and drop the file into Randovania.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="import_game_file_button">
+          <property name="text">
+           <string>Import game file</string>
           </property>
          </widget>
         </item>

--- a/randovania/gui/ui_files/main_window.ui
+++ b/randovania/gui/ui_files/main_window.ui
@@ -128,7 +128,7 @@
            </layout>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="button_layout" stretch="0,0,0,0,0,0,0,0">
+           <layout class="QVBoxLayout" name="button_layout" stretch="0,0,0,0,0,0,0,0,0">
             <property name="sizeConstraint">
              <enum>QLayout::SizeConstraint::SetFixedSize</enum>
             </property>
@@ -222,6 +222,25 @@
               </property>
               <property name="autoDefault">
                <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="intro_item_tracker_button">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Item Tracker</string>
               </property>
              </widget>
             </item>
@@ -341,8 +360,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>678</width>
-          <height>403</height>
+          <width>674</width>
+          <height>401</height>
          </rect>
         </property>
        </widget>

--- a/randovania/gui/ui_files/main_window.ui
+++ b/randovania/gui/ui_files/main_window.ui
@@ -91,92 +91,6 @@
              </widget>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="intro_games_layout">
-              <property name="spacing">
-               <number>6</number>
-              </property>
-              <property name="sizeConstraint">
-               <enum>QLayout::SizeConstraint::SetMaximumSize</enum>
-              </property>
-              <item>
-               <layout class="QVBoxLayout" name="verticalLayout_2">
-                <item>
-                 <widget class="Foldable" name="intro_games_supported_foldable" native="true">
-                  <property name="title" stdset="0">
-                   <string>Supported Games</string>
-                  </property>
-                  <property name="folded" stdset="0">
-                   <bool>true</bool>
-                  </property>
-                  <layout class="QVBoxLayout" name="intro_games_supported_foldable_layout">
-                   <item>
-                    <widget class="QLabel" name="games_supported_label">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="text">
-                      <string>Supported</string>
-                     </property>
-                     <property name="textFormat">
-                      <enum>Qt::TextFormat::MarkdownText</enum>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <spacer name="intro_top_spacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>30</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="Foldable" name="intro_games_experimental_foldable" native="true">
-              <property name="title" stdset="0">
-               <string>Experimental Games</string>
-              </property>
-              <property name="folded" stdset="0">
-               <bool>true</bool>
-              </property>
-              <layout class="QVBoxLayout" name="intro_games_experimental_foldable_layout">
-               <item>
-                <widget class="QLabel" name="games_experimental_label">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Experimental</string>
-                 </property>
-                 <property name="textFormat">
-                  <enum>Qt::TextFormat::MarkdownText</enum>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
              <widget class="QLabel" name="intro_welcome_label">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
@@ -893,12 +807,6 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
-  <customwidget>
-   <class>Foldable</class>
-   <extends>QWidget</extends>
-   <header>randovania/gui/lib/foldable.h</header>
-   <container>1</container>
-  </customwidget>
   <customwidget>
    <class>GamesHelpWidget</class>
    <extends>QTabWidget</extends>

--- a/randovania/gui/ui_files/main_window.ui
+++ b/randovania/gui/ui_files/main_window.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>688</width>
+    <width>698</width>
     <height>582</height>
    </rect>
   </property>
@@ -49,159 +49,366 @@
         <property name="bottomMargin">
          <number>0</number>
         </property>
-        <item row="1" column="0" colspan="3">
-         <layout class="QHBoxLayout" name="intro_games_layout">
-          <property name="spacing">
-           <number>6</number>
-          </property>
+        <item row="2" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout">
           <property name="sizeConstraint">
-           <enum>QLayout::SetMaximumSize</enum>
+           <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
           </property>
           <item>
-           <widget class="QLabel" name="games_supported_label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+           <layout class="QVBoxLayout" name="text_layout">
+            <property name="sizeConstraint">
+             <enum>QLayout::SizeConstraint::SetMaximumSize</enum>
             </property>
-            <property name="text">
-             <string>Supported</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::MarkdownText</enum>
-            </property>
-           </widget>
+            <item>
+             <widget class="QLabel" name="intro_label">
+              <property name="text">
+               <string>Welcome to Randovania, a randomizer for a multitude of games.</string>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::TextFormat::MarkdownText</enum>
+              </property>
+              <property name="scaledContents">
+               <bool>false</bool>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+              <property name="margin">
+               <number>7</number>
+              </property>
+              <property name="indent">
+               <number>-1</number>
+              </property>
+              <property name="openExternalLinks">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="intro_games_layout">
+              <property name="spacing">
+               <number>6</number>
+              </property>
+              <property name="sizeConstraint">
+               <enum>QLayout::SizeConstraint::SetMaximumSize</enum>
+              </property>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_2">
+                <item>
+                 <widget class="Foldable" name="intro_games_supported_foldable" native="true">
+                  <property name="title" stdset="0">
+                   <string>Supported Games</string>
+                  </property>
+                  <property name="folded" stdset="0">
+                   <bool>true</bool>
+                  </property>
+                  <layout class="QVBoxLayout" name="intro_games_supported_foldable_layout">
+                   <item>
+                    <widget class="QLabel" name="games_supported_label">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="text">
+                      <string>Supported</string>
+                     </property>
+                     <property name="textFormat">
+                      <enum>Qt::TextFormat::MarkdownText</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <spacer name="intro_top_spacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>30</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="Foldable" name="intro_games_experimental_foldable" native="true">
+              <property name="title" stdset="0">
+               <string>Experimental Games</string>
+              </property>
+              <property name="folded" stdset="0">
+               <bool>true</bool>
+              </property>
+              <layout class="QVBoxLayout" name="intro_games_experimental_foldable_layout">
+               <item>
+                <widget class="QLabel" name="games_experimental_label">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Experimental</string>
+                 </property>
+                 <property name="textFormat">
+                  <enum>Qt::TextFormat::MarkdownText</enum>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="intro_welcome_label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::TextFormat::MarkdownText</enum>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="intro_vertical_spacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>30</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
           <item>
-           <widget class="QLabel" name="games_experimental_label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+           <layout class="QVBoxLayout" name="button_layout" stretch="0,0,0,0,0,0,0,0">
+            <property name="sizeConstraint">
+             <enum>QLayout::SizeConstraint::SetFixedSize</enum>
             </property>
-            <property name="text">
-             <string>Experimental</string>
+            <property name="topMargin">
+             <number>6</number>
             </property>
-            <property name="textFormat">
-             <enum>Qt::MarkdownText</enum>
+            <property name="bottomMargin">
+             <number>6</number>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
+            <item>
+             <widget class="QPushButton" name="intro_play_solo_button">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Play Solo Game</string>
+              </property>
+              <property name="autoDefault">
+               <bool>true</bool>
+              </property>
+              <property name="default">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="intro_play_multiworld_button">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Play Multiworld</string>
+              </property>
+              <property name="autoDefault">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="intro_play_existing_button">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Import Game</string>
+              </property>
+              <property name="autoDefault">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="button_vertical_spacer_big">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="intro_about_button">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>About</string>
+              </property>
+              <property name="autoDefault">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="intro_changelog_button">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Changelog</string>
+              </property>
+              <property name="autoDefault">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="button_vertical_spacer_small">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Policy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="intro_help_button">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Help</string>
+              </property>
+              <property name="autoDefault">
+               <bool>true</bool>
+              </property>
+              <property name="default">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
-        </item>
-        <item row="0" column="0" colspan="3">
-         <widget class="QLabel" name="intro_label">
-          <property name="text">
-           <string>Welcome to Randovania {version}, a randomizer for a multitude of games.</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::MarkdownText</enum>
-          </property>
-          <property name="scaledContents">
-           <bool>false</bool>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="margin">
-           <number>7</number>
-          </property>
-          <property name="indent">
-           <number>-1</number>
-          </property>
-          <property name="openExternalLinks">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QPushButton" name="intro_play_solo_button">
-          <property name="font">
-           <font>
-            <pointsize>14</pointsize>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Play a new solo game</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QPushButton" name="intro_play_existing_button">
-          <property name="font">
-           <font>
-            <pointsize>12</pointsize>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Import a game</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <spacer name="intro_top_spacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>30</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="3" column="1">
-         <spacer name="intro_vertical_spacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>30</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="4" column="2">
-         <widget class="QPushButton" name="intro_play_multiworld_button">
-          <property name="font">
-           <font>
-            <pointsize>12</pointsize>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Play a multiworld</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0" colspan="3">
-         <widget class="QLabel" name="intro_welcome_label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::MarkdownText</enum>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
         </item>
        </layout>
       </widget>
@@ -217,8 +424,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>664</width>
-          <height>411</height>
+          <width>674</width>
+          <height>401</height>
          </rect>
         </property>
        </widget>
@@ -256,7 +463,7 @@
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Are you joining a race hosted in &lt;a href=&quot;https://racetime.gg/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;racetime.gg&lt;/span&gt;&lt;/a&gt;?&lt;/p&gt;&lt;p&gt;Select the race from Randovania and automatically import the permalink!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="textFormat">
-           <enum>Qt::AutoText</enum>
+           <enum>Qt::TextFormat::AutoText</enum>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
@@ -305,7 +512,7 @@
 For more information, check [Randovania Help](help://tab_multiworld)!</string>
           </property>
           <property name="textFormat">
-           <enum>Qt::MarkdownText</enum>
+           <enum>Qt::TextFormat::MarkdownText</enum>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
@@ -315,7 +522,7 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
         <item>
          <widget class="Line" name="multiworld_line">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
          </widget>
         </item>
@@ -356,7 +563,7 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
         <item>
          <widget class="Line" name="game_connection_line">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
          </widget>
         </item>
@@ -448,7 +655,7 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
        <string/>
       </property>
       <property name="alignment">
-       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
       </property>
       <property name="wordWrap">
        <bool>true</bool>
@@ -463,8 +670,8 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>688</width>
-     <height>21</height>
+     <width>698</width>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_open">
@@ -485,11 +692,11 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     </property>
     <widget class="QMenu" name="menu_database">
      <property name="title">
-      <string>Database</string>
+      <string>&amp;Database</string>
      </property>
      <widget class="QMenu" name="menu_internal">
       <property name="title">
-       <string>Internal</string>
+       <string>&amp;Internal</string>
       </property>
      </widget>
      <addaction name="menu_internal"/>
@@ -503,7 +710,7 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     </property>
     <widget class="QMenu" name="menu_advanced">
      <property name="title">
-      <string>Advanced</string>
+      <string>Ad&amp;vanced</string>
      </property>
      <addaction name="menu_action_validate_seed_after"/>
      <addaction name="menu_action_timeout_generation_after_a_time_limit"/>
@@ -511,7 +718,7 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     </widget>
     <widget class="QMenu" name="menu_alert_when_generation_completes">
      <property name="title">
-      <string>Alert When Generation Completes</string>
+      <string>&amp;Alert When Generation Completes</string>
      </property>
      <property name="toolTipsVisible">
       <bool>false</bool>
@@ -546,7 +753,7 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
   </widget>
   <action name="menu_action_edit_existing_database">
    <property name="text">
-    <string>External file</string>
+    <string>&amp;External file</string>
    </property>
   </action>
   <action name="menu_action_validate_seed_after">
@@ -557,7 +764,7 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Validate if a game is possible after generation</string>
+    <string>&amp;Validate if a game is possible after generation</string>
    </property>
   </action>
   <action name="menu_action_timeout_generation_after_a_time_limit">
@@ -568,17 +775,17 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Timeout generation after a time limit</string>
+    <string>&amp;Timeout generation after a time limit</string>
    </property>
   </action>
   <action name="menu_action_open_auto_tracker">
    <property name="text">
-    <string>Automatic Item Tracker</string>
+    <string>&amp;Automatic Item Tracker</string>
    </property>
   </action>
   <action name="menu_action_login_window">
    <property name="text">
-    <string>Login</string>
+    <string>L&amp;ogin</string>
    </property>
   </action>
   <action name="menu_action_dark_mode">
@@ -586,7 +793,7 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Dark Mode</string>
+    <string>&amp;Dark Mode</string>
    </property>
   </action>
   <action name="menu_action_show_multiworld_banner">
@@ -594,12 +801,12 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show Multiworld Banner</string>
+    <string>&amp;Show Multiworld Banner</string>
    </property>
   </action>
   <action name="menu_action_previously_generated_games">
    <property name="text">
-    <string>Previously generated games</string>
+    <string>&amp;Previously generated games</string>
    </property>
   </action>
   <action name="menu_action_layout_editor">
@@ -609,27 +816,27 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
   </action>
   <action name="menu_action_log_files_directory">
    <property name="text">
-    <string>Log files folder</string>
+    <string>&amp;Log files folder</string>
    </property>
   </action>
   <action name="menu_action_help">
    <property name="text">
-    <string>Randovania Help</string>
+    <string>&amp;Randovania Help</string>
    </property>
   </action>
   <action name="menu_action_changelog">
    <property name="text">
-    <string>Change Log</string>
+    <string>&amp;Change Log</string>
    </property>
   </action>
   <action name="menu_action_about">
    <property name="text">
-    <string>About</string>
+    <string>&amp;About</string>
    </property>
   </action>
   <action name="menu_action_dependencies">
    <property name="text">
-    <string>Dependencies</string>
+    <string>&amp;Dependencies</string>
    </property>
   </action>
   <action name="menu_action_experimental_settings">
@@ -637,12 +844,12 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show Experimental Settings</string>
+    <string>Show &amp;Experimental Settings</string>
    </property>
   </action>
   <action name="menu_action_automatic_reporting">
    <property name="text">
-    <string>Automatic Data Collection and Reporting</string>
+    <string>Automatic Data &amp;Collection and Reporting</string>
    </property>
   </action>
   <action name="menu_action_generate_in_another_process">
@@ -653,12 +860,12 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Generate games in another process</string>
+    <string>&amp;Generate games in another process</string>
    </property>
   </action>
   <action name="menu_action_verify_installation">
    <property name="text">
-    <string>Verify installation</string>
+    <string>&amp;Verify installation</string>
    </property>
   </action>
   <action name="menu_action_audible_generation_alert">
@@ -669,7 +876,7 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Audible Sound Alert</string>
+    <string>&amp;Audible Sound Alert</string>
    </property>
   </action>
   <action name="menu_action_visual_generation_alert">
@@ -680,12 +887,18 @@ For more information, check [Randovania Help](help://tab_multiworld)!</string>
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Visual Taskbar Alert</string>
+    <string>&amp;Visual Taskbar Alert</string>
    </property>
   </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
+  <customwidget>
+   <class>Foldable</class>
+   <extends>QWidget</extends>
+   <header>randovania/gui/lib/foldable.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>GamesHelpWidget</class>
    <extends>QTabWidget</extends>


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/321d4073-ffa6-44c8-9111-9a98cb025beb)

Highlights:
- changed tab ordering because more people use MW functionality than importing games
- removed supported and experimental games list. It's not scalable, longer text has higher chance of being ignored, and there are already plenty of chances of seeing the supported games (website, games tab, word of mouth)
- use default button to indicate primary action instead of varying button and font sizes
- extra buttons for often missed help/troubleshooting actions
- shortened button text