### PR TITLE
Fix typo in Dread logic database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: Mining Facility Alpha Nest Access now has a Spider Ball method of crossing the room from either side.
 
+### Metroid Dread
+
+#### Logic Database
+
+- Fixed: A typo in the event name Artaria - Prepare Speedboost in Map Station has been changed from Prepare Speeboost in Map Station.
+
 ## [8.8.0] - 2025-01-02
 
 - Added: Experimental preset option to place all majors or pickups logically. This makes sure pickups that are not required can be collected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### Main Caves
 
+- Added: Mining Facility Alpha Nest Access now has a Spider Ball method of crossing the room from either side.
 - Added: Mining Facility Gamma Nest Access now has a Spider Ball method of crossing the room from either side.
+
+### Metroid Dread
+
+#### Logic Database
+
+- Fixed: A typo in the event name Artaria - Prepare Speedboost in Map Station has been changed from Prepare Speeboost in Map Station.
 
 ### Metroid: Samus Returns
 
@@ -26,28 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Incorrect rotation of a progressive item if the previous stage of the progressive item was received without leaving the area.
 - Fixed: Once you have collected all Metroid DNA, when traveling from Surface West to Surface East, a message will always appear asking if you want to fight Proteus Ridley or not. Canceling the message will load Surface East like normal. This is to prevent Surface East from being potentially inaccessible if the only entry point is from Surface West.
 
-### Metroid: Samus Returns
-
 #### Logic Database
 
 ##### Area 4 Central Caverns
 
 - Added: Transport to Area 3 and Crystal Mines: A beginner Spider Ball Clip to reach the elevator to Crystal Mines from the bottom Chozo Seal with Space Jump.
-
-
-### AM2R
-
-#### Logic Database
-
-##### Main Caves
-
-- Added: Mining Facility Alpha Nest Access now has a Spider Ball method of crossing the room from either side.
-
-### Metroid Dread
-
-#### Logic Database
-
-- Fixed: A typo in the event name Artaria - Prepare Speedboost in Map Station has been changed from Prepare Speeboost in Map Station.
 
 ## [8.8.0] - 2025-01-02
 

--- a/randovania/games/dread/logic_database/Artaria.json
+++ b/randovania/games/dread/logic_database/Artaria.json
@@ -18662,7 +18662,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Prepare Speeboost in Map Station": {
+                        "Event - Prepare Speedboost in Map Station": {
                             "type": "resource",
                             "data": {
                                 "type": "misc",
@@ -19596,7 +19596,7 @@
                         }
                     }
                 },
-                "Event - Prepare Speeboost in Map Station": {
+                "Event - Prepare Speedboost in Map Station": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/dread/logic_database/Artaria.txt
+++ b/randovania/games/dread/logic_database/Artaria.txt
@@ -3368,7 +3368,7 @@ Extra - asset_id: collision_camera_056
   * Extra - right_shield_def: None
   > Dock to Water Tunnel under Map
       Trivial
-  > Event - Prepare Speeboost in Map Station
+  > Event - Prepare Speedboost in Map Station
       Disabled Door Lock Randomizer
 
 > Door to Save Station West; Heals? False
@@ -3526,7 +3526,7 @@ Extra - asset_id: collision_camera_056
   > Right of Rotatable
       Trivial
 
-> Event - Prepare Speeboost in Map Station; Heals? False
+> Event - Prepare Speedboost in Map Station; Heals? False
   * Layers: default
   * Event Artaria - Prepare Speed Booster in Map Station
   > Door to Map Station


### PR DESCRIPTION
I noticed a small typo in Dread's logic database yesterday involving this event:
![image](https://github.com/user-attachments/assets/e4b21621-a621-453b-a1a9-28d9fcafec96)

It didn't seem intentional (as literally everywhere else, it's written as "speedboost"), so I fixed it. I have two questions about this change:
- Do I need to do a migration for this? I saw that there was `dairon_typo` migration data for Dread, but that seems to be because those strings are used for `dock_weakness`. I see no such thing for this event, which makes me think a migration is unnecessary.
- Do I need to update the changelog for this? The [contributing guide](https://github.com/randovania/randovania/blob/6012fa9dc176789bd38709182ea3febbb50cb428/CONTRIBUTING.md#example-of-changes-that-should-have-changelog) says it should be updated for "any database change for a stable game," which is what this fix is. I also see such a change in the [6.2.0 changelog](https://github.com/randovania/randovania/releases/tag/v6.2.0) where the aforementioned Dairon typo was fixed. However, I wasn't sure if this change was necessary to call out since, as I said above, it doesn't seem like it needs a migration.

Sorry for my newbie questions! I'm happy to change things if it's necessary to get this in.