### PR TITLE
MSR - Force enable `enable_remote_lua` when exporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid: Samus Returns
 
 - Fixed: One Area 8 theme from not being included in music shuffle.
+- Removed: Enabling the automatic item tracker is no longer a cosmetic option, as it is now forced to always be enabled.
 
 #### Logic Database
 

--- a/randovania/games/samus_returns/exporter/patch_data_factory.py
+++ b/randovania/games/samus_returns/exporter/patch_data_factory.py
@@ -728,7 +728,7 @@ class MSRPatchDataFactory(PatchDataFactory):
             },
             "objective": self._objective(self.configuration),
             "layout_uuid": str(self.players_config.get_own_uuid()),
-            "enable_remote_lua": self.cosmetic_patches.enable_remote_lua or self.players_config.is_multiworld,
+            "enable_remote_lua": True,
         }
 
 

--- a/randovania/games/samus_returns/gui/dialog/cosmetic_patches_dialog.py
+++ b/randovania/games/samus_returns/gui/dialog/cosmetic_patches_dialog.py
@@ -57,7 +57,6 @@ class MSRCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_MSRCosmeticPatchesD
         self._persist_check_field(self.custom_energy_tank_color_check, "use_energy_tank_color")
         self._persist_check_field(self.custom_aeion_bar_color_check, "use_aeion_bar_color")
         self._persist_check_field(self.custom_ammo_hud_color_check, "use_ammo_hud_color")
-        self._persist_check_field(self.enable_remote_lua, "enable_remote_lua")
         for field_name, slider in self.field_name_to_slider_mapping.items():
             slider.valueChanged.connect(functools.partial(self._on_slider_update, slider, field_name))
         self.custom_laser_locked_color_button.clicked.connect(
@@ -98,7 +97,6 @@ class MSRCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_MSRCosmeticPatchesD
         self.custom_energy_tank_color_check.setChecked(patches.use_energy_tank_color)
         self.custom_aeion_bar_color_check.setChecked(patches.use_aeion_bar_color)
         self.custom_ammo_hud_color_check.setChecked(patches.use_ammo_hud_color)
-        self.enable_remote_lua.setChecked(patches.enable_remote_lua)
         for field_name, slider in self.field_name_to_slider_mapping.items():
             slider = self.field_name_to_slider_mapping[field_name]
             slider.setValue(getattr(patches, f"{field_name}_volume"))

--- a/randovania/games/samus_returns/gui/ui_files/msr_cosmetic_patches_dialog.ui
+++ b/randovania/games/samus_returns/gui/ui_files/msr_cosmetic_patches_dialog.ui
@@ -30,13 +30,6 @@
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <widget class="QCheckBox" name="enable_remote_lua">
-         <property name="text">
-          <string>Enable automatic item tracker for solo seeds</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QGroupBox" name="game_changes_box">
          <property name="title">
           <string>Samus Changes</string>

--- a/randovania/games/samus_returns/layout/msr_cosmetic_patches.py
+++ b/randovania/games/samus_returns/layout/msr_cosmetic_patches.py
@@ -55,7 +55,6 @@ class MSRCosmeticPatches(BaseCosmeticPatches):
     aeion_bar_color: tuple[int, int, int] = DEFAULT_AEION_BAR_COLOR
     ammo_hud_color: tuple[int, int, int] = DEFAULT_AMMO_HUD_COLOR
     show_room_names: MSRRoomGuiType = MSRRoomGuiType.ALWAYS
-    enable_remote_lua: bool = False
     music: MusicMode = MusicMode.VANILLA
     music_volume: int = 100
     ambience_volume: int = 100

--- a/randovania/interface_common/persisted_options.py
+++ b/randovania/interface_common/persisted_options.py
@@ -149,6 +149,11 @@ def _remove_msr_fields(options: dict) -> None:
         options["game_samus_returns"]["input_file"] = None
 
 
+def _msr_enable_remote_lua(options: dict) -> None:
+    if "cosmetic_patches" in options.get("game_samus_returns", {}):
+        options["game_samus_returns"]["cosmetic_patches"].pop("enable_remote_lua", None)
+
+
 _CONVERTER_FOR_VERSION = [
     None,
     None,
@@ -188,6 +193,7 @@ _CONVERTER_FOR_VERSION = [
     _only_new_fields,  # added MSR's music sliders
     _remove_msr_fields,  # removes MSR's exheader and input field
     _only_new_fields,  # added last_changelog_displayed_dev
+    _msr_enable_remote_lua,  # removes enable_remote_lua as it'll always be enabled
 ]
 _CURRENT_OPTIONS_FILE_VERSION = migration_lib.get_version(_CONVERTER_FOR_VERSION)
 

--- a/test/games/samus_returns/gui/dialog/test_msr_cosmetic_patches_dialog.py
+++ b/test/games/samus_returns/gui/dialog/test_msr_cosmetic_patches_dialog.py
@@ -122,20 +122,3 @@ def test_room_names_dropdown(skip_qtbot: pytestqt.qtbot.QtBot) -> None:
     set_combo_with_value(dialog.room_names_dropdown, MSRRoomGuiType.ALWAYS)
 
     assert dialog.cosmetic_patches == MSRCosmeticPatches(show_room_names=MSRRoomGuiType.ALWAYS)
-
-
-@pytest.mark.parametrize(
-    ("widget_field", "field_name"),
-    [
-        ("enable_remote_lua", "enable_remote_lua"),
-    ],
-)
-def test_certain_field(skip_qtbot: pytestqt.qtbot.QtBot, widget_field: str, field_name: str) -> None:
-    cosmetic_patches = MSRCosmeticPatches(**{field_name: False})  # type: ignore[arg-type]
-
-    dialog = MSRCosmeticPatchesDialog(None, cosmetic_patches)
-    skip_qtbot.addWidget(dialog)
-
-    skip_qtbot.mouseClick(getattr(dialog, widget_field), QtCore.Qt.MouseButton.LeftButton)
-
-    assert dialog.cosmetic_patches == MSRCosmeticPatches(**{field_name: True})  # type: ignore[arg-type]

--- a/test/test_files/patcher_data/samus_returns/samus_returns/arachnus_boss_start_inventory/cosmetic_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/arachnus_boss_start_inventory/cosmetic_1.json
@@ -39,7 +39,6 @@
         0
     ],
     "show_room_names": "ALWAYS",
-    "enable_remote_lua": false,
     "music": "type_music",
     "music_volume": 100,
     "ambience_volume": 100

--- a/test/test_files/patcher_data/samus_returns/samus_returns/arachnus_boss_start_inventory/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/arachnus_boss_start_inventory/world_1.json
@@ -4638,7 +4638,7 @@
         "final_boss": "Arachnus"
     },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
-    "enable_remote_lua": false,
+    "enable_remote_lua": true,
     "_randovania_meta": {
         "layout_was_user_modified": false
     }

--- a/test/test_files/patcher_data/samus_returns/samus_returns/diggernaut_boss_free_placement_dna/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/diggernaut_boss_free_placement_dna/world_1.json
@@ -4573,7 +4573,7 @@
         "final_boss": "Diggernaut"
     },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
-    "enable_remote_lua": false,
+    "enable_remote_lua": true,
     "_randovania_meta": {
         "layout_was_user_modified": false
     }

--- a/test/test_files/patcher_data/samus_returns/samus_returns/door_lock/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/door_lock/world_1.json
@@ -6205,7 +6205,7 @@
         "final_boss": "Ridley"
     },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
-    "enable_remote_lua": false,
+    "enable_remote_lua": true,
     "_randovania_meta": {
         "layout_was_user_modified": true
     }

--- a/test/test_files/patcher_data/samus_returns/samus_returns/door_lock_access_open/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/door_lock_access_open/world_1.json
@@ -6668,7 +6668,7 @@
         "final_boss": "Ridley"
     },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
-    "enable_remote_lua": false,
+    "enable_remote_lua": true,
     "_randovania_meta": {
         "layout_was_user_modified": true
     }

--- a/test/test_files/patcher_data/samus_returns/samus_returns/progressive_beams_and_suits/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/progressive_beams_and_suits/world_1.json
@@ -4573,7 +4573,7 @@
         "final_boss": "Ridley"
     },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
-    "enable_remote_lua": false,
+    "enable_remote_lua": true,
     "_randovania_meta": {
         "layout_was_user_modified": true
     }

--- a/test/test_files/patcher_data/samus_returns/samus_returns/queen_boss_custom_required_dna/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/queen_boss_custom_required_dna/world_1.json
@@ -4571,7 +4571,7 @@
         "final_boss": "Queen"
     },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
-    "enable_remote_lua": false,
+    "enable_remote_lua": true,
     "_randovania_meta": {
         "layout_was_user_modified": false
     }

--- a/test/test_files/patcher_data/samus_returns/samus_returns/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/starter_preset/world_1.json
@@ -4520,7 +4520,7 @@
         "final_boss": "Ridley"
     },
     "layout_uuid": "00000000-0000-1111-0000-000000000000",
-    "enable_remote_lua": false,
+    "enable_remote_lua": true,
     "_randovania_meta": {
         "layout_was_user_modified": false
     }


### PR DESCRIPTION
As was discussed in [the server](https://discord.com/channels/914291389293027329/1236719072318718084/1340834768714993716), there is no reason to have `enable_remote_lua` be optional when exporting. Now, it will always be enabled.

Removed from `Cosmetic Options` as shown below:
![image](https://github.com/user-attachments/assets/76be9189-411a-42b0-a8ba-287527339bc2)
