### PR TITLE
Add support for launching Dolphin from within RDV

### DIFF
--- a/randovania/game_connection/builder/dolphin_connector_builder.py
+++ b/randovania/game_connection/builder/dolphin_connector_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from subprocess import Popen, TimeoutExpired
 from typing import TYPE_CHECKING
 
 from randovania.game_connection.builder.prime_connector_builder import PrimeConnectorBuilder
@@ -11,12 +12,69 @@ if TYPE_CHECKING:
 
 
 class DolphinConnectorBuilder(PrimeConnectorBuilder):
+    dolphin_cmd: str
+    dolphin_comm: str
+    dolphin_child_process: Popen | None
+
+    def __init__(self, dolphin_cmd: str = "", dolphin_comm: str = ""):
+        super().__init__()
+        self.dolphin_cmd = dolphin_cmd
+        self.dolphin_comm = dolphin_comm
+        self.dolphin_child_process = None
+
+    @property
+    def pretty_text(self) -> str:
+        name = super().pretty_text
+
+        # If dolphin_comm is set, display both the program being run (if applicable)
+        # and the commname we will search for in the connector description.
+        if self.dolphin_comm:
+            if self.dolphin_cmd:
+                return f"{name}: run '{self.dolphin_cmd}', attach to '{self.dolphin_comm}'"
+            else:
+                return f"{name}: attach to already-running '{self.dolphin_comm}'"
+
+        # Otherwise just display the program we're running (again, if any) and
+        # rely on pyDME's compiled-in defaults for autodetection.
+        elif self.dolphin_cmd:
+            return f"{name}: run '{self.dolphin_cmd}', then autodetect"
+        else:
+            return f"{name}: autodetect using defaults"
+
     @property
     def connector_builder_choice(self) -> ConnectorBuilderChoice:
         return ConnectorBuilderChoice.DOLPHIN
 
+    def start_dolphin(self) -> None:
+        if not self.dolphin_cmd:
+            return
+
+        if self.dolphin_child_process is None:
+            self.logger.info(f"Dolphin not running, attempting to start it: {self.dolphin_cmd}")
+            self.dolphin_child_process = Popen(self.dolphin_cmd, shell=True)
+
+        elif self.dolphin_child_process.poll() is not None:
+            self.logger.info(f"Dolphin has exited, restarting it: {self.dolphin_cmd}")
+            self.dolphin_child_process = Popen(self.dolphin_cmd, shell=True)
+
+    def stop_dolphin(self) -> None:
+        if self.dolphin_child_process is not None:
+            self.logger.info("Shutting down child Dolphin process.")
+            # Send TERM twice, since the first one just opens a
+            # "are you sure you want to exit?" popup.
+            self.dolphin_child_process.terminate()
+            self.dolphin_child_process.terminate()
+            try:
+                self.dolphin_child_process.wait(timeout=1)
+            except TimeoutExpired:
+                self.dolphin_child_process.kill()
+            self.dolphin_child_process = None
+
     def create_executor(self) -> MemoryOperationExecutor:
-        return DolphinExecutor()
+        return DolphinExecutor(self.dolphin_comm)
 
     def configuration_params(self) -> dict:
-        return {}
+        return {
+            "dolphin_cmd": self.dolphin_cmd,
+            "dolphin_comm": self.dolphin_comm,
+        }

--- a/randovania/game_connection/connector_builder_choice.py
+++ b/randovania/game_connection/connector_builder_choice.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import sys
 from enum import Enum
 from typing import Self
@@ -32,7 +31,7 @@ class ConnectorBuilderChoice(Enum):
             if sys.platform == "darwin":
                 return False
             if sys.platform == "linux" and randovania.is_frozen():
-                return os.getuid() == 0 and not randovania.is_flatpak()
+                return not randovania.is_flatpak()
 
         return True
 

--- a/randovania/games/common/prime_family/gui/dolphin_connector_prompt_dialog.py
+++ b/randovania/games/common/prime_family/gui/dolphin_connector_prompt_dialog.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6 import QtWidgets
+
+from randovania.gui.dialog.text_prompt_dialog import TextPromptDialog
+from randovania.gui.lib import async_dialog
+
+
+class DolphinConnectorPromptDialog(TextPromptDialog):
+    """Similar to ConnectorPromptDialog, but with more options."""
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+
+        # Top line: Launch & Autodetect radio buttons
+        self.launch = QtWidgets.QRadioButton("Launch", self)
+        self.launch.setToolTip(
+            "Run a custom command under Randovania's control, then connect to it. "
+            "This may be needed to work on Linux systems with default security settings."
+        )
+        self.autodetect = QtWidgets.QRadioButton("Autodetect", self)
+        self.autodetect.setToolTip("Attempt to find and connect to an already running Dolphin.")
+        self.gridLayout.addWidget(self.autodetect, 1, 0, 1, 1)
+        self.gridLayout.addWidget(self.launch, 1, 1, 1, 2)
+
+        # Next line, Run Command radio button, text field
+        self.cmd_label = QtWidgets.QLabel("Command", self)
+        self.prompt_edit.setToolTip(
+            "The command to run. This can either be an absolute path (e.g. /usr/bin/dolphin-emu) "
+            "or a plain command name (e.g. dolphin-emu)."
+        )
+        self.gridLayout.addWidget(self.cmd_label, 2, 0, 1, 1)
+        self.gridLayout.addWidget(self.prompt_edit, 2, 1, 1, 2)
+
+        # Third line, custom commname search
+        self.comm_label = QtWidgets.QLabel("Search", self)
+        self.comm_edit = QtWidgets.QLineEdit("", self)
+        self.comm_edit.setToolTip(
+            "The program name to search for when connecting. Leave blank to use the default "
+            "for whatever system you are on. Dolphin on NixOS requires '.dolphin-emu-wr' here."
+        )
+        self.gridLayout.addWidget(self.comm_label, 3, 0, 1, 1)
+        self.gridLayout.addWidget(self.comm_edit, 3, 1, 1, 2)
+
+        # Move around stuff from TextPromptDialog that no longer fits in its
+        # original position.
+        self.gridLayout.addWidget(self.description_label, 4, 0, 1, 3)
+        self.gridLayout.addWidget(self.error_label, 6, 1, 1, 1)
+
+        self.launch.toggled.connect(self._select_launch)
+        self.autodetect.toggled.connect(self._select_autodetect)
+        self.autodetect.setChecked(True)
+
+        self.description_label.setText(
+            "On Windows, the default of 'Autodetect' should work for most users. "
+            "If you are running Linux, you may need to experiment with these settings somewhat -- "
+            "mouse over the options for more information."
+        )
+
+        self.description_label.setWordWrap(True)
+        self.gridLayout.setColumnStretch(1, 1)
+        self._auto_resize()
+
+    def _auto_resize(self) -> None:
+        # The text_prompt_dialog.ui file has hardcoded dimensions which may be too
+        # small for this dialog, so recompute it whenever we hide/show elements.
+        self.resize(self.width(), self.sizeHint().height())
+
+    def _select_autodetect(self) -> None:
+        self.cmd_label.hide()
+        self.prompt_edit.hide()
+        self.comm_label.hide()
+        self.comm_edit.hide()
+        self.accept_button.setEnabled(True)
+        self.error_label.setText("")
+
+    def _select_launch(self) -> None:
+        self.cmd_label.show()
+        self.prompt_edit.show()
+        self.comm_label.show()
+        self.comm_edit.show()
+        self._on_text_changed("")
+
+    @property
+    def value(self) -> (str, str):
+        return (self.prompt_edit.text().strip(), self.comm_edit.text().strip())
+
+    @classmethod
+    async def prompt(
+        cls,
+        *,
+        parent: QtWidgets.QWidget | None = None,
+        is_modal: bool = False,
+    ) -> (str, str) | None:
+        inst = cls(
+            parent=parent,
+            is_modal=is_modal,
+            title="Configure Dolphin Connection",
+            description="",
+            max_length=None,
+            initial_value=None,
+            is_password=False,
+            check_re=None,
+        )
+
+        if await async_dialog.execute_dialog(inst) == QtWidgets.QDialog.DialogCode.Accepted:
+            return inst.value
+        else:
+            return None

--- a/randovania/gui/widgets/game_connection_window.py
+++ b/randovania/gui/widgets/game_connection_window.py
@@ -13,11 +13,15 @@ import randovania
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_connection.builder.connector_builder_option import ConnectorBuilderOption
 from randovania.game_connection.builder.debug_connector_builder import DebugConnectorBuilder
+from randovania.game_connection.builder.dolphin_connector_builder import DolphinConnectorBuilder
 from randovania.game_connection.builder.nintendont_connector_builder import NintendontConnectorBuilder
 from randovania.game_connection.connector.debug_remote_connector import DebugRemoteConnector
 from randovania.game_connection.connector.remote_connector import ImportantStatusMessage, RemoteConnector
 from randovania.game_connection.connector_builder_choice import ConnectorBuilderChoice
 from randovania.games.cave_story.gui.dialog.cs_connector_prompt_dialog import CSConnectorPromptDialog
+from randovania.games.common.prime_family.gui.dolphin_connector_prompt_dialog import (
+    DolphinConnectorPromptDialog,
+)
 from randovania.games.dread.gui.dialog.dread_connector_prompt_dialog import (
     DreadConnectorPromptDialog,
 )
@@ -238,6 +242,13 @@ class GameConnectionWindow(QtWidgets.QMainWindow, Ui_GameConnectionWindow):
                 return
             args["ip"] = new_ip
 
+        if choice == ConnectorBuilderChoice.DOLPHIN:
+            dolphin_settings = await DolphinConnectorPromptDialog.prompt(parent=self, is_modal=True)
+            if dolphin_settings is None:
+                return
+            args["dolphin_cmd"] = dolphin_settings[0]
+            args["dolphin_comm"] = dolphin_settings[1]
+
         if choice == ConnectorBuilderChoice.DREAD:
             new_ip = await DreadConnectorPromptDialog.prompt(
                 parent=self,
@@ -367,6 +378,17 @@ class GameConnectionWindow(QtWidgets.QMainWindow, Ui_GameConnectionWindow):
             action = QtGui.QAction(ui.menu)
             action.setText("Open debug interface")
             action.triggered.connect(functools.partial(self.open_debug_connector_window, builder))
+            ui.menu.addAction(action)
+
+        if isinstance(builder, DolphinConnectorBuilder) and builder.dolphin_cmd:
+            ui.menu.addSeparator()
+            action = QtGui.QAction(ui.menu)
+            action.setText("Start Dolphin")
+            action.triggered.connect(builder.start_dolphin)
+            ui.menu.addAction(action)
+            action = QtGui.QAction(ui.menu)
+            action.setText("Force Quit Dolphin")
+            action.triggered.connect(builder.stop_dolphin)
             ui.menu.addAction(action)
 
         if not randovania.is_frozen():

--- a/randovania/interface_common/persisted_options.py
+++ b/randovania/interface_common/persisted_options.py
@@ -149,6 +149,15 @@ def _remove_msr_fields(options: dict) -> None:
         options["game_samus_returns"]["input_file"] = None
 
 
+def _dolphin_configuration_fields(options: dict) -> None:
+    for connector_builder in options["connector_builders"]:
+        if connector_builder["choice"] == "dolphin":
+            connector_builder["params"] = {
+                "dolphin_cmd": "",
+                "dolphin_comm": "",
+            }
+
+
 _CONVERTER_FOR_VERSION = [
     None,
     None,
@@ -188,6 +197,7 @@ _CONVERTER_FOR_VERSION = [
     _only_new_fields,  # added MSR's music sliders
     _remove_msr_fields,  # removes MSR's exheader and input field
     _only_new_fields,  # added last_changelog_displayed_dev
+    _dolphin_configuration_fields,  # added dolphin process management settings
 ]
 _CURRENT_OPTIONS_FILE_VERSION = migration_lib.get_version(_CONVERTER_FOR_VERSION)
 


### PR DESCRIPTION
This is a mild convenience, but more importantly, it fixes PTRACE permission issues on linux by making dolphin a child process of RDV.

Not entirely happy with the UI, but it works.

![image](https://github.com/user-attachments/assets/6aaa1542-97cc-4343-8f19-dd1ea74531df)
![image](https://github.com/user-attachments/assets/bb3f9d8c-bbc0-4f35-a453-b84e7d37be2f)
![image](https://github.com/user-attachments/assets/a4145689-07c1-4319-bc42-9f1ef550bb9e)
