### PR TITLE
MSR - Fix A5 Grapple Shuffler Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: Tower Exterior Spider Ball Clip added to traverse from Next to Teleporter to Pickup (Super Missile Tank Bottom).
 
+##### Area 5 Tower Interior
+
+- Fixed: Grapple Shuffler - Impossible connection back from the pickup if it was reach via a Melee Clip.
+
 ## [8.8.0] - 2025-01-02
 
 - Added: Experimental preset option to place all majors or pickups logically. This makes sure pickups that are not required can be collected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed: Starting in Screw Attack Chamber or Zeta Arena Access now places Samus in the correct room.
 
+##### Area 5 Tower Interior
+
+- Fixed: Grapple Shuffler - Coming back up from the pickup if it was reached via a Melee Clip.
+
 ## [8.9.0] - 2025-02-02
 
 - Added: It is now possible to focus the game images in the "Games" tab via a Keyboard.
@@ -139,10 +143,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ##### Area 5 Tower Exterior
 
 - Added: Tower Exterior Spider Ball Clip added to traverse from Next to Teleporter to Pickup (Super Missile Tank Bottom).
-
-##### Area 5 Tower Interior
-
-- Fixed: Grapple Shuffler - Impossible connection back from the pickup if it was reach via a Melee Clip.
 
 ## [8.8.0] - 2025-01-02
 

--- a/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.json
+++ b/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.json
@@ -2782,7 +2782,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "https://youtu.be/i9kuD1yPSSk",
+                                                        "comment": "Ice Clip using the left Glow Fly: https://youtu.be/i9kuD1yPSSk",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -2832,7 +2832,7 @@
                         "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": "https://youtu.be/wA-kNgVe_6c",
+                                "comment": "Ice Clip using the right Glow Fly: https://youtu.be/wA-kNgVe_6c",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -3269,7 +3269,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Grapple",
+                                            "name": "Screw",
                                             "amount": 1,
                                             "negate": false
                                         }

--- a/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.json
+++ b/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.json
@@ -2906,12 +2906,29 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": "Move the shuffler block both ways",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Grapple",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "Area 5 Tower Interior - Grapple Shuffler Long Grapple Block",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
@@ -2941,6 +2958,32 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Shuffler Grapple Block": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Grapple",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -3120,8 +3163,8 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Grapple",
+                                            "type": "events",
+                                            "name": "Area 5 Tower Interior - Grapple Shuffler Long Grapple Block",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -3484,6 +3527,33 @@
                                         }
                                     }
                                 ]
+                            }
+                        }
+                    }
+                },
+                "Event - Shuffler Grapple Block": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -4046.99,
+                        "y": 3005.01,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "Area 5 Tower Interior - Grapple Shuffler Long Grapple Block",
+                    "connections": {
+                        "Door to Interior Teleporter (Bottom)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }

--- a/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.json
+++ b/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.json
@@ -2963,7 +2963,7 @@
                                 ]
                             }
                         },
-                        "Event - Shuffler Grapple Block": {
+                        "Event - Shuffler Long Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3531,7 +3531,7 @@
                         }
                     }
                 },
-                "Event - Shuffler Grapple Block": {
+                "Event - Shuffler Long Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.json
+++ b/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.json
@@ -2917,7 +2917,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Top of big Grapple block",
+                                                        "comment": "Melee Clip from on top of big Grapple block: https://youtu.be/l5mTl6UJoNY",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -3008,41 +3008,6 @@
                     "location_category": "minor",
                     "hint_features": [],
                     "connections": {
-                        "Door to Plasma Beam Chamber": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Screw",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "Area 5 (Tower Interior) - Grapple Shuffler Grapple Block",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Door to Interior Teleporter (Bottom)": {
                             "type": "and",
                             "data": {
@@ -3080,6 +3045,249 @@
                                         "data": {
                                             "type": "items",
                                             "name": "Ice",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Below Pickup": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    }
+                },
+                "Event - Grapple Block": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -4234.886055024206,
+                        "y": 2612.1856181367334,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "Area 5 (Tower Interior) - Grapple Shuffler Grapple Block",
+                    "connections": {
+                        "Above Pickup": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Above Pickup": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -3661.34662820352,
+                        "y": 2726.6162186267543,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
+                        "Door to Interior Teleporter (Bottom)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Grapple",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Pickup (Missile Tank)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Screw",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Power Bomb"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Lay Bomb"
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Phase",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Break the Screw Attack block then use spider",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Use Spider Ball"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "AirMorph",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Morph to lay bomb and immediately unmorph to grab ledge: https://youtu.be/Kh03Ra2Qn7Q",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Movement",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Grapple Block": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Grapple",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Below Pickup": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    }
+                },
+                "Below Pickup": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -3938.444786062004,
+                        "y": 2048.5609360321123,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
+                        "Door to Plasma Beam Chamber": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Grapple",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Area 5 (Tower Interior) - Grapple Shuffler Grapple Block",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -3276,162 +3484,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        }
-                    }
-                },
-                "Event - Grapple Block": {
-                    "node_type": "event",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -4234.886055024206,
-                        "y": 2612.1856181367334,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "valid_starting_location": false,
-                    "event_name": "Area 5 (Tower Interior) - Grapple Shuffler Grapple Block",
-                    "connections": {
-                        "Above Pickup": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Above Pickup": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3661.34662820352,
-                        "y": 2726.6162186267543,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "valid_starting_location": false,
-                    "connections": {
-                        "Door to Interior Teleporter (Bottom)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Pickup (Missile Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Screw",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Lay Power Bomb"
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Lay Bomb"
-                                                            },
-                                                            {
-                                                                "type": "or",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Phase",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "and",
-                                                                            "data": {
-                                                                                "comment": "Break the Screw Attack block then use spider",
-                                                                                "items": [
-                                                                                    {
-                                                                                        "type": "template",
-                                                                                        "data": "Use Spider Ball"
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "AirMorph",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    }
-                                                                                ]
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "and",
-                                                                            "data": {
-                                                                                "comment": "Morph to lay bomb and immediately unmorph to grab ledge: https://youtu.be/Kh03Ra2Qn7Q",
-                                                                                "items": [
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "Movement",
-                                                                                            "amount": 3,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    }
-                                                                                ]
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Event - Grapple Block": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Grapple",
-                                "amount": 1,
-                                "negate": false
                             }
                         }
                     }

--- a/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.txt
@@ -405,7 +405,7 @@ Extra - asset_id: collision_camera_007
               Grapple Beam and After Area 5 Tower Interior - Grapple Shuffler Long Grapple Block
               # Melee Clip from on top of big Grapple block: https://youtu.be/l5mTl6UJoNY
               Melee Clip (Intermediate) and Out of Bounds Movement (Intermediate)
-  > Event - Shuffler Grapple Block
+  > Event - Shuffler Long Grapple Block
       Grapple Beam and Morph Ball
 
 > Door to Interior Teleporter (Top); Heals? False
@@ -485,7 +485,7 @@ Extra - asset_id: collision_camera_007
               # Screw only: https://youtu.be/eI3DtHqx5dU?t=43
               Movement (Expert)
 
-> Event - Shuffler Grapple Block; Heals? False
+> Event - Shuffler Long Grapple Block; Heals? False
   * Layers: default
   * Event Area 5 Tower Interior - Grapple Shuffler Long Grapple Block
   > Door to Interior Teleporter (Bottom)

--- a/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.txt
@@ -401,9 +401,12 @@ Extra - asset_id: collision_camera_007
       All of the following:
           Morph Ball
           Any of the following:
-              Grapple Beam
+              # Move the shuffler block both ways
+              Grapple Beam and After Area 5 Tower Interior - Grapple Shuffler Long Grapple Block
               # Melee Clip from on top of big Grapple block: https://youtu.be/l5mTl6UJoNY
               Melee Clip (Intermediate) and Out of Bounds Movement (Intermediate)
+  > Event - Shuffler Grapple Block
+      Grapple Beam and Morph Ball
 
 > Door to Interior Teleporter (Top); Heals? False
   * Layers: default
@@ -433,7 +436,7 @@ Extra - asset_id: collision_camera_007
 > Above Pickup; Heals? False
   * Layers: default
   > Door to Interior Teleporter (Bottom)
-      Grapple Beam and Morph Ball
+      Morph Ball and After Area 5 Tower Interior - Grapple Shuffler Long Grapple Block
   > Pickup (Missile Tank)
       All of the following:
           Screw Attack
@@ -481,6 +484,12 @@ Extra - asset_id: collision_camera_007
                           Lay Bomb
               # Screw only: https://youtu.be/eI3DtHqx5dU?t=43
               Movement (Expert)
+
+> Event - Shuffler Grapple Block; Heals? False
+  * Layers: default
+  * Event Area 5 Tower Interior - Grapple Shuffler Long Grapple Block
+  > Door to Interior Teleporter (Bottom)
+      Morph Ball
 
 ----------------
 Autrack Acropolis

--- a/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.txt
@@ -402,7 +402,7 @@ Extra - asset_id: collision_camera_007
           Morph Ball
           Any of the following:
               Grapple Beam
-              # Top of big Grapple block
+              # Melee Clip from on top of big Grapple block: https://youtu.be/l5mTl6UJoNY
               Melee Clip (Intermediate) and Out of Bounds Movement (Intermediate)
 
 > Door to Interior Teleporter (Top); Heals? False
@@ -418,11 +418,44 @@ Extra - asset_id: collision_camera_007
   * Pickup 127; Category? Minor
   * Extra - actor_name: HiddenPowerup002
   * Extra - actor_type: item_missiletank
-  > Door to Plasma Beam Chamber
-      Morph Ball and Screw Attack and After Area 5 (Tower Interior) - Grapple Shuffler Grapple Block
   > Door to Interior Teleporter (Bottom)
       # Requirements to prevent Screw Attack paths escaping this way
       Ice Beam and Morph Ball and Ice Beam Clip (Expert) and Out of Bounds Movement (Intermediate)
+  > Below Pickup
+      Morph Ball
+
+> Event - Grapple Block; Heals? False
+  * Layers: default
+  * Event Area 5 (Tower Interior) - Grapple Shuffler Grapple Block
+  > Above Pickup
+      Trivial
+
+> Above Pickup; Heals? False
+  * Layers: default
+  > Door to Interior Teleporter (Bottom)
+      Grapple Beam and Morph Ball
+  > Pickup (Missile Tank)
+      All of the following:
+          Screw Attack
+          Any of the following:
+              Lay Power Bomb
+              All of the following:
+                  Lay Bomb
+                  Any of the following:
+                      Phase Drift
+                      # Break the Screw Attack block then use spider
+                      Mid-Air Morph (Beginner) and Use Spider Ball
+                      # Morph to lay bomb and immediately unmorph to grab ledge: https://youtu.be/Kh03Ra2Qn7Q
+                      Movement (Advanced)
+  > Event - Grapple Block
+      Grapple Beam
+  > Below Pickup
+      Screw Attack
+
+> Below Pickup; Heals? False
+  * Layers: default
+  > Door to Plasma Beam Chamber
+      Grapple Beam and Morph Ball and After Area 5 (Tower Interior) - Grapple Shuffler Grapple Block
   > Above Pickup
       All of the following:
           Morph Ball and Screw Attack
@@ -448,32 +481,6 @@ Extra - asset_id: collision_camera_007
                           Lay Bomb
               # Screw only: https://youtu.be/eI3DtHqx5dU?t=43
               Movement (Expert)
-
-> Event - Grapple Block; Heals? False
-  * Layers: default
-  * Event Area 5 (Tower Interior) - Grapple Shuffler Grapple Block
-  > Above Pickup
-      Trivial
-
-> Above Pickup; Heals? False
-  * Layers: default
-  > Door to Interior Teleporter (Bottom)
-      Morph Ball
-  > Pickup (Missile Tank)
-      All of the following:
-          Screw Attack
-          Any of the following:
-              Lay Power Bomb
-              All of the following:
-                  Lay Bomb
-                  Any of the following:
-                      Phase Drift
-                      # Break the Screw Attack block then use spider
-                      Mid-Air Morph (Beginner) and Use Spider Ball
-                      # Morph to lay bomb and immediately unmorph to grab ledge: https://youtu.be/Kh03Ra2Qn7Q
-                      Movement (Advanced)
-  > Event - Grapple Block
-      Grapple Beam
 
 ----------------
 Autrack Acropolis

--- a/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 5 Tower Interior.txt
@@ -392,10 +392,10 @@ Extra - asset_id: collision_camera_007
           Morph Ball
           Any of the following:
               Grapple Beam and After Area 5 (Tower Interior) - Grapple Shuffler Grapple Block
-              # https://youtu.be/i9kuD1yPSSk
+              # Ice Clip using the left Glow Fly: https://youtu.be/i9kuD1yPSSk
               Charge Beam and Ice Beam and Ice Beam Clip (Expert) and Out of Bounds Movement (Intermediate)
   > Pickup (Missile Tank)
-      # https://youtu.be/wA-kNgVe_6c
+      # Ice Clip using the right Glow Fly: https://youtu.be/wA-kNgVe_6c
       Charge Beam and Ice Beam and Morph Ball and Ice Beam Clip (Expert) and Out of Bounds Movement (Intermediate) and Lay Any Bomb
   > Above Pickup
       All of the following:
@@ -455,7 +455,7 @@ Extra - asset_id: collision_camera_007
 > Below Pickup; Heals? False
   * Layers: default
   > Door to Plasma Beam Chamber
-      Grapple Beam and Morph Ball and After Area 5 (Tower Interior) - Grapple Shuffler Grapple Block
+      Morph Ball and Screw Attack and After Area 5 (Tower Interior) - Grapple Shuffler Grapple Block
   > Above Pickup
       All of the following:
           Morph Ball and Screw Attack

--- a/randovania/games/samus_returns/logic_database/header.json
+++ b/randovania/games/samus_returns/logic_database/header.json
@@ -1061,6 +1061,10 @@
             "Credits": {
                 "long_name": "Credits",
                 "extra": {}
+            },
+            "Area 5 Tower Interior - Grapple Shuffler Long Grapple Block": {
+                "long_name": "Area 5 Tower Interior - Grapple Shuffler Long Grapple Block",
+                "extra": {}
             }
         },
         "tricks": {


### PR DESCRIPTION
An path to the item with a Melee Clip expected passing through the top Grapple Block without moving it on the return trip.