### PR TITLE
Improve the appearance of the hint feature tabs

### DIFF
--- a/randovania/game_description/hint_features.py
+++ b/randovania/game_description/hint_features.py
@@ -31,6 +31,9 @@ class HintFeature(JsonDataclass):
     hidden: bool = dataclasses.field(default=False, metadata=EXCLUDE_DEFAULT)
     """Hidden features aren't displayed in the GUI, and can't be placed by the FeatureChooser."""
 
+    description: str = dataclasses.field(default="", metadata=EXCLUDE_DEFAULT)
+    """Additional description to display in the GUI in the HintFeatureTab."""
+
     def __post_init__(self) -> None:
         assert self.name, "Name must not be empty"
         assert self.long_name, "Long name must not be empty"

--- a/randovania/games/binary_data.py
+++ b/randovania/games/binary_data.py
@@ -338,6 +338,7 @@ ConstructHintFeatureDatabase = ConstructDict(
             long_name=String,
             hint_details=String[2],
             hidden=Default(Flag, False),
+            description=Default(String, ""),
         )
     )
 )

--- a/randovania/games/prime2/logic_database/header.json
+++ b/randovania/games/prime2/logic_database/header.json
@@ -3033,7 +3033,8 @@
             "hint_details": [
                 "",
                 "near a Boost Spinner"
-            ]
+            ],
+            "description": "Objects in transdimensional flux are included."
         },
         "abyss": {
             "long_name": "Abyss",
@@ -3054,7 +3055,8 @@
             "hint_details": [
                 "",
                 "near a Bomb Slot"
-            ]
+            ],
+            "description": "Objects in transdimensional flux are included."
         },
         "translator_gate": {
             "long_name": "Translator Gate",

--- a/randovania/gui/dialog/trick_usage_popup.py
+++ b/randovania/gui/dialog/trick_usage_popup.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
 from PySide6 import QtWidgets
@@ -11,6 +10,7 @@ from randovania.game_description.resources.resource_collection import ResourceCo
 from randovania.game_description.resources.resource_type import ResourceType
 from randovania.gui.generated.trick_usage_popup_ui import Ui_TrickUsagePopup
 from randovania.gui.lib.common_qt_lib import set_default_window_icon
+from randovania.gui.lib.data_editor_links import data_editor_href, on_click_data_editor_link
 from randovania.layout import filtered_database
 from randovania.layout.base.trick_level import LayoutTrickLevel
 
@@ -92,7 +92,12 @@ class TrickUsagePopup(QtWidgets.QDialog, Ui_TrickUsagePopup):
             )
 
         # setup
-        self.area_list_label.linkActivated.connect(self._on_click_link_to_data_editor)
+        self.area_list_label.linkActivated.connect(
+            on_click_data_editor_link(
+                self._window_manager,
+                self._game_description.game,
+            )
+        )
         self.setWindowTitle(f"{self.windowTitle()} for preset {preset.name}")
         self.title_label.setText(self.title_label.text().format(trick_levels=trick_usage_description))
 
@@ -116,19 +121,9 @@ class TrickUsagePopup(QtWidgets.QDialog, Ui_TrickUsagePopup):
             for area in sorted(region.areas, key=lambda it: it.name):
                 used_tricks = _check_used_tricks(area, trick_resources, context)
                 if used_tricks:
-                    lines.append(
-                        f'<p><a href="data-editor://{region.correct_name(area.in_dark_aether)}/{area.name}">'
-                        f"{region.correct_name(area.in_dark_aether)} - {area.name}</a>"
-                        f"<br />{'<br />'.join(used_tricks)}</p>"
-                    )
+                    lines.append(data_editor_href(region, area) + f"<br />{'<br />'.join(used_tricks)}</p>")
 
         self.area_list_label.setText("".join(lines))
 
     def button_box_close(self):
         self.reject()
-
-    def _on_click_link_to_data_editor(self, link: str):
-        info = re.match(r"^data-editor://([^)]+)/([^)]+)$", link)
-        if info:
-            region_name, area_name = info.group(1, 2)
-            self._window_manager.open_data_visualizer_at(region_name, area_name, game=self._game_description.game)

--- a/randovania/gui/docks/hint_feature_database_editor.py
+++ b/randovania/gui/docks/hint_feature_database_editor.py
@@ -27,6 +27,7 @@ class HintFeatureDatabaseModel(EditableTableModel[HintFeature]):
                 from_qt=lambda v: (True, HintDetails("", v)),
             ),
             BoolFieldDefinition("Hidden?", "hidden"),
+            FieldDefinition[str, str]("Description", "description"),
         ]
 
     @override

--- a/randovania/gui/lib/data_editor_links.py
+++ b/randovania/gui/lib/data_editor_links.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from randovania.game.game_enum import RandovaniaGame
+    from randovania.game_description.db.area import Area
+    from randovania.game_description.db.region import Region
+    from randovania.gui.lib.window_manager import WindowManager
+    from randovania.layout.base.trick_level_configuration import TrickLevelConfiguration
+
+
+def on_click_data_editor_link(
+    window_manager: WindowManager, game: RandovaniaGame, trick_levels: TrickLevelConfiguration | None = None
+) -> Callable[[str], None]:
+    """
+    Returns a callable that can be attached to a Label's `linkActivated` signal
+    which opens the Data Editor to the region and area indicated in the URL.
+
+    If `trick_levels` is provided, the data editor will automatically set its trick filters accordingly.
+    """
+
+    link_pattern = re.compile(r"^data-editor://([^)]+)/([^)]+)$")
+
+    def inner(link: str) -> None:
+        info = link_pattern.match(link)
+        if info:
+            region_name, area_name = info.group(1, 2)
+            window_manager.open_data_visualizer_at(
+                region_name,
+                area_name,
+                game=game,
+                trick_levels=trick_levels,
+            )
+
+    return inner
+
+
+def data_editor_href(region: Region, area: Area, text: str | None = None) -> str:
+    """
+    Creates a clickable data editor link for the given Region and Area.
+
+    If text is not provided, a default of "Region - Area" is used.
+    """
+
+    if text is None:
+        text = get_human_readable_region_and_area(region, area)
+    return f'<a href="data-editor://{region.correct_name(area.in_dark_aether)}/{area.name}">{text}</a>'
+
+
+def get_human_readable_region_and_area(region: Region, area: Area) -> str:
+    return f"{region.correct_name(area.in_dark_aether)} - {area.name}"

--- a/randovania/gui/widgets/base_game_tab_widget.py
+++ b/randovania/gui/widgets/base_game_tab_widget.py
@@ -57,7 +57,7 @@ class BaseGameTabWidget(QtWidgets.QTabWidget):
 
         if self.location_hint_features_tab is not None:
             game_description = default_database.game_description_for(game)
-            self.location_hint_features_tab.add_features(game_description)
+            self.location_hint_features_tab.add_features(game_description, self._window_manager)
 
         if self.pickup_hint_features_tab is not None:
             pickup_db = default_database.pickup_database_for_game(game)

--- a/randovania/gui/widgets/hint_feature_tab.py
+++ b/randovania/gui/widgets/hint_feature_tab.py
@@ -1,14 +1,27 @@
-from collections.abc import Iterable
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from PySide6.QtWidgets import QLabel, QSizePolicy, QSpacerItem, QVBoxLayout, QWidget
 
 from randovania.game_description.db.pickup_node import PickupNode
-from randovania.game_description.game_description import GameDescription
-from randovania.game_description.hint_features import HintFeature
-from randovania.game_description.pickup.pickup_database import PickupDatabase
-from randovania.game_description.pickup.pickup_definition.base_pickup import BasePickupDefinition
 from randovania.gui.generated.hint_feature_tab_ui import Ui_HintFeatureTab
+from randovania.gui.lib.data_editor_links import (
+    data_editor_href,
+    on_click_data_editor_link,
+)
 from randovania.gui.lib.foldable import Foldable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from randovania.game_description.db.area_identifier import AreaIdentifier
+    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.hint_features import HintFeature
+    from randovania.game_description.pickup.pickup_database import PickupDatabase
+    from randovania.game_description.pickup.pickup_definition.base_pickup import BasePickupDefinition
+    from randovania.gui.lib.window_manager import WindowManager
 
 
 class HintFeatureTab(QWidget, Ui_HintFeatureTab):
@@ -43,18 +56,22 @@ class HintFeatureTab(QWidget, Ui_HintFeatureTab):
 
         title = f'{feature.long_name}: "{feature.hint_details[0]}{feature.hint_details[1]}"'
 
-        feature_widget = Foldable(self, title)
-        feature_widget.setObjectName(f"feature_box {feature.name}")
-        feature_layout = QVBoxLayout()
-        feature_layout.setObjectName(f"feature_layout {feature.name}")
-        feature_widget.set_content_layout(feature_layout)
+        self.feature_widget = Foldable(self, title)
+        self.feature_widget.setObjectName(f"feature_box {feature.name}")
+        self.feature_layout = QVBoxLayout()
+        self.feature_layout.setObjectName(f"feature_layout {feature.name}")
+        self.feature_widget.set_content_layout(self.feature_layout)
 
         for i, element in enumerate(elements_with_feature):
-            element_label = QLabel(element, feature_widget)
+            element_label = self.create_element_label(element)
             element_label.setObjectName(f"feature_label {feature.name} {i}")
-            feature_layout.addWidget(element_label)
+            self.feature_layout.addWidget(element_label)
 
-        self.scroll_area_contents.layout().addWidget(feature_widget)
+        self.scroll_area_contents.layout().addWidget(self.feature_widget)
+
+    def create_element_label(self, element: str) -> QLabel:
+        """Creates a label to refer to the given element."""
+        return QLabel(element, self.feature_widget)
 
     def add_spacer(self) -> None:
         """Adds a vertical spacer to the tab"""
@@ -88,7 +105,20 @@ class LocationHintFeatureTab(HintFeatureTab):
             )
         )
 
-    def add_features(self, game: GameDescription) -> None:
+    def create_element_label(self, element: str):
+        element_label = super().create_element_label(element)
+        element_label.linkActivated.connect(
+            on_click_data_editor_link(
+                self._window_manager,
+                self._game.game,
+            )
+        )
+        return element_label
+
+    def add_features(self, game: GameDescription, window_manager: WindowManager) -> None:
+        self._game = game
+        self._window_manager = window_manager
+
         for feature in sorted(game.hint_feature_database.values(), key=_keyfunc):
             if feature.hidden:
                 continue
@@ -100,14 +130,30 @@ class LocationHintFeatureTab(HintFeatureTab):
 
                 return id_.region, area.in_dark_aether, id_.area, id_.node
 
-            node_names = [
-                game.region_list.node_name(node, True, True)
-                for node in sorted(
-                    game.region_list.pickup_nodes_with_feature(feature),
-                    key=nodes_keyfunc,
-                )
-            ]
-            self.add_feature_widget(feature, node_names)
+            sorted_nodes = sorted(
+                game.region_list.pickup_nodes_with_feature(feature),
+                key=nodes_keyfunc,
+            )
+
+            # group pickup nodes by area
+            feature_nodes: dict[AreaIdentifier, list[PickupNode]] = defaultdict(list)
+            for node in sorted_nodes:
+                feature_nodes[node.identifier.area_identifier].append(node)
+
+            node_links: list[str] = []
+
+            for area_id, nodes in feature_nodes.items():
+                region, area = game.region_list.region_and_area_by_area_identifier(area_id)
+                url = data_editor_href(region, area)
+
+                if len(nodes) == len([node for node in area.actual_nodes if isinstance(node, PickupNode)]):
+                    node_links.append(url)
+                    continue
+
+                for node in nodes:
+                    node_links.append(f"{url} ({node.name})")
+
+            self.add_feature_widget(feature, node_links)
         self.add_spacer()
 
 

--- a/randovania/network_common/pickup_serializer.py
+++ b/randovania/network_common/pickup_serializer.py
@@ -87,6 +87,8 @@ def _encode_hint_feature(feature: HintFeature):
     yield from bitpacking.encode_string(feature.long_name)
     yield from bitpacking.encode_string(feature.hint_details[0])
     yield from bitpacking.encode_string(feature.hint_details[1])
+    yield from bitpacking.encode_bool(feature.hidden)
+    yield from bitpacking.encode_string(feature.description)
 
 
 def _decode_hint_feature(decoder: BitPackDecoder) -> HintFeature:
@@ -94,6 +96,8 @@ def _decode_hint_feature(decoder: BitPackDecoder) -> HintFeature:
         name=bitpacking.decode_string(decoder),
         long_name=bitpacking.decode_string(decoder),
         hint_details=(bitpacking.decode_string(decoder), bitpacking.decode_string(decoder)),
+        hidden=bitpacking.decode_bool(decoder),
+        description=bitpacking.decode_string(decoder),
     )
 
 

--- a/test/gui/dialog/test_trick_details_popup.py
+++ b/test/gui/dialog/test_trick_details_popup.py
@@ -5,20 +5,17 @@ from unittest.mock import MagicMock
 import pytest
 from PySide6.QtWidgets import QWidget
 
-from randovania.game.game_enum import RandovaniaGame
 from randovania.game_description.resources.trick_resource_info import TrickResourceInfo
 from randovania.gui.dialog import trick_details_popup
 from randovania.layout.base.trick_level import LayoutTrickLevel
 
 
 @pytest.mark.parametrize("trick_levels", [None, MagicMock()])
-def test_click_on_link(echoes_game_description, skip_qtbot, trick_levels):
+def test_create(echoes_game_description, skip_qtbot, trick_levels):
     # Setup
     main_window = QWidget()
     main_window.open_data_visualizer_at = MagicMock()
     skip_qtbot.add_widget(main_window)
-    world_name = "World"
-    area_name = "Area"
 
     # Run
     popup = trick_details_popup.TrickDetailsPopup(
@@ -29,12 +26,6 @@ def test_click_on_link(echoes_game_description, skip_qtbot, trick_levels):
         LayoutTrickLevel.EXPERT,
         trick_levels,
     )
-    popup._on_click_link_to_data_editor(f"data-editor://{world_name}/{area_name}")
 
     # Assert
-    main_window.open_data_visualizer_at.assert_called_once_with(
-        world_name,
-        area_name,
-        game=RandovaniaGame.METROID_PRIME_ECHOES,
-        trick_levels=trick_levels,
-    )
+    assert popup.area_list_label.text() == "This trick is not used in this level."

--- a/test/gui/dialog/test_trick_usage_dialog.py
+++ b/test/gui/dialog/test_trick_usage_dialog.py
@@ -4,24 +4,17 @@ from unittest.mock import MagicMock
 
 from PySide6.QtWidgets import QWidget
 
-from randovania.game.game_enum import RandovaniaGame
 from randovania.gui.dialog import trick_usage_popup
 
 
-def test_click_on_link(echoes_game_description, skip_qtbot, default_echoes_preset):
+def test_create(skip_qtbot, default_echoes_preset):
     # Setup
     main_window = QWidget()
     main_window.open_data_visualizer_at = MagicMock()
     skip_qtbot.add_widget(main_window)
-    world_name = "World"
-    area_name = "Area"
 
     # Run
     popup = trick_usage_popup.TrickUsagePopup(main_window, main_window, default_echoes_preset)
-    popup._on_click_link_to_data_editor(f"data-editor://{world_name}/{area_name}")
 
     # Assert
-    main_window.open_data_visualizer_at.assert_called_once_with(
-        world_name, area_name, game=RandovaniaGame.METROID_PRIME_ECHOES
-    )
     assert popup.area_list_label.text() == ""

--- a/test/gui/lib/test_data_editor_links.py
+++ b/test/gui/lib/test_data_editor_links.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QWidget
+
+from randovania.game.game_enum import RandovaniaGame
+from randovania.game_description.db.area_identifier import AreaIdentifier
+from randovania.gui.lib.data_editor_links import (
+    data_editor_href,
+    get_human_readable_region_and_area,
+    on_click_data_editor_link,
+)
+
+
+@pytest.mark.parametrize("trick_levels", [None, MagicMock()])
+def test_click_on_link(skip_qtbot, trick_levels):
+    # Setup
+    main_window = QWidget()
+    main_window.open_data_visualizer_at = MagicMock()
+    skip_qtbot.add_widget(main_window)
+    world_name = "World"
+    area_name = "Area"
+
+    # Run
+    signal_handler = on_click_data_editor_link(main_window, RandovaniaGame.BLANK, trick_levels)
+    signal_handler(f"data-editor://{world_name}/{area_name}")
+
+    # Assert
+    main_window.open_data_visualizer_at.assert_called_once_with(
+        world_name,
+        area_name,
+        game=RandovaniaGame.BLANK,
+        trick_levels=trick_levels,
+    )
+
+
+@pytest.mark.parametrize("text", [None, "Some random text"])
+@pytest.mark.parametrize(
+    "area_id",
+    [
+        AreaIdentifier("Agon Wastes", "Agon Temple"),
+        AreaIdentifier("Agon Wastes", "Dark Agon Temple"),
+    ],
+)
+def test_data_editor_href(echoes_game_description, text: str | None, area_id: AreaIdentifier):
+    # Setup
+    region, area = echoes_game_description.region_list.region_and_area_by_area_identifier(area_id)
+    if text is None:
+        text = get_human_readable_region_and_area(region, area)
+
+    # Run
+    url = data_editor_href(region, area, text)
+
+    # Assert
+    assert url == f'<a href="data-editor://{region.correct_name(area.in_dark_aether)}/{area.name}">{text}</a>'

--- a/test/network_client/test_network_client.py
+++ b/test/network_client/test_network_client.py
@@ -299,7 +299,7 @@ def test_decode_pickup(
 ):
     data = (
         "h^WxYK%Bzb%2NU&w=%giys9}cw>h&ixhA)=I<_*yXJu|>a%p3j6&;nimC2=yfhEzEw1EwU(UqOO$>p%O5KI8-+"
-        "~(lQ#?s8v%E&;{=*rq*v$D4`xiqoN3XaO$%H-0<K$7Un+CYZF=*rIC<nq{Ch$aAaZgX&DV`*k-Wn>^}bY*P-u>b"
+        "~(lQ#?s8v%E&;{=*rp#8#^m=E0aqcz^Lr4%&tu=WC<>et)vKSE{v@0?oTa+xPo8@R_8YcRyLMqmR3Rrmqu350I>i"
     )
     expected_pickup = PickupEntry(
         name="The Name",

--- a/test/server/multiplayer/test_world_api.py
+++ b/test/server/multiplayer/test_world_api.py
@@ -35,21 +35,21 @@ if TYPE_CHECKING:
             [("Power", 1)],
             (
                 "C?ypIwY9x9y^)o&8#^m=E0aqcz^Lr4%&tu=WC<>et)vKSE{v@0?oTa+xPo8@R_8YcRyLMqmR3Rr"
-                "mqu384V{&_mC2=!U{rQi=2s?`G6a`KR?-AE7e-cg_a~OZ+(9q{t8<%!D;rBQODiD*OQS1k0RqG"
+                "mqu35FxlB#nOvG!<^@M(Ze?<5V<1U%Wo;lsVRU6@Z*qBTEyNQ5I=4BvGO@I?G_tY~G`cdjfdK-<"
             ),
         ),
         (  # negative
             [("Missile", -5)],
             (
                 "C?ypIwY9x9y^)o&8#^m=E0aqcz^Lr4%&tu=WC<>et)vKSE{v@0?oTa+xPo8@R_8YcRyLMqmR3Rr"
-                "mqu384V{&_mC2=!U{rQi=2s?`G6a`KR?-AE7e-cg_a~OZ+(9q{t8<%!D;rBQODiD*OQS1kQ2GUk"
+                "mqu35FxlB#nOvG!<^@M(Ze?<5V<1U%Wo;lsVRU6@Z*qBTEyNQ5I=4BvGO@I?G_tY~G`cdjfl&Gdhy"
             ),
         ),
         (  # progressive
             [("DarkSuit", 1), ("LightSuit", 1)],
             (
                 "C?ypIwY9x9y^)o&8#^m=E0aqcz^Lr4%&tu=WC<>et)vKSE{v@0?oTa+xPo8@R_8YcRyLMqmR3Rr"
-                "mqu384V{&_mC2=!U{rQi=2s?`G6a`KR?-AE7e-cg_a~OZ+(9q{t8<%!D;rBQODiD*OQS1l8xDbD"
+                "mqu35FxlB#nOvG!<^@M(Ze?<5V<1U%Wo;lsVRU6@Z*qBTEyNQ5I=4BvGO@I?G_tY~G`cdjf*THjVg"
             ),
         ),
     ],


### PR DESCRIPTION
Location features now use database links, and omit the pickup name if all pickups in the area have the feature.

Also, features can define a description which gets displayed at the top of their foldable in the feature tab.

![image](https://github.com/user-attachments/assets/b08c62a2-323d-44c7-be0b-d5c3b7bcee29)

