### PR TITLE
Fix option to check if base patches is beatable with all pickups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.9.x] - 2025-02-??
 
 - Added: It is now possible to focus the game images in the "Games" tab via a Keyboard.
+- Added: Experimental option under Generation -> Logic Settings that makes an early check if the game is unbeatable due to options such as starting location, transports etc.
 - Changed: Wording on the Door Locks preset tab to be clearer.
 - Changed: The main Randovania window now doesn't have an unnecessary border.
 - Changed: The highlighted button in the cosmetic options is now `Accept` instead of `Reset to Defaults`.

--- a/randovania/game_description/game_patches.py
+++ b/randovania/game_description/game_patches.py
@@ -239,3 +239,7 @@ class GamePatches:
 
     def set_cached_dock_connections_from(self, node: DockNode, cache: tuple[tuple[Node, Requirement], ...]) -> None:
         self.cached_dock_connections_from[node.node_index] = cache
+
+    def reset_cached_dock_connections_from(self) -> None:
+        for i in range(len(self.cached_dock_connections_from)):
+            self.cached_dock_connections_from[i] = None

--- a/randovania/generator/generator.py
+++ b/randovania/generator/generator.py
@@ -73,6 +73,8 @@ async def check_if_beatable(patches: GamePatches, pool: PoolResults) -> bool:
             return await resolver.advance_depth(state, logic, lambda s: None, max_attempts=1000) is not None
         except exceptions.ResolverTimeoutError:
             return False
+        finally:
+            patches.reset_cached_dock_connections_from()
 
 
 async def create_player_pool(

--- a/randovania/gui/preset_settings/generation_tab.py
+++ b/randovania/gui/preset_settings/generation_tab.py
@@ -62,7 +62,6 @@ class PresetGeneration(PresetTab, Ui_PresetGeneration):
             self.check_if_beatable_after_base_patches_check,
             self._persist_bool_layout_field("check_if_beatable_after_base_patches"),
         )
-        self.check_if_beatable_after_base_patches_check.setVisible(False)  # broken, hide it
 
         # Damage strictness
         self.damage_strictness_combo.setItemData(0, LayoutDamageStrictness.STRICT)
@@ -88,10 +87,6 @@ class PresetGeneration(PresetTab, Ui_PresetGeneration):
         self.trick_level_minimal_logic_check.setChecked(layout.trick_level.minimal_logic)
         signal_handling.set_combo_with_value(self.dangerous_combo, layout.logical_resource_action)
 
-        self.check_if_beatable_after_base_patches_check.setChecked(
-            layout.check_if_beatable_after_base_patches and False  # always disable it when changing from the UI
-        )
-
         signal_handling.set_combo_with_value(self.damage_strictness_combo, preset.configuration.damage_strictness)
 
     @classmethod
@@ -113,7 +108,7 @@ class PresetGeneration(PresetTab, Ui_PresetGeneration):
     @property
     def experimental_settings(self) -> Iterable[QtWidgets.QWidget]:
         # Always hidden right now
-        # yield self.check_if_beatable_after_base_patches_check
+        yield self.check_if_beatable_after_base_patches_check
         yield self.local_first_progression_check
         yield self.local_first_progression_label
         yield self.dangerous_combo


### PR DESCRIPTION
Closes #7096 

There's a funky ownership model where the connection cache lives in the GamePatches object that is shared with later stages of generation, while the underlying connection data is not. 