### PR TITLE
Add DLR exclusions to Prime 3

### DIFF
--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -860,7 +860,7 @@
                         "node": "Morph Ball Door to Imperial Hall"
                     },
                     "default_dock_weakness": "Morph Ball Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -4733,7 +4733,7 @@
                         "node": "Morph Ball Door to Gel Cavern"
                     },
                     "default_dock_weakness": "Morph Ball Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -5121,7 +5121,7 @@
                         "node": "Teleporter to Bryyo - Fire"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -108,7 +108,7 @@ Extra - asset_id: 4215957264467390882
 
 > Morph Ball Door to Gel Cavern; Heals? False
   * Layers: default
-  * Morph Ball Door to Gel Cavern/Morph Ball Door to Imperial Hall
+  * Morph Ball Door to Gel Cavern/Morph Ball Door to Imperial Hall; Excluded from Dock Lock Rando
   * Extra - dock_index: 3
   > Door to Gel Refinery Site
       Trivial
@@ -641,7 +641,7 @@ Extra - asset_id: 11307336868361004418
 
 > Morph Ball Door to Imperial Hall; Heals? False
   * Layers: default
-  * Morph Ball Door to Imperial Hall/Morph Ball Door to Gel Cavern
+  * Morph Ball Door to Imperial Hall/Morph Ball Door to Gel Cavern; Excluded from Dock Lock Rando
   * Extra - dock_index: 2
 
 ----------------
@@ -702,7 +702,7 @@ Extra - asset_id: 4474147916478522354
 
 > Teleporter to Bryyo - Ice; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Teleporter to Warp Site Bravo/Teleporter to Bryyo - Fire
+  * Teleporter to Warp Site Bravo/Teleporter to Bryyo - Fire; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: 1245247
   > Door to Main Lift

--- a/randovania/games/prime3/logic_database/Bryyo - Ice.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Ice.json
@@ -72,7 +72,7 @@
                         "node": "Teleporter to Bryyo - Ice"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/Bryyo - Ice.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Ice.txt
@@ -10,7 +10,7 @@ Extra - asset_id: 9245834436705857859
 
 > Teleporter to Bryyo - Fire; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Teleporter to Warp Site Alpha/Teleporter to Bryyo - Ice
+  * Teleporter to Warp Site Alpha/Teleporter to Bryyo - Ice; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: 131452
   > Door to Imperial Caverns

--- a/randovania/games/prime3/logic_database/Bryyo - Seed.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Seed.json
@@ -436,7 +436,7 @@
                         "node": "Samus Ship"
                     },
                     "default_dock_weakness": "Open Passage",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/Bryyo - Seed.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Seed.txt
@@ -50,7 +50,7 @@ Extra - asset_id: 9708827741160794862
 
 > Dock to Bryyo - Reptilicus; Heals? False
   * Layers: default
-  * Open Passage to Cliffside Airdock/Samus Ship
+  * Open Passage to Cliffside Airdock/Samus Ship; Excluded from Dock Lock Rando
 
 > Pickup (Hyper Ball); Heals? False
   * Layers: default

--- a/randovania/games/prime3/logic_database/GFS Olympus.json
+++ b/randovania/games/prime3/logic_database/GFS Olympus.json
@@ -784,7 +784,7 @@
                         "node": "Door to Aurora Access"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -906,7 +906,7 @@
                         "node": "Door to Repair Bay Shaft"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -1773,7 +1773,7 @@
                         "node": "Door to Disposal Chamber"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -1803,7 +1803,7 @@
                         "node": "Morph Ball Door to Disposal Chamber"
                     },
                     "default_dock_weakness": "Morph Ball Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -1878,7 +1878,7 @@
                         "node": "Morph Ball Door to Ventilation Shaft"
                     },
                     "default_dock_weakness": "Morph Ball Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -1935,7 +1935,7 @@
                         "node": "Morph Ball Door to Ventilation Shaft"
                     },
                     "default_dock_weakness": "Morph Ball Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2204,7 +2204,7 @@
                         "node": "Door to Gunship"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2242,7 +2242,7 @@
                         "node": "Door to Repair Bay A"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2522,7 +2522,7 @@
                         "node": "Door to Docking Bay 5"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2600,7 +2600,7 @@
                         "node": "Door to Docking Bay 5"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2638,7 +2638,7 @@
                         "node": "Door to Docking Bay 5"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2747,7 +2747,7 @@
                         "node": "Door to Aurora Chamber"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/GFS Olympus.txt
+++ b/randovania/games/prime3/logic_database/GFS Olympus.txt
@@ -151,7 +151,7 @@ Extra - asset_id: 17930423943250813827
 
 > Door to Aurora Chamber; Heals? False
   * Layers: default
-  * Normal Door to Aurora Chamber/Door to Aurora Access
+  * Normal Door to Aurora Chamber/Door to Aurora Access; Excluded from Dock Lock Rando
   * Extra - dock_index: 1
   > Door to Flag Bridge
       Trivial
@@ -175,7 +175,7 @@ Extra - asset_id: 11421266353153196460
 
 > Door to Repair Bay A; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Repair Bay A/Door to Repair Bay Shaft
+  * Normal Door to Repair Bay A/Door to Repair Bay Shaft; Excluded from Dock Lock Rando
   * Extra - dock_index: 2
   > Door to Save Station B
       Trivial
@@ -339,12 +339,12 @@ Disposal Chamber
 Extra - asset_id: 659263668515774583
 > Door to Repair Bay A; Heals? False
   * Layers: default
-  * Normal Door to Repair Bay A/Door to Disposal Chamber
+  * Normal Door to Repair Bay A/Door to Disposal Chamber; Excluded from Dock Lock Rando
   * Extra - dock_index: 0
 
 > Morph Ball Door to Ventilation Shaft; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Morph Ball Door to Ventilation Shaft/Morph Ball Door to Disposal Chamber
+  * Morph Ball Door to Ventilation Shaft/Morph Ball Door to Disposal Chamber; Excluded from Dock Lock Rando
   * Extra - dock_index: 1
   > Door to Repair Bay A
       Morph Ball Bomb and Morph Ball and Scan Visor
@@ -354,7 +354,7 @@ Ventilation Shaft
 Extra - asset_id: 9908630587780032110
 > Morph Ball Door to Xenoresearch Lab; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Morph Ball Door to Xenoresearch Lab/Morph Ball Door to Ventilation Shaft
+  * Morph Ball Door to Xenoresearch Lab/Morph Ball Door to Ventilation Shaft; Excluded from Dock Lock Rando
   * Extra - dock_index: 0
   * Extra - different_strongly_connected_component: True
   > Pickup (Energy Tank)
@@ -362,7 +362,7 @@ Extra - asset_id: 9908630587780032110
 
 > Morph Ball Door to Disposal Chamber; Heals? False
   * Layers: default
-  * Morph Ball Door to Disposal Chamber/Morph Ball Door to Ventilation Shaft
+  * Morph Ball Door to Disposal Chamber/Morph Ball Door to Ventilation Shaft; Excluded from Dock Lock Rando
   * Extra - dock_index: 1
 
 > Pickup (Energy Tank); Heals? False
@@ -412,7 +412,7 @@ Gunship
 Extra - asset_id: 15628730931753443250
 > Door to Docking Bay 5; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Docking Bay 5/Door to Gunship
+  * Normal Door to Docking Bay 5/Door to Gunship; Excluded from Dock Lock Rando
   * Extra - dock_index: 0
 
 ----------------
@@ -420,7 +420,7 @@ Repair Bay A
 Extra - asset_id: 16233775155696881050
 > Door to Repair Bay Shaft; Heals? False
   * Layers: default
-  * Normal Door to Repair Bay Shaft/Door to Repair Bay A
+  * Normal Door to Repair Bay Shaft/Door to Repair Bay A; Excluded from Dock Lock Rando
   * Extra - dock_index: 0
   > Door to Disposal Chamber
       Trivial
@@ -467,7 +467,7 @@ Docking Bay 5
 Extra - asset_id: 5834535855679580949
 > Door to Repair Bay Shaft; Heals? False
   * Layers: default
-  * Normal Door to Repair Bay Shaft/Door to Docking Bay 5
+  * Normal Door to Repair Bay Shaft/Door to Docking Bay 5; Excluded from Dock Lock Rando
   * Extra - dock_index: 0
   > Event - Berserker Lord
       After Ready Room Briefing
@@ -481,14 +481,14 @@ Extra - asset_id: 5834535855679580949
 
 > Door to Gunship; Heals? True; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Gunship/Door to Docking Bay 5
+  * Normal Door to Gunship/Door to Docking Bay 5; Excluded from Dock Lock Rando
   * Extra - dock_index: 2
   > Door to Docking Bay Access
       Trivial
 
 > Door to Aurora Chamber; Heals? False
   * Layers: default
-  * Normal Door to Aurora Chamber/Door to Docking Bay 5
+  * Normal Door to Aurora Chamber/Door to Docking Bay 5; Excluded from Dock Lock Rando
   * Extra - dock_index: 3
   > Door to Gunship
       Trivial
@@ -511,6 +511,6 @@ Extra - asset_id: 14583031681898448395
 
 > Door to Docking Bay 5; Heals? False
   * Layers: default
-  * Normal Door to Docking Bay 5/Door to Aurora Chamber
+  * Normal Door to Docking Bay 5/Door to Aurora Chamber; Excluded from Dock Lock Rando
   * Extra - dock_index: 1
 

--- a/randovania/games/prime3/logic_database/GFS Valhalla.json
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.json
@@ -33,7 +33,7 @@
                         "node": "Door to Docking Bay 5"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -199,7 +199,7 @@
                         "node": "Door to Hangar A Access"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -295,7 +295,7 @@
                         "node": "Door to Hangar A Access"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -399,7 +399,7 @@
                         "node": "Door to Repair Bay"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/GFS Valhalla.txt
+++ b/randovania/games/prime3/logic_database/GFS Valhalla.txt
@@ -3,7 +3,7 @@ Docking Bay 5
 Extra - asset_id: 15622764306970326849
 > Door to Hangar A Access; Heals? False
   * Layers: default
-  * Normal Door to Hangar A Access/Door to Docking Bay 5
+  * Normal Door to Hangar A Access/Door to Docking Bay 5; Excluded from Dock Lock Rando
   * Extra - dock_index: 0
   > Samus Ship
       Trivial
@@ -36,7 +36,7 @@ Hangar A Access
 Extra - asset_id: 5398996635579069682
 > Door to Docking Bay 5; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Docking Bay 5/Door to Hangar A Access
+  * Normal Door to Docking Bay 5/Door to Hangar A Access; Excluded from Dock Lock Rando
   * Extra - dock_index: 0
   > Door to Repair Bay
       Any of the following:
@@ -46,7 +46,7 @@ Extra - asset_id: 5398996635579069682
 
 > Door to Repair Bay; Heals? False
   * Layers: default
-  * Normal Door to Repair Bay/Door to Hangar A Access
+  * Normal Door to Repair Bay/Door to Hangar A Access; Excluded from Dock Lock Rando
   * Extra - dock_index: 1
   > Door to Docking Bay 5
       Any of the following:
@@ -59,7 +59,7 @@ Repair Bay
 Extra - asset_id: 10896162079835248148
 > Door to Hangar A Access; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Hangar A Access/Door to Repair Bay
+  * Normal Door to Hangar A Access/Door to Repair Bay; Excluded from Dock Lock Rando
   * Extra - dock_index: 0
   > Door to Stairwell
       Any of the following:

--- a/randovania/games/prime3/logic_database/Norion.json
+++ b/randovania/games/prime3/logic_database/Norion.json
@@ -2903,7 +2903,7 @@
                         "node": "Door to Generator C"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -3188,7 +3188,7 @@
                         "node": "Door to Generator Shaft"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/Norion.txt
+++ b/randovania/games/prime3/logic_database/Norion.txt
@@ -499,7 +499,7 @@ Extra - asset_id: 8948533108801763587
 
 > Door to Generator Shaft; Heals? False
   * Layers: default
-  * Normal Door to Generator Shaft/Door to Generator C
+  * Normal Door to Generator Shaft/Door to Generator C; Excluded from Dock Lock Rando
   * Extra - dock_index: 1
   > Door to Generator C Access
       Trivial
@@ -549,7 +549,7 @@ Generator Shaft
 Extra - asset_id: 2389417385720268120
 > Door to Generator C; Heals? False; Default Node
   * Layers: default
-  * Normal Door to Generator C/Door to Generator Shaft
+  * Normal Door to Generator C/Door to Generator Shaft; Excluded from Dock Lock Rando
   * Extra - dock_index: 0
   > Event - Meta Ridley
       Trivial

--- a/randovania/games/prime3/logic_database/Phaaze.json
+++ b/randovania/games/prime3/logic_database/Phaaze.json
@@ -433,7 +433,7 @@
                         "node": "Door to Genesis Chamber"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -795,7 +795,7 @@
                         "node": "Door to Sanctum (Dark Samus)"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -833,7 +833,7 @@
                         "node": "Door to Sanctum (Dark Samus)"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -1170,7 +1170,7 @@
                         "node": "Door to Sanctum (Aurora Unit 313)"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -1233,7 +1233,7 @@
                         "node": "Samus Ship"
                     },
                     "default_dock_weakness": "Open Passage",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/Phaaze.txt
+++ b/randovania/games/prime3/logic_database/Phaaze.txt
@@ -70,7 +70,7 @@ Genesis Chamber
 Extra - asset_id: 5543768504991159971
 > Door to Sanctum (Dark Samus); Heals? False
   * Layers: default
-  * Normal Door to Sanctum (Dark Samus)/Door to Genesis Chamber
+  * Normal Door to Sanctum (Dark Samus)/Door to Genesis Chamber; Excluded from Dock Lock Rando
   * Extra - dock_index: 0
 
 > Door to Hatcher Tunnel; Heals? False; Spawn Point; Default Node
@@ -134,14 +134,14 @@ Sanctum (Dark Samus)
 Extra - asset_id: 13423174227721576677
 > Door to Genesis Chamber; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Genesis Chamber/Door to Sanctum (Dark Samus)
+  * Normal Door to Genesis Chamber/Door to Sanctum (Dark Samus); Excluded from Dock Lock Rando
   * Extra - dock_index: 0
   > Event - Dark Samus
       Trivial
 
 > Door to Sanctum (Aurora Unit 313); Heals? False
   * Layers: default
-  * Normal Door to Sanctum (Aurora Unit 313)/Door to Sanctum (Dark Samus)
+  * Normal Door to Sanctum (Aurora Unit 313)/Door to Sanctum (Dark Samus); Excluded from Dock Lock Rando
   * Extra - dock_index: 1
 
 > Event - Dark Samus; Heals? False
@@ -193,7 +193,7 @@ Sanctum (Aurora Unit 313)
 Extra - asset_id: 17351725518036616530
 > Door to Sanctum (Dark Samus); Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Sanctum (Dark Samus)/Door to Sanctum (Aurora Unit 313)
+  * Normal Door to Sanctum (Dark Samus)/Door to Sanctum (Aurora Unit 313); Excluded from Dock Lock Rando
   * Extra - dock_index: 0
   > Event - Aurora Unit 313
       Grapple Lasso
@@ -206,5 +206,5 @@ Extra - asset_id: 17351725518036616530
 
 > Dock to G.F.S. Valhalla; Heals? False
   * Layers: default
-  * Open Passage to Docking Bay 5/Samus Ship
+  * Open Passage to Docking Bay 5/Samus Ship; Excluded from Dock Lock Rando
 

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Command.json
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Command.json
@@ -2616,7 +2616,7 @@
                         "node": "Teleporter to Transit Station 2-A"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2703,7 +2703,7 @@
                         "node": "Teleporter to Transit Station 2-B"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2820,7 +2820,7 @@
                         "node": "Teleporter to Leviathan Access Portal"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -3909,7 +3909,7 @@
                         "node": "Teleporter to Leviathan"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -5183,7 +5183,7 @@
                         "node": "Teleporter to Pirate Homeworld - Command"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -5270,7 +5270,7 @@
                         "node": "Teleporter to Pirate Homeworld - Command"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Command.txt
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Command.txt
@@ -433,7 +433,7 @@ Extra - asset_id: 1933322814469947092
 
 > Teleporter to Transit Station 2-B; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Teleporter to Transit Station 2-B/Teleporter to Transit Station 2-A
+  * Teleporter to Transit Station 2-B/Teleporter to Transit Station 2-A; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: 15720495307184570570
   * Extra - teleporter_instance_id: 851982
   > Door to Command Station
@@ -451,7 +451,7 @@ Extra - asset_id: 9768654166807123312
 
 > Teleporter to Transit Station 2-A; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Teleporter to Transit Station 2-A/Teleporter to Transit Station 2-B
+  * Teleporter to Transit Station 2-A/Teleporter to Transit Station 2-B; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: 7193511573108640398
   * Extra - teleporter_instance_id: 917798
   > Door to Leviathan Access Portal
@@ -471,7 +471,7 @@ Extra - asset_id: 13825059228540765135
 
 > Teleporter to Leviathan; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Teleporter to Leviathan/Teleporter to Leviathan Access Portal
+  * Teleporter to Leviathan/Teleporter to Leviathan Access Portal; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: 983248
   > Door to Transit Station 2-B
@@ -607,7 +607,7 @@ Leviathan
 Extra - asset_id: 5604040344596242484
 > Teleporter to Leviathan Access Portal; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Teleporter to Leviathan Access Portal/Teleporter to Leviathan
+  * Teleporter to Leviathan Access Portal/Teleporter to Leviathan; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: 1245367
   > Event - Control Leviathan Battleship
@@ -806,7 +806,7 @@ Leads to Research Facility
 > Teleporter to Pirate Homeworld - Research; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Teleporter to Transit Station 3-A
-Leads to Command Center/Teleporter to Pirate Homeworld - Command
+Leads to Command Center/Teleporter to Pirate Homeworld - Command; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: 11245391886377035438
   * Extra - teleporter_instance_id: 1507642
   > Door to Lift Hub
@@ -827,7 +827,7 @@ Leads to Mining Site
 > Teleporter to Pirate Homeworld - Mines; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Teleporter to Transit Station 4-B
-Leads to Command Center/Teleporter to Pirate Homeworld - Command
+Leads to Command Center/Teleporter to Pirate Homeworld - Command; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: 7888662215166705640
   * Extra - teleporter_instance_id: 1573178
   > Door to Defense Access

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Mines.json
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Mines.json
@@ -119,7 +119,7 @@
                         "node": "Teleporter to Pirate Homeworld - Mines"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Mines.txt
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Mines.txt
@@ -23,7 +23,7 @@ Leads to Command Center
 > Teleporter to Pirate Homeworld - Command; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Teleporter to Transit Station 4-A
-Leads to Mining Site/Teleporter to Pirate Homeworld - Mines
+Leads to Mining Site/Teleporter to Pirate Homeworld - Mines; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: 10585155416642007825
   * Extra - teleporter_instance_id: 131408
   > Door to Phazon Quarry

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Research.json
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Research.json
@@ -2932,7 +2932,7 @@
                         "node": "Teleporter to Transit Station 1-A"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -3019,7 +3019,7 @@
                         "node": "Teleporter to Transit Station 1-B"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -4569,7 +4569,7 @@
                         "node": "Teleporter to Pirate Homeworld - Research"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Research.txt
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Research.txt
@@ -424,7 +424,7 @@ Extra - asset_id: 14633273468387956199
 
 > Teleporter to Transit Station 1-B; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Teleporter to Transit Station 1-B/Teleporter to Transit Station 1-A
+  * Teleporter to Transit Station 1-B/Teleporter to Transit Station 1-A; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: 5661123094437393302
   * Extra - teleporter_instance_id: 721185
   > Door to Landing Site Alpha
@@ -442,7 +442,7 @@ Extra - asset_id: 2640383633522526
 
 > Teleporter to Transit Station 1-A; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Teleporter to Transit Station 1-A/Teleporter to Transit Station 1-B
+  * Teleporter to Transit Station 1-A/Teleporter to Transit Station 1-B; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: 8972164031291810221
   * Extra - teleporter_instance_id: 786679
   > Door to Proving Grounds
@@ -690,7 +690,7 @@ Leads to Command Center
 > Teleporter to Pirate Homeworld - Command; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Teleporter to Transit Station 3-B
-Leads to Research Facility/Teleporter to Pirate Homeworld - Research
+Leads to Research Facility/Teleporter to Pirate Homeworld - Research; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: 8781321056372031970
   * Extra - teleporter_instance_id: 1048906
   > Door to Save Station

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Seed.json
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Seed.json
@@ -342,7 +342,7 @@
                         "node": "Samus Ship"
                     },
                     "default_dock_weakness": "Open Passage",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Seed.txt
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Seed.txt
@@ -48,7 +48,7 @@ Extra - asset_id: 4585599704880367469
 
 > Dock to Pirate Homeworld - Command; Heals? False
   * Layers: default
-  * Open Passage to Landing Site Bravo/Samus Ship
+  * Open Passage to Landing Site Bravo/Samus Ship; Excluded from Dock Lock Rando
 
 > Pickup (Hyper Grapple); Heals? False
   * Layers: default

--- a/randovania/games/prime3/logic_database/SkyTown Elysia - Main.json
+++ b/randovania/games/prime3/logic_database/SkyTown Elysia - Main.json
@@ -6657,7 +6657,7 @@
                         "node": "Door to Escape Pod Bay"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -6703,7 +6703,7 @@
                         "node": "Morph Ball Door to Spire"
                     },
                     "default_dock_weakness": "Morph Ball Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -6743,7 +6743,7 @@
                         "node": "Door to Spire"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -6781,7 +6781,7 @@
                         "node": "Door to Spire"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -7015,7 +7015,7 @@
                         "node": "Door to Spire Dock (Pre-Bomb)"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -7331,7 +7331,7 @@
                         "node": "Teleporter to SkyTown, Elysia - Main"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/SkyTown Elysia - Main.txt
+++ b/randovania/games/prime3/logic_database/SkyTown Elysia - Main.txt
@@ -1000,7 +1000,7 @@ Extra - asset_id: 7293006450314500398
 
 > Door to Spire; Heals? False
   * Layers: default
-  * Normal Door to Spire/Door to Escape Pod Bay
+  * Normal Door to Spire/Door to Escape Pod Bay; Excluded from Dock Lock Rando
   * Extra - dock_index: 1
   > Door to Escape Pod Bay Access
       Trivial
@@ -1010,21 +1010,21 @@ Spire
 Extra - asset_id: 6637485379588009329
 > Morph Ball Door to Podworks; Heals? False
   * Layers: default
-  * Morph Ball Door to Podworks/Morph Ball Door to Spire
+  * Morph Ball Door to Podworks/Morph Ball Door to Spire; Excluded from Dock Lock Rando
   * Extra - dock_index: 0
   > Room Center
       Morph Ball
 
 > Door to Spire Dock (Pre-Bomb); Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Spire Dock (Pre-Bomb)/Door to Spire
+  * Normal Door to Spire Dock (Pre-Bomb)/Door to Spire; Excluded from Dock Lock Rando
   * Extra - dock_index: 1
   > Room Center
       Trivial
 
 > Door to Escape Pod Bay; Heals? False
   * Layers: default
-  * Normal Door to Escape Pod Bay/Door to Spire
+  * Normal Door to Escape Pod Bay/Door to Spire; Excluded from Dock Lock Rando
   * Extra - dock_index: 2
 
 > Event - Destroy Leviathan Shield; Heals? False
@@ -1070,7 +1070,7 @@ Extra - asset_id: 2782037876215597956
 
 > Door to Spire; Heals? False
   * Layers: default
-  * Normal Door to Spire/Door to Spire Dock (Pre-Bomb)
+  * Normal Door to Spire/Door to Spire Dock (Pre-Bomb); Excluded from Dock Lock Rando
   * Extra - dock_index: 3
   > Spire Pod
       Trivial
@@ -1122,7 +1122,7 @@ Extra - asset_id: 1051771406754533733
 
 > Teleporter to SkyTown, Elysia - Pod; Heals? False
   * Layers: default
-  * Teleporter to Skytram East/Teleporter to SkyTown, Elysia - Main
+  * Teleporter to Skytram East/Teleporter to SkyTown, Elysia - Main; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: 2031842
   > Door to Security Tube

--- a/randovania/games/prime3/logic_database/SkyTown Elysia - Pod.json
+++ b/randovania/games/prime3/logic_database/SkyTown Elysia - Pod.json
@@ -72,7 +72,7 @@
                         "node": "Teleporter to SkyTown, Elysia - Pod"
                     },
                     "default_dock_weakness": "Teleporter",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/SkyTown Elysia - Pod.txt
+++ b/randovania/games/prime3/logic_database/SkyTown Elysia - Pod.txt
@@ -10,7 +10,7 @@ Extra - asset_id: 10057915363412886881
 
 > Teleporter to SkyTown, Elysia - Main; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Teleporter to Skytram West/Teleporter to SkyTown, Elysia - Pod
+  * Teleporter to Skytram West/Teleporter to SkyTown, Elysia - Pod; Excluded from Dock Lock Rando
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: 131197
   > Door to Concourse Access A

--- a/randovania/games/prime3/logic_database/SkyTown Elysia - Seed.json
+++ b/randovania/games/prime3/logic_database/SkyTown Elysia - Seed.json
@@ -279,7 +279,7 @@
                         "node": "Samus Ship (Catch.)"
                     },
                     "default_dock_weakness": "Open Passage",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/prime3/logic_database/SkyTown Elysia - Seed.txt
+++ b/randovania/games/prime3/logic_database/SkyTown Elysia - Seed.txt
@@ -43,7 +43,7 @@ Extra - asset_id: 17766988414710659705
 
 > Dock to SkyTown, Elysia - Main; Heals? False
   * Layers: default
-  * Open Passage to Main Docking Bay/Samus Ship (Catch.)
+  * Open Passage to Main Docking Bay/Samus Ship (Catch.); Excluded from Dock Lock Rando
 
 > Pickup (Hyper Missile); Heals? False
   * Layers: default


### PR DESCRIPTION
Excludes all hangar doors, teleporters, and cutscene transitions from DLR