### PR TITLE
adjust echoes hint distribution params

### DIFF
--- a/randovania/games/prime2/generator/hint_distributor.py
+++ b/randovania/games/prime2/generator/hint_distributor.py
@@ -112,3 +112,8 @@ class EchoesHintDistributor(HintDistributor):
         ]
 
         return {keybearer: precision for keybearer in keybearers}
+
+    @override
+    @property
+    def use_region_location_precision(self) -> bool:
+        return False

--- a/randovania/generator/hint_distributor.py
+++ b/randovania/generator/hint_distributor.py
@@ -582,7 +582,7 @@ class HintDistributor(ABC):
         Params for the precision distribution for location features.
         Override in subclass to fine-tune the balance.
         """
-        return 0.8, 0.15
+        return 0.8, 0.075
 
     @classmethod
     def item_feature_distribution(cls) -> HintFeatureGaussianParams:
@@ -590,7 +590,7 @@ class HintDistributor(ABC):
         Params for the precision distribution for item features.
         Override in subclass to fine-tune the balance.
         """
-        return 0.9, 0.1
+        return 0.9, 0.05
 
 
 class AllJokesHintDistributor(HintDistributor):

--- a/test/generator/filler/test_runner.py
+++ b/test/generator/filler/test_runner.py
@@ -128,6 +128,8 @@ def test_add_hints_precision(empty_patches, blank_pickup):
 
     hint_distributor = EchoesHintDistributor()
 
+    expected_feature = empty_patches.game.hint_feature_database["hint1"]
+
     # Run
     result = hint_distributor.add_hints_precision(initial_patches, rng, player_pools)
 
@@ -138,7 +140,7 @@ def test_add_hints_precision(empty_patches, blank_pickup):
             PickupIndex(1),
         ),
         nc("Intro", "Hint Room", "Hint with Translator"): LocationHint(
-            PrecisionPair(HintLocationPrecision.REGION_ONLY, HintItemPrecision.DETAILED, include_owner=True),
+            PrecisionPair(expected_feature, HintItemPrecision.DETAILED, include_owner=True),
             PickupIndex(2),
         ),
     }


### PR DESCRIPTION
standard deviation has been halved for both types of hint feature. this keeps the average precision the same, but makes extremely low precisions *much* rarer and high precisions somewhat rarer

also, region-only precision has been removed from echoes hints. the changes to precision calculation made them significantly more common than intended, and they're pretty much antithetical to the new direction for hint design