### PR TITLE
Include generated pickups (DNA, STKs, etc.) and their categories in the pickup database

### DIFF
--- a/randovania/cli/commands/new_game.py
+++ b/randovania/cli/commands/new_game.py
@@ -269,6 +269,7 @@ def create_pickup_database(game_enum: RandovaniaGame) -> PickupDatabase:
     }
     pickup_db = PickupDatabase(
         pickup_categories=pickup_categories,
+        generated_pickups={},
         standard_pickups={
             "Powerful Weapon": StandardPickupDefinition(
                 game=game_enum,

--- a/randovania/cli/commands/new_game.py
+++ b/randovania/cli/commands/new_game.py
@@ -22,7 +22,7 @@ from randovania.game_description.db.pickup_node import PickupNode
 from randovania.game_description.db.region import Region
 from randovania.game_description.db.region_list import RegionList
 from randovania.game_description.game_description import GameDescription
-from randovania.game_description.pickup.pickup_category import PickupCategory
+from randovania.game_description.pickup.pickup_category import GENERIC_KEY_CATEGORY, PickupCategory
 from randovania.game_description.pickup.pickup_database import PickupDatabase
 from randovania.game_description.pickup.standard_pickup import StandardPickupDefinition
 from randovania.game_description.requirements.base import Requirement
@@ -269,7 +269,19 @@ def create_pickup_database(game_enum: RandovaniaGame) -> PickupDatabase:
     }
     pickup_db = PickupDatabase(
         pickup_categories=pickup_categories,
-        generated_pickups={},
+        generated_pickups={
+            "Victory Key": StandardPickupDefinition(
+                game=game_enum,
+                name="Victory Key",
+                pickup_category=GENERIC_KEY_CATEGORY,
+                broad_category=GENERIC_KEY_CATEGORY,
+                model_name="VictoryKey",
+                offworld_models=frozendict(),
+                progression=("VictoryKey",),
+                preferred_location_category=LocationCategory.MAJOR,
+                probability_offset=0.25,
+            ),
+        },
         standard_pickups={
             "Powerful Weapon": StandardPickupDefinition(
                 game=game_enum,

--- a/randovania/game_description/migration_data.py
+++ b/randovania/game_description/migration_data.py
@@ -57,3 +57,10 @@ def get_node_name_for_area(game: RandovaniaGame, world_name: str, area_name: str
 
 def get_default_dock_lock_settings(game: RandovaniaGame) -> dict:
     return get_raw_data(game)["default_dock_lock_settings"]
+
+
+def get_generated_pickups(game: RandovaniaGame) -> dict:
+    data = get_raw_data(game)
+    if "generated_pickups" not in data:
+        return {"categories": {}, "pickups": {}}
+    return data["generated_pickups"]

--- a/randovania/game_description/pickup/pickup_database.py
+++ b/randovania/game_description/pickup/pickup_database.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from randovania.game_description.pickup import pickup_migration
 from randovania.game_description.pickup.ammo_pickup import AmmoPickupDefinition
-from randovania.game_description.pickup.pickup_category import PickupCategory
+from randovania.game_description.pickup.pickup_category import GENERIC_KEY_CATEGORY, PickupCategory
 from randovania.game_description.pickup.standard_pickup import StandardPickupDefinition
 
 if TYPE_CHECKING:
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 @dataclass(frozen=True)
 class PickupDatabase:
     pickup_categories: dict[str, PickupCategory]
+    generated_pickups: dict[str, StandardPickupDefinition]
     standard_pickups: dict[str, StandardPickupDefinition]
     ammo_pickups: dict[str, AmmoPickupDefinition]
     default_pickups: dict[PickupCategory, tuple[StandardPickupDefinition, ...]]
@@ -36,6 +37,17 @@ def read_database(database_data: dict, game: RandovaniaGame) -> PickupDatabase:
         name: PickupCategory.from_json(name, category) for name, category in database_data["pickup_categories"].items()
     }
 
+    generated_pickups = {
+        group_name: StandardPickupDefinition.from_json(
+            pickup,
+            name=pickup.pop("name_template"),
+            game=game,
+            pickup_category=pickup_categories.get("pickup_category", GENERIC_KEY_CATEGORY),
+            broad_category=pickup_categories.get("broad_category", GENERIC_KEY_CATEGORY),
+        )
+        for group_name, pickup in database_data["generated_pickups"].items()
+    }
+
     standard_pickups = {
         name: StandardPickupDefinition.from_json_with_categories(name, game, pickup_categories, pickup)
         for name, pickup in database_data["standard_pickups"].items()
@@ -55,6 +67,7 @@ def read_database(database_data: dict, game: RandovaniaGame) -> PickupDatabase:
 
     return PickupDatabase(
         pickup_categories,
+        generated_pickups,
         standard_pickups,
         ammo_pickups,
         default_pickups,
@@ -70,6 +83,14 @@ def write_database(database: PickupDatabase) -> dict:
     """
     pickup_categories = {name: pickup_category.as_json for name, pickup_category in database.pickup_categories.items()}
 
+    generated_pickups = {
+        group_name: {
+            "name_template": pickup.name,
+            **pickup.as_json,
+        }
+        for group_name, pickup in database.generated_pickups.items()
+    }
+
     standard_pickups = {name: pickup.as_json for name, pickup in database.standard_pickups.items()}
 
     ammo_pickups = {name: ammo.as_json for name, ammo in database.ammo_pickups.items()}
@@ -83,6 +104,7 @@ def write_database(database: PickupDatabase) -> dict:
     return {
         "schema_version": pickup_migration.CURRENT_VERSION,
         "pickup_categories": pickup_categories,
+        "generated_pickups": generated_pickups,
         "standard_pickups": standard_pickups,
         "ammo_pickups": ammo_pickups,
         "default_pickups": default_pickups,

--- a/randovania/game_description/pickup/pickup_database.py
+++ b/randovania/game_description/pickup/pickup_database.py
@@ -38,12 +38,8 @@ def read_database(database_data: dict, game: RandovaniaGame) -> PickupDatabase:
     }
 
     generated_pickups = {
-        group_name: StandardPickupDefinition.from_json(
-            pickup,
-            name=pickup.pop("name_template"),
-            game=game,
-            pickup_category=pickup_categories.get("pickup_category", GENERIC_KEY_CATEGORY),
-            broad_category=pickup_categories.get("broad_category", GENERIC_KEY_CATEGORY),
+        group_name: StandardPickupDefinition.from_json_with_categories(
+            pickup.pop("name_template"), game, pickup_categories, pickup, default_category=GENERIC_KEY_CATEGORY
         )
         for group_name, pickup in database_data["generated_pickups"].items()
     }

--- a/randovania/game_description/pickup/pickup_migration.py
+++ b/randovania/game_description/pickup/pickup_migration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 
 from randovania.game.game_enum import RandovaniaGame
+from randovania.game_description import migration_data
 from randovania.lib import migration_lib
 
 
@@ -87,6 +88,12 @@ def _migrate_v8(pickup_data: dict, game: RandovaniaGame) -> None:
             pickup["original_locations"] = [pickup.pop("original_location")]
 
 
+def _migrate_v9(pickup_data: dict, game: RandovaniaGame) -> None:
+    generated = migration_data.get_generated_pickups(game)
+    pickup_data["pickup_categories"].update(generated["categories"])
+    pickup_data["generated_pickups"] = generated["pickups"]
+
+
 _MIGRATIONS = [
     None,
     _migrate_v2,
@@ -96,6 +103,7 @@ _MIGRATIONS = [
     _migrate_v6,
     _migrate_v7,
     _migrate_v8,
+    _migrate_v9,
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/randovania/game_description/pickup/standard_pickup.py
+++ b/randovania/game_description/pickup/standard_pickup.py
@@ -126,14 +126,22 @@ class StandardPickupDefinition(JsonDataclass, DataclassPostInitTypeCheck):
 
     @classmethod
     def from_json_with_categories(
-        cls, name: str, game: RandovaniaGame, pickup_categories: dict[str, PickupCategory], value: dict
+        cls,
+        name: str,
+        game: RandovaniaGame,
+        pickup_categories: dict[str, PickupCategory],
+        value: dict,
+        *,
+        default_category: PickupCategory | None = None,
     ) -> Self:
+        pickup_category = pickup_categories.get(value.get("pickup_category", ""), default_category)
+        broad_category = pickup_categories.get(value.get("broad_category", ""), default_category)
         return cls.from_json(
             value,
             game=game,
             name=name,
-            pickup_category=pickup_categories[value["pickup_category"]],
-            broad_category=pickup_categories[value["broad_category"]],
+            pickup_category=pickup_category,
+            broad_category=broad_category,
         )
 
     @property

--- a/randovania/game_description/pickup/standard_pickup.py
+++ b/randovania/game_description/pickup/standard_pickup.py
@@ -9,7 +9,7 @@ from frozendict import frozendict
 from randovania.bitpacking.json_dataclass import JsonDataclass
 from randovania.bitpacking.type_enforcement import DataclassPostInitTypeCheck
 from randovania.game.game_enum import RandovaniaGame
-from randovania.game_description.pickup.pickup_category import PickupCategory
+from randovania.game_description.pickup.pickup_category import GENERIC_KEY_CATEGORY, PickupCategory
 from randovania.game_description.resources.location_category import LocationCategory
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.layout.base.standard_pickup_state import StandardPickupStateCase
@@ -138,11 +138,13 @@ class StandardPickupDefinition(JsonDataclass, DataclassPostInitTypeCheck):
 
     @property
     def as_json(self) -> dict:
-        return {
-            "pickup_category": self.pickup_category.name,
-            "broad_category": self.broad_category.name,
-            **super().as_json,
-        }
+        data = {}
+        if self.pickup_category is not GENERIC_KEY_CATEGORY:
+            data["pickup_category"] = self.pickup_category.name
+        if self.broad_category is not GENERIC_KEY_CATEGORY:
+            data["broad_category"] = self.broad_category.name
+        data.update(super().as_json)
+        return data
 
     @property
     def count_for_shuffled_case(self) -> int:

--- a/randovania/games/am2r/assets/migration_data.json
+++ b/randovania/games/am2r/assets/migration_data.json
@@ -24,5 +24,33 @@
             "Distribution Center/Gravity Area Barricade/Door to Gravity Area Barricade Pipe": "Distribution Center/Gravity Area Barricade/Door to Gravity Area East Pipe",
             "Distribution Center/Gravity Area Barricade Pipe/Door to Gravity Area Barricade": "Distribution Center/Gravity Area East Pipe/Door to Gravity Area Barricade"
         }
+    },
+    "generated_pickups": {
+        "categories": {
+            "dna": {
+                "long_name": "Metroid DNA",
+                "hint_details": [
+                    "some ",
+                    "Metroid DNA"
+                ],
+                "hinted_as_major": false,
+                "is_key": true
+            }
+        },
+        "pickups": {
+            "Metroid DNA": {
+                "name_template": "Metroid DNA {i}",
+                "pickup_category": "dna",
+                "model_name": "sItemDNA",
+                "offworld_models": {
+                    "samus_returns": "adn"
+                },
+                "progression": [
+                    "Metroid DNA {i}"
+                ],
+                "preferred_location_category": "major",
+                "probability_offset": 0.25
+            }
+        }
     }
 }

--- a/randovania/games/am2r/generator/bootstrap.py
+++ b/randovania/games/am2r/generator/bootstrap.py
@@ -4,7 +4,6 @@ import dataclasses
 from functools import partial
 from typing import TYPE_CHECKING
 
-from randovania.games.am2r.generator.pool_creator import METROID_DNA_CATEGORY
 from randovania.games.am2r.layout import AM2RConfiguration
 from randovania.resolver.bootstrap import Bootstrap
 from randovania.resolver.energy_tank_damage_state import EnergyTankDamageState
@@ -108,6 +107,6 @@ class AM2RBootstrap(Bootstrap):
             return super().assign_pool_results(rng, patches, pool_results)
 
         locations = self.all_preplaced_item_locations(patches.game, patches.configuration, is_dna_node)
-        self.pre_place_items(rng, locations, pool_results, METROID_DNA_CATEGORY)
+        self.pre_place_items(rng, locations, pool_results, "dna", patches.game.game)
 
         return super().assign_pool_results(rng, patches, pool_results)

--- a/randovania/games/am2r/generator/pool_creator.py
+++ b/randovania/games/am2r/generator/pool_creator.py
@@ -2,42 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from frozendict import frozendict
-
-from randovania.game.game_enum import RandovaniaGame
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
-from randovania.game_description.resources.location_category import LocationCategory
 from randovania.games.am2r.layout.am2r_configuration import AM2RArtifactConfig, AM2RConfiguration
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
     from randovania.game_description.game_description import GameDescription
-    from randovania.game_description.resources.resource_database import ResourceDatabase
+    from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.layout.base.base_configuration import BaseConfiguration
-
-METROID_DNA_CATEGORY = pickup_category.PickupCategory(
-    name="dna", long_name="Metroid DNA", hint_details=("some ", "Metroid DNA"), hinted_as_major=False, is_key=True
-)
-
-
-def create_am2r_artifact(
-    artifact_number: int,
-    resource_database: ResourceDatabase,
-) -> PickupEntry:
-    return PickupEntry(
-        name=f"Metroid DNA {artifact_number + 1}",
-        progression=((resource_database.get_item(f"Metroid DNA {artifact_number + 1}"), 1),),
-        model=PickupModel(game=resource_database.game_enum, name="sItemDNA"),
-        pickup_category=METROID_DNA_CATEGORY,
-        broad_category=pickup_category.GENERIC_KEY_CATEGORY,
-        offworld_models=frozendict({RandovaniaGame.METROID_SAMUS_RETURNS: "adn"}),
-        generator_params=PickupGeneratorParams(
-            preferred_location_category=LocationCategory.MAJOR,
-            probability_offset=0.25,
-        ),
-    )
 
 
 def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
@@ -58,7 +31,7 @@ def artifact_pool(game: GameDescription, config: AM2RArtifactConfig) -> PoolResu
     if config.required_artifacts > max_artifacts:
         raise InvalidConfiguration("More Metroid DNA than allowed!")
 
-    keys: list[PickupEntry] = [create_am2r_artifact(i, game.resource_database) for i in range(46)]
+    keys: list[PickupEntry] = [create_generated_pickup("Metroid DNA", game.resource_database, i + 1) for i in range(46)]
     keys_to_shuffle = keys[: config.placed_artifacts]
     starting_keys = keys[config.placed_artifacts :]
 

--- a/randovania/games/am2r/generator/pool_creator.py
+++ b/randovania/games/am2r/generator/pool_creator.py
@@ -31,7 +31,9 @@ def artifact_pool(game: GameDescription, config: AM2RArtifactConfig) -> PoolResu
     if config.required_artifacts > max_artifacts:
         raise InvalidConfiguration("More Metroid DNA than allowed!")
 
-    keys: list[PickupEntry] = [create_generated_pickup("Metroid DNA", game.resource_database, i + 1) for i in range(46)]
+    keys: list[PickupEntry] = [
+        create_generated_pickup("Metroid DNA", game.resource_database, i=i + 1) for i in range(46)
+    ]
     keys_to_shuffle = keys[: config.placed_artifacts]
     starting_keys = keys[config.placed_artifacts :]
 

--- a/randovania/games/am2r/pickup_database/pickup-database.json
+++ b/randovania/games/am2r/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "beam": {
             "long_name": "Beams",
@@ -88,6 +88,31 @@
                 "miscellaneous system"
             ],
             "hinted_as_major": false
+        },
+        "dna": {
+            "long_name": "Metroid DNA",
+            "hint_details": [
+                "some ",
+                "Metroid DNA"
+            ],
+            "hinted_as_major": false,
+            "is_key": true
+        }
+    },
+    "generated_pickups": {
+        "Metroid DNA": {
+            "name_template": "Metroid DNA {i}",
+            "pickup_category": "dna",
+            "model_name": "sItemDNA",
+            "offworld_models": {
+                "samus_returns": "adn"
+            },
+            "progression": [
+                "Metroid DNA {i}"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "probability_offset": 0.25
         }
     },
     "standard_pickups": {

--- a/randovania/games/blank/assets/migration_data.json
+++ b/randovania/games/blank/assets/migration_data.json
@@ -25,5 +25,20 @@
             "can_change_from": [],
             "can_change_to": []
         }
+    },
+    "generated_pickups": {
+        "categories": {},
+        "pickups": {
+            "Victory Key": {
+                "name_template": "Victory Key",
+                "model_name": "VictoryKey",
+                "offworld_models": {},
+                "progression": [
+                    "VictoryKey"
+                ],
+                "preferred_location_category": "major",
+                "probability_offset": 0.25
+            }
+        }
     }
 }

--- a/randovania/games/blank/generator/pool_creator.py
+++ b/randovania/games/blank/generator/pool_creator.py
@@ -2,33 +2,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
-from randovania.game_description.resources.location_category import LocationCategory
 from randovania.games.blank.layout.blank_configuration import BlankConfiguration
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 if TYPE_CHECKING:
     from randovania.game_description.game_description import GameDescription
-    from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.generator.pickup_pool import PoolResults
     from randovania.layout.base.base_configuration import BaseConfiguration
-
-
-def create_victory_key(resource_database: ResourceDatabase) -> PickupEntry:
-    return PickupEntry(
-        name="Victory Key",
-        progression=((resource_database.get_item("VictoryKey"), 1),),
-        model=PickupModel(game=resource_database.game_enum, name="VictoryKey"),
-        pickup_category=pickup_category.GENERIC_KEY_CATEGORY,
-        broad_category=pickup_category.GENERIC_KEY_CATEGORY,
-        generator_params=PickupGeneratorParams(
-            preferred_location_category=LocationCategory.MAJOR,
-            probability_offset=0.25,
-        ),
-    )
 
 
 def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
     assert isinstance(configuration, BlankConfiguration)
 
-    results.to_place.append(create_victory_key(game.resource_database))
+    results.to_place.append(create_generated_pickup("Victory Key", game.resource_database))

--- a/randovania/games/blank/pickup_database/pickup-database.json
+++ b/randovania/games/blank/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "gear": {
             "long_name": "Gear",
@@ -16,6 +16,19 @@
                 "ammo"
             ],
             "hinted_as_major": false
+        }
+    },
+    "generated_pickups": {
+        "Victory Key": {
+            "name_template": "Victory Key",
+            "model_name": "VictoryKey",
+            "offworld_models": {},
+            "progression": [
+                "VictoryKey"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "probability_offset": 0.25
         }
     },
     "standard_pickups": {

--- a/randovania/games/cave_story/generator/bootstrap.py
+++ b/randovania/games/cave_story/generator/bootstrap.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from randovania.game_description import default_database
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.games.cave_story.layout.cs_configuration import CSConfiguration, CSObjective
 from randovania.resolver.bootstrap import Bootstrap
@@ -82,10 +81,8 @@ class CSBootstrap(Bootstrap):
 
         # puppies
         if not configuration.puppies_anywhere:
-            pickup_database = default_database.pickup_database_for_game(patches.game.game)
-            puppies_category = pickup_database.pickup_categories["puppies"]
             locations = self.all_preplaced_item_locations(patches.game, patches.configuration, is_puppy_node)
-            self.pre_place_items(rng, locations, results, puppies_category)
+            self.pre_place_items(rng, locations, results, "puppies", patches.game.game)
 
         # weapon to break blocks in first cave (do it this way to ensure a particular distribution chance)
         if patches.starting_location.area in {"Start Point", "First Cave", "Hermit Gunsmith"}:

--- a/randovania/games/cave_story/pickup_database/pickup-database.json
+++ b/randovania/games/cave_story/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "weapon": {
             "long_name": "Weapons",
@@ -74,6 +74,7 @@
             "hinted_as_major": false
         }
     },
+    "generated_pickups": {},
     "standard_pickups": {
         "Polar Star": {
             "pickup_category": "weapon",

--- a/randovania/games/dread/assets/migration_data.json
+++ b/randovania/games/dread/assets/migration_data.json
@@ -867,5 +867,32 @@
     "dairon_typo": {
         "Ferenia/East Transport to Darion/Door to Total Recharge Station": "Ferenia/East Transport to Dairon/Door to Total Recharge Station",
         "Ferenia/Total Recharge Station/Door to East Transport to Darion": "Ferenia/Total Recharge Station/Door to East Transport to Dairon"
+    },
+    "generated_pickups": {
+        "categories": {
+            "dna": {
+                "long_name": "Metroid DNA",
+                "hint_details": [
+                    "some ",
+                    "Metroid DNA"
+                ],
+                "hinted_as_major": false
+            }
+        },
+        "pickups": {
+            "Metroid DNA": {
+                "name_template": "Metroid DNA {i}",
+                "pickup_category": "dna",
+                "model_name": "DNA_{i}",
+                "offworld_models": {
+                    "am2r": "sItemDNA"
+                },
+                "progression": [
+                    "Artifact{i}"
+                ],
+                "preferred_location_category": "major",
+                "probability_offset": 0.25
+            }
+        }
     }
 }

--- a/randovania/games/dread/assets/migration_data.json
+++ b/randovania/games/dread/assets/migration_data.json
@@ -876,7 +876,8 @@
                     "some ",
                     "Metroid DNA"
                 ],
-                "hinted_as_major": false
+                "hinted_as_major": false,
+                "is_key": true
             }
         },
         "pickups": {

--- a/randovania/games/dread/generator/bootstrap.py
+++ b/randovania/games/dread/generator/bootstrap.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from randovania.games.dread.generator.pool_creator import DREAD_ARTIFACT_CATEGORY
 from randovania.games.dread.layout.dread_configuration import DreadConfiguration
 from randovania.resolver.bootstrap import Bootstrap
 from randovania.resolver.energy_tank_damage_state import EnergyTankDamageState
@@ -91,5 +90,5 @@ class DreadBootstrap(Bootstrap):
     def assign_pool_results(self, rng: Random, patches: GamePatches, pool_results: PoolResults) -> GamePatches:
         assert isinstance(patches.configuration, DreadConfiguration)
         locations = self.all_preplaced_item_locations(patches.game, patches.configuration, is_dna_node)
-        self.pre_place_items(rng, locations, pool_results, DREAD_ARTIFACT_CATEGORY)
+        self.pre_place_items(rng, locations, pool_results, "dna", patches.game.game)
         return super().assign_pool_results(rng, patches, pool_results)

--- a/randovania/games/dread/generator/pool_creator.py
+++ b/randovania/games/dread/generator/pool_creator.py
@@ -18,7 +18,7 @@ def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: G
 
 
 def artifact_pool(game: GameDescription, config: DreadArtifactConfig) -> PoolResults:
-    keys = [create_generated_pickup("Metroid DNA", game.resource_database, i + 1) for i in range(12)]
+    keys = [create_generated_pickup("Metroid DNA", game.resource_database, i=i + 1) for i in range(12)]
     keys_to_shuffle = keys[: config.required_artifacts]
     starting_keys = keys[config.required_artifacts :]
 

--- a/randovania/games/dread/generator/pool_creator.py
+++ b/randovania/games/dread/generator/pool_creator.py
@@ -2,23 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from frozendict import frozendict
-
-from randovania.game.game_enum import RandovaniaGame
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
-from randovania.game_description.resources.location_category import LocationCategory
 from randovania.games.dread.layout.dread_configuration import DreadArtifactConfig, DreadConfiguration
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 if TYPE_CHECKING:
     from randovania.game_description.game_description import GameDescription
-    from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.layout.base.base_configuration import BaseConfiguration
-
-DREAD_ARTIFACT_CATEGORY = pickup_category.PickupCategory(
-    name="dna", long_name="Metroid DNA", hint_details=("some ", "Metroid DNA"), hinted_as_major=False, is_key=True
-)
 
 
 def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
@@ -28,26 +18,8 @@ def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: G
 
 
 def artifact_pool(game: GameDescription, config: DreadArtifactConfig) -> PoolResults:
-    keys = [create_dread_artifact(i, game.resource_database) for i in range(12)]
+    keys = [create_generated_pickup("Metroid DNA", game.resource_database, i + 1) for i in range(12)]
     keys_to_shuffle = keys[: config.required_artifacts]
     starting_keys = keys[config.required_artifacts :]
 
     return PoolResults(keys_to_shuffle, {}, starting_keys)
-
-
-def create_dread_artifact(
-    artifact_number: int,
-    resource_database: ResourceDatabase,
-) -> PickupEntry:
-    return PickupEntry(
-        name=f"Metroid DNA {artifact_number + 1}",
-        progression=((resource_database.get_item(f"Artifact{artifact_number + 1}"), 1),),
-        model=PickupModel(game=resource_database.game_enum, name=f"DNA_{artifact_number + 1}"),
-        pickup_category=DREAD_ARTIFACT_CATEGORY,
-        broad_category=pickup_category.GENERIC_KEY_CATEGORY,
-        offworld_models=frozendict({RandovaniaGame.AM2R: "sItemDNA"}),
-        generator_params=PickupGeneratorParams(
-            preferred_location_category=LocationCategory.MAJOR,
-            probability_offset=0.25,
-        ),
-    )

--- a/randovania/games/dread/pickup_database/pickup-database.json
+++ b/randovania/games/dread/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "beam": {
             "long_name": "Beams",
@@ -88,6 +88,31 @@
                 "life support system"
             ],
             "hinted_as_major": false
+        },
+        "dna": {
+            "long_name": "Metroid DNA",
+            "hint_details": [
+                "some ",
+                "Metroid DNA"
+            ],
+            "hinted_as_major": false,
+            "is_key": true
+        }
+    },
+    "generated_pickups": {
+        "Metroid DNA": {
+            "name_template": "Metroid DNA {i}",
+            "pickup_category": "dna",
+            "model_name": "DNA_{i}",
+            "offworld_models": {
+                "am2r": "sItemDNA"
+            },
+            "progression": [
+                "Artifact{i}"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "probability_offset": 0.25
         }
     },
     "standard_pickups": {

--- a/randovania/games/factorio/pickup_database/pickup-database.json
+++ b/randovania/games/factorio/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "construction": {
             "long_name": "Construction",
@@ -82,6 +82,7 @@
             "hinted_as_major": true
         }
     },
+    "generated_pickups": {},
     "standard_pickups": {
         "Circuit Network": {
             "pickup_category": "construction",
@@ -354,10 +355,10 @@
             ],
             "preferred_location_category": "minor",
             "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 5,
             "original_locations": [
                 157
-            ],
-            "custom_count_for_shuffled_case": 5
+            ]
         },
         "Bulk Inserter Capacity Bonus": {
             "pickup_category": "enhancement",
@@ -418,10 +419,10 @@
             ],
             "preferred_location_category": "minor",
             "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 3,
             "original_locations": [
                 16
-            ],
-            "custom_count_for_shuffled_case": 3
+            ]
         },
         "Weapon Shooting Speed": {
             "pickup_category": "enhancement",
@@ -459,10 +460,10 @@
             ],
             "preferred_location_category": "minor",
             "expected_case_for_describer": "shuffled",
+            "custom_count_for_shuffled_case": 5,
             "original_locations": [
                 179
-            ],
-            "custom_count_for_shuffled_case": 5
+            ]
         },
         "Armor": {
             "pickup_category": "gear",
@@ -1064,10 +1065,10 @@
             ],
             "preferred_location_category": "major",
             "expected_case_for_describer": "vanilla",
+            "hide_from_gui": true,
             "original_locations": [
                 156
-            ],
-            "hide_from_gui": true
+            ]
         },
         "Speed Module": {
             "pickup_category": "production",

--- a/randovania/games/fusion/assets/migration_data.json
+++ b/randovania/games/fusion/assets/migration_data.json
@@ -1,2 +1,28 @@
 {
+    "generated_pickups": {
+        "categories": {
+            "InfantMetroid": {
+                "long_name": "Infant Metroid",
+                "hint_details": [
+                    "an ",
+                    "Infant Metroid"
+                ],
+                "hinted_as_major": false,
+                "is_key": true
+            }
+        },
+        "pickups": {
+            "Infant Metroid": {
+                "name_template": "Infant Metroid {i}",
+                "pickup_category": "InfantMetroid",
+                "model_name": "InfantMetroid",
+                "offworld_models": {},
+                "progression": [
+                    "Infant Metroid {i}"
+                ],
+                "preferred_location_category": "major",
+                "probability_offset": 0.25
+            }
+        }
+    }
 }

--- a/randovania/games/fusion/generator/bootstrap.py
+++ b/randovania/games/fusion/generator/bootstrap.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING
 
-from randovania.games.fusion.generator.pool_creator import INFANT_METROID_CATEGORY
 from randovania.games.fusion.layout import FusionConfiguration
 from randovania.resolver.bootstrap import Bootstrap
 from randovania.resolver.energy_tank_damage_state import EnergyTankDamageState
@@ -72,5 +71,5 @@ class FusionBootstrap(Bootstrap):
             return super().assign_pool_results(rng, patches, pool_results)
 
         locations = self.all_preplaced_item_locations(patches.game, patches.configuration, is_metroid_location)
-        self.pre_place_items(rng, locations, pool_results, INFANT_METROID_CATEGORY)
+        self.pre_place_items(rng, locations, pool_results, "InfantMetroid", patches.game.game)
         return super().assign_pool_results(rng, patches, pool_results)

--- a/randovania/games/fusion/generator/pool_creator.py
+++ b/randovania/games/fusion/generator/pool_creator.py
@@ -2,42 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
-from randovania.game_description.resources.location_category import LocationCategory
 from randovania.games.fusion.layout.fusion_configuration import FusionArtifactConfig, FusionConfiguration
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
     from randovania.game_description.game_description import GameDescription
-    from randovania.game_description.resources.resource_database import ResourceDatabase
+    from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.layout.base.base_configuration import BaseConfiguration
-
-INFANT_METROID_CATEGORY = pickup_category.PickupCategory(
-    name="InfantMetroid",
-    long_name="Infant Metroid",
-    hint_details=("some ", "Infant Metroid"),
-    hinted_as_major=False,
-    is_key=True,
-)
-
-
-def create_fusion_artifact(
-    artifact_number: int,
-    resource_database: ResourceDatabase,
-) -> PickupEntry:
-    return PickupEntry(
-        name=f"Infant Metroid {artifact_number + 1}",
-        progression=((resource_database.get_item(f"Infant Metroid {artifact_number + 1}"), 1),),
-        model=PickupModel(game=resource_database.game_enum, name="InfantMetroid"),
-        pickup_category=INFANT_METROID_CATEGORY,
-        broad_category=pickup_category.GENERIC_KEY_CATEGORY,
-        generator_params=PickupGeneratorParams(
-            preferred_location_category=LocationCategory.MAJOR,
-            probability_offset=0.25,
-        ),
-    )
 
 
 def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
@@ -56,7 +29,9 @@ def artifact_pool(game: GameDescription, config: FusionArtifactConfig) -> PoolRe
     if config.required_artifacts > max_artifacts:
         raise InvalidConfiguration("More Infant Metroids than allowed!")
 
-    keys: list[PickupEntry] = [create_fusion_artifact(i, game.resource_database) for i in range(20)]
+    keys: list[PickupEntry] = [
+        create_generated_pickup("Infant Metroid", game.resource_database, i + 1) for i in range(20)
+    ]
     keys_to_shuffle = keys[: config.placed_artifacts]
     starting_keys = keys[config.placed_artifacts :]
 

--- a/randovania/games/fusion/generator/pool_creator.py
+++ b/randovania/games/fusion/generator/pool_creator.py
@@ -30,7 +30,7 @@ def artifact_pool(game: GameDescription, config: FusionArtifactConfig) -> PoolRe
         raise InvalidConfiguration("More Infant Metroids than allowed!")
 
     keys: list[PickupEntry] = [
-        create_generated_pickup("Infant Metroid", game.resource_database, i + 1) for i in range(20)
+        create_generated_pickup("Infant Metroid", game.resource_database, i=i + 1) for i in range(20)
     ]
     keys_to_shuffle = keys[: config.placed_artifacts]
     starting_keys = keys[config.placed_artifacts :]

--- a/randovania/games/fusion/pickup_database/pickup-database.json
+++ b/randovania/games/fusion/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "beam": {
             "long_name": "Beams",
@@ -88,6 +88,29 @@
                 "miscellaneous system"
             ],
             "hinted_as_major": true
+        },
+        "InfantMetroid": {
+            "long_name": "Infant Metroid",
+            "hint_details": [
+                "an ",
+                "Infant Metroid"
+            ],
+            "hinted_as_major": false,
+            "is_key": true
+        }
+    },
+    "generated_pickups": {
+        "Infant Metroid": {
+            "name_template": "Infant Metroid {i}",
+            "pickup_category": "InfantMetroid",
+            "model_name": "InfantMetroid",
+            "offworld_models": {},
+            "progression": [
+                "Infant Metroid {i}"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "probability_offset": 0.25
         }
     },
     "standard_pickups": {
@@ -517,11 +540,11 @@
             "preferred_location_category": "minor",
             "expected_case_for_describer": "shuffled",
             "custom_count_for_shuffled_case": 20,
+            "probability_offset": 1.5,
+            "probability_multiplier": 2.0,
             "extra": {
                 "StartingItemCategory": "Energy"
-            },
-            "probability_offset": 1.5,
-            "probability_multiplier": 2.0
+            }
         },
         "Level 0 Keycard": {
             "pickup_category": "misc",
@@ -627,12 +650,11 @@
             "preferred_location_category": "minor",
             "unlocked_by": "MissileData",
             "temporary": "LockedMissiles",
+            "probability_offset": 1.5,
             "allows_negative": true,
             "extra": {
                 "TankIncrementName": "MissileTank"
-            },
-            "probability_offset": 1.5,
-            "probability_multiplier": 2.0
+            }
         },
         "Power Bomb Tank": {
             "broad_category": "morph_ball_related",

--- a/randovania/games/planets_zebeth/assets/migration_data.json
+++ b/randovania/games/planets_zebeth/assets/migration_data.json
@@ -1,2 +1,28 @@
 {
+    "generated_pickups": {
+        "categories": {
+            "tourian_key": {
+                "long_name": "Tourian Key",
+                "hint_details": [
+                    "a ",
+                    "key"
+                ],
+                "hinted_as_major": false,
+                "is_key": true
+            }
+        },
+        "pickups": {
+            "Tourian Key": {
+                "name_template": "Tourian Key {i}",
+                "pickup_category": "tourian_key",
+                "model_name": "spr_ITEM_Tourian_Key",
+                "offworld_models": {},
+                "progression": [
+                    "Tourian Key"
+                ],
+                "preferred_location_category": "major",
+                "probability_offset": 0.25
+            }
+        }
+    }
 }

--- a/randovania/games/planets_zebeth/generator/pool_creator.py
+++ b/randovania/games/planets_zebeth/generator/pool_creator.py
@@ -2,42 +2,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
-from randovania.game_description.resources.location_category import LocationCategory
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.games.planets_zebeth.layout.planets_zebeth_configuration import (
     PlanetsZebethArtifactConfig,
     PlanetsZebethConfiguration,
 )
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
     from randovania.game_description.game_description import GameDescription
-    from randovania.game_description.resources.resource_database import ResourceDatabase
+    from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.layout.base.base_configuration import BaseConfiguration
-
-TOURIAN_KEY_CATEGORY = pickup_category.PickupCategory(
-    name="key", long_name="Tourian Key", hint_details=("some ", "key"), hinted_as_major=False, is_key=True
-)
-
-
-def create_planets_zebeth_artifact(
-    artifact_number: int,
-    resource_database: ResourceDatabase,
-) -> PickupEntry:
-    return PickupEntry(
-        name=f"Tourian Key {artifact_number + 1}",
-        progression=((resource_database.get_item("Tourian Key"), 1),),
-        model=PickupModel(game=resource_database.game_enum, name="spr_ITEM_Tourian_Key"),
-        pickup_category=TOURIAN_KEY_CATEGORY,
-        broad_category=pickup_category.GENERIC_KEY_CATEGORY,
-        generator_params=PickupGeneratorParams(
-            preferred_location_category=LocationCategory.MAJOR,
-            probability_offset=0.25,
-        ),
-    )
 
 
 def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
@@ -47,7 +24,7 @@ def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: G
 
 
 def artifact_pool(game: GameDescription, config: PlanetsZebethArtifactConfig) -> PoolResults:
-    keys: list[PickupEntry] = [create_planets_zebeth_artifact(i, game.resource_database) for i in range(9)]
+    keys: list[PickupEntry] = [create_generated_pickup("Tourian Key", game.resource_database, i + 1) for i in range(9)]
 
     # Check if we have vanilla tourian keys checked
     if config.vanilla_tourian_keys:

--- a/randovania/games/planets_zebeth/generator/pool_creator.py
+++ b/randovania/games/planets_zebeth/generator/pool_creator.py
@@ -24,7 +24,9 @@ def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: G
 
 
 def artifact_pool(game: GameDescription, config: PlanetsZebethArtifactConfig) -> PoolResults:
-    keys: list[PickupEntry] = [create_generated_pickup("Tourian Key", game.resource_database, i + 1) for i in range(9)]
+    keys: list[PickupEntry] = [
+        create_generated_pickup("Tourian Key", game.resource_database, i=i + 1) for i in range(9)
+    ]
 
     # Check if we have vanilla tourian keys checked
     if config.vanilla_tourian_keys:

--- a/randovania/games/planets_zebeth/pickup_database/pickup-database.json
+++ b/randovania/games/planets_zebeth/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "beam": {
             "long_name": "Beams",
@@ -80,6 +80,29 @@
                 "life support system"
             ],
             "hinted_as_major": false
+        },
+        "tourian_key": {
+            "long_name": "Tourian Key",
+            "hint_details": [
+                "a ",
+                "key"
+            ],
+            "hinted_as_major": false,
+            "is_key": true
+        }
+    },
+    "generated_pickups": {
+        "Tourian Key": {
+            "name_template": "Tourian Key {i}",
+            "pickup_category": "tourian_key",
+            "model_name": "spr_ITEM_Tourian_Key",
+            "offworld_models": {},
+            "progression": [
+                "Tourian Key"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "probability_offset": 0.25
         }
     },
     "standard_pickups": {
@@ -96,8 +119,8 @@
             "progression": [
                 "Bombs"
             ],
-            "expected_case_for_describer": "shuffled",
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_locations": [
                 6
             ]
@@ -114,8 +137,8 @@
             "progression": [
                 "Screw Attack"
             ],
-            "expected_case_for_describer": "shuffled",
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_locations": [
                 23
             ]
@@ -133,8 +156,8 @@
             "progression": [
                 "Varia Suit"
             ],
-            "expected_case_for_describer": "shuffled",
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_locations": [
                 3
             ]
@@ -152,8 +175,8 @@
             "progression": [
                 "Hi-Jump"
             ],
-            "expected_case_for_describer": "shuffled",
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_locations": [
                 16
             ]
@@ -169,9 +192,9 @@
             "progression": [
                 "Ice Beam"
             ],
+            "preferred_location_category": "major",
             "expected_case_for_describer": "shuffled",
             "custom_count_for_shuffled_case": 2,
-            "preferred_location_category": "major",
             "original_locations": [
                 8,
                 10
@@ -189,8 +212,8 @@
             "progression": [
                 "Wave Beam"
             ],
-            "expected_case_for_describer": "shuffled",
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_locations": [
                 24
             ]
@@ -205,8 +228,8 @@
             "progression": [
                 "Long Beam"
             ],
-            "expected_case_for_describer": "shuffled",
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_locations": [
                 2
             ]
@@ -223,8 +246,8 @@
             "progression": [
                 "Morph Ball"
             ],
-            "expected_case_for_describer": "shuffled",
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "original_locations": [
                 0
             ]
@@ -242,8 +265,8 @@
             "progression": [
                 "Missile Launcher"
             ],
-            "expected_case_for_describer": "shuffled",
             "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
             "ammo": [
                 "Missiles"
             ],
@@ -265,9 +288,9 @@
             "progression": [
                 "Energy Tank"
             ],
+            "preferred_location_category": "minor",
             "expected_case_for_describer": "shuffled",
-            "custom_count_for_shuffled_case": 8,
-            "preferred_location_category": "minor"
+            "custom_count_for_shuffled_case": 8
         }
     },
     "ammo_pickups": {

--- a/randovania/games/prime1/assets/migration_data.json
+++ b/randovania/games/prime1/assets/migration_data.json
@@ -954,7 +954,7 @@
         "Magmoor Caverns/Transport to Chozo Ruins North/Teleporter to Chozo Ruins": "Lava Lake Elevator",
         "Magmoor Caverns/Transport to Phendrana Drifts North/Teleporter to Phendrana Drifts": "Monitor Station Elevator",
         "Magmoor Caverns/Transport to Tallon Overworld West/Teleporter to Tallon Overworld": "Twin Fires Elevator",
-        "Magmoor Caverns/Transport to Phazon Mines West/Teleporter to Phazon Mines": "Magmoor Workstation West Elevator (Debris)",        
+        "Magmoor Caverns/Transport to Phazon Mines West/Teleporter to Phazon Mines": "Magmoor Workstation West Elevator (Debris)",
         "Magmoor Caverns/Transport to Phendrana Drifts South/Teleporter to Phendrana Drifts": "Magmoor Workstation South Elevator (Save)",
         "Phazon Mines/Transport to Tallon Overworld South/Teleporter to Tallon Overworld": "Main Quarry Elevator",
         "Phazon Mines/Transport to Magmoor Caverns South/Teleporter to Magmoor Caverns": "Phazon Processing Elevator",
@@ -967,6 +967,35 @@
         "Chozo Ruins/Transport to Magmoor Caverns North/Teleporter to Magmoor Caverns": "Sun Tower Elevator",
         "Chozo Ruins/Transport to Tallon Overworld East/Teleporter to Tallon Overworld": "Reflecting Pool West Elevator (Save)",
         "Chozo Ruins/Transport to Tallon Overworld South/Teleporter to Tallon Overworld": "Reflecting Pool South Elevator (Far)"
+    },
+    "generated_pickups": {
+        "categories": {
+            "artifact": {
+                "long_name": "Artifact",
+                "hint_details": [
+                    "an ",
+                    "artifact"
+                ],
+                "hinted_as_major": false,
+                "is_key": true
+            }
+        },
+        "pickups": {
+            "Chozo Artifact": {
+                "name_template": "Artifact of {i}",
+                "pickup_category": "artifact",
+                "model_name": "Artifact of {i}",
+                "offworld_models": {
+                    "am2r": "sItemArtifact{i}Prime"
+                },
+                "progression": [
+                    "{i}"
+                ],
+                "preferred_location_category": "major",
+                "probability_offset": 0.25,
+                "probability_multiplier": 1.2
+            }
+        }
     }
 }
 

--- a/randovania/games/prime1/assets/migration_data.json
+++ b/randovania/games/prime1/assets/migration_data.json
@@ -982,14 +982,14 @@
         },
         "pickups": {
             "Chozo Artifact": {
-                "name_template": "Artifact of {i}",
+                "name_template": "Artifact of {name}",
                 "pickup_category": "artifact",
-                "model_name": "Artifact of {i}",
+                "model_name": "Artifact of {name}",
                 "offworld_models": {
-                    "am2r": "sItemArtifact{i}Prime"
+                    "am2r": "sItemArtifact{name}Prime"
                 },
                 "progression": [
-                    "{i}"
+                    "{name}"
                 ],
                 "preferred_location_category": "major",
                 "probability_offset": 0.25,

--- a/randovania/games/prime1/generator/pickup_pool/artifacts.py
+++ b/randovania/games/prime1/generator/pickup_pool/artifacts.py
@@ -32,8 +32,8 @@ def add_artifacts(
             create_generated_pickup(
                 "Chozo Artifact",
                 resource_database,
-                prime_items.ARTIFACT_ITEMS[i],
-                artifact_minimum_progression,
+                name=prime_items.ARTIFACT_ITEMS[i],
+                minimum_progression=artifact_minimum_progression,
             )
         )
 
@@ -43,8 +43,8 @@ def add_artifacts(
         create_generated_pickup(
             "Chozo Artifact",
             resource_database,
-            prime_items.ARTIFACT_ITEMS[automatic_artifact],
-            artifact_minimum_progression,
+            name=prime_items.ARTIFACT_ITEMS[automatic_artifact],
+            minimum_progression=artifact_minimum_progression,
         )
         for automatic_artifact in range(first_automatic_artifact, 12)
     ]

--- a/randovania/games/prime1/generator/pickup_pool/artifacts.py
+++ b/randovania/games/prime1/generator/pickup_pool/artifacts.py
@@ -2,22 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from frozendict import frozendict
-
-from randovania.game.game_enum import RandovaniaGame
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
-from randovania.game_description.resources.location_category import LocationCategory
 from randovania.games.prime1.patcher import prime_items
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 if TYPE_CHECKING:
+    from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.games.prime1.layout.artifact_mode import LayoutArtifactMode
-
-ARTIFACT_CATEGORY = pickup_category.PickupCategory(
-    name="artifact", long_name="Artifact", hint_details=("an ", "artifact"), hinted_as_major=False, is_key=True
-)
 
 
 def add_artifacts(
@@ -36,39 +28,25 @@ def add_artifacts(
     artifacts_to_place = total.value
 
     for i in range(artifacts_to_place):
-        item_pool.append(create_artifact(i, artifact_minimum_progression, resource_database))
+        item_pool.append(
+            create_generated_pickup(
+                "Chozo Artifact",
+                resource_database,
+                prime_items.ARTIFACT_ITEMS[i],
+                artifact_minimum_progression,
+            )
+        )
 
     first_automatic_artifact = artifacts_to_place
 
     starting = [
-        create_artifact(automatic_artifact, artifact_minimum_progression, resource_database)
+        create_generated_pickup(
+            "Chozo Artifact",
+            resource_database,
+            prime_items.ARTIFACT_ITEMS[automatic_artifact],
+            artifact_minimum_progression,
+        )
         for automatic_artifact in range(first_automatic_artifact, 12)
     ]
 
     return PoolResults(item_pool, {}, starting)
-
-
-def create_artifact(
-    artifact_index: int,
-    minimum_progression: int,
-    resource_database: ResourceDatabase,
-) -> PickupEntry:
-    return PickupEntry(
-        name=prime_items.ARTIFACT_NAMES[artifact_index],
-        progression=((resource_database.get_item(prime_items.ARTIFACT_ITEMS[artifact_index]), 1),),
-        model=PickupModel(
-            game=resource_database.game_enum,
-            name=prime_items.ARTIFACT_MODEL[artifact_index],
-        ),
-        pickup_category=ARTIFACT_CATEGORY,
-        broad_category=pickup_category.GENERIC_KEY_CATEGORY,
-        offworld_models=frozendict(
-            {RandovaniaGame.AM2R: f"sItemArtifact{prime_items.ARTIFACT_ITEMS[artifact_index]}Prime"}
-        ),
-        generator_params=PickupGeneratorParams(
-            preferred_location_category=LocationCategory.MAJOR,
-            probability_offset=0.25,
-            probability_multiplier=1.2,
-            required_progression=minimum_progression,
-        ),
-    )

--- a/randovania/games/prime1/pickup_database/pickup-database.json
+++ b/randovania/games/prime1/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "visor": {
             "long_name": "Visors",
@@ -104,6 +104,32 @@
                 "miscellaneous system"
             ],
             "hinted_as_major": false
+        },
+        "artifact": {
+            "long_name": "Artifact",
+            "hint_details": [
+                "an ",
+                "artifact"
+            ],
+            "hinted_as_major": false,
+            "is_key": true
+        }
+    },
+    "generated_pickups": {
+        "Chozo Artifact": {
+            "name_template": "Artifact of {i}",
+            "pickup_category": "artifact",
+            "model_name": "Artifact of {i}",
+            "offworld_models": {
+                "am2r": "sItemArtifact{i}Prime"
+            },
+            "progression": [
+                "{i}"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "probability_offset": 0.25,
+            "probability_multiplier": 1.2
         }
     },
     "standard_pickups": {
@@ -495,7 +521,6 @@
             "original_locations": [
                 83
             ],
-            "probability_offset": 0.0,
             "probability_multiplier": 0.7
         },
         "Super Missile": {
@@ -585,9 +610,8 @@
             "preferred_location_category": "minor",
             "unlocked_by": "MissileLauncher",
             "temporary": "LockedMissile",
-            "allows_negative": true,
-            "probability_offset": 0.0,
-            "probability_multiplier": 0.85
+            "probability_multiplier": 0.85,
+            "allows_negative": true
         },
         "Power Bomb Expansion": {
             "broad_category": "morph_ball_related",
@@ -616,9 +640,9 @@
             "preferred_location_category": "minor",
             "allows_negative": false,
             "description": "Refills your Energy by a set amount.",
-            "mention_limit": false,
+            "include_expected_counts": false,
             "explain_other_sources": false,
-            "include_expected_counts": false
+            "mention_limit": false
         },
         "Missile Refill": {
             "broad_category": "misc",
@@ -630,9 +654,9 @@
             "preferred_location_category": "minor",
             "allows_negative": false,
             "description": "Refills your Missiles by a set amount.",
-            "mention_limit": false,
+            "include_expected_counts": false,
             "explain_other_sources": false,
-            "include_expected_counts": false
+            "mention_limit": false
         },
         "Power Bomb Refill": {
             "broad_category": "misc",
@@ -644,9 +668,9 @@
             "preferred_location_category": "minor",
             "allows_negative": false,
             "description": "Refills your Power Bombs by a set amount.",
-            "mention_limit": false,
+            "include_expected_counts": false,
             "explain_other_sources": false,
-            "include_expected_counts": false
+            "mention_limit": false
         }
     },
     "default_pickups": {},

--- a/randovania/games/prime1/pickup_database/pickup-database.json
+++ b/randovania/games/prime1/pickup_database/pickup-database.json
@@ -117,14 +117,14 @@
     },
     "generated_pickups": {
         "Chozo Artifact": {
-            "name_template": "Artifact of {i}",
+            "name_template": "Artifact of {name}",
             "pickup_category": "artifact",
-            "model_name": "Artifact of {i}",
+            "model_name": "Artifact of {name}",
             "offworld_models": {
-                "am2r": "sItemArtifact{i}Prime"
+                "am2r": "sItemArtifact{name}Prime"
             },
             "progression": [
-                "{i}"
+                "{name}"
             ],
             "preferred_location_category": "major",
             "expected_case_for_describer": "shuffled",

--- a/randovania/games/prime2/assets/migration_data.json
+++ b/randovania/games/prime2/assets/migration_data.json
@@ -972,12 +972,88 @@
         "Great Temple/Temple Transport B/Elevator to Temple Grounds": "Temple Transport Violet",
         "Agon Wastes/Transport to Temple Grounds/Elevator to Temple Grounds": "Agon Entrance",
         "Agon Wastes/Transport to Torvus Bog/Elevator to Torvus Bog": "Agon Portal Access",
-        "Agon Wastes/Transport to Sanctuary Fortress/Elevator to Sanctuary Fortress": "Agon Temple Access",        
+        "Agon Wastes/Transport to Sanctuary Fortress/Elevator to Sanctuary Fortress": "Agon Temple Access",
         "Torvus Bog/Transport to Temple Grounds/Elevator to Temple Grounds": "Torvus Entrance",
         "Torvus Bog/Transport to Agon Wastes/Elevator to Agon Wastes": "Torvus Temple Access",
-        "Torvus Bog/Transport to Sanctuary Fortress/Elevator to Sanctuary Fortress": "Lower Torvus Access",        
+        "Torvus Bog/Transport to Sanctuary Fortress/Elevator to Sanctuary Fortress": "Lower Torvus Access",
         "Sanctuary Fortress/Transport to Temple Grounds/Elevator to Temple Grounds": "Sanctuary Entrance",
         "Sanctuary Fortress/Transport to Agon Wastes/Elevator to Agon Wastes": "Sanctuary Spider side",
         "Sanctuary Fortress/Transport to Torvus Bog/Elevator to Torvus Bog": "Sanctuary Vault side"
+    },
+    "generated_pickups": {
+        "categories": {
+            "temple_key": {
+                "long_name": "Dark Temple Key",
+                "hint_details": [
+                    "a ",
+                    "red Temple Key"
+                ],
+                "hinted_as_major": false,
+                "is_key": true
+            },
+            "sky_temple_key": {
+                "long_name": "Sky Temple Key",
+                "hint_details": [
+                    "a ",
+                    "Sky Temple Key"
+                ],
+                "hinted_as_major": false,
+                "is_key": true
+            }
+        },
+        "pickups": {
+            "Sky Temple Key": {
+                "name_template": "Sky Temple Key {i}",
+                "pickup_category": "sky_temple_key",
+                "model_name": "SkyTempleKey",
+                "offworld_models": {
+                    "am2r": "sItemSkyTempleKeyEchoes"
+                },
+                "progression": [
+                    "TempleKey{i}"
+                ],
+                "preferred_location_category": "major",
+                "probability_offset": 3.0
+            },
+            "Dark Agon Key": {
+                "name_template": "Dark Agon Key {i}",
+                "pickup_category": "temple_key",
+                "model_name": "DarkTempleKey",
+                "offworld_models": {
+                    "am2r": "sItemDarkAgonKeyEchoes"
+                },
+                "progression": [
+                    "AgonKey{i}"
+                ],
+                "preferred_location_category": "major",
+                "probability_offset": 3.0
+            },
+            "Dark Torvus Key": {
+                "name_template": "Dark Torvus Key {i}",
+                "pickup_category": "temple_key",
+                "model_name": "DarkTempleKey",
+                "offworld_models": {
+                    "am2r": "sItemDarkTorvusKeyEchoes"
+                },
+                "progression": [
+                    "TorvusKey{i}"
+                ],
+                "preferred_location_category": "major",
+                "probability_offset": 3.0
+            },
+            "Ing Hive Key": {
+                "name_template": "Ing Hive Key {i}",
+                "pickup_category": "temple_key",
+                "model_name": "DarkTempleKey",
+                "offworld_models": {
+                    "am2r": "sItemIngHiveKeyEchoes"
+                },
+                "progression": [
+                    "HiveKey{i}"
+                ],
+                "preferred_location_category": "major",
+                "probability_offset": 3.0
+            }
+        }
     }
 }

--- a/randovania/games/prime2/generator/bootstrap.py
+++ b/randovania/games/prime2/generator/bootstrap.py
@@ -10,7 +10,6 @@ from randovania.game_description.requirements.resource_requirement import Resour
 from randovania.game_description.resources import search
 from randovania.game_description.resources.damage_reduction import DamageReduction
 from randovania.game_description.resources.resource_type import ResourceType
-from randovania.games.prime2.generator.pickup_pool import sky_temple_keys
 from randovania.games.prime2.layout.echoes_configuration import EchoesConfiguration, LayoutSkyTempleKeyMode
 from randovania.games.prime2.layout.translator_configuration import LayoutTranslatorRequirement
 from randovania.resolver.bootstrap import Bootstrap
@@ -115,7 +114,7 @@ class EchoesBootstrap(Bootstrap):
 
         if mode == LayoutSkyTempleKeyMode.ALL_BOSSES or mode == LayoutSkyTempleKeyMode.ALL_GUARDIANS:
             locations = self.all_preplaced_item_locations(patches.game, patches.configuration, is_boss_location)
-            self.pre_place_items(rng, locations, pool_results, sky_temple_keys.SKY_TEMPLE_KEY_CATEGORY)
+            self.pre_place_items(rng, locations, pool_results, "sky_temple_key", patches.game.game)
 
         return super().assign_pool_results(rng, patches, pool_results)
 

--- a/randovania/games/prime2/generator/pickup_pool/dark_temple_keys.py
+++ b/randovania/games/prime2/generator/pickup_pool/dark_temple_keys.py
@@ -21,6 +21,6 @@ def add_dark_temple_keys(
 
     for temple_key in ("Dark Agon Key", "Dark Torvus Key", "Ing Hive Key"):
         for i in range(3):
-            item_pool.append(create_generated_pickup(temple_key, resource_database, i + 1))
+            item_pool.append(create_generated_pickup(temple_key, resource_database, i=i + 1))
 
     return PoolResults(item_pool, {}, [])

--- a/randovania/games/prime2/generator/pickup_pool/dark_temple_keys.py
+++ b/randovania/games/prime2/generator/pickup_pool/dark_temple_keys.py
@@ -2,16 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from frozendict import frozendict
-
-from randovania.game.game_enum import RandovaniaGame
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
-from randovania.game_description.resources.location_category import LocationCategory
-from randovania.games.prime2.patcher import echoes_items
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 if TYPE_CHECKING:
+    from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.game_description.resources.resource_database import ResourceDatabase
 
 
@@ -24,47 +19,8 @@ def add_dark_temple_keys(
     """
     item_pool: list[PickupEntry] = []
 
-    for temple_index in range(3):
+    for temple_key in ("Dark Agon Key", "Dark Torvus Key", "Ing Hive Key"):
         for i in range(3):
-            item_pool.append(create_dark_temple_key(i, temple_index, resource_database))
+            item_pool.append(create_generated_pickup(temple_key, resource_database, i + 1))
 
     return PoolResults(item_pool, {}, [])
-
-
-def create_dark_temple_key(
-    key_number: int,
-    temple_index: int,
-    resource_database: ResourceDatabase,
-) -> PickupEntry:
-    """
-    Creates a Dark Temple Key
-    :param key_number:
-    :param temple_index: The index of the temple: Dark Agon, Dark Torvus, Hive Temple
-    :param resource_database:
-    :return:
-    """
-    TEMPLE_KEY_CATEGORY = pickup_category.PickupCategory(
-        name="temple_key",
-        long_name="Dark Temple Key",
-        hint_details=("a ", "red Temple Key"),
-        hinted_as_major=False,
-        is_key=True,
-    )
-
-    am2r_dark_key_sprite = {0: "sItemDarkAgonKeyEchoes", 1: "sItemDarkTorvusKeyEchoes", 2: "sItemIngHiveKeyEchoes"}
-
-    return PickupEntry(
-        name=echoes_items.DARK_TEMPLE_KEY_NAMES[temple_index].format(key_number + 1),
-        progression=((resource_database.get_item(echoes_items.DARK_TEMPLE_KEY_ITEMS[temple_index][key_number]), 1),),
-        model=PickupModel(
-            game=resource_database.game_enum,
-            name=echoes_items.DARK_TEMPLE_KEY_MODEL,
-        ),
-        pickup_category=TEMPLE_KEY_CATEGORY,
-        broad_category=pickup_category.GENERIC_KEY_CATEGORY,
-        offworld_models=frozendict({RandovaniaGame.AM2R: am2r_dark_key_sprite[temple_index]}),
-        generator_params=PickupGeneratorParams(
-            preferred_location_category=LocationCategory.MAJOR,
-            probability_offset=3.0,
-        ),
-    )

--- a/randovania/games/prime2/generator/pickup_pool/sky_temple_keys.py
+++ b/randovania/games/prime2/generator/pickup_pool/sky_temple_keys.py
@@ -51,7 +51,7 @@ def add_sky_temple_key_distribution_logic(
     first_automatic_key = keys_to_place
 
     starting = [
-        create_generated_pickup("Sky Temple Key", resource_database, automatic_key_number)
+        create_generated_pickup("Sky Temple Key", resource_database, automatic_key_number + 1)
         for automatic_key_number in range(first_automatic_key, 9)
     ]
 

--- a/randovania/games/prime2/generator/pickup_pool/sky_temple_keys.py
+++ b/randovania/games/prime2/generator/pickup_pool/sky_temple_keys.py
@@ -47,11 +47,11 @@ def add_sky_temple_key_distribution_logic(
             raise InvalidConfiguration(f"Unknown Sky Temple Key mode: {mode}")
 
     for key_number in range(keys_to_place):
-        item_pool.append(create_generated_pickup("Sky Temple Key", resource_database, key_number + 1))
+        item_pool.append(create_generated_pickup("Sky Temple Key", resource_database, i=key_number + 1))
     first_automatic_key = keys_to_place
 
     starting = [
-        create_generated_pickup("Sky Temple Key", resource_database, automatic_key_number + 1)
+        create_generated_pickup("Sky Temple Key", resource_database, i=automatic_key_number + 1)
         for automatic_key_number in range(first_automatic_key, 9)
     ]
 

--- a/randovania/games/prime2/generator/pickup_pool/sky_temple_keys.py
+++ b/randovania/games/prime2/generator/pickup_pool/sky_temple_keys.py
@@ -2,29 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from frozendict import frozendict
-
-from randovania.game.game_enum import RandovaniaGame
 from randovania.game_description.db.pickup_node import PickupNode
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
-from randovania.game_description.resources.location_category import LocationCategory
 from randovania.games.prime2.layout.echoes_configuration import LayoutSkyTempleKeyMode
-from randovania.games.prime2.patcher import echoes_items
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
     from randovania.game_description.game_description import GameDescription
-    from randovania.game_description.resources.resource_database import ResourceDatabase
-
-SKY_TEMPLE_KEY_CATEGORY = pickup_category.PickupCategory(
-    name="sky_temple_key",
-    long_name="Sky Temple Key",
-    hint_details=("a ", "Sky Temple Key"),
-    hinted_as_major=False,
-    is_key=True,
-)
+    from randovania.game_description.pickup.pickup_entry import PickupEntry
 
 
 def pickup_nodes_for_stk_mode(game: GameDescription, mode: LayoutSkyTempleKeyMode) -> list[PickupNode]:
@@ -61,40 +47,12 @@ def add_sky_temple_key_distribution_logic(
             raise InvalidConfiguration(f"Unknown Sky Temple Key mode: {mode}")
 
     for key_number in range(keys_to_place):
-        item_pool.append(create_sky_temple_key(key_number, resource_database))
+        item_pool.append(create_generated_pickup("Sky Temple Key", resource_database, key_number + 1))
     first_automatic_key = keys_to_place
 
     starting = [
-        create_sky_temple_key(automatic_key_number, resource_database)
+        create_generated_pickup("Sky Temple Key", resource_database, automatic_key_number)
         for automatic_key_number in range(first_automatic_key, 9)
     ]
 
     return PoolResults(item_pool, {}, starting)
-
-
-def create_sky_temple_key(
-    key_number: int,
-    resource_database: ResourceDatabase,
-) -> PickupEntry:
-    """
-
-    :param key_number:
-    :param resource_database:
-    :return:
-    """
-
-    return PickupEntry(
-        name=f"Sky Temple Key {key_number + 1}",
-        progression=((resource_database.get_item(echoes_items.SKY_TEMPLE_KEY_ITEMS[key_number]), 1),),
-        model=PickupModel(
-            game=resource_database.game_enum,
-            name=echoes_items.SKY_TEMPLE_KEY_MODEL,
-        ),
-        pickup_category=SKY_TEMPLE_KEY_CATEGORY,
-        broad_category=pickup_category.GENERIC_KEY_CATEGORY,
-        offworld_models=frozendict({RandovaniaGame.AM2R: "sItemSkyTempleKeyEchoes"}),
-        generator_params=PickupGeneratorParams(
-            preferred_location_category=LocationCategory.MAJOR,
-            probability_offset=3.0,
-        ),
-    )

--- a/randovania/games/prime2/pickup_database/pickup-database.json
+++ b/randovania/games/prime2/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "visor": {
             "long_name": "Visors",
@@ -112,6 +112,82 @@
                 "HUD system"
             ],
             "hinted_as_major": false
+        },
+        "temple_key": {
+            "long_name": "Dark Temple Key",
+            "hint_details": [
+                "a ",
+                "red Temple Key"
+            ],
+            "hinted_as_major": false,
+            "is_key": true
+        },
+        "sky_temple_key": {
+            "long_name": "Sky Temple Key",
+            "hint_details": [
+                "a ",
+                "Sky Temple Key"
+            ],
+            "hinted_as_major": false,
+            "is_key": true
+        }
+    },
+    "generated_pickups": {
+        "Sky Temple Key": {
+            "name_template": "Sky Temple Key {i}",
+            "pickup_category": "sky_temple_key",
+            "model_name": "SkyTempleKey",
+            "offworld_models": {
+                "am2r": "sItemSkyTempleKeyEchoes"
+            },
+            "progression": [
+                "TempleKey{i}"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "probability_offset": 3.0
+        },
+        "Dark Agon Key": {
+            "name_template": "Dark Agon Key {i}",
+            "pickup_category": "temple_key",
+            "model_name": "DarkTempleKey",
+            "offworld_models": {
+                "am2r": "sItemDarkAgonKeyEchoes"
+            },
+            "progression": [
+                "AgonKey{i}"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "probability_offset": 3.0
+        },
+        "Dark Torvus Key": {
+            "name_template": "Dark Torvus Key {i}",
+            "pickup_category": "temple_key",
+            "model_name": "DarkTempleKey",
+            "offworld_models": {
+                "am2r": "sItemDarkTorvusKeyEchoes"
+            },
+            "progression": [
+                "TorvusKey{i}"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "probability_offset": 3.0
+        },
+        "Ing Hive Key": {
+            "name_template": "Ing Hive Key {i}",
+            "pickup_category": "temple_key",
+            "model_name": "DarkTempleKey",
+            "offworld_models": {
+                "am2r": "sItemIngHiveKeyEchoes"
+            },
+            "progression": [
+                "HiveKey{i}"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "probability_offset": 3.0
         }
     },
     "standard_pickups": {
@@ -273,7 +349,8 @@
                 "Percent": 1
             },
             "original_locations": [
-                43, 24
+                43,
+                24
             ]
         },
         "Power Beam": {
@@ -652,7 +729,8 @@
                 "Percent": 1
             },
             "original_locations": [
-                86, 112
+                86,
+                112
             ],
             "probability_offset": 0.5
         },

--- a/randovania/games/prime3/assets/migration_data.json
+++ b/randovania/games/prime3/assets/migration_data.json
@@ -914,5 +914,35 @@
         "Phaaze/Sanctum (Aurora Unit 313)/Leave Phaaze": "Dock to G.F.S. Valhalla",
         "Pirate Homeworld - Seed/Pirate Homeworld Leviathan Core/Teleporter to Pirate Homeworld": "Dock to Pirate Homeworld - Command",
         "SkyTown, Elysia - Seed/Elysian Leviathan Core/Teleporter to Elysia": "Dock to SkyTown, Elysia - Main"
+    },
+    "generated_pickups": {
+        "categories": {
+            "energy_cell": {
+                "long_name": "Energy Cell",
+                "hint_details": [
+                    "an ",
+                    "energy cell"
+                ],
+                "hinted_as_major": true,
+                "is_key": true
+            }
+        },
+        "pickups": {
+            "Energy Cell": {
+                "name_template": "Energy Cell {i}",
+                "pickup_category": "energy_cell",
+                "model_name": "Energy Cell",
+                "offworld_models": {},
+                "progression": [
+                    "Fuse{i}"
+                ],
+                "additional_resources": {
+                    "Fuses": 1,
+                    "ItemPercentage": 1
+                },
+                "preferred_location_category": "major",
+                "probability_offset": 0.25
+            }
+        }
     }
 }

--- a/randovania/games/prime3/generator/pickup_pool/energy_cells.py
+++ b/randovania/games/prime3/generator/pickup_pool/energy_cells.py
@@ -20,6 +20,6 @@ def add_energy_cells(
     item_pool: list[PickupEntry] = []
 
     for i in range(9):
-        item_pool.append(create_generated_pickup("Energy Cell", resource_database, i + 1))
+        item_pool.append(create_generated_pickup("Energy Cell", resource_database, i=i + 1))
 
     return PoolResults(item_pool, {}, [])

--- a/randovania/games/prime3/generator/pickup_pool/energy_cells.py
+++ b/randovania/games/prime3/generator/pickup_pool/energy_cells.py
@@ -2,18 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
-from randovania.game_description.resources.location_category import LocationCategory
-from randovania.games.prime3.patcher import corruption_items
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 if TYPE_CHECKING:
+    from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.game_description.resources.resource_database import ResourceDatabase
-
-ENERGY_CELL_CATEGORY = pickup_category.PickupCategory(
-    name="energy_cell", long_name="Energy Cell", hint_details=("an ", "energy cell"), hinted_as_major=True, is_key=True
-)
 
 
 def add_energy_cells(
@@ -26,30 +20,6 @@ def add_energy_cells(
     item_pool: list[PickupEntry] = []
 
     for i in range(9):
-        item_pool.append(create_energy_cell(i, resource_database))
+        item_pool.append(create_generated_pickup("Energy Cell", resource_database, i + 1))
 
     return PoolResults(item_pool, {}, [])
-
-
-def create_energy_cell(
-    cell_index: int,
-    resource_database: ResourceDatabase,
-) -> PickupEntry:
-    return PickupEntry(
-        name=f"Energy Cell {cell_index + 1}",
-        progression=((resource_database.get_item(corruption_items.ENERGY_CELL_ITEMS[cell_index]), 1),),
-        extra_resources=(
-            (resource_database.get_item(corruption_items.ENERGY_CELL_TOTAL_ITEM), 1),
-            (resource_database.get_item(corruption_items.PERCENTAGE), 1),
-        ),
-        model=PickupModel(
-            game=resource_database.game_enum,
-            name=corruption_items.ENERGY_CELL_MODEL,
-        ),
-        pickup_category=ENERGY_CELL_CATEGORY,
-        broad_category=pickup_category.GENERIC_KEY_CATEGORY,
-        generator_params=PickupGeneratorParams(
-            preferred_location_category=LocationCategory.MAJOR,
-            probability_offset=0.25,
-        ),
-    )

--- a/randovania/games/prime3/pickup_database/pickup-database.json
+++ b/randovania/games/prime3/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "visor": {
             "long_name": "Visors",
@@ -104,6 +104,33 @@
                 "life support system"
             ],
             "hinted_as_major": false
+        },
+        "energy_cell": {
+            "long_name": "Energy Cell",
+            "hint_details": [
+                "an ",
+                "energy cell"
+            ],
+            "hinted_as_major": true,
+            "is_key": true
+        }
+    },
+    "generated_pickups": {
+        "Energy Cell": {
+            "name_template": "Energy Cell {i}",
+            "pickup_category": "energy_cell",
+            "model_name": "Energy Cell",
+            "offworld_models": {},
+            "progression": [
+                "Fuse{i}"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "additional_resources": {
+                "Fuses": 1,
+                "ItemPercentage": 1
+            },
+            "probability_offset": 0.25
         }
     },
     "standard_pickups": {

--- a/randovania/games/samus_returns/assets/migration_data.json
+++ b/randovania/games/samus_returns/assets/migration_data.json
@@ -401,5 +401,33 @@
     },
     "a1_dlr_rename": {
         "Area 1/Water Maze/Door to Gullugg Gangway": "Area 1/Water Maze/Door to Gullugg Gangway (Bottom)"
+    },
+    "generated_pickups": {
+        "categories": {
+            "dna": {
+                "long_name": "Metroid DNA",
+                "hint_details": [
+                    "some ",
+                    "Metroid DNA"
+                ],
+                "hinted_as_major": false,
+                "is_key": true
+            }
+        },
+        "pickups": {
+            "Metroid DNA": {
+                "name_template": "Metroid DNA {i}",
+                "pickup_category": "dna",
+                "model_name": "adn",
+                "offworld_models": {
+                    "am2r": "sItemDNA"
+                },
+                "progression": [
+                    "Metroid DNA {i}"
+                ],
+                "preferred_location_category": "major",
+                "probability_offset": 0.25
+            }
+        }
     }
 }

--- a/randovania/games/samus_returns/generator/bootstrap.py
+++ b/randovania/games/samus_returns/generator/bootstrap.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from randovania.games.samus_returns.generator.pool_creator import METROID_DNA_CATEGORY
 from randovania.games.samus_returns.layout import MSRConfiguration
 from randovania.games.samus_returns.layout.msr_configuration import FinalBossConfiguration
 from randovania.layout.base.dock_rando_configuration import DockRandoMode
@@ -143,6 +142,6 @@ class MSRBootstrap(Bootstrap):
             return super().assign_pool_results(rng, patches, pool_results)
 
         locations = self.all_preplaced_item_locations(patches.game, patches.configuration, is_dna_node)
-        self.pre_place_items(rng, locations, pool_results, METROID_DNA_CATEGORY)
+        self.pre_place_items(rng, locations, pool_results, "dna", patches.game.game)
 
         return super().assign_pool_results(rng, patches, pool_results)

--- a/randovania/games/samus_returns/generator/pool_creator.py
+++ b/randovania/games/samus_returns/generator/pool_creator.py
@@ -2,42 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from frozendict import frozendict
-
-from randovania.game.game_enum import RandovaniaGame
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
-from randovania.game_description.resources.location_category import LocationCategory
 from randovania.games.samus_returns.layout.msr_configuration import MSRArtifactConfig, MSRConfiguration
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
     from randovania.game_description.game_description import GameDescription
-    from randovania.game_description.resources.resource_database import ResourceDatabase
+    from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.layout.base.base_configuration import BaseConfiguration
-
-METROID_DNA_CATEGORY = pickup_category.PickupCategory(
-    name="dna", long_name="Metroid DNA", hint_details=("some ", "Metroid DNA"), hinted_as_major=False, is_key=True
-)
-
-
-def create_msr_artifact(
-    artifact_number: int,
-    resource_database: ResourceDatabase,
-) -> PickupEntry:
-    return PickupEntry(
-        name=f"Metroid DNA {artifact_number + 1}",
-        progression=((resource_database.get_item(f"Metroid DNA {artifact_number + 1}"), 1),),
-        model=PickupModel(game=resource_database.game_enum, name="adn"),
-        pickup_category=METROID_DNA_CATEGORY,
-        broad_category=pickup_category.GENERIC_KEY_CATEGORY,
-        offworld_models=frozendict({RandovaniaGame.AM2R: "sItemDNA"}),
-        generator_params=PickupGeneratorParams(
-            preferred_location_category=LocationCategory.MAJOR,
-            probability_offset=0.25,
-        ),
-    )
 
 
 def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
@@ -60,7 +33,7 @@ def artifact_pool(game: GameDescription, config: MSRArtifactConfig) -> PoolResul
     if config.required_artifacts > max_artifacts:
         raise InvalidConfiguration("More Metroid DNA than allowed!")
 
-    keys: list[PickupEntry] = [create_msr_artifact(i, game.resource_database) for i in range(39)]
+    keys: list[PickupEntry] = [create_generated_pickup("Metroid DNA", game.resource_database, i + 1) for i in range(39)]
     keys_to_shuffle = keys[: config.placed_artifacts]
     starting_keys = keys[config.placed_artifacts :]
 

--- a/randovania/games/samus_returns/generator/pool_creator.py
+++ b/randovania/games/samus_returns/generator/pool_creator.py
@@ -33,7 +33,9 @@ def artifact_pool(game: GameDescription, config: MSRArtifactConfig) -> PoolResul
     if config.required_artifacts > max_artifacts:
         raise InvalidConfiguration("More Metroid DNA than allowed!")
 
-    keys: list[PickupEntry] = [create_generated_pickup("Metroid DNA", game.resource_database, i + 1) for i in range(39)]
+    keys: list[PickupEntry] = [
+        create_generated_pickup("Metroid DNA", game.resource_database, i=i + 1) for i in range(39)
+    ]
     keys_to_shuffle = keys[: config.placed_artifacts]
     starting_keys = keys[config.placed_artifacts :]
 

--- a/randovania/games/samus_returns/pickup_database/pickup-database.json
+++ b/randovania/games/samus_returns/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "beam": {
             "long_name": "Beams",
@@ -104,6 +104,31 @@
                 "life support system"
             ],
             "hinted_as_major": false
+        },
+        "dna": {
+            "long_name": "Metroid DNA",
+            "hint_details": [
+                "some ",
+                "Metroid DNA"
+            ],
+            "hinted_as_major": false,
+            "is_key": true
+        }
+    },
+    "generated_pickups": {
+        "Metroid DNA": {
+            "name_template": "Metroid DNA {i}",
+            "pickup_category": "dna",
+            "model_name": "adn",
+            "offworld_models": {
+                "am2r": "sItemDNA"
+            },
+            "progression": [
+                "Metroid DNA {i}"
+            ],
+            "preferred_location_category": "major",
+            "expected_case_for_describer": "shuffled",
+            "probability_offset": 0.25
         }
     },
     "standard_pickups": {

--- a/randovania/games/super_metroid/pickup_database/pickup-database.json
+++ b/randovania/games/super_metroid/pickup_database/pickup-database.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": 9,
+    "schema_version": 10,
     "pickup_categories": {
         "beam": {
             "long_name": "Beams",
@@ -90,6 +90,7 @@
             "hinted_as_major": false
         }
     },
+    "generated_pickups": {},
     "standard_pickups": {
         "Charge Beam": {
             "pickup_category": "beam",

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -11,6 +11,7 @@ from randovania.game_description.resources.location_category import LocationCate
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Any
 
     from randovania.game.game_enum import RandovaniaGame
     from randovania.game_description.pickup.ammo_pickup import AmmoPickupDefinition
@@ -113,14 +114,14 @@ def create_ammo_pickup(
 def create_generated_pickup(
     pickup_group: str,
     resource_database: ResourceDatabase,
-    identifier: str | int | None = None,
+    *,
     minimum_progression: int = 0,
+    **format_kwargs: Any,
 ) -> PickupEntry:
     """
     Creates a concrete PickupEntry given a generated pickup group and an identifier
     :param pickup_group:
     :param resource_database:
-    :param identifier:
     :param minimum_progression:
     :return:
     """
@@ -132,18 +133,18 @@ def create_generated_pickup(
     assert not pickup.unlocks_ammo
 
     def _create_resources(base_resource: str, count: int = 1) -> tuple[ItemResourceInfo, int]:
-        return resource_database.get_item(base_resource.format(i=identifier)), count
+        return resource_database.get_item(base_resource.format(**format_kwargs)), count
 
     return PickupEntry(
-        name=pickup.name.format(i=identifier),
+        name=pickup.name.format(**format_kwargs),
         progression=tuple(_create_resources(progression) for progression in pickup.progression),
         extra_resources=tuple(_create_resources(item, count) for item, count in pickup.additional_resources.items()),
         model=PickupModel(
             game=resource_database.game_enum,
-            name=pickup.model_name.format(i=identifier),
+            name=pickup.model_name.format(**format_kwargs),
         ),
         offworld_models=frozendict(
-            {game: model_name.format(i=identifier) for game, model_name in pickup.offworld_models.items()}
+            {game: model_name.format(**format_kwargs) for game, model_name in pickup.offworld_models.items()}
         ),
         pickup_category=pickup.pickup_category,
         broad_category=pickup.broad_category,

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -154,8 +154,6 @@ def create_generated_pickup(
             index_age_impact=pickup.index_age_impact,
             required_progression=minimum_progression,
         ),
-        show_in_credits_spoiler=True,
-        is_expansion=False,
     )
 
 

--- a/randovania/gui/lib/hints_text.py
+++ b/randovania/gui/lib/hints_text.py
@@ -7,13 +7,13 @@ from PySide6 import QtCore, QtWidgets
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_description import default_database
 from randovania.game_description.db.hint_node import HintNode
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 
 def prime1_hint_text():
     db = default_database.resource_database_for(RandovaniaGame.METROID_PRIME)
-    from randovania.games.prime1.generator.pickup_pool import artifacts
 
-    artifact = artifacts.create_artifact(0, 0, db)
+    artifact = create_generated_pickup("Chozo Artifact", db, "Truth", 0)
 
     result = [
         (
@@ -26,14 +26,12 @@ def prime1_hint_text():
 
 
 def prime2_hint_text():
-    from randovania.games.prime2.generator.pickup_pool import dark_temple_keys, sky_temple_keys
-
     db = default_database.resource_database_for(RandovaniaGame.METROID_PRIME_ECHOES)
 
     result = []
 
-    for temple in range(3):
-        key = dark_temple_keys.create_dark_temple_key(0, temple, db)
+    for temple_key in ("Dark Agon Key", "Dark Torvus Key", "Ing Hive Key"):
+        key = create_generated_pickup(temple_key, db, 1)
         result.append(
             (
                 key.name.replace(" 1", "").strip(),
@@ -42,7 +40,7 @@ def prime2_hint_text():
             )
         )
 
-    key = sky_temple_keys.create_sky_temple_key(0, db)
+    key = create_generated_pickup("Sky Temple Key", db, 1)
     result.append(
         (
             "Sky Temple Key",
@@ -56,9 +54,8 @@ def prime2_hint_text():
 
 def prime3_hint_text():
     db = default_database.resource_database_for(RandovaniaGame.METROID_PRIME_CORRUPTION)
-    from randovania.games.prime3.generator.pickup_pool import energy_cells
 
-    cell = energy_cells.create_energy_cell(0, db)
+    cell = create_generated_pickup("Energy Cell", db, 1)
 
     result = [
         (

--- a/randovania/gui/lib/hints_text.py
+++ b/randovania/gui/lib/hints_text.py
@@ -13,7 +13,7 @@ from randovania.generator.pickup_pool.pickup_creator import create_generated_pic
 def prime1_hint_text():
     db = default_database.resource_database_for(RandovaniaGame.METROID_PRIME)
 
-    artifact = create_generated_pickup("Chozo Artifact", db, "Truth", 0)
+    artifact = create_generated_pickup("Chozo Artifact", db, name="Truth")
 
     result = [
         (
@@ -31,7 +31,7 @@ def prime2_hint_text():
     result = []
 
     for temple_key in ("Dark Agon Key", "Dark Torvus Key", "Ing Hive Key"):
-        key = create_generated_pickup(temple_key, db, 1)
+        key = create_generated_pickup(temple_key, db, i=1)
         result.append(
             (
                 key.name.replace(" 1", "").strip(),
@@ -40,7 +40,7 @@ def prime2_hint_text():
             )
         )
 
-    key = create_generated_pickup("Sky Temple Key", db, 1)
+    key = create_generated_pickup("Sky Temple Key", db, i=1)
     result.append(
         (
             "Sky Temple Key",
@@ -55,7 +55,7 @@ def prime2_hint_text():
 def prime3_hint_text():
     db = default_database.resource_database_for(RandovaniaGame.METROID_PRIME_CORRUPTION)
 
-    cell = create_generated_pickup("Energy Cell", db, 1)
+    cell = create_generated_pickup("Energy Cell", db, i=1)
 
     result = [
         (

--- a/randovania/resolver/bootstrap.py
+++ b/randovania/resolver/bootstrap.py
@@ -15,9 +15,9 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from random import Random
 
+    from randovania.game.game_enum import RandovaniaGame
     from randovania.game_description.game_description import GameDescription
     from randovania.game_description.game_patches import GamePatches
-    from randovania.game_description.pickup.pickup_category import PickupCategory
     from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.game_description.resources.resource_info import ResourceGain
     from randovania.generator.pickup_pool import PoolResults
@@ -253,14 +253,18 @@ class Bootstrap:
         rng: Random,
         locations: list[PickupNode],
         pool_results: PoolResults,
-        item_category: PickupCategory,
+        item_category: str,
+        game: RandovaniaGame,
     ) -> None:
         pre_placed_indices = list(pool_results.assignment.keys())
         reduced_locations = [loc for loc in locations if loc.pickup_index not in pre_placed_indices]
 
         rng.shuffle(reduced_locations)
 
-        all_artifacts = [pickup for pickup in list(pool_results.to_place) if pickup.pickup_category is item_category]
+        pickup_database = default_database.pickup_database_for_game(game)
+        category = pickup_database.pickup_categories[item_category]
+
+        all_artifacts = [pickup for pickup in list(pool_results.to_place) if pickup.pickup_category is category]
         if len(all_artifacts) > len(reduced_locations):
             raise InvalidConfiguration(
                 f"Has {len(all_artifacts)} {item_category.long_name} in the pool, "

--- a/test/games/am2r/generator/test_am2r_bootstrap.py
+++ b/test/games/am2r/generator/test_am2r_bootstrap.py
@@ -11,7 +11,6 @@ from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.game_description.resources.resource_collection import ResourceCollection
 from randovania.games.am2r.generator import AM2RBootstrap
-from randovania.games.am2r.generator.pool_creator import METROID_DNA_CATEGORY
 from randovania.games.am2r.layout.am2r_configuration import AM2RArtifactConfig
 from randovania.generator.pickup_pool import pool_creator
 
@@ -41,7 +40,7 @@ def test_assign_pool_results_predetermined(am2r_game_description, am2r_configura
     )
 
     # Assert
-    shuffled_dna = [pickup for pickup in pool_results.to_place if pickup.pickup_category == METROID_DNA_CATEGORY]
+    shuffled_dna = [pickup for pickup in pool_results.to_place if pickup.pickup_category.name == "dna"]
 
     assert result.starting_equipment == pool_results.starting
     assert set(result.pickup_assignment.keys()) == {PickupIndex(i) for i in expected}
@@ -72,7 +71,7 @@ def test_assign_pool_results_prefer_anywhere(am2r_game_description, am2r_configu
     )
 
     # Assert
-    shuffled_dna = [pickup for pickup in pool_results.to_place if pickup.pickup_category == METROID_DNA_CATEGORY]
+    shuffled_dna = [pickup for pickup in pool_results.to_place if pickup.pickup_category.name == "dna"]
 
     assert pool_results.to_place == initial_starting_place
     assert len(shuffled_dna) == artifacts.placed_artifacts

--- a/test/games/am2r/generator/test_am2r_pool_creator.py
+++ b/test/games/am2r/generator/test_am2r_pool_creator.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from randovania.games.am2r.generator.pool_creator import artifact_pool, create_am2r_artifact
+from randovania.games.am2r.generator.pool_creator import artifact_pool
 from randovania.games.am2r.layout.am2r_configuration import AM2RArtifactConfig
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 from randovania.layout.exceptions import InvalidConfiguration
 
 
@@ -16,9 +17,9 @@ def test_am2r_pool_creator(am2r_game_description, required_dna, placed_dna):
 
     # Assert
     assert results == PoolResults(
-        [create_am2r_artifact(i, db) for i in range(required_dna)],
+        [create_generated_pickup("Metroid DNA", db, i + 1) for i in range(required_dna)],
         {},
-        [create_am2r_artifact(i, db) for i in range(required_dna, 46)],
+        [create_generated_pickup("Metroid DNA", db, i + 1) for i in range(required_dna, 46)],
     )
 
 

--- a/test/games/am2r/generator/test_am2r_pool_creator.py
+++ b/test/games/am2r/generator/test_am2r_pool_creator.py
@@ -17,9 +17,9 @@ def test_am2r_pool_creator(am2r_game_description, required_dna, placed_dna):
 
     # Assert
     assert results == PoolResults(
-        [create_generated_pickup("Metroid DNA", db, i + 1) for i in range(required_dna)],
+        [create_generated_pickup("Metroid DNA", db, i=i + 1) for i in range(required_dna)],
         {},
-        [create_generated_pickup("Metroid DNA", db, i + 1) for i in range(required_dna, 46)],
+        [create_generated_pickup("Metroid DNA", db, i=i + 1) for i in range(required_dna, 46)],
     )
 
 

--- a/test/games/dread/generator/test_dread_bootstrap.py
+++ b/test/games/dread/generator/test_dread_bootstrap.py
@@ -8,7 +8,6 @@ import pytest
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.games.dread.generator.bootstrap import DreadBootstrap
-from randovania.games.dread.generator.pool_creator import DREAD_ARTIFACT_CATEGORY
 from randovania.games.dread.layout.dread_configuration import DreadArtifactConfig
 from randovania.generator.pickup_pool import pool_creator
 
@@ -39,7 +38,7 @@ def test_assign_pool_results(dread_game_description, dread_configuration, artifa
     )
 
     # Assert
-    shuffled_dna = [pickup for pickup in pool_results.to_place if pickup.pickup_category == DREAD_ARTIFACT_CATEGORY]
+    shuffled_dna = [pickup for pickup in pool_results.to_place if pickup.pickup_category.name == "dna"]
 
     assert result.starting_equipment == pool_results.starting
     assert set(result.pickup_assignment.keys()) == {PickupIndex(i) for i in expected}

--- a/test/games/dread/generator/test_dread_pool_creator.py
+++ b/test/games/dread/generator/test_dread_pool_creator.py
@@ -17,7 +17,7 @@ def test_artifact_pool(dread_game_description, dread_configuration, count: int):
 
     # Assert
     assert results == PoolResults(
-        to_place=[create_generated_pickup("Metroid DNA", db, i + 1) for i in range(count)],
+        to_place=[create_generated_pickup("Metroid DNA", db, i=i + 1) for i in range(count)],
         assignment={},
-        starting=[create_generated_pickup("Metroid DNA", db, i + 1) for i in range(count, 12)],
+        starting=[create_generated_pickup("Metroid DNA", db, i=i + 1) for i in range(count, 12)],
     )

--- a/test/games/dread/generator/test_dread_pool_creator.py
+++ b/test/games/dread/generator/test_dread_pool_creator.py
@@ -5,6 +5,7 @@ import pytest
 from randovania.games.dread.generator import pool_creator
 from randovania.games.dread.layout.dread_configuration import DreadArtifactConfig
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 
 @pytest.mark.parametrize("count", [0, 1, 6, 11, 12])
@@ -16,7 +17,7 @@ def test_artifact_pool(dread_game_description, dread_configuration, count: int):
 
     # Assert
     assert results == PoolResults(
-        to_place=[pool_creator.create_dread_artifact(i, db) for i in range(count)],
+        to_place=[create_generated_pickup("Metroid DNA", db, i + 1) for i in range(count)],
         assignment={},
-        starting=[pool_creator.create_dread_artifact(i, db) for i in range(count, 12)],
+        starting=[create_generated_pickup("Metroid DNA", db, i + 1) for i in range(count, 12)],
     )

--- a/test/games/fusion/generator/test_fusion_bootstrap.py
+++ b/test/games/fusion/generator/test_fusion_bootstrap.py
@@ -9,7 +9,6 @@ import pytest
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.games.fusion.generator import FusionBootstrap
-from randovania.games.fusion.generator.pool_creator import INFANT_METROID_CATEGORY
 from randovania.games.fusion.layout.fusion_configuration import FusionArtifactConfig
 from randovania.generator.pickup_pool import pool_creator
 
@@ -38,9 +37,7 @@ def test_assign_pool_results_predetermined(fusion_game_description, fusion_confi
     )
 
     # Assert
-    shuffled_metroids = [
-        pickup for pickup in pool_results.to_place if pickup.pickup_category == INFANT_METROID_CATEGORY
-    ]
+    shuffled_metroids = [pickup for pickup in pool_results.to_place if pickup.pickup_category.name == "InfantMetroid"]
 
     assert result.starting_equipment == pool_results.starting
     assert {index for index, entry in result.pickup_assignment.items() if "Infant Metroid" in entry.pickup.name} == {
@@ -72,9 +69,7 @@ def test_assign_pool_results_prefer_anywhere(fusion_game_description, fusion_con
     )
 
     # Assert
-    shuffled_metroids = [
-        pickup for pickup in pool_results.to_place if pickup.pickup_category == INFANT_METROID_CATEGORY
-    ]
+    shuffled_metroids = [pickup for pickup in pool_results.to_place if pickup.pickup_category.name == "InfantMetroid"]
 
     assert pool_results.to_place == initial_starting_place
     assert len(shuffled_metroids) == artifacts.placed_artifacts

--- a/test/games/fusion/generator/test_fusion_pool_creator.py
+++ b/test/games/fusion/generator/test_fusion_pool_creator.py
@@ -27,9 +27,9 @@ def test_fusion_pool_creator(fusion_game_description, required_metroids, placed_
 
     # Assert
     assert results == PoolResults(
-        [create_generated_pickup("Infant Metroid", db, i + 1) for i in range(required_metroids)],
+        [create_generated_pickup("Infant Metroid", db, i=i + 1) for i in range(required_metroids)],
         {},
-        [create_generated_pickup("Infant Metroid", db, i + 1) for i in range(required_metroids, 20)],
+        [create_generated_pickup("Infant Metroid", db, i=i + 1) for i in range(required_metroids, 20)],
     )
 
 

--- a/test/games/fusion/generator/test_fusion_pool_creator.py
+++ b/test/games/fusion/generator/test_fusion_pool_creator.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from randovania.games.fusion.generator.pool_creator import artifact_pool, create_fusion_artifact
+from randovania.games.fusion.generator.pool_creator import artifact_pool
 from randovania.games.fusion.layout.fusion_configuration import FusionArtifactConfig
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 from randovania.layout.exceptions import InvalidConfiguration
 
 
@@ -26,9 +27,9 @@ def test_fusion_pool_creator(fusion_game_description, required_metroids, placed_
 
     # Assert
     assert results == PoolResults(
-        [create_fusion_artifact(i, db) for i in range(required_metroids)],
+        [create_generated_pickup("Infant Metroid", db, i + 1) for i in range(required_metroids)],
         {},
-        [create_fusion_artifact(i, db) for i in range(required_metroids, 20)],
+        [create_generated_pickup("Infant Metroid", db, i + 1) for i in range(required_metroids, 20)],
     )
 
 

--- a/test/games/planets_zebeth/generator/test_planets_zebeth_pool_creator.py
+++ b/test/games/planets_zebeth/generator/test_planets_zebeth_pool_creator.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from randovania.games.planets_zebeth.generator.pool_creator import artifact_pool, create_planets_zebeth_artifact
+from randovania.games.planets_zebeth.generator.pool_creator import artifact_pool
 from randovania.games.planets_zebeth.layout.planets_zebeth_configuration import PlanetsZebethArtifactConfig
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 from randovania.layout.exceptions import InvalidConfiguration
 
 
@@ -16,9 +17,9 @@ def test_planets_zebeth_pool_creator(planets_zebeth_game_description, keys_count
 
     # Assert
     assert results == PoolResults(
-        [create_planets_zebeth_artifact(i, db) for i in range(keys_count)],
+        [create_generated_pickup("Tourian Key", db, i + 1) for i in range(keys_count)],
         {},
-        [create_planets_zebeth_artifact(i, db) for i in range(keys_count, 9)],
+        [create_generated_pickup("Tourian Key", db, i + 1) for i in range(keys_count, 9)],
     )
 
 

--- a/test/games/planets_zebeth/generator/test_planets_zebeth_pool_creator.py
+++ b/test/games/planets_zebeth/generator/test_planets_zebeth_pool_creator.py
@@ -17,9 +17,9 @@ def test_planets_zebeth_pool_creator(planets_zebeth_game_description, keys_count
 
     # Assert
     assert results == PoolResults(
-        [create_generated_pickup("Tourian Key", db, i + 1) for i in range(keys_count)],
+        [create_generated_pickup("Tourian Key", db, i=i + 1) for i in range(keys_count)],
         {},
-        [create_generated_pickup("Tourian Key", db, i + 1) for i in range(keys_count, 9)],
+        [create_generated_pickup("Tourian Key", db, i=i + 1) for i in range(keys_count, 9)],
     )
 
 

--- a/test/games/prime/patcher_file_lib/test_sky_temple_key_hint.py
+++ b/test/games/prime/patcher_file_lib/test_sky_temple_key_hint.py
@@ -10,7 +10,7 @@ from randovania.game_description import default_database
 from randovania.game_description.assignment import PickupTarget
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.games.prime2.exporter.hint_namer import EchoesHintNamer
-from randovania.games.prime2.generator.pickup_pool import sky_temple_keys
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 from randovania.interface_common.players_configuration import PlayersConfiguration
 
 
@@ -63,7 +63,7 @@ def test_create_hints_all_placed(
         [
             (
                 PickupIndex(17 + key),
-                PickupTarget(sky_temple_keys.create_sky_temple_key(key, echoes_game.resource_database), 0),
+                PickupTarget(create_generated_pickup("Sky Temple Key", echoes_game.resource_database, key + 1), 0),
             )
             for key in range(5 if multiworld else 9)
         ]
@@ -74,7 +74,7 @@ def test_create_hints_all_placed(
         [
             (
                 PickupIndex(17 + key),
-                PickupTarget(sky_temple_keys.create_sky_temple_key(key, echoes_game.resource_database), 0),
+                PickupTarget(create_generated_pickup("Sky Temple Key", echoes_game.resource_database, key + 1), 0),
             )
             for key in range(5, 9)
         ]
@@ -141,7 +141,10 @@ def test_create_hints_all_starting(
     players_config = PlayersConfiguration(0, {0: "you", 1: "them"} if multiworld else {0: "you"})
 
     patches = empty_patches.assign_extra_starting_pickups(
-        [(sky_temple_keys.create_sky_temple_key(key, echoes_game_description.resource_database)) for key in range(9)]
+        [
+            (create_generated_pickup("Sky Temple Key", echoes_game_description.resource_database, key + 1))
+            for key in range(9)
+        ]
     )
     patches = dataclasses.replace(patches, configuration=default_echoes_configuration)
     namer = EchoesHintNamer({0: patches}, players_config)

--- a/test/games/prime/patcher_file_lib/test_sky_temple_key_hint.py
+++ b/test/games/prime/patcher_file_lib/test_sky_temple_key_hint.py
@@ -63,7 +63,7 @@ def test_create_hints_all_placed(
         [
             (
                 PickupIndex(17 + key),
-                PickupTarget(create_generated_pickup("Sky Temple Key", echoes_game.resource_database, key + 1), 0),
+                PickupTarget(create_generated_pickup("Sky Temple Key", echoes_game.resource_database, i=key + 1), 0),
             )
             for key in range(5 if multiworld else 9)
         ]
@@ -74,7 +74,7 @@ def test_create_hints_all_placed(
         [
             (
                 PickupIndex(17 + key),
-                PickupTarget(create_generated_pickup("Sky Temple Key", echoes_game.resource_database, key + 1), 0),
+                PickupTarget(create_generated_pickup("Sky Temple Key", echoes_game.resource_database, i=key + 1), 0),
             )
             for key in range(5, 9)
         ]
@@ -142,7 +142,7 @@ def test_create_hints_all_starting(
 
     patches = empty_patches.assign_extra_starting_pickups(
         [
-            (create_generated_pickup("Sky Temple Key", echoes_game_description.resource_database, key + 1))
+            (create_generated_pickup("Sky Temple Key", echoes_game_description.resource_database, i=key + 1))
             for key in range(9)
         ]
     )

--- a/test/games/prime2/generator/test_echoes_bootstrap.py
+++ b/test/games/prime2/generator/test_echoes_bootstrap.py
@@ -13,7 +13,6 @@ from randovania.games.common.prime_family.layout.lib.prime_trilogy_teleporters i
     PrimeTrilogyTeleporterConfiguration,
 )
 from randovania.games.prime2.generator.bootstrap import EchoesBootstrap
-from randovania.games.prime2.generator.pickup_pool import sky_temple_keys
 from randovania.games.prime2.layout.echoes_configuration import LayoutSkyTempleKeyMode
 from randovania.generator.pickup_pool import pool_creator
 
@@ -78,9 +77,7 @@ def test_assign_pool_results(echoes_game_description, default_echoes_configurati
     )
 
     # Assert
-    shuffled_stks = [
-        pickup for pickup in pool_results.to_place if pickup.pickup_category == sky_temple_keys.SKY_TEMPLE_KEY_CATEGORY
-    ]
+    shuffled_stks = [pickup for pickup in pool_results.to_place if pickup.pickup_category.name == "sky_temple_key"]
 
     assert result.starting_equipment == pool_results.starting
     if stk_mode == LayoutSkyTempleKeyMode.ALL_BOSSES:

--- a/test/games/prime2/generator/test_sky_temple_key.py
+++ b/test/games/prime2/generator/test_sky_temple_key.py
@@ -15,15 +15,15 @@ if TYPE_CHECKING:
 
 def _create_pool_with(shuffled_count: int, db: ResourceDatabase):
     return PoolResults(
-        to_place=[create_generated_pickup("Sky Temple Key", db, i + 1) for i in range(shuffled_count)],
+        to_place=[create_generated_pickup("Sky Temple Key", db, i=i + 1) for i in range(shuffled_count)],
         assignment={},
-        starting=[create_generated_pickup("Sky Temple Key", db, i + 1) for i in range(shuffled_count, 9)],
+        starting=[create_generated_pickup("Sky Temple Key", db, i=i + 1) for i in range(shuffled_count, 9)],
     )
 
 
 @pytest.mark.parametrize("index", range(9))
 def test_create_key_id(index: int, echoes_resource_database):
-    key = create_generated_pickup("Sky Temple Key", echoes_resource_database, index + 1)
+    key = create_generated_pickup("Sky Temple Key", echoes_resource_database, i=index + 1)
 
     assert key.pickup_category.name == "sky_temple_key"
     assert key.progression == ((echoes_resource_database.get_item(f"TempleKey{index + 1}"), 1),)

--- a/test/games/prime2/generator/test_sky_temple_key.py
+++ b/test/games/prime2/generator/test_sky_temple_key.py
@@ -7,6 +7,7 @@ import pytest
 from randovania.games.prime2.generator.pickup_pool import sky_temple_keys
 from randovania.games.prime2.layout.echoes_configuration import LayoutSkyTempleKeyMode
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 if TYPE_CHECKING:
     from randovania.game_description.resources.resource_database import ResourceDatabase
@@ -14,17 +15,17 @@ if TYPE_CHECKING:
 
 def _create_pool_with(shuffled_count: int, db: ResourceDatabase):
     return PoolResults(
-        to_place=[sky_temple_keys.create_sky_temple_key(i, db) for i in range(shuffled_count)],
+        to_place=[create_generated_pickup("Sky Temple Key", db, i + 1) for i in range(shuffled_count)],
         assignment={},
-        starting=[sky_temple_keys.create_sky_temple_key(i, db) for i in range(shuffled_count, 9)],
+        starting=[create_generated_pickup("Sky Temple Key", db, i + 1) for i in range(shuffled_count, 9)],
     )
 
 
 @pytest.mark.parametrize("index", range(9))
 def test_create_key_id(index: int, echoes_resource_database):
-    key = sky_temple_keys.create_sky_temple_key(index, echoes_resource_database)
+    key = create_generated_pickup("Sky Temple Key", echoes_resource_database, index + 1)
 
-    assert key.pickup_category is sky_temple_keys.SKY_TEMPLE_KEY_CATEGORY
+    assert key.pickup_category.name == "sky_temple_key"
     assert key.progression == ((echoes_resource_database.get_item(f"TempleKey{index + 1}"), 1),)
 
 

--- a/test/games/samus_returns/generator/test_msr_bootstrap.py
+++ b/test/games/samus_returns/generator/test_msr_bootstrap.py
@@ -9,7 +9,6 @@ import pytest
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.games.samus_returns.generator import MSRBootstrap
-from randovania.games.samus_returns.generator.pool_creator import METROID_DNA_CATEGORY
 from randovania.games.samus_returns.layout.msr_configuration import MSRArtifactConfig
 from randovania.generator.pickup_pool import pool_creator
 
@@ -38,7 +37,7 @@ def test_assign_pool_results_predetermined(msr_game_description, msr_configurati
         pool_results,
     )
     # Assert
-    shuffled_dna = [pickup for pickup in pool_results.to_place if pickup.pickup_category == METROID_DNA_CATEGORY]
+    shuffled_dna = [pickup for pickup in pool_results.to_place if pickup.pickup_category.name == "dna"]
     assert result.starting_equipment == pool_results.starting
     assert set(result.pickup_assignment.keys()) == {PickupIndex(i) for i in expected}
     assert shuffled_dna == []
@@ -68,7 +67,7 @@ def test_assign_pool_results_prefer_anywhere(msr_game_description, msr_configura
     )
 
     # Assert
-    shuffled_dna = [pickup for pickup in pool_results.to_place if pickup.pickup_category == METROID_DNA_CATEGORY]
+    shuffled_dna = [pickup for pickup in pool_results.to_place if pickup.pickup_category.name == "dna"]
 
     assert pool_results.to_place == initial_starting_place
     assert len(shuffled_dna) == artifacts.placed_artifacts

--- a/test/games/samus_returns/generator/test_msr_pool_creator.py
+++ b/test/games/samus_returns/generator/test_msr_pool_creator.py
@@ -17,9 +17,9 @@ def test_msr_pool_creator(msr_game_description, required_dna, placed_dna):
 
     # Assert
     assert results == PoolResults(
-        [create_generated_pickup("Metroid DNA", db, i + 1) for i in range(required_dna)],
+        [create_generated_pickup("Metroid DNA", db, i=i + 1) for i in range(required_dna)],
         {},
-        [create_generated_pickup("Metroid DNA", db, i + 1) for i in range(placed_dna, 39)],
+        [create_generated_pickup("Metroid DNA", db, i=i + 1) for i in range(placed_dna, 39)],
     )
 
 

--- a/test/games/samus_returns/generator/test_msr_pool_creator.py
+++ b/test/games/samus_returns/generator/test_msr_pool_creator.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from randovania.games.samus_returns.generator.pool_creator import artifact_pool, create_msr_artifact
+from randovania.games.samus_returns.generator.pool_creator import artifact_pool
 from randovania.games.samus_returns.layout.msr_configuration import MSRArtifactConfig
 from randovania.generator.pickup_pool import PoolResults
+from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 from randovania.layout.exceptions import InvalidConfiguration
 
 
@@ -16,9 +17,9 @@ def test_msr_pool_creator(msr_game_description, required_dna, placed_dna):
 
     # Assert
     assert results == PoolResults(
-        [create_msr_artifact(i, db) for i in range(required_dna)],
+        [create_generated_pickup("Metroid DNA", db, i + 1) for i in range(required_dna)],
         {},
-        [create_msr_artifact(i, db) for i in range(placed_dna, 39)],
+        [create_generated_pickup("Metroid DNA", db, i + 1) for i in range(placed_dna, 39)],
     )
 
 


### PR DESCRIPTION
another necessary refactor for my hint rework. I'm specifically interested in thoughts on:
1) the use of `{i}` as the name of the variable for string formatting
2) whether `create_generated_pickup()` should automatically increase the identifier by 1 if it's an int. every game that passes an int currently passed `i + 1` and the old functions incremented it automatically