### PR TITLE
Echoes: Add area features

### DIFF
--- a/randovania/games/prime2/logic_database/Agon Wastes.json
+++ b/randovania/games/prime2/logic_database/Agon Wastes.json
@@ -1227,6 +1227,7 @@
         "Mining Station Access": {
             "default_node": "Door to Mining Plaza",
             "hint_features": [
+                "morph",
                 "orb_cannon"
             ],
             "extra": {
@@ -5536,7 +5537,9 @@
         },
         "Ing Cache 4": {
             "default_node": "Door to Duelling Range",
-            "hint_features": [],
+            "hint_features": [
+                "morph"
+            ],
             "extra": {
                 "asset_id": 3318204883,
                 "in_dark_aether": true
@@ -5652,6 +5655,7 @@
             "default_node": "Door to Duelling Range",
             "hint_features": [
                 "bomb_slot",
+                "morph",
                 "spider"
             ],
             "extra": {
@@ -6039,7 +6043,9 @@
         },
         "Mine Shaft": {
             "default_node": "Door to Mining Station B",
-            "hint_features": [],
+            "hint_features": [
+                "morph"
+            ],
             "extra": {
                 "asset_id": 3617674289,
                 "in_dark_aether": false
@@ -8698,6 +8704,7 @@
         "Portal Access A": {
             "default_node": "Door to Mining Station A",
             "hint_features": [
+                "morph",
                 "orb_cannon"
             ],
             "extra": {
@@ -19328,7 +19335,9 @@
         },
         "Ventilation Area A": {
             "default_node": "Door to Main Reactor",
-            "hint_features": [],
+            "hint_features": [
+                "morph"
+            ],
             "extra": {
                 "asset_id": 2217754069,
                 "in_dark_aether": false
@@ -19755,7 +19764,9 @@
         },
         "Command Center": {
             "default_node": "Morph Ball Door to Command Center Access",
-            "hint_features": [],
+            "hint_features": [
+                "morph"
+            ],
             "extra": {
                 "asset_id": 834819415,
                 "in_dark_aether": false

--- a/randovania/games/prime2/logic_database/Agon Wastes.json
+++ b/randovania/games/prime2/logic_database/Agon Wastes.json
@@ -12823,6 +12823,7 @@
         "Central Mining Station": {
             "default_node": "Door to Central Station Access",
             "hint_features": [
+                "keybearer",
                 "luminoth_corpse",
                 "spider"
             ],
@@ -20826,6 +20827,7 @@
         "Main Reactor": {
             "default_node": "Door to Sand Processing",
             "hint_features": [
+                "keybearer",
                 "luminoth_corpse",
                 "phazon",
                 "spider"

--- a/randovania/games/prime2/logic_database/Agon Wastes.txt
+++ b/randovania/games/prime2/logic_database/Agon Wastes.txt
@@ -213,7 +213,7 @@ Extra - in_dark_aether: False
 Mining Station Access
 Extra - asset_id: 2373615500
 Extra - in_dark_aether: False
-Hint Features - Kinetic Orb Cannon
+Hint Features - Morph Ball Tunnel, Kinetic Orb Cannon
 > Door to Mining Station A; Heals? False
   * Layers: default
   * Normal Door to Mining Station A/Door to Mining Station Access
@@ -766,6 +766,7 @@ Extra - in_dark_aether: True
 Ing Cache 4
 Extra - asset_id: 3318204883
 Extra - in_dark_aether: True
+Hint Features - Morph Ball Tunnel
 > Door to Duelling Range; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Dark Door to Duelling Range/Door to Ing Cache 4
@@ -784,7 +785,7 @@ Extra - in_dark_aether: True
 Junction Site
 Extra - asset_id: 369673571
 Extra - in_dark_aether: True
-Hint Features - Bomb Slot, Spider Track
+Hint Features - Bomb Slot, Morph Ball Tunnel, Spider Track
 > Door to Duelling Range; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Duelling Range/Door to Junction Site
@@ -837,6 +838,7 @@ Extra - in_dark_aether: False
 Mine Shaft
 Extra - asset_id: 3617674289
 Extra - in_dark_aether: False
+Hint Features - Morph Ball Tunnel
 > Door to Agon Temple; Heals? False
   * Layers: default
   * Dark Door to Agon Temple/Door to Mine Shaft
@@ -1176,7 +1178,7 @@ Extra - in_dark_aether: False
 Portal Access A
 Extra - asset_id: 588443165
 Extra - in_dark_aether: False
-Hint Features - Kinetic Orb Cannon
+Hint Features - Morph Ball Tunnel, Kinetic Orb Cannon
 > Door to Portal Terminal; Heals? False
   * Layers: default
   * Normal Door to Portal Terminal/Door to Portal Access A
@@ -2384,6 +2386,7 @@ Hint Features - Energy Controller, Luminoth Lore, Luminoth Corpse
 Ventilation Area A
 Extra - asset_id: 2217754069
 Extra - in_dark_aether: False
+Hint Features - Morph Ball Tunnel
 > Door to Transport to Sanctuary Fortress; Heals? False
   * Layers: default
   * Power Bomb Blast Shield to Transport to Sanctuary Fortress/Door to Ventilation Area A
@@ -2448,6 +2451,7 @@ Extra - in_dark_aether: True
 Command Center
 Extra - asset_id: 834819415
 Extra - in_dark_aether: False
+Hint Features - Morph Ball Tunnel
 > Door to Command Center Access (Top); Heals? False
   * Layers: default
   * Light Door to Command Center Access/Door to Command Center (Top)

--- a/randovania/games/prime2/logic_database/Agon Wastes.txt
+++ b/randovania/games/prime2/logic_database/Agon Wastes.txt
@@ -1620,7 +1620,7 @@ Extra - in_dark_aether: True
 Central Mining Station
 Extra - asset_id: 4121352562
 Extra - in_dark_aether: False
-Hint Features - Luminoth Corpse, Spider Track
+Hint Features - Keybearer Corpse, Luminoth Corpse, Spider Track
 > Door to Command Center Access (Top); Heals? False
   * Layers: default
   * Light Door to Command Center Access/Door to Central Mining Station (Top)
@@ -2607,7 +2607,7 @@ Main Reactor
 Extra - asset_id: 3436835742
 Extra - in_dark_aether: False
 Extra - low_memory_mode: True
-Hint Features - Luminoth Corpse, Phazon, Spider Track
+Hint Features - Keybearer Corpse, Luminoth Corpse, Phazon, Spider Track
 > Portal from Dark Oasis; Heals? False
   * Layers: default
   * No Return Portal to Dark Oasis/Portal to Main Reactor

--- a/randovania/games/prime2/logic_database/Great Temple.json
+++ b/randovania/games/prime2/logic_database/Great Temple.json
@@ -1494,7 +1494,9 @@
         },
         "Transport B Access": {
             "default_node": "Door to Temple Sanctuary",
-            "hint_features": [],
+            "hint_features": [
+                "morph"
+            ],
             "extra": {
                 "asset_id": 4273454375,
                 "in_dark_aether": false

--- a/randovania/games/prime2/logic_database/Great Temple.txt
+++ b/randovania/games/prime2/logic_database/Great Temple.txt
@@ -244,6 +244,7 @@ Extra - in_dark_aether: False
 Transport B Access
 Extra - asset_id: 4273454375
 Extra - in_dark_aether: False
+Hint Features - Morph Ball Tunnel
 > Door to Temple Sanctuary; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Temple Sanctuary/Door to Transport B Access

--- a/randovania/games/prime2/logic_database/Sanctuary Fortress.json
+++ b/randovania/games/prime2/logic_database/Sanctuary Fortress.json
@@ -7229,7 +7229,6 @@
                 "boost",
                 "keybearer",
                 "luminoth_corpse",
-                "morph",
                 "spider"
             ],
             "extra": {
@@ -7764,7 +7763,9 @@
                     "valid_starting_location": false,
                     "pickup_index": 103,
                     "location_category": "minor",
-                    "hint_features": [],
+                    "hint_features": [
+                        "morph"
+                    ],
                     "connections": {
                         "Door to Dynamo Storage": {
                             "type": "and",

--- a/randovania/games/prime2/logic_database/Sanctuary Fortress.json
+++ b/randovania/games/prime2/logic_database/Sanctuary Fortress.json
@@ -3084,6 +3084,7 @@
             "hint_features": [
                 "bomb_slot",
                 "lore",
+                "morph",
                 "phazon",
                 "spider"
             ],
@@ -5338,6 +5339,7 @@
         "Culling Chamber": {
             "default_node": "Portal to Hall of Combat Mastery",
             "hint_features": [
+                "morph",
                 "phazon",
                 "spider"
             ],
@@ -6325,6 +6327,7 @@
             "default_node": "Door to Main Research",
             "hint_features": [
                 "echo_lock",
+                "morph",
                 "orb_cannon"
             ],
             "extra": {
@@ -7226,6 +7229,7 @@
                 "boost",
                 "keybearer",
                 "luminoth_corpse",
+                "morph",
                 "spider"
             ],
             "extra": {
@@ -9105,6 +9109,7 @@
                 "abyss",
                 "bomb_slot",
                 "lore",
+                "morph",
                 "orb_cannon",
                 "spider"
             ],
@@ -24833,6 +24838,7 @@
                 "boost_spinner",
                 "dark_visor_lock",
                 "echo_lock",
+                "morph",
                 "orb_cannon"
             ],
             "extra": {

--- a/randovania/games/prime2/logic_database/Sanctuary Fortress.json
+++ b/randovania/games/prime2/logic_database/Sanctuary Fortress.json
@@ -236,6 +236,7 @@
             "default_node": "Door to Temple Transport Access",
             "hint_features": [
                 "abyss",
+                "keybearer",
                 "lore",
                 "luminoth_corpse",
                 "orb_cannon",
@@ -7223,6 +7224,7 @@
             "hint_features": [
                 "bomb_slot",
                 "boost",
+                "keybearer",
                 "luminoth_corpse",
                 "spider"
             ],

--- a/randovania/games/prime2/logic_database/Sanctuary Fortress.txt
+++ b/randovania/games/prime2/logic_database/Sanctuary Fortress.txt
@@ -1001,7 +1001,7 @@ Dynamo Works
 Extra - asset_id: 3222355176
 Extra - in_dark_aether: False
 Extra - low_memory_mode: True
-Hint Features - Bomb Slot, Boost Pipe, Keybearer Corpse, Luminoth Corpse, Morph Ball Tunnel, Spider Track
+Hint Features - Bomb Slot, Boost Pipe, Keybearer Corpse, Luminoth Corpse, Spider Track
 > Door to Workers Path; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Workers Path/Door to Dynamo Works
@@ -1063,6 +1063,7 @@ Hint Features - Bomb Slot, Boost Pipe, Keybearer Corpse, Luminoth Corpse, Morph 
 > Pickup 2 (Missile); Heals? False
   * Layers: default
   * Pickup 103; Category? Minor
+  * Hint Features - Morph Ball Tunnel
   * Extra - location_data: frozendict.frozendict({'type': 'standard', 'exclude_memo_from_removal': False, 'original_model': 'MissileExpansion', 'connections': (), 'removals': (1311917,), 'collision_offset': frozendict.frozendict({'x': 0.0, 'y': 0.0, 'z': 1.0}), 'instances': frozendict.frozendict({'pickup': 1311926, 'hud_memo': 1311918, 'streamed_audio': 1311916, 'sound': 1311915, 'audio_fade': 1311923})})
   > Door to Dynamo Storage
       Morph Ball Bomb and Morph Ball and After Spider Guardian

--- a/randovania/games/prime2/logic_database/Sanctuary Fortress.txt
+++ b/randovania/games/prime2/logic_database/Sanctuary Fortress.txt
@@ -467,7 +467,7 @@ Extra - in_dark_aether: False
 Hall of Combat Mastery
 Extra - asset_id: 1433528478
 Extra - in_dark_aether: False
-Hint Features - Bomb Slot, Luminoth Lore, Phazon, Spider Track
+Hint Features - Bomb Slot, Luminoth Lore, Morph Ball Tunnel, Phazon, Spider Track
 > Door to Central Area Transport East; Heals? False
   * Layers: default
   * Normal Door to Central Area Transport East/Door to Hall of Combat Mastery
@@ -774,7 +774,7 @@ Extra - in_dark_aether: False
 Culling Chamber
 Extra - asset_id: 1762359402
 Extra - in_dark_aether: True
-Hint Features - Phazon, Spider Track
+Hint Features - Morph Ball Tunnel, Phazon, Spider Track
 > Door to Hazing Cliff; Heals? False
   * Layers: default
   * Normal Door to Hazing Cliff/Door to Culling Chamber
@@ -878,7 +878,7 @@ Hint Features - Phazon, Spider Track
 Central Area Transport West
 Extra - asset_id: 1894024576
 Extra - in_dark_aether: False
-Hint Features - Echo Visor Lock, Kinetic Orb Cannon
+Hint Features - Echo Visor Lock, Morph Ball Tunnel, Kinetic Orb Cannon
 > Door to Main Research; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Main Research/Door to Central Area Transport West; Excluded from Dock Lock Rando
@@ -1001,7 +1001,7 @@ Dynamo Works
 Extra - asset_id: 3222355176
 Extra - in_dark_aether: False
 Extra - low_memory_mode: True
-Hint Features - Bomb Slot, Boost Pipe, Keybearer Corpse, Luminoth Corpse, Spider Track
+Hint Features - Bomb Slot, Boost Pipe, Keybearer Corpse, Luminoth Corpse, Morph Ball Tunnel, Spider Track
 > Door to Workers Path; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Workers Path/Door to Dynamo Works
@@ -1221,7 +1221,7 @@ Extra - in_dark_aether: True
 Watch Station
 Extra - asset_id: 2722128775
 Extra - in_dark_aether: False
-Hint Features - Abyss, Bomb Slot, Luminoth Lore, Kinetic Orb Cannon, Spider Track
+Hint Features - Abyss, Bomb Slot, Luminoth Lore, Morph Ball Tunnel, Kinetic Orb Cannon, Spider Track
 > Door to Watch Station Access; Heals? False
   * Layers: default
   * Light Door to Watch Station Access/Door to Watch Station
@@ -2876,7 +2876,7 @@ Extra - in_dark_aether: True
 Temple Access
 Extra - asset_id: 3312357786
 Extra - in_dark_aether: False
-Hint Features - Boost Spinner, Dark Visor Lock, Echo Visor Lock, Kinetic Orb Cannon
+Hint Features - Boost Spinner, Dark Visor Lock, Echo Visor Lock, Morph Ball Tunnel, Kinetic Orb Cannon
 > Door to Main Gyro Chamber; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Main Gyro Chamber/Door to Temple Access

--- a/randovania/games/prime2/logic_database/Sanctuary Fortress.txt
+++ b/randovania/games/prime2/logic_database/Sanctuary Fortress.txt
@@ -50,7 +50,7 @@ Extra - in_dark_aether: False
 Sanctuary Entrance
 Extra - asset_id: 1193696267
 Extra - in_dark_aether: False
-Hint Features - Abyss, Luminoth Lore, Luminoth Corpse, Kinetic Orb Cannon, Spider Track
+Hint Features - Abyss, Keybearer Corpse, Luminoth Lore, Luminoth Corpse, Kinetic Orb Cannon, Spider Track
 > Door to Power Junction; Heals? False
   * Layers: default
   * Light Door to Power Junction/Door to Sanctuary Entrance
@@ -1001,7 +1001,7 @@ Dynamo Works
 Extra - asset_id: 3222355176
 Extra - in_dark_aether: False
 Extra - low_memory_mode: True
-Hint Features - Bomb Slot, Boost Pipe, Luminoth Corpse, Spider Track
+Hint Features - Bomb Slot, Boost Pipe, Keybearer Corpse, Luminoth Corpse, Spider Track
 > Door to Workers Path; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Workers Path/Door to Dynamo Works

--- a/randovania/games/prime2/logic_database/Temple Grounds.json
+++ b/randovania/games/prime2/logic_database/Temple Grounds.json
@@ -5954,7 +5954,9 @@
         },
         "Hive Chamber B": {
             "default_node": "Door to Hive Storage",
-            "hint_features": [],
+            "hint_features": [
+                "morph"
+            ],
             "extra": {
                 "asset_id": 494654382,
                 "in_dark_aether": false

--- a/randovania/games/prime2/logic_database/Temple Grounds.txt
+++ b/randovania/games/prime2/logic_database/Temple Grounds.txt
@@ -911,6 +911,7 @@ Extra - in_dark_aether: False
 Hive Chamber B
 Extra - asset_id: 494654382
 Extra - in_dark_aether: False
+Hint Features - Morph Ball Tunnel
 > Morph Ball Door to Hive Chamber C; Heals? False
   * Layers: default
   * Morph Ball Door to Hive Chamber C/Morph Ball Door to Hive Chamber B

--- a/randovania/games/prime2/logic_database/Torvus Bog.json
+++ b/randovania/games/prime2/logic_database/Torvus Bog.json
@@ -168,6 +168,7 @@
         "Torvus Lagoon": {
             "default_node": "Door to Temple Transport Access",
             "hint_features": [
+                "keybearer",
                 "luminoth_corpse",
                 "water"
             ],

--- a/randovania/games/prime2/logic_database/Torvus Bog.json
+++ b/randovania/games/prime2/logic_database/Torvus Bog.json
@@ -4666,7 +4666,8 @@
             "default_node": "Door to Forgotten Bridge",
             "hint_features": [
                 "bomb_slot",
-                "boost"
+                "boost",
+                "morph"
             ],
             "extra": {
                 "asset_id": 3250751238,
@@ -11157,7 +11158,9 @@
         },
         "Temple Access": {
             "default_node": "Door to Great Bridge (Top)",
-            "hint_features": [],
+            "hint_features": [
+                "morph"
+            ],
             "extra": {
                 "asset_id": 121681107,
                 "in_dark_aether": false
@@ -16828,7 +16831,8 @@
         "Underground Tunnel": {
             "default_node": "Door to Torvus Temple",
             "hint_features": [
-                "lore"
+                "lore",
+                "morph"
             ],
             "extra": {
                 "asset_id": 2162589584,
@@ -33312,6 +33316,7 @@
             "default_node": "Door to Catacombs",
             "hint_features": [
                 "bomb_slot",
+                "morph",
                 "water"
             ],
             "extra": {
@@ -33695,6 +33700,7 @@
             "default_node": "Door to Training Chamber",
             "hint_features": [
                 "bomb_slot",
+                "morph",
                 "water"
             ],
             "extra": {
@@ -34804,7 +34810,9 @@
         },
         "Undertransit One": {
             "default_node": "Door to Sacrificial Chamber",
-            "hint_features": [],
+            "hint_features": [
+                "morph"
+            ],
             "extra": {
                 "asset_id": 1557447417,
                 "in_dark_aether": true

--- a/randovania/games/prime2/logic_database/Torvus Bog.txt
+++ b/randovania/games/prime2/logic_database/Torvus Bog.txt
@@ -656,7 +656,7 @@ Extra - in_dark_aether: True
 Plaza Access
 Extra - asset_id: 3250751238
 Extra - in_dark_aether: False
-Hint Features - Bomb Slot, Boost Pipe
+Hint Features - Bomb Slot, Boost Pipe, Morph Ball Tunnel
 > Door to Torvus Plaza; Heals? False
   * Layers: default
   * Normal Door to Torvus Plaza/Door to Plaza Access
@@ -1269,6 +1269,7 @@ Hint Features - Grapple Point
 Temple Access
 Extra - asset_id: 121681107
 Extra - in_dark_aether: False
+Hint Features - Morph Ball Tunnel
 > Door to Great Bridge (Top); Heals? False; Spawn Point; Default Node
   * Layers: default
   * Dark Door to Great Bridge/Door to Temple Access (Top)
@@ -1926,7 +1927,7 @@ Extra - in_dark_aether: True
 Underground Tunnel
 Extra - asset_id: 2162589584
 Extra - in_dark_aether: False
-Hint Features - Luminoth Lore
+Hint Features - Luminoth Lore, Morph Ball Tunnel
 > Door to Torvus Temple; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Torvus Temple/Door to Underground Tunnel
@@ -3734,7 +3735,7 @@ Hint Features - Bomb Slot, Spider Track
 Transit Tunnel South
 Extra - asset_id: 3072694950
 Extra - in_dark_aether: False
-Hint Features - Bomb Slot, Underwater
+Hint Features - Bomb Slot, Morph Ball Tunnel, Underwater
 > Door to Catacombs; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Annihilator Door to Catacombs/Door to Transit Tunnel South
@@ -3784,7 +3785,7 @@ Extra - in_dark_aether: False
 Transit Tunnel East
 Extra - asset_id: 1727410190
 Extra - in_dark_aether: False
-Hint Features - Bomb Slot, Underwater
+Hint Features - Bomb Slot, Morph Ball Tunnel, Underwater
 > Door to Training Chamber; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Dark Door to Training Chamber/Door to Transit Tunnel East; Dock Lock Rando incompatible with: Screw Attack Blast Shield
@@ -3919,6 +3920,7 @@ Hint Features - Boss, Underwater
 Undertransit One
 Extra - asset_id: 1557447417
 Extra - in_dark_aether: True
+Hint Features - Morph Ball Tunnel
 > Door to Crypt; Heals? False
   * Layers: default
   * Normal Door to Crypt/Door to Undertransit One

--- a/randovania/games/prime2/logic_database/Torvus Bog.txt
+++ b/randovania/games/prime2/logic_database/Torvus Bog.txt
@@ -40,7 +40,7 @@ Extra - in_dark_aether: False
 Torvus Lagoon
 Extra - asset_id: 2114709145
 Extra - in_dark_aether: False
-Hint Features - Luminoth Corpse, Underwater
+Hint Features - Keybearer Corpse, Luminoth Corpse, Underwater
 > Door to Temple Transport Access; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Temple Transport Access/Door to Torvus Lagoon


### PR DESCRIPTION
Added "keybearer corpse" and "morph ball tunnel" hint features to applicable areas with pickup nodes.