### PR TITLE
Echoes: Many logic changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Double Damage is now classified as a Beam instead of a Suit.
 - Fixed: Typo in the Differences tab.
 
+#### Logic Database
+
+##### Agon Wastes
+
+- Added: Mining Station B: Hypermode method to open the portal without Space Jump Boots or Morph Ball Bombs.
+
+##### Torvus Bog
+
+- Added: Torvus Grove: Two expert difficulty methods to cross the upper part of this room without Space Jump Boots.
+
+##### Sanctuary Fortress
+
+- Added: Worker's Path: Advanced bomb jumps to get to the cannon platforms NSJ.
+- Added: Grand Abyss: Expert extended dashes and standables to cross from the Vault side to the Watch Station side.
+
+##### Ing Hive
+
+- Added: Hive Dynamo Works: Advanced/Expert NSJ Extended Dashes to go across the gap with the grapple point.
+- Added: Hive Entrance: Expert inbounds method to get to the item without Light Suit.
+- Changed: Temple Security Access: Crossing the room after the gates have been triggered with only Screw Attack no longer requires Screw Attack at Z-Axis. 
+
 ### Metroid: Samus Returns
 
 - Changed: The hinted item after collecting the last required DNA is now dependent on the final boss. The Baby Metroid is hinted for Proteus Ridley, the Ice Beam for Metroid Queen and the Bomb for Diggernaut.

--- a/randovania/games/prime2/logic_database/Agon Wastes.json
+++ b/randovania/games/prime2/logic_database/Agon Wastes.json
@@ -3049,49 +3049,10 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Bombs",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Scan",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Use Screw Attack (Space Jump)"
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "StandableTerrain",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
                                                 {
                                                     "type": "and",
                                                     "data": {
@@ -3101,8 +3062,89 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "SpaceJump",
+                                                                    "name": "Bombs",
                                                                     "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Scan",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "StandableTerrain",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Use Screw Attack (Space Jump)"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "SpaceJump",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "SlopeJump",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "https://www.youtube.com/watch?v=CvU0QLIgzms",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "BomblessSlot",
+                                                                    "amount": 5,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -3110,8 +3152,119 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "SlopeJump",
-                                                                    "amount": 3,
+                                                                    "name": "Movement",
+                                                                    "amount": 4,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Boost",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "WallBoost",
+                                                                                            "amount": 5,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "InstantMorph",
+                                                                                "amount": 4,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "or",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Shoot Darkburst"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "and",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "template",
+                                                                                                    "data": "Shoot Sonic Boom"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "items",
+                                                                                                        "name": "LightAmmo",
+                                                                                                        "amount": 60,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "DarkAmmo",
+                                                                                "amount": 60,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Missile",
+                                                                                "amount": 10,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Scan",
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             }

--- a/randovania/games/prime2/logic_database/Agon Wastes.txt
+++ b/randovania/games/prime2/logic_database/Agon Wastes.txt
@@ -424,11 +424,23 @@ Extra - in_dark_aether: False
                   Screw Attack at Z-Axis (Expert) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
   > Event - Mining Station B Portal Opened
       All of the following:
-          Morph Ball Bomb and Morph Ball
+          Morph Ball
           Any of the following:
-              Scan Visor
-              Standable Terrain (Intermediate) and Use Screw Attack (Space Jump)
-              Space Jump Boots and Slope Jump (Advanced)
+              All of the following:
+                  Morph Ball Bomb
+                  Any of the following:
+                      Scan Visor
+                      Standable Terrain (Intermediate) and Use Screw Attack (Space Jump)
+                      Space Jump Boots and Slope Jump (Advanced)
+              All of the following:
+                  # https://www.youtube.com/watch?v=CvU0QLIgzms
+                  Dark Ammo ≥ 60 and Missile ≥ 10 and Scan Visor and Bomb Slot without Bombs (Hypermode) and Movement (Expert)
+                  Any of the following:
+                      Instant Morph (Expert)
+                      Boost Ball and Wall Boost (Hypermode)
+                  Any of the following:
+                      Shoot Darkburst
+                      Light Ammo ≥ 60 and Shoot Sonic Boom
   > Lore Scan
       Scan Visor
 

--- a/randovania/games/prime2/logic_database/Sanctuary Fortress.json
+++ b/randovania/games/prime2/logic_database/Sanctuary Fortress.json
@@ -10598,7 +10598,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": null,
+                                                                    "comment": "https://youtu.be/5zsYbZsSTPA",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",
@@ -11468,6 +11468,59 @@
                                                                             }
                                                                         }
                                                                     ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "https://youtu.be/9N3PB7M4lzc?t=119",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Scan",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "EDash",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "TerminalFall",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 10,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "DarkWorld1",
+                                                                    "amount": 25,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -12367,6 +12420,41 @@
                                                                 }
                                                             }
                                                         ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "https://youtu.be/9N3PB7M4lzc?t=98",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Scan",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "EDash",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "DarkWorld1",
+                                                        "amount": 20,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -14748,7 +14836,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://www.youtube.com/watch?v=j4zqFghBcfM&list=PLZkUEWCHwYRyXIU-to88js2M6mEOBoHUy&index=31",
+                                            "comment": "https://www.youtube.com/watch?v=j4zqFghBcfM",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -14774,6 +14862,86 @@
                                                         "type": "items",
                                                         "name": "Scan",
                                                         "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "https://youtu.be/4mjY6vPZHyE",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Scan",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpaceJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "MorphBall",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Bombs",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "EDash",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "StandableTerrain",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Dash",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "BSJ",
+                                                        "amount": 3,
                                                         "negate": false
                                                     }
                                                 }
@@ -23063,26 +23231,8 @@
                                                                         {
                                                                             "type": "and",
                                                                             "data": {
-                                                                                "comment": null,
+                                                                                "comment": "https://www.youtube.com/watch?v=sGIG5aaPkNM",
                                                                                 "items": [
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "misc",
-                                                                                            "name": "RoomRando",
-                                                                                            "amount": 1,
-                                                                                            "negate": true
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "SAnoSJ",
-                                                                                            "amount": 2,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    },
                                                                                     {
                                                                                         "type": "or",
                                                                                         "data": {
@@ -23556,26 +23706,8 @@
                                                                                                 {
                                                                                                     "type": "and",
                                                                                                     "data": {
-                                                                                                        "comment": null,
+                                                                                                        "comment": "https://www.youtube.com/watch?v=sGIG5aaPkNM",
                                                                                                         "items": [
-                                                                                                            {
-                                                                                                                "type": "resource",
-                                                                                                                "data": {
-                                                                                                                    "type": "misc",
-                                                                                                                    "name": "RoomRando",
-                                                                                                                    "amount": 1,
-                                                                                                                    "negate": true
-                                                                                                                }
-                                                                                                            },
-                                                                                                            {
-                                                                                                                "type": "resource",
-                                                                                                                "data": {
-                                                                                                                    "type": "tricks",
-                                                                                                                    "name": "SAnoSJ",
-                                                                                                                    "amount": 2,
-                                                                                                                    "negate": false
-                                                                                                                }
-                                                                                                            },
                                                                                                             {
                                                                                                                 "type": "or",
                                                                                                                 "data": {
@@ -24085,26 +24217,8 @@
                                                                                                 {
                                                                                                     "type": "and",
                                                                                                     "data": {
-                                                                                                        "comment": null,
+                                                                                                        "comment": "https://www.youtube.com/watch?v=sGIG5aaPkNM",
                                                                                                         "items": [
-                                                                                                            {
-                                                                                                                "type": "resource",
-                                                                                                                "data": {
-                                                                                                                    "type": "misc",
-                                                                                                                    "name": "RoomRando",
-                                                                                                                    "amount": 1,
-                                                                                                                    "negate": true
-                                                                                                                }
-                                                                                                            },
-                                                                                                            {
-                                                                                                                "type": "resource",
-                                                                                                                "data": {
-                                                                                                                    "type": "tricks",
-                                                                                                                    "name": "SAnoSJ",
-                                                                                                                    "amount": 2,
-                                                                                                                    "negate": false
-                                                                                                                }
-                                                                                                            },
                                                                                                             {
                                                                                                                 "type": "or",
                                                                                                                 "data": {
@@ -24471,26 +24585,8 @@
                                                                         {
                                                                             "type": "and",
                                                                             "data": {
-                                                                                "comment": null,
+                                                                                "comment": "https://www.youtube.com/watch?v=sGIG5aaPkNM",
                                                                                 "items": [
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "SAnoSJ",
-                                                                                            "amount": 2,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "misc",
-                                                                                            "name": "RoomRando",
-                                                                                            "amount": 1,
-                                                                                            "negate": true
-                                                                                        }
-                                                                                    },
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
@@ -30555,6 +30651,110 @@
                                                                     "type": "damage",
                                                                     "name": "Damage",
                                                                     "amount": 10,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "RollJump",
+                                                                    "amount": 4,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "StandableTerrain",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "https://youtu.be/UFJToddgAMQ",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Movement",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "SlopeJump",
+                                                                                            "amount": 4,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "https://www.youtube.com/watch?v=5318bW_bopY",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Bombs",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "BSJ",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "SlopeJump",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "DarkWorld1",
+                                                                    "amount": 200,
                                                                     "negate": false
                                                                 }
                                                             }

--- a/randovania/games/prime2/logic_database/Sanctuary Fortress.txt
+++ b/randovania/games/prime2/logic_database/Sanctuary Fortress.txt
@@ -1420,6 +1420,7 @@ Extra - in_dark_aether: False
               Morph Ball and Scan Visor
               Any of the following:
                   Space Jump Boots or Movement (Intermediate)
+                  # https://youtu.be/5zsYbZsSTPA
                   Morph Ball Bomb and Bomb Jump (Advanced)
           # NSJ with Screw Attack at Z-Axis https://youtu.be/_OKEYHWQQr0?t=14
           Morph Ball Bomb and Bomb Space Jump (Intermediate) and Screw Attack at Z-Axis (Intermediate) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
@@ -1493,6 +1494,8 @@ Extra - in_dark_aether: True
                       Scan Visor and Combat/Scan Dash (Intermediate) and Dark World Damage ≥ 16
                       Morph Ball and Roll Jump (Intermediate) and Dark World Damage ≥ 15
                       Terminal Fall Abuse (Beginner) and Normal Damage ≥ 10 and Dark World Damage ≥ 25
+              # https://youtu.be/9N3PB7M4lzc?t=119
+              Scan Visor and Extended Dash (Advanced) and Terminal Fall Abuse (Beginner) and Normal Damage ≥ 10 and Dark World Damage ≥ 25
 
 > Portal to Dynamo Works; Heals? False
   * Layers: default
@@ -1566,6 +1569,8 @@ Extra - in_dark_aether: True
               Any of the following:
                   Scan Visor and Combat/Scan Dash (Intermediate)
                   Morph Ball and Roll Jump (Intermediate)
+          # https://youtu.be/9N3PB7M4lzc?t=98
+          Scan Visor and Extended Dash (Expert) and Dark World Damage ≥ 20
   > Door to Central Hive East Transport
       Any of the following:
           All of the following:
@@ -1829,8 +1834,10 @@ Extra - in_dark_aether: False
           Use Screw Attack (Space Jump)
           # https://www.youtube.com/watch?v=KSEnyKhKPfs&t=13s
           Screw Attack at Z-Axis (Intermediate) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
-          # https://www.youtube.com/watch?v=j4zqFghBcfM&list=PLZkUEWCHwYRyXIU-to88js2M6mEOBoHUy&index=31
+          # https://www.youtube.com/watch?v=j4zqFghBcfM
           Scan Visor and Space Jump Boots and Extended Dash (Hypermode)
+          # https://youtu.be/4mjY6vPZHyE
+          Morph Ball Bomb and Morph Ball and Scan Visor and Space Jump Boots and Bomb Space Jump (Advanced) and Combat/Scan Dash (Expert) and Extended Dash (Expert) and Standable Terrain (Expert)
 
 ----------------
 Aerial Training Site
@@ -2715,7 +2722,8 @@ Extra - in_dark_aether: True
                               Light Suit
                               Suitless Dark Aether (Intermediate) and Dark World Damage ≥ 50 and Ingstorm Damage ≥ 70
                       All of the following:
-                          Screw Attack at Z-Axis (Intermediate) and Screw Attack into Tunnels/Openings (Expert) and Disabled Room Randomizer
+                          # https://www.youtube.com/watch?v=sGIG5aaPkNM
+                          Screw Attack into Tunnels/Openings (Expert)
                           Any of the following:
                               Light Suit
                               Suitless Dark Aether (Advanced) and Dark World Damage ≥ 70 and Ingstorm Damage ≥ 50
@@ -2759,7 +2767,8 @@ Extra - in_dark_aether: True
                                       Light Suit
                                       Suitless Dark Aether (Intermediate) and Dark World Damage ≥ 25 and Ingstorm Damage ≥ 80
                               All of the following:
-                                  Screw Attack at Z-Axis (Intermediate) and Screw Attack into Tunnels/Openings (Expert) and Disabled Room Randomizer
+                                  # https://www.youtube.com/watch?v=sGIG5aaPkNM
+                                  Screw Attack into Tunnels/Openings (Expert)
                                   Any of the following:
                                       Light Suit
                                       Suitless Dark Aether (Advanced) and Dark World Damage ≥ 50 and Ingstorm Damage ≥ 40
@@ -2803,7 +2812,8 @@ Extra - in_dark_aether: True
                                       Light Suit
                                       Suitless Dark Aether (Intermediate) and Dark World Damage ≥ 60 and Ingstorm Damage ≥ 75
                               All of the following:
-                                  Screw Attack at Z-Axis (Intermediate) and Screw Attack into Tunnels/Openings (Expert) and Disabled Room Randomizer
+                                  # https://www.youtube.com/watch?v=sGIG5aaPkNM
+                                  Screw Attack into Tunnels/Openings (Expert)
                                   Any of the following:
                                       Light Suit
                                       Suitless Dark Aether (Advanced) and Dark World Damage ≥ 85 and Ingstorm Damage ≥ 50
@@ -2832,7 +2842,8 @@ Extra - in_dark_aether: True
                               Light Suit
                               Suitless Dark Aether (Intermediate) and Dark World Damage ≥ 60 and Ingstorm Damage ≥ 60
                       All of the following:
-                          Screw Attack at Z-Axis (Intermediate) and Screw Attack into Tunnels/Openings (Expert) and Disabled Room Randomizer
+                          # https://www.youtube.com/watch?v=sGIG5aaPkNM
+                          Screw Attack into Tunnels/Openings (Expert)
                           Any of the following:
                               Light Suit
                               Suitless Dark Aether (Advanced) and Dark World Damage ≥ 30 and Ingstorm Damage ≥ 50
@@ -3531,6 +3542,13 @@ Extra - in_dark_aether: True
               Light Suit
               # https://www.youtube.com/watch?v=NUbKATjYJDc
               Morph Ball Bomb and Bomb Jump (Hypermode) and Single Room Out of Bounds (Hypermode) and Standable Terrain (Hypermode) and Terminal Fall Abuse (Hypermode) and Normal Damage ≥ 10 and Dark World Damage ≥ 400
+              All of the following:
+                  Roll Jump (Expert) and Standable Terrain (Advanced) and Dark World Damage ≥ 200
+                  Any of the following:
+                      # https://youtu.be/UFJToddgAMQ
+                      Movement (Advanced) and Slope Jump (Expert)
+                      # https://www.youtube.com/watch?v=5318bW_bopY
+                      Morph Ball Bomb and Bomb Space Jump (Advanced) and Slope Jump (Advanced)
 
 > Pickup (Sky Temple Key 5); Heals? False
   * Layers: default

--- a/randovania/games/prime2/logic_database/Torvus Bog.json
+++ b/randovania/games/prime2/logic_database/Torvus Bog.json
@@ -1199,6 +1199,32 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "https://www.youtube.com/watch?v=EB_tvB6dOd8",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpaceJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "EDash",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -4344,6 +4370,41 @@
                                                         "type": "tricks",
                                                         "name": "SlopeJump",
                                                         "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "https://www.youtube.com/watch?v=nSHgMLE9k8o",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpaceJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "EDash",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SlopeJump",
+                                                        "amount": 3,
                                                         "negate": false
                                                     }
                                                 }
@@ -14048,28 +14109,10 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "SpaceJump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Boost",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
                                                 {
                                                     "type": "and",
                                                     "data": {
@@ -14079,10 +14122,137 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "ScrewAttack",
+                                                                    "name": "Boost",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "SpaceJump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Bombs",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "or",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "and",
+                                                                                                    "data": {
+                                                                                                        "comment": "https://www.youtube.com/watch?v=JTfbOmmyfZ8",
+                                                                                                        "items": [
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "tricks",
+                                                                                                                    "name": "BSJ",
+                                                                                                                    "amount": 4,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "or",
+                                                                                                                "data": {
+                                                                                                                    "comment": null,
+                                                                                                                    "items": [
+                                                                                                                        {
+                                                                                                                            "type": "resource",
+                                                                                                                            "data": {
+                                                                                                                                "type": "tricks",
+                                                                                                                                "name": "Dash",
+                                                                                                                                "amount": 2,
+                                                                                                                                "negate": false
+                                                                                                                            }
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "type": "resource",
+                                                                                                                            "data": {
+                                                                                                                                "type": "tricks",
+                                                                                                                                "name": "SlopeJump",
+                                                                                                                                "amount": 3,
+                                                                                                                                "negate": false
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "and",
+                                                                                                    "data": {
+                                                                                                        "comment": "https://www.youtube.com/watch?v=pXscSB2QLcQ",
+                                                                                                        "items": [
+                                                                                                            {
+                                                                                                                "type": "template",
+                                                                                                                "data": "Use Screw Attack (No Space Jump)"
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "tricks",
+                                                                                                                    "name": "BombJump",
+                                                                                                                    "amount": 4,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "tricks",
+                                                                                                                    "name": "Movement",
+                                                                                                                    "amount": 4,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Screw Attack (Space Jump)"
                                                             },
                                                             {
                                                                 "type": "resource",

--- a/randovania/games/prime2/logic_database/Torvus Bog.txt
+++ b/randovania/games/prime2/logic_database/Torvus Bog.txt
@@ -209,6 +209,8 @@ Extra - in_dark_aether: False
           Grapple Beam or Use Screw Attack (Space Jump)
           # https://www.youtube.com/watch?v=OdntNzXbtug
           Boost Ball and Morph Ball and Space Jump Boots and Boost Jump (Advanced)
+          # https://www.youtube.com/watch?v=EB_tvB6dOd8
+          Space Jump Boots and Extended Dash (Expert)
   > Under Lore Scan
       Trivial
   > Lore Scan
@@ -599,6 +601,8 @@ Extra - in_dark_aether: False
           Morph Ball and After Great Bridge Cannon
           # https://youtu.be/cHJX27JZYso
           Slope Jump (Intermediate) and Use Screw Attack (Space Jump)
+          # https://www.youtube.com/watch?v=nSHgMLE9k8o
+          Space Jump Boots and Extended Dash (Advanced) and Slope Jump (Advanced)
   > Door to Abandoned Worksite
       Scan Visor and Space Jump Boots and Extended Dash (Advanced)
   > Door to Temple Access (Bottom)
@@ -1579,10 +1583,22 @@ Extra - in_dark_aether: False
   * Extra - dock_name: South
   > Door to Grove Access
       All of the following:
-          Morph Ball and Space Jump Boots
+          Morph Ball
           Any of the following:
-              Boost Ball
-              Screw Attack and After Torvus Grove Tree and Standable Terrain (Advanced)
+              All of the following:
+                  Boost Ball
+                  Any of the following:
+                      Space Jump Boots
+                      All of the following:
+                          Morph Ball Bomb
+                          Any of the following:
+                              All of the following:
+                                  # https://www.youtube.com/watch?v=JTfbOmmyfZ8
+                                  Bomb Space Jump (Expert)
+                                  Combat/Scan Dash (Intermediate) or Slope Jump (Advanced)
+                              # https://www.youtube.com/watch?v=pXscSB2QLcQ
+                              Bomb Jump (Expert) and Movement (Expert) and Use Screw Attack (No Space Jump)
+              After Torvus Grove Tree and Standable Terrain (Advanced) and Use Screw Attack (Space Jump)
   > Door to Meditation Vista
       Trivial
   > Pickup (Missile)


### PR DESCRIPTION
Adds a bunch of new tricks with their respective videos and changes the logic for Temple Security Access to remove an incorrect requirement.

Shamelessly copied from the changelog:

##### Agon Wastes

- Added: Mining Station B: Hypermode method to open the portal without Space Jump Boots or Morph Ball Bombs.

##### Torvus Bog

- Added: Torvus Grove: Two expert difficulty methods to cross the upper part of this room without Space Jump Boots.

##### Sanctuary Fortress

- Added: Worker's Path: Advanced bomb jumps to get to the cannon platforms NSJ.
- Added: Grand Abyss: Expert extended dashes and standables to cross from the Vault side to the Watch Station side.

##### Ing Hive

- Added: Hive Dynamo Works: Advanced/Expert NSJ Extended Dashes to go across the gap with the grapple point.
- Added: Hive Entrance: Expert inbounds method to get to the item without Light Suit.
- Changed: Temple Security Access: Crossing the room after the gates have been triggered with only Screw Attack no longer requires Screw Attack at Z-Axis. 