### PR TITLE
Rework Arachnus logic to remove Generator Workarounds

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -6798,30 +6798,11 @@
                     "pickup_index": 3,
                     "location_category": "major",
                     "connections": {
-                        "Beside Door": {
-                            "type": "or",
+                        "Next to Pickup": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "GeneratorHack",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "WallJump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -6857,23 +6838,6 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Arena": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "GeneratorHack",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Beside Door": {
                             "type": "and",
                             "data": {
@@ -7028,8 +6992,8 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Beside Door": {
-                            "type": "and",
+                        "Next to Pickup": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -7040,32 +7004,6 @@
                                             "name": "Missiles",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "misc",
-                                                        "name": "GeneratorHack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "WallJump",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
                                         }
                                     }
                                 ]
@@ -7225,24 +7163,17 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 586.43,
-                        "y": 275.19,
+                        "x": 601.02,
+                        "y": 318.22,
                         "z": 0.0
                     },
-                    "description": "FIXME: The connections to return back here technically arent trivial, but are\ncurrently assumed until a few generator issues have been figured out.",
+                    "description": "",
                     "layers": [
                         "default"
                     ],
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Pickup (Energy Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Door to Crew Quarters East": {
                             "type": "or",
                             "data": {
@@ -7286,8 +7217,39 @@
                                 ]
                             }
                         },
+                        "Next to Pickup": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Next to Pickup": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 882.614442020445,
+                        "y": 481.7010122286583,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
+                        "Pickup (Energy Tank)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Other to The Attic": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -7308,6 +7270,23 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Beside Door": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "WallJump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -1123,15 +1123,13 @@ Extra - room_id: [38]
   * Extra - room: 38
   * Extra - blockx: 53
   * Extra - blocky: 10
-  > Beside Door
-      Wall Jump (Beginner) or Enabled Generator Workaround
+  > Next to Pickup
+      Trivial
 
 > Door to Crew Quarters East; Heals? False
   * Layers: default
   * L0 Hatch to Crew Quarters East/Door to Arachnus Arena
   * Extra - door_idx: (88,)
-  > Arena
-      Enabled Generator Workaround
   > Beside Door
       Trivial
 
@@ -1154,10 +1152,8 @@ Extra - room_id: [38]
   * Layers: default
   * Open Passage to The Attic/Other to Arachnus Arena
   * Extra - door_idx: (200,)
-  > Beside Door
-      All of the following:
-          Missiles
-          Wall Jump (Beginner) or Enabled Generator Workaround
+  > Next to Pickup
+      Missiles
 
 > Event - Arachnus; Heals? False
   * Layers: default
@@ -1190,18 +1186,23 @@ Extra - room_id: [38]
 
 > Beside Door; Heals? False
   * Layers: default
-  * FIXME: The connections to return back here technically arent trivial, but are
-currently assumed until a few generator issues have been figured out.
-  > Pickup (Energy Tank)
-      Trivial
   > Door to Crew Quarters East
       After Boss Arachnus Defeated
   > Other to Concourse Ventilation
       Morph Ball and Screw Attack
+  > Next to Pickup
+      Trivial
+
+> Next to Pickup; Heals? False
+  * Layers: default
+  > Pickup (Energy Tank)
+      Trivial
   > Other to The Attic
       Missiles
   > Arena
       Trivial
+  > Beside Door
+      Wall Jump (Beginner)
 
 ----------------
 Operations Deck Data Room


### PR DESCRIPTION
Turns out that this works just fine as is. Not sure if we did something else that changed it, or if I was just previously tripped up by the values because arachnus is weighted differently on whether he has dna or not.