### PR TITLE
Fix some logic involving heated rooms in Cataris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: All other connections in Screw Attack Room that are only open before flipping the spinner are now only logical when Highly Dangerous Logic is enabled.
 - Changed: The conditions that depends on not having blown up the blob in Screw Attack Room are now only logical when Highly Dangerous Logic is enabled.
 
+##### Cataris
+
+- Changed: The Energy Part pickup in Thermal Device Room North no longer requires the Varia Suit if the "Cataris - Lower Lava Button" event has been triggered.
+- Changed: The blob in Z-57 Heat Room West (Right) now requires the Varia Suit to be destroyed.
+
 ### Metroid Prime 2: Echoes
 - Removed: Relative hints will no longer be placed.
 - Changed: Legacy multiworld sessions where an Echoes hint points to a Cave Story item may have very slightly altered wording.

--- a/randovania/games/dread/logic_database/Cataris.json
+++ b/randovania/games/dread/logic_database/Cataris.json
@@ -9749,17 +9749,68 @@
                             }
                         },
                         "Event - Blob": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Beam"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Bomb"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 100,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -9904,10 +9955,46 @@
                     "event_name": "s020_magma:default:breakablemag013",
                     "connections": {
                         "Door to Above Z-57 Fight": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Varia",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Heat",
+                                                        "amount": 100,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -18785,6 +18872,15 @@
                                         }
                                     },
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisThermalLowerLava",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
                                         "type": "and",
                                         "data": {
                                             "comment": null,
@@ -18942,6 +19038,15 @@
                                         "data": {
                                             "type": "items",
                                             "name": "Varia",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisThermalLowerLava",
                                             "amount": 1,
                                             "negate": false
                                         }

--- a/randovania/games/dread/logic_database/Cataris.txt
+++ b/randovania/games/dread/logic_database/Cataris.txt
@@ -1506,7 +1506,11 @@ Extra - asset_id: collision_camera_021
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Event - Blob
-      Lay Small Bomb or Shoot Beam
+      All of the following:
+          Lay Small Bomb or Shoot Beam
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -1530,7 +1534,9 @@ Extra - asset_id: collision_camera_021
   * Layers: default
   * Event Cataris - Z-57 Open Passage Blob
   > Door to Above Z-57 Fight
-      Trivial
+      Any of the following:
+          Varia Suit
+          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
 > Tunnel to Z-57 Heat Room West (Left); Heals? False
   * Layers: default
@@ -2984,7 +2990,7 @@ Extra - asset_id: collision_camera_042
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Tunnel to Lava Button West
       Any of the following:
-          Varia Suit
+          Varia Suit or After Cataris - Lower Lava Button
           Heat/Cold Runs (Beginner) and Heat Damage ≥ 60
 
 > Pickup (Energy Tank); Heals? False
@@ -3020,7 +3026,7 @@ Extra - asset_id: collision_camera_042
   * Slide Tunnel to Lava Button West/Tunnel to Thermal Device Room North
   > Pickup (Energy Part)
       Any of the following:
-          Varia Suit
+          Varia Suit or After Cataris - Lower Lava Button
           Heat/Cold Runs (Beginner) and Heat Damage ≥ 60
 
 > Dock to Lava Button West (Bottom); Heals? False


### PR DESCRIPTION
This PR basically bundles two unrelated Cataris logic changes into one; the only thing they have in common is that they coincidentally involve heated rooms.
- One change involves the Energy Part pickup in Thermal Device Room North. For those unfamiliar, this pickup is placed in a room that is normally heated, but you can turn the heat off by activating the "Cataris - Lower Lava Button" event in Lava Button West. The problem was that the connection between "Tunnel to Lava Button West" and "Pickup (Energy Part)" (and vice versa) expected you to have the Varia Suit in order to avoid taking heat damage, even though it was possible to avoid it via the event as well. I added the event to the logic for these connections; this will potentially affect item placement (for example, I think it was impossible to place Varia Suit in this location before).
- The other change involves the blob in Z-57 Heat Room West (Right). This is a heated room, but the blob had no heat requirements on it, meaning that it was logically expected of you to destroy it with the basic Power Suit. In actual practice, this shouldn't affect item placement at all, since the only thing the blob does is open the path to "Dock to Z-57 Heat Room West (Left)", and the connection between that node and the door already had a heat requirement on it. However, it's a nice bit of polish, since the tracker is currently telling people to run into a heated room to blow up a blob for no reason:

![image](https://github.com/user-attachments/assets/cc6375f8-f79f-409c-816f-81c1f0365758)