### PR TITLE
Fusion: Rework sector 2 eastern shaft

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -7783,6 +7783,18 @@
                                     {
                                         "type": "or",
                                         "data": {
+                                            "comment": "Weapon Requirements for Kihunter",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Kill Tough Beam-Weak Enemy"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
                                             "comment": "Movement Requirements",
                                             "items": [
                                                 {
@@ -7797,38 +7809,143 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Start WJ on left, to big vine solids on the right. Easier with HJ",
                                                         "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Hi-Jump",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
                                                             {
                                                                 "type": "or",
                                                                 "data": {
-                                                                    "comment": "Climb using vine blocks: https://youtu.be/sQdvfgu3fKA",
+                                                                    "comment": null,
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
                                                                                 "type": "tricks",
                                                                                 "name": "WallJump",
-                                                                                "amount": 1,
+                                                                                "amount": 3,
                                                                                 "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Hi-Jump",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "WallJump",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         }
                                                                     ]
                                                                 }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Freeze Enemies with normal ice weapons",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "StandOnFrozenEnemies",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
                                                             },
                                                             {
-                                                                "type": "and",
+                                                                "type": "or",
                                                                 "data": {
-                                                                    "comment": "SWJ",
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Freeze Enemies With Ice Beam"
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Missiles",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Can Freeze Enemies With Ice Missiles"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Freeze Enemies with Diffusion",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "StandOnFrozenEnemies",
+                                                                    "amount": 4,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Missiles",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Freeze Enemies With Diffusion"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Freeze Kihunter and either WJ or HJ onto it",
+                                                        "items": [
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",
@@ -7840,29 +7957,67 @@
                                                                             }
                                                                         },
                                                                         {
-                                                                            "type": "template",
-                                                                            "data": "Can Screw Single Walljump"
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Hi-Jump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
                                                                         }
                                                                     ]
                                                                 }
                                                             },
                                                             {
-                                                                "type": "and",
+                                                                "type": "resource",
                                                                 "data": {
-                                                                    "comment": "Freeze kihunter: https://youtu.be/roSeFDbWr1s",
+                                                                    "type": "tricks",
+                                                                    "name": "StandOnFrozenEnemies",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "StandOnFrozenEnemies",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
+                                                                            "type": "template",
+                                                                            "data": "Can Freeze Enemies With Ice Beam"
                                                                         },
                                                                         {
-                                                                            "type": "template",
-                                                                            "data": "Can Freeze Enemies With Any Weapon"
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Missiles",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "or",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "template",
+                                                                                                    "data": "Can Freeze Enemies With Diffusion"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "template",
+                                                                                                    "data": "Can Freeze Enemies With Ice Missiles"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
                                                                         }
                                                                     ]
                                                                 }
@@ -7873,13 +8028,34 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Climb using vine blocks: https://youtu.be/sQdvfgu3fKA",
+                                                        "comment": "SWJ up",
                                                         "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Screw Single Walljump"
+                                                            },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "WallJump",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Shinespark up",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "SpeedBooster",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
@@ -7888,25 +8064,31 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Movement",
+                                                                    "name": "ShinesparkTrick",
                                                                     "amount": 1,
                                                                     "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "EnemyRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "OpenHatchLockRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
                                                                 }
                                                             }
                                                         ]
                                                     }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": "Weapon Requirements",
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Kill Tough Beam-Weak Enemy"
                                                 }
                                             ]
                                         }

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1224,21 +1224,37 @@ Extra - room_id: [32, 35]
       Trivial
   > Door to Kihunter Hallway
       All of the following:
+          # Weapon Requirements for Kihunter
+          Can Kill Tough Beam-Weak Enemy
           Any of the following:
               # Movement Requirements
               Space Jump
               All of the following:
-                  Hi-Jump
-                  # Climb using vine blocks: https://youtu.be/sQdvfgu3fKA
-                  Wall Jump (Beginner)
-                  # SWJ
-                  Wall Jump (Intermediate) and Can Single Walljump
-                  # Freeze kihunter: https://youtu.be/roSeFDbWr1s
-                  Stand On Frozen Enemies (Beginner) and Can Freeze Enemies With Any Weapon
-              # Climb using vine blocks: https://youtu.be/sQdvfgu3fKA
-              Movement (Beginner) and Wall Jump (Beginner)
-          # Weapon Requirements
-          Can Kill Tough Beam-Weak Enemy
+                  # Start WJ on left, to big vine solids on the right. Easier with HJ
+                  Any of the following:
+                      Wall Jump (Advanced)
+                      Hi-Jump and Wall Jump (Intermediate)
+              All of the following:
+                  # Freeze Enemies with normal ice weapons
+                  Stand On Frozen Enemies (Advanced)
+                  Any of the following:
+                      Can Freeze Enemies With Ice Beam
+                      Missiles ≥ 2 and Can Freeze Enemies With Ice Missiles
+              # Freeze Enemies with Diffusion
+              Missiles ≥ 2 and Stand On Frozen Enemies (Expert) and Can Freeze Enemies With Diffusion
+              All of the following:
+                  # Freeze Kihunter and either WJ or HJ onto it
+                  Stand On Frozen Enemies (Intermediate)
+                  Hi-Jump or Wall Jump (Intermediate)
+                  Any of the following:
+                      Can Freeze Enemies With Ice Beam
+                      All of the following:
+                          Missiles ≥ 2
+                          Can Freeze Enemies With Diffusion or Can Freeze Enemies With Ice Missiles
+              # SWJ up
+              Wall Jump (Intermediate) and Can Single Walljump
+              # Shinespark up
+              Speed Booster and Shinespark Tricks (Beginner) and Disabled Enemy Rando and Disabled Open Hatch Lock Rando
   > Door to Collapsed Shaft
       After Boss Nettori Defeated
 


### PR DESCRIPTION
Reason for WJ intermediate on most is due to you being on a time frame until enemy unfreezes
Reason for freezing intermediate on most is that you more or less have one attempt at freezing the first kihunter in the correct position and if that fails you need to reload the room because its then too low. Since its initial descent happens relatively quickly, if you're not prepared for it it will catch you off-guard.

Due to the room change most if not all of the old videos are now outdated. I'd need to search which ones still apply and which ones don't.