### PR TITLE
rework interesting pickup code

### DIFF
--- a/randovania/games/dread/generator/hint_distributor.py
+++ b/randovania/games/dread/generator/hint_distributor.py
@@ -25,7 +25,7 @@ class DreadHintDistributor(HintDistributor):
         return PrecisionPair(HintLocationPrecision.REGION_ONLY, HintItemPrecision.DETAILED, True)
 
     @override
-    def less_interesting_pickup_to_hint(self, pickup: PickupEntry) -> bool:
+    def is_pickup_interesting(self, pickup: PickupEntry) -> bool:
         return not pickup.has_hint_feature("dna")
 
     @override

--- a/randovania/games/prime2/generator/hint_distributor.py
+++ b/randovania/games/prime2/generator/hint_distributor.py
@@ -36,7 +36,7 @@ class EchoesHintDistributor(HintDistributor):
         return 2
 
     @override
-    def less_interesting_pickup_to_hint(self, pickup: PickupEntry) -> bool:
+    def is_pickup_interesting(self, pickup: PickupEntry) -> bool:
         return not pickup.has_hint_feature("key")
 
     @override

--- a/randovania/games/samus_returns/generator/hint_distributor.py
+++ b/randovania/games/samus_returns/generator/hint_distributor.py
@@ -16,5 +16,5 @@ class MSRHintDistributor(HintDistributor):
         return PrecisionPair(HintLocationPrecision.REGION_ONLY, HintItemPrecision.DETAILED, True)
 
     @override
-    def less_interesting_pickup_to_hint(self, pickup: PickupEntry) -> bool:
+    def is_pickup_interesting(self, pickup: PickupEntry) -> bool:
         return not pickup.has_hint_feature("dna")

--- a/randovania/generator/hint_distributor.py
+++ b/randovania/generator/hint_distributor.py
@@ -6,9 +6,9 @@ import math
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Collection, Container, Mapping, Sequence
-from enum import Enum
+from enum import Enum, IntEnum
 from random import Random
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any, final, override
 
 from randovania.game_description.db.hint_node import HintNode, HintNodeKind
 from randovania.game_description.db.pickup_node import PickupNode
@@ -30,6 +30,7 @@ from randovania.generator.filler.player_state import HintState, PlayerState
 from randovania.resolver import debug
 
 if TYPE_CHECKING:
+    from randovania.game_description.assignment import PickupTarget
     from randovania.game_description.db.node_identifier import NodeIdentifier
     from randovania.game_description.db.region_list import RegionList
     from randovania.game_description.pickup.pickup_entry import PickupEntry
@@ -139,6 +140,19 @@ class FeatureChooser[PrecisionT: Enum]:
         return feature
 
 
+class HintSuitability(IntEnum):
+    """How high priority a given pickup is for hinting."""
+
+    LEAST_INTERESTING = 0
+    """Last resort for hint placement."""
+
+    INTERESTING = 1
+    """Fallback for when there are no `MORE_INTERESTING` pickups."""
+
+    MORE_INTERESTING = 2
+    """Highest priority."""
+
+
 class HintDistributor(ABC):
     @property
     def num_joke_hints(self) -> int:
@@ -242,6 +256,7 @@ class HintDistributor(ABC):
             player_state.game.region_list,
             rng,
             player_state.hint_state,
+            player_pools,
         )
         return await self.assign_precision_to_hints(full_hints_patches, rng, player_pool, player_pools)
 
@@ -263,12 +278,30 @@ class HintDistributor(ABC):
         """
         return self.add_hints_precision(patches, rng, player_pools, hint_kinds)
 
-    def interesting_pickup_to_hint(self, pickup: PickupEntry) -> bool:
-        """Highest priority pickups are those shown in the credits"""
-        return pickup.show_in_credits_spoiler and self.less_interesting_pickup_to_hint(pickup)
+    @final
+    @staticmethod
+    def hint_suitability_for_target(target: PickupTarget, player_pools: list[PlayerPool]) -> HintSuitability:
+        """
+        Determines the HintSuitability for the given target,
+        according to the criteria of its *owner's* HintDistributor.
 
-    def less_interesting_pickup_to_hint(self, pickup: PickupEntry) -> bool:
-        """Certain games may want certain pickups to only be hinted as a last resort"""
+        `MORE_INTERESTING` pickups are a subset of `INTERESTING` pickups,
+        which are a subset of `LEAST_INTERESTING` pickups.
+        """
+        hint_distributor = player_pools[target.player].game_generator.hint_distributor
+
+        if not hint_distributor.is_pickup_interesting(target.pickup):
+            return HintSuitability.LEAST_INTERESTING
+        if not hint_distributor.is_pickup_more_interesting(target.pickup):
+            return HintSuitability.INTERESTING
+        return HintSuitability.MORE_INTERESTING
+
+    def is_pickup_more_interesting(self, pickup: PickupEntry) -> bool:
+        """Pickups which don't satisfy this check are lower priority for hinting than those that do."""
+        return pickup.show_in_credits_spoiler
+
+    def is_pickup_interesting(self, pickup: PickupEntry) -> bool:
+        """Pickups which don't satisfy this check are only hinted as a last resort."""
         return True
 
     def fill_unassigned_hints(
@@ -277,6 +310,7 @@ class HintDistributor(ABC):
         region_list: RegionList,
         rng: Random,
         hint_state: HintState,
+        player_pools: list[PlayerPool],
     ) -> GamePatches:
         """
         Selects targets for all remaining unassigned generic hint nodes
@@ -303,7 +337,8 @@ class HintDistributor(ABC):
             real_potential_targets = {
                 target
                 for target in potential_targets
-                if self.interesting_pickup_to_hint(patches.pickup_assignment[target].pickup)
+                if self.hint_suitability_for_target(patches.pickup_assignment[target], player_pools)
+                >= HintSuitability.MORE_INTERESTING
             }
             # don't hint things twice
             real_potential_targets -= hinted_locations
@@ -313,7 +348,7 @@ class HintDistributor(ABC):
                 real_potential_targets = {
                     pickup
                     for pickup, entry in patches.pickup_assignment.items()
-                    if self.less_interesting_pickup_to_hint(entry.pickup)
+                    if self.hint_suitability_for_target(entry, player_pools) >= HintSuitability.INTERESTING
                 }
                 real_potential_targets -= hinted_locations
                 debug.debug_print(

--- a/test/generator/filler/test_runner.py
+++ b/test/generator/filler/test_runner.py
@@ -72,7 +72,7 @@ async def test_run_filler(
     assert initial_pickup_count == len(remaining_items) + len(result_patches.pickup_assignment.values())
 
 
-def test_fill_unassigned_hints_empty_assignment(echoes_game_description, echoes_game_patches):
+async def test_fill_unassigned_hints_empty_assignment(echoes_game_description, echoes_game_patches):
     # Setup
     rng = Random(5000)
     hint_nodes = [
@@ -88,12 +88,17 @@ def test_fill_unassigned_hints_empty_assignment(echoes_game_description, echoes_
     empty_set: frozenset[PickupIndex] = frozenset()
     hint_state.hint_initial_pickups = {node.identifier: empty_set for node in hint_nodes}
 
+    player_pools = [
+        await create_player_pool(rng, echoes_game_patches.configuration, 0, 1, "World 1", MagicMock()),
+    ]
+
     # Run
     result = hint_distributor.fill_unassigned_hints(
         echoes_game_patches,
         echoes_game_description.region_list,
         rng,
         hint_state,
+        player_pools,
     )
 
     # Assert


### PR DESCRIPTION
closes #7852
implements `HintSuitability`, but with a slightly different approach I discussed in that PR. also fixes a bug where offworld pickups weren't having their suitability respected