### PR TITLE
Dread: Add preset option to remove all light sources in a region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
+- Added: There is now a preset option for each region that will remove all of its light sources when enabled, making the game very dark.
+
 #### Logic Database
 
 - Fixed: A typo in the event name Artaria - Prepare Speedboost in Map Station has been changed from Prepare Speeboost in Map Station.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ exporters = [
     "factorio-randovania-mod>=0.5.0",
 
     # Metroid Dread
-    "open-dread-rando>=2.15.0",
+    "open-dread-rando>=2.16.0",
 
     # Metroid Prime 1
     "py_randomprime>=1.27.0",

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -44,18 +44,6 @@ _ALTERNATIVE_MODELS = {
     PickupModel(RandovaniaGame.METROID_DREAD, "PROGRESSIVE_SPIN"): ["powerup_doublejump", "powerup_spacejump"],
 }
 
-_SCENARIO_IDS = {
-    "artaria": "s010_cave",
-    "cataris": "s020_magma",
-    "dairon": "s030_baselab",
-    "burenia": "s040_aqua",
-    "ghavoran": "s050_forest",
-    "elun": "s060_quarantine",
-    "ferenia": "s070_basesanc",
-    "hanubia": "s080_shipyard",
-    "itorash": "s090_skybase",
-}
-
 
 def get_item_id_for_item(item: ItemResourceInfo) -> str:
     if "item_capacity_id" in item.extra:
@@ -502,9 +490,11 @@ class DreadPatchDataFactory(PatchDataFactory):
         config = self.configuration.disabled_lights.as_json
         patches = []
 
-        for region, is_disabled in config.items():
+        for region_name, is_disabled in config.items():
             if is_disabled:
-                patches.append({"scenario": _SCENARIO_IDS[region], "actor_layer": "rLightsLayer", "method": "all"})
+                scenario_id = self.game.region_list.region_with_name(region_name.capitalize()).extra["scenario_id"]
+
+                patches.append({"scenario": scenario_id, "actor_layer": "rLightsLayer", "method": "all"})
 
         return patches
 

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -44,6 +44,18 @@ _ALTERNATIVE_MODELS = {
     PickupModel(RandovaniaGame.METROID_DREAD, "PROGRESSIVE_SPIN"): ["powerup_doublejump", "powerup_spacejump"],
 }
 
+_SCENARIO_IDS = {
+    "artaria": "s010_cave",
+    "cataris": "s020_magma",
+    "dairon": "s030_baselab",
+    "burenia": "s040_aqua",
+    "ghavoran": "s050_forest",
+    "elun": "s060_quarantine",
+    "ferenia": "s070_basesanc",
+    "hanubia": "s080_shipyard",
+    "itorash": "s090_skybase",
+}
+
 
 def get_item_id_for_item(item: ItemResourceInfo) -> str:
     if "item_capacity_id" in item.extra:
@@ -486,6 +498,16 @@ class DreadPatchDataFactory(PatchDataFactory):
             }
         ]
 
+    def _light_patches(self):
+        config = self.configuration.disabled_lights.as_json
+        patches = []
+
+        for region, is_disabled in config.items():
+            if is_disabled:
+                patches.append({"scenario": _SCENARIO_IDS[region], "actor_layer": "rLightsLayer", "method": "all"})
+
+        return patches
+
     def create_memo_data(self) -> dict:
         """Used to generate pickup collection messages."""
         tank = self.configuration.energy_per_tank
@@ -564,6 +586,9 @@ class DreadPatchDataFactory(PatchDataFactory):
             "tile_group_patches": self._tilegroup_patches(),
             "new_spawn_points": list(self.new_spawn_points.values()),
             "objective": self._objective_patches(),
+            "mass_delete_actors": {
+                "to_remove": self._light_patches(),
+            },
             "layout_uuid": str(self.players_config.get_own_uuid()),
         }
 

--- a/randovania/games/dread/gui/preset_settings/__init__.py
+++ b/randovania/games/dread/gui/preset_settings/__init__.py
@@ -13,6 +13,7 @@ def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager) -> li
     from randovania.games.dread.gui.preset_settings.dread_generation_tab import PresetDreadGeneration
     from randovania.games.dread.gui.preset_settings.dread_goal_tab import PresetDreadGoal
     from randovania.games.dread.gui.preset_settings.dread_item_pool_tab import DreadPresetItemPool
+    from randovania.games.dread.gui.preset_settings.dread_lights_tab import PresetDreadLights
     from randovania.games.dread.gui.preset_settings.dread_patches_chaos import PresetDreadChaos
     from randovania.games.dread.gui.preset_settings.dread_patches_tab import PresetDreadPatches
     from randovania.games.dread.gui.preset_settings.dread_teleporters_tab import PresetTeleportersDread
@@ -32,5 +33,6 @@ def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager) -> li
         PresetDockRando,
         PresetDreadEnergy,
         PresetDreadPatches,
+        PresetDreadLights,
         PresetDreadChaos,
     ]

--- a/randovania/games/dread/gui/preset_settings/dread_lights_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_lights_tab.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import dataclasses
+import typing
+
+from PySide6.QtWidgets import QCheckBox
+
+from randovania.games.dread.gui.generated.preset_dread_lights_ui import Ui_PresetDreadLights
+from randovania.games.dread.layout.dread_configuration import DreadConfiguration, DreadLightConfiguration
+from randovania.gui.lib import signal_handling
+from randovania.gui.preset_settings.preset_tab import PresetTab
+
+if typing.TYPE_CHECKING:
+    from randovania.game_description.game_description import GameDescription
+    from randovania.gui.lib.window_manager import WindowManager
+    from randovania.interface_common.preset_editor import PresetEditor
+    from randovania.layout.preset import Preset
+
+
+class PresetDreadLights(PresetTab, Ui_PresetDreadLights):
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
+        self.setupUi(self)
+
+        self._regions = DreadLightConfiguration()
+
+        for region in self._regions.as_json.keys():
+            check_name = f"{region}_check"
+
+            region_check = QCheckBox(region.capitalize(), self)
+            region_check.setObjectName(check_name)
+
+            setattr(self, check_name, region_check)
+            self.lights_out_layout.addWidget(region_check)
+            self._add_persist_option(region_check, region)
+
+        self.enable_button.pressed.connect(self._enable_all)
+        self.disable_button.pressed.connect(self._disable_all)
+
+    @classmethod
+    def tab_title(cls) -> str:
+        return "Lights"
+
+    @classmethod
+    def header_name(cls) -> str | None:
+        return None
+
+    def _enable_all(self) -> None:
+        for region in self._regions.as_json.keys():
+            typing.cast(QCheckBox, getattr(self, f"{region}_check")).setChecked(True)
+
+    def _disable_all(self) -> None:
+        for region in self._regions.as_json.keys():
+            typing.cast(QCheckBox, getattr(self, f"{region}_check")).setChecked(False)
+
+    def _add_persist_option(self, check: QCheckBox, attribute_name: str) -> None:
+        def persist(value: bool) -> None:
+            with self._editor as editor:
+                self._regions = dataclasses.replace(self._regions, **{attribute_name: value})
+                editor.set_configuration_field("disabled_lights", self._regions)
+
+        signal_handling.on_checked(check, persist)
+
+    def on_preset_changed(self, preset: Preset) -> None:
+        config = typing.cast(DreadConfiguration, preset.configuration)
+
+        for region, is_checked in config.disabled_lights.as_json.items():
+            typing.cast(QCheckBox, getattr(self, f"{region}_check")).setChecked(is_checked)

--- a/randovania/games/dread/gui/ui_files/preset_dread_lights.ui
+++ b/randovania/games/dread/gui/ui_files/preset_dread_lights.ui
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PresetDreadLights</class>
+ <widget class="QMainWindow" name="PresetDreadLights">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>438</width>
+    <height>284</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Lights</string>
+  </property>
+  <widget class="QWidget" name="central_widget">
+   <property name="maximumSize">
+    <size>
+     <width>16777215</width>
+     <height>16777215</height>
+    </size>
+   </property>
+   <layout class="QVBoxLayout" name="central_layout">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="QScrollArea" name="scroll_area">
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <widget class="QWidget" name="scroll_contents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>436</width>
+         <height>282</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="scroll_layout">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>2</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <spacer name="top_spacer">
+          <property name="orientation">
+           <enum>Qt::Orientation::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Policy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>8</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="lights_out_box">
+          <property name="title">
+           <string>Lights out</string>
+          </property>
+          <layout class="QVBoxLayout" name="lights_out_layout">
+           <item>
+            <widget class="QLabel" name="lights_out_label">
+             <property name="text">
+              <string>If a region is enabled, every light source within it will be removed.
+This setting makes the game very dark, but still somewhat visible.</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="buttons_layout">
+             <item>
+              <widget class="QPushButton" name="enable_button">
+               <property name="text">
+                <string>Enable All</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="disable_button">
+               <property name="text">
+                <string>Disable All</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="bottom_spacer">
+          <property name="orientation">
+           <enum>Qt::Orientation::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>

--- a/randovania/games/dread/layout/dread_configuration.py
+++ b/randovania/games/dread/layout/dread_configuration.py
@@ -49,6 +49,19 @@ enum_lib.add_long_name(
 
 
 @dataclasses.dataclass(frozen=True)
+class DreadLightConfiguration(BitPackDataclass, JsonDataclass):
+    artaria: bool = False
+    burenia: bool = False
+    cataris: bool = False
+    dairon: bool = False
+    elun: bool = False
+    ferenia: bool = False
+    ghavoran: bool = False
+    hanubia: bool = False
+    itorash: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
 class DreadConfiguration(BaseConfiguration):
     teleporters: DreadTeleporterConfiguration
     energy_per_tank: int = dataclasses.field(metadata={"min": 1, "max": 1000, "precision": 1})
@@ -66,6 +79,7 @@ class DreadConfiguration(BaseConfiguration):
     constant_heat_damage: int | None = dataclasses.field(metadata={"min": 0, "max": 1000, "precision": 1})
     constant_cold_damage: int | None = dataclasses.field(metadata={"min": 0, "max": 1000, "precision": 1})
     constant_lava_damage: int | None = dataclasses.field(metadata={"min": 0, "max": 1000, "precision": 1})
+    disabled_lights: DreadLightConfiguration
 
     @classmethod
     def game_enum(cls) -> RandovaniaGame:

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1084,6 +1084,21 @@ def _migrate_v95(preset: dict, game: RandovaniaGame) -> None:
         hints.pop("baby_metroid")
 
 
+def _migrate_v96(preset: dict, game: RandovaniaGame) -> None:
+    if game == RandovaniaGame.METROID_DREAD:
+        preset["configuration"]["disabled_lights"] = {
+            "artaria": False,
+            "burenia": False,
+            "cataris": False,
+            "dairon": False,
+            "elun": False,
+            "ferenia": False,
+            "ghavoran": False,
+            "hanubia": False,
+            "itorash": False,
+        }
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -1180,6 +1195,7 @@ _MIGRATIONS = [
     _migrate_v93,  # update default dock_rando in Prime 1 to use RP Blast Shield Change
     _migrate_v94,
     _migrate_v95,  # msr rename baby_metroid hint to final_boss_item hint
+    _migrate_v96,  # dread disable lights per region
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -177,7 +177,7 @@ oauthlib==3.2.2
     # via
     #   flask-discord
     #   requests-oauthlib
-open-dread-rando==2.15.0
+open-dread-rando==2.16.0
     # via randovania (setup.py)
 open-prime-rando==0.15.1
     # via randovania (setup.py)

--- a/test/test_files/log_files/dread/all_settings.rdvgame
+++ b/test/test_files/log_files/dread/all_settings.rdvgame
@@ -10,7 +10,7 @@
         "word_hash": "Armadigger Spittail Armadigger",
         "presets": [
             {
-                "schema_version": 76,
+                "schema_version": 97,
                 "base_preset_uuid": null,
                 "name": "All Settings",
                 "uuid": "38849a5f-ed44-47cc-83a7-8f084ea27612",
@@ -362,6 +362,7 @@
                     "pickup_model_data_source": "random",
                     "logical_resource_action": "randomly",
                     "first_progression_must_be_local": true,
+                    "two_sided_door_lock_search": false,
                     "minimum_available_locations_for_hint_placement": 5,
                     "minimum_location_weight_for_hint_placement": 0.1,
                     "dock_rando": {
@@ -403,6 +404,7 @@
                     "single_set_for_pickups_that_solve": true,
                     "staggered_multi_pickup_placement": true,
                     "check_if_beatable_after_base_patches": false,
+                    "logical_pickup_placement": "minimal",
                     "teleporters": {
                         "mode": "one-way-teleporter",
                         "excluded_teleporters": [],
@@ -418,6 +420,7 @@
                     "nerf_power_bombs": true,
                     "warp_to_start": true,
                     "april_fools_hints": false,
+                    "freesink": false,
                     "artifacts": {
                         "prefer_emmi": true,
                         "prefer_major_bosses": true,
@@ -425,7 +428,18 @@
                     },
                     "constant_heat_damage": 15,
                     "constant_cold_damage": 20,
-                    "constant_lava_damage": 25
+                    "constant_lava_damage": 25,
+                    "disabled_lights": {
+                        "artaria": true,
+                        "burenia": true,
+                        "cataris": true,
+                        "dairon": true,
+                        "elun": false,
+                        "ferenia": false,
+                        "ghavoran": false,
+                        "hanubia": false,
+                        "itorash": false
+                    }
                 }
             }
         ]

--- a/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
@@ -7783,6 +7783,30 @@
             "{c1}Metroid DNA 10{c0} is guarded by {c2}Kraid{c0}.|{c1}Metroid DNA 11{c0} is guarded by {c2}Golzuna{c0}.|{c1}Metroid DNA 12{c0} is guarded by {c2}E.M.M.I.-07PB{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": [
+            {
+                "scenario": "s010_cave",
+                "actor_layer": "rLightsLayer",
+                "method": "all"
+            },
+            {
+                "scenario": "s040_aqua",
+                "actor_layer": "rLightsLayer",
+                "method": "all"
+            },
+            {
+                "scenario": "s020_magma",
+                "actor_layer": "rLightsLayer",
+                "method": "all"
+            },
+            {
+                "scenario": "s030_baselab",
+                "actor_layer": "rLightsLayer",
+                "method": "all"
+            }
+        ]
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/dread/crazy_settings/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/crazy_settings/world_1.json
@@ -7102,6 +7102,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c2}E.M.M.I.-02SM{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c2}Drogyga{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c2}E.M.M.I.-03MB{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/dread/custom_patcher_data/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/custom_patcher_data/world_1.json
@@ -3579,6 +3579,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c2}E.M.M.I.-04SB{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c2}Golzuna{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c2}Corpius{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/dread/custom_start/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/custom_start/world_1.json
@@ -3645,6 +3645,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c2}Escue{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c2}E.M.M.I.-04SB{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c2}Kraid{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_1.json
@@ -4124,6 +4124,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c3}World 1{c0}'s {c2}E.M.M.I.-07PB{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c3}World 1{c0}'s {c2}E.M.M.I.-04SB{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c3}World 1{c0}'s {c2}Golzuna{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_2.json
+++ b/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_2.json
@@ -4144,6 +4144,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c3}World 2{c0}'s {c2}E.M.M.I.-07PB{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c3}World 2{c0}'s {c2}Escue{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c3}World 2{c0}'s {c2}E.M.M.I.-05IM{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/dread/elevator_rando/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/elevator_rando/world_1.json
@@ -4003,6 +4003,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c2}Corpius{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c2}Drogyga{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c2}Kraid{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/dread/hide_all_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/hide_all_with_nothing/world_1.json
@@ -3843,6 +3843,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c2}E.M.M.I.-06WB{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c2}E.M.M.I.-02SM{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c2}E.M.M.I.-05IM{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/dread/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/starter_preset/world_1.json
@@ -3606,6 +3606,9 @@
         "required_artifacts": 0,
         "hints": []
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/dread_prime1_multiworld/world_1.json
+++ b/test/test_files/patcher_data/dread/dread_prime1_multiworld/world_1.json
@@ -3753,6 +3753,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c3}World 1{c0}'s {c2}E.M.M.I.-05IM{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c3}World 1{c0}'s {c2}E.M.M.I.-06WB{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c3}World 1{c0}'s {c2}E.M.M.I.-02SM{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2+msr/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2+msr/world_4.json
@@ -3863,6 +3863,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c3}World 4{c0}'s {c2}E.M.M.I.-04SB{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c3}World 4{c0}'s {c2}Escue{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c3}World 4{c0}'s {c2}Kraid{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_4.json
@@ -3836,6 +3836,9 @@
             "{c1}Metroid DNA 4{c0} is guarded by {c3}World 4{c0}'s {c2}E.M.M.I.-05IM{c0}.|{c1}Metroid DNA 5{c0} is guarded by {c3}World 4{c0}'s {c2}Experiment Z-57{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_4.json
@@ -3865,6 +3865,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c3}World 4{c0}'s {c2}Corpius{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c3}World 4{c0}'s {c2}E.M.M.I.-02SM{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c3}World 4{c0}'s {c2}E.M.M.I.-06WB{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_8.json
+++ b/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_8.json
@@ -3866,6 +3866,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c3}World 8{c0}'s {c2}E.M.M.I.-07PB{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c3}World 8{c0}'s {c2}Corpius{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c3}World 8{c0}'s {c2}Escue{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": true

--- a/test/test_files/patcher_data/dread/multi_coop_am2r+bdg+cs+dread+prime1+echoes+msr/world_4.json
+++ b/test/test_files/patcher_data/dread/multi_coop_am2r+bdg+cs+dread+prime1+echoes+msr/world_4.json
@@ -3925,6 +3925,9 @@
             "{c1}Metroid DNA 1{c0} is guarded by {c3}World 4{c0}'s {c2}E.M.M.I.-06WB{c0}.|{c1}Metroid DNA 2{c0} is guarded by {c3}World 4{c0}'s {c2}Corpius{c0}.|{c1}Metroid DNA 3{c0} is guarded by {c3}World 4{c0}'s {c2}E.M.M.I.-07PB{c0}."
         ]
     },
+    "mass_delete_actors": {
+        "to_remove": []
+    },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
     "_randovania_meta": {
         "layout_was_user_modified": false


### PR DESCRIPTION
As titled, when this option is enabled all light actors within a scenario will be deleted. This is a preset option rather than a cosmetic option, as it provides a substantially different gameplay experience. Enabling it makes many elements of the game very difficult to see, primarily items.

This also includes an open-dread-rando bump from 2.15.0 -> 2.16.0.

![image](https://github.com/user-attachments/assets/c9c7115c-2c50-4de4-8802-fb16a116c265)
