### PR TITLE
Dread: Make events in Screw Attack Room non dangerous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.10.x] - 2025-03-??
 
+### Metroid Dread
+
+#### Logic Database
+
+##### Artaria
+
+- Changed: Flipping the spinner. in Screw Attack Room when by going from the door to the transport is now logically possible also after having flipped the spinner.
+- Changed: All other connections in Screw Attack Room that are only open before flipping the spinner are now only logical when Highly Dangerous Logic is enabled.
+- Changed: The conditions that depends on not having blown up the blob in Screw Attack Room are now only logical when Highly Dangerous Logic is enabled.
+
 ### Metroid: Samus Returns
 
 - Fixed: One Area 8 theme from not being included in music shuffle.

--- a/randovania/games/dread/logic_database/Artaria.json
+++ b/randovania/games/dread/logic_database/Artaria.json
@@ -26193,17 +26193,32 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "HighDanger",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
                         },
                         "Event - Screw Attack Rotatable": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "ArtariaSARotatable",
-                                "amount": 1,
-                                "negate": true
+                                "comment": "Technically only possible when turning the flipper. This keeps the event safe and assumes there are no bad consequences.",
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": []
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Under left side blocks": {
@@ -26819,6 +26834,15 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "HighDanger",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -27334,12 +27358,29 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "events",
-                                                                    "name": "s010_cave:default:breakablecave019",
-                                                                    "amount": 1,
-                                                                    "negate": true
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "events",
+                                                                                "name": "s010_cave:default:breakablecave019",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "HighDanger",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             {
@@ -27398,6 +27439,15 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Perform WBJ"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "HighDanger",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -27449,6 +27499,15 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "HighDanger",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -27522,6 +27581,15 @@
                                                     "data": "Lay Cross Bomb"
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "HighDanger",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -27680,6 +27748,15 @@
                                                         "name": "ArtariaSARotatable",
                                                         "amount": 1,
                                                         "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "HighDanger",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]

--- a/randovania/games/dread/logic_database/Artaria.txt
+++ b/randovania/games/dread/logic_database/Artaria.txt
@@ -4831,12 +4831,12 @@ Extra - asset_id: collision_camera_081
   * Extra - right_shield_def: None
   > Next to Upper Tank
       All of the following:
-          Before Artaria - Screw Attack Rotatable
+          Before Artaria - Screw Attack Rotatable and Enabled Highly Dangerous Logic
           Any of the following:
               Flash Shift or Movement (Beginner) or Lay Cross Bomb
               Speed Booster and Shoot Missile
   > Event - Screw Attack Rotatable
-      Before Artaria - Screw Attack Rotatable
+      Trivial
   > Under left side blocks
       All of the following:
           After Artaria - Screw Attack Rotatable
@@ -4933,7 +4933,7 @@ Extra - asset_id: collision_camera_081
           Water Bomb Jump (Beginner) and Lay Cross Bomb
           Water Bomb Jump (Intermediate) and Lay Normal Bomb
           All of the following:
-              Before Artaria - Screw Attack Rotatable
+              Before Artaria - Screw Attack Rotatable and Enabled Highly Dangerous Logic
               Simple IBJ or Use Spin Boost
               Morph Ball or Screw Attack
 
@@ -5013,17 +5013,17 @@ Extra - asset_id: collision_camera_081
           All of the following:
               Gravity Suit
               Any of the following:
-                  Before Artaria - Screw Attack Water Blob
+                  Before Artaria - Screw Attack Water Blob and Enabled Highly Dangerous Logic
                   All of the following:
                       After Artaria - Screw Attack Water Blob
                       Simple IBJ or Use Spin Boost
-          Before Artaria - Screw Attack Water Blob and Perform WBJ
+          Before Artaria - Screw Attack Water Blob and Enabled Highly Dangerous Logic and Perform WBJ
   > Blob - Right
       After Artaria - Screw Attack Water Blob
   > Early SA Platform
       Any of the following:
           Gravity Suit or Perform WBJ
-          Before Artaria - Screw Attack Water Blob and Use Spin Boost
+          Before Artaria - Screw Attack Water Blob and Enabled Highly Dangerous Logic and Use Spin Boost
 
 > Next to Upper Tank; Heals? False
   * Layers: default
@@ -5031,7 +5031,7 @@ Extra - asset_id: collision_camera_081
       Trivial
   > Door to Transport to Burenia
       All of the following:
-          Before Artaria - Screw Attack Rotatable
+          Before Artaria - Screw Attack Rotatable and Enabled Highly Dangerous Logic
           Flash Shift or Movement (Beginner) or Lay Cross Bomb
   > Total Recharge
       After Artaria - Screw Attack Rotatable
@@ -5054,7 +5054,7 @@ Extra - asset_id: collision_camera_081
       Any of the following:
           Gravity Suit or Perform WBJ
           Infinite Bomb Jump (Beginner) and Lay Cross Bomb
-          Screw Attack and Before Artaria - Screw Attack Rotatable
+          Screw Attack and Before Artaria - Screw Attack Rotatable and Enabled Highly Dangerous Logic
   > Early SA Platform
       Trivial
 


### PR DESCRIPTION
Put Highly Dangerous Logic on most before-conditions. Assume flipping the spinner from the left is safe.