### PR TITLE
fusion: sector 2 video documentation and logic update

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -7692,7 +7692,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "Get up",
+                                            "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -7706,7 +7706,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Wall Jump and Stand on Frozen Enemies: https://youtu.be/Q7MO9USGxtk",
                                                         "items": [
                                                             {
                                                                 "type": "template",
@@ -7954,7 +7954,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Start WJ on left, to big vine solids on the right. Easier with HJ",
+                                                        "comment": "Start WJ on left, to big vine solids on the right. Easier with HJ: https://youtu.be/q2iC8lqGfUU",
                                                         "items": [
                                                             {
                                                                 "type": "or",
@@ -8005,7 +8005,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Freeze Enemies with normal ice weapons",
+                                                        "comment": "Freeze Enemies with normal ice weapons: https://youtu.be/j61d7VEexCU",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -8055,7 +8055,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Freeze Enemies with Diffusion",
+                                                        "comment": "Freeze Enemies with Diffusion: https://youtu.be/eWffis_hHyI",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -8085,7 +8085,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Freeze Kihunter and either WJ or HJ onto it",
+                                                        "comment": "Freeze Kihunter and either WJ or HJ onto it: https://youtu.be/6Iiwoby8JsY",
                                                         "items": [
                                                             {
                                                                 "type": "or",
@@ -8194,7 +8194,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Shinespark up",
+                                                        "comment": "Shinespark up: https://youtu.be/z71Uv0TURcU",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -10147,7 +10147,7 @@
                         "Door to Collapsed Shaft": {
                             "type": "and",
                             "data": {
-                                "comment": "Shinespark diagonally on the bottom at the door",
+                                "comment": "Shinespark diagonally on the bottom at the door: https://youtu.be/gNMipkMaDa4",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -10177,75 +10177,12 @@
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": "Shinespark is harder if you can't get back up",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "ShinesparkTrick",
-                                                        "amount": 3,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": "Easier if you can repeat it",
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "ShinesparkTrick",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "or",
-                                                                "data": {
-                                                                    "comment": "Get up",
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "SpaceJump",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "and",
-                                                                            "data": {
-                                                                                "comment": null,
-                                                                                "items": [
-                                                                                    {
-                                                                                        "type": "template",
-                                                                                        "data": "Can Screw Single Walljump"
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "WallJump",
-                                                                                            "amount": 2,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    }
-                                                                                ]
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
+                                            "type": "tricks",
+                                            "name": "ShinesparkTrick",
+                                            "amount": 3,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -10653,7 +10590,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": null,
+                                                                    "comment": "Diffusion Only: https://youtu.be/PieCASrvAqY",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -10147,7 +10147,7 @@
                         "Door to Collapsed Shaft": {
                             "type": "and",
                             "data": {
-                                "comment": "Shinespark diagonally on the bottom at the door: https://youtu.be/gNMipkMaDa4",
+                                "comment": "Shinespark diagonally on the bottom at the door: https://youtu.be/fvu8Jlvg_Vw",
                                 "items": [
                                     {
                                         "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -7654,23 +7654,6 @@
                                             "amount": 1,
                                             "negate": false
                                         }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": "Use vines as platforms",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Movement",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
                                     }
                                 ]
                             }
@@ -7812,27 +7795,6 @@
                                             "name": "WallJump",
                                             "amount": 2,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Freeze Enemies With Any Weapon"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "StandOnFrozenEnemies",
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1209,10 +1209,7 @@ Extra - room_id: [32, 35]
   * Open Hatch to Collapsed Shaft/Door to Eastern Shaft
   * Extra - door_idx: (71, 80)
   > Door to Overgrown Checkpoint
-      Any of the following:
-          Space Jump or After Boss Nettori Defeated or Wall Jump (Beginner)
-          # Use vines as platforms
-          Movement (Beginner)
+      Space Jump or After Boss Nettori Defeated or Wall Jump (Beginner)
   > Door to Nettori Save Room
       All of the following:
           After Boss Nettori Defeated
@@ -1226,9 +1223,7 @@ Extra - room_id: [32, 35]
   * Open Hatch to Overgrown Checkpoint/Door to Eastern Shaft
   * Extra - door_idx: (72, 81)
   > Door to Collapsed Shaft
-      Any of the following:
-          Space Jump or After Boss Nettori Defeated or Wall Jump (Intermediate)
-          Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies With Any Weapon
+      Space Jump or After Boss Nettori Defeated or Wall Jump (Intermediate)
 
 > Other to Hidden Recharge Room; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1217,8 +1217,8 @@ Extra - room_id: [32, 35]
       All of the following:
           After Boss Nettori Defeated
           Any of the following:
-              # Get up
               Space Jump
+              # Wall Jump and Stand on Frozen Enemies: https://youtu.be/Q7MO9USGxtk
               Hi-Jump and Stand On Frozen Enemies (Intermediate) and Wall Jump (Intermediate) and Can Freeze Enemies With Any Weapon
 
 > Door to Overgrown Checkpoint; Heals? False
@@ -1251,20 +1251,20 @@ Extra - room_id: [32, 35]
               # Movement Requirements
               Space Jump
               All of the following:
-                  # Start WJ on left, to big vine solids on the right. Easier with HJ
+                  # Start WJ on left, to big vine solids on the right. Easier with HJ: https://youtu.be/q2iC8lqGfUU
                   Any of the following:
                       Wall Jump (Advanced)
                       Hi-Jump and Wall Jump (Intermediate)
               All of the following:
-                  # Freeze Enemies with normal ice weapons
+                  # Freeze Enemies with normal ice weapons: https://youtu.be/j61d7VEexCU
                   Stand On Frozen Enemies (Advanced)
                   Any of the following:
                       Can Freeze Enemies With Ice Beam
                       Missiles ≥ 2 and Can Freeze Enemies With Ice Missiles
-              # Freeze Enemies with Diffusion
+              # Freeze Enemies with Diffusion: https://youtu.be/eWffis_hHyI
               Missiles ≥ 2 and Stand On Frozen Enemies (Expert) and Can Freeze Enemies With Diffusion
               All of the following:
-                  # Freeze Kihunter and either WJ or HJ onto it
+                  # Freeze Kihunter and either WJ or HJ onto it: https://youtu.be/6Iiwoby8JsY
                   Stand On Frozen Enemies (Intermediate)
                   Hi-Jump or Wall Jump (Intermediate)
                   Any of the following:
@@ -1274,7 +1274,7 @@ Extra - room_id: [32, 35]
                           Can Freeze Enemies With Diffusion or Can Freeze Enemies With Ice Missiles
               # SWJ up
               Wall Jump (Intermediate) and Can Single Walljump
-              # Shinespark up
+              # Shinespark up: https://youtu.be/z71Uv0TURcU
               Speed Booster and Shinespark Tricks (Beginner) and Disabled Enemy Rando and Disabled Open Hatch Lock Rando
   > Door to Collapsed Shaft
       After Boss Nettori Defeated
@@ -1573,19 +1573,8 @@ Extra - room_id: [47]
       # Space Jump, or don't fall down: https://youtu.be/yEFbN8WOEBU
       Space Jump or Movement (Intermediate)
   > Door to Collapsed Shaft
-      All of the following:
-          # Shinespark diagonally on the bottom at the door
-          Speed Booster and Disabled Entrance Rando and Disabled Open Hatch Lock Rando
-          Any of the following:
-              # Shinespark is harder if you can't get back up
-              Shinespark Tricks (Advanced)
-              All of the following:
-                  # Easier if you can repeat it
-                  Shinespark Tricks (Intermediate)
-                  Any of the following:
-                      # Get up
-                      Space Jump
-                      Wall Jump (Intermediate) and Can Single Walljump
+      # Shinespark diagonally on the bottom at the door: https://youtu.be/gNMipkMaDa4
+      Speed Booster and Shinespark Tricks (Advanced) and Disabled Entrance Rando and Disabled Open Hatch Lock Rando
   > Door to Central Shaft
       Trivial
 
@@ -1676,6 +1665,7 @@ Extra - room_id: [50]
               Any of the following:
                   # Freezing requirements
                   Can Freeze Enemies With Ice Beam or Can Freeze Enemies With Ice Missiles
+                  # Diffusion Only: https://youtu.be/PieCASrvAqY
                   Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies With Diffusion
           # Crumble jumps: https://youtu.be/TBeE7JbT6OA
           Movement (Hypermode)

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1573,7 +1573,7 @@ Extra - room_id: [47]
       # Space Jump, or don't fall down: https://youtu.be/yEFbN8WOEBU
       Space Jump or Movement (Intermediate)
   > Door to Collapsed Shaft
-      # Shinespark diagonally on the bottom at the door: https://youtu.be/gNMipkMaDa4
+      # Shinespark diagonally on the bottom at the door: https://youtu.be/fvu8Jlvg_Vw
       Speed Booster and Shinespark Tricks (Advanced) and Disabled Entrance Rando and Disabled Open Hatch Lock Rando
   > Door to Central Shaft
       Trivial


### PR DESCRIPTION
Added videos for:
* Eastern Shaft
  * From Door to "Nettori Save Room" to KiHunter Hallway (multiple)
  * From Door to "Collapsed Shaft" to Door to "Nettori Save Room"
* Puyo Palace
  * Nettori Save Room to Collapsed Shaft via shinespark trick
* Ripper Tower
  * Freeze the enemies with Diffusion Only

Adjusted Logic in Puyo Palace due to redundant requirements.
Door to Central Shaft -> Door to Collapsed Shaft has single wall jump trick or space jump requirements and is already trivial from Nettori Save Room door. No need to go back up to Nettori Save Room to try the shinespark trick again.

Adjusted Logic in Eastern Shaft.
Doors to Collapsed Shaft and Door to Overgrown checkpoint had requirements which could not be satisfied.
Moving Left to Right was asking to maneuver without wall jumps pre-nettori (not possible due to most blocks in that cluster being 2x2 that all break at the same time.
Moving Right to Left was asking to stand on frozen enemies, which you couldn't aggro/reach without wall jumping or space jump.