### PR TITLE
REGION_ONLY now distinguishes between light and dark world for precision

### DIFF
--- a/randovania/generator/hint_distributor.py
+++ b/randovania/generator/hint_distributor.py
@@ -379,9 +379,12 @@ class HintDistributor(ABC):
         for feature in patches.game.hint_feature_database.values():
             locations_with_feature[feature].extend(region_list.pickup_nodes_with_feature(feature))
 
+        area = region_list.nodes_to_area
         if location is not None:
             locations_with_feature[HintLocationPrecision.REGION_ONLY] = [
-                node for node in region_list.nodes_to_region(location).all_nodes if isinstance(node, PickupNode)
+                node
+                for node in region_list.nodes_to_region(location).all_nodes
+                if (isinstance(node, PickupNode) and area(node).in_dark_aether == area(location).in_dark_aether)
             ]
 
         return FeatureChooser[HintFeature, HintLocationPrecision](


### PR DESCRIPTION
this is important because the hint namers make the distinction, so the information is being provided to the player