### PR TITLE
Change PickupIndexCollected to be emitted as soon as possible.

### DIFF
--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -164,14 +164,14 @@ class PrimeRemoteConnector(RemoteConnector):
 
         return Inventory(inventory)
 
-    async def known_collected_locations(self) -> set[PickupIndex]:
-        """Fetches pickup indices that have been collected.
-        The list may return less than all collected locations, depending on implementation details.
-        This function also returns a list of remote patches that must be performed via `execute_remote_patches`.
+    async def check_for_collected_location(self) -> bool:
+        """
+        Queries the game for the multiworld magic item and checks if a new location was collected.
+        :return: True, if a new location was found and remote patches were executed. False otherwise.
         """
         multiworld_magic_item = self.multiworld_magic_item
         if multiworld_magic_item is None:
-            return set()
+            return False
 
         memory_ops = await self._memory_op_for_items([multiworld_magic_item])
         op_result = await self.executor.perform_single_memory_operation(*memory_ops)
@@ -180,7 +180,7 @@ class PrimeRemoteConnector(RemoteConnector):
         magic_inv = InventoryItem(*struct.unpack(">II", op_result))
         if magic_inv.amount > 0:
             self.logger.info(f"magic item was at {magic_inv.amount}/{magic_inv.capacity}")
-            locations = {PickupIndex(magic_inv.amount - 1)}
+            self.PickupIndexCollected.emit(PickupIndex(magic_inv.amount - 1))
             patches = [
                 DolRemotePatch(
                     [],
@@ -193,9 +193,9 @@ class PrimeRemoteConnector(RemoteConnector):
                 )
             ]
             await self.execute_remote_patches(patches)
-            return locations
-        else:
-            return set()
+            return True
+
+        return False
 
     async def receive_remote_pickups(
         self,
@@ -358,10 +358,7 @@ class PrimeRemoteConnector(RemoteConnector):
 
     async def _multiworld_interaction(self) -> bool:
         """Returns true if an operation was sent."""
-        locations = await self.known_collected_locations()
-        if len(locations) != 0:
-            for location in locations:
-                self.PickupIndexCollected.emit(location)
+        if await self.check_for_collected_location():
             return True
         else:
             return await self.receive_remote_pickups(self.last_inventory, self.remote_pickups)

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -170,8 +170,6 @@ class PrimeRemoteConnector(RemoteConnector):
         :return: True, if a new location was found and remote patches were executed. False otherwise.
         """
         multiworld_magic_item = self.multiworld_magic_item
-        if multiworld_magic_item is None:
-            return False
 
         memory_ops = await self._memory_op_for_items([multiworld_magic_item])
         op_result = await self.executor.perform_single_memory_operation(*memory_ops)

--- a/test/game_connection/connector/test_prime1_remote_connector.py
+++ b/test/game_connection/connector/test_prime1_remote_connector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from retro_data_structures.game_check import Game as RDSGame
@@ -10,7 +10,6 @@ from randovania.game_connection.connector.prime1_remote_connector import Prime1R
 from randovania.game_connection.executor.memory_operation import MemoryOperationException
 from randovania.game_description.pickup.pickup_entry import PickupEntry
 from randovania.game_description.resources.inventory import Inventory, InventoryItem
-from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.network_common.remote_pickup import RemotePickup
 
 if TYPE_CHECKING:
@@ -129,33 +128,24 @@ async def test_multiworld_interaction_missing_remote_pickups(has_cooldown: bool,
 @pytest.mark.parametrize("depth", [0, 1])
 async def test_multiworld_interaction(connector: Prime1RemoteConnector, depth: int):
     # Setup
-    # depth 0: non-empty known_collected_locations with patch
-    # depth 1: empty known_collected_locations and empty receive_remote_pickups
+    # depth 0: non-empty check_for_collected_location with patch
+    # depth 1: empty check_for_collected_location and empty receive_remote_pickups
 
-    location_collected = MagicMock()
-    connector.PickupIndexCollected.connect(location_collected)
-
-    connector.receive_remote_pickups = AsyncMock(return_value=([], False))
-    connector.known_collected_locations = AsyncMock(return_value=[PickupIndex(2), PickupIndex(5)] if depth == 0 else [])
+    connector.receive_remote_pickups = AsyncMock()
+    connector.check_for_collected_location = AsyncMock(return_value=True if depth == 0 else False)
 
     # Run
-    await connector._multiworld_interaction()
+    result = await connector._multiworld_interaction()
 
     # Assert
-    connector.known_collected_locations.assert_awaited_once_with()
+    connector.check_for_collected_location.assert_awaited_once_with()
 
     if depth == 0:
-        location_collected.assert_has_calls(
-            [
-                call(PickupIndex(2)),
-                call(PickupIndex(5)),
-            ]
-        )
-    else:
-        location_collected.assert_not_called()
+        assert result is True
 
     if depth == 1:
         connector.receive_remote_pickups.assert_awaited_once_with(connector.last_inventory, connector.remote_pickups)
+        assert result is connector.receive_remote_pickups.return_value
     else:
         connector.receive_remote_pickups.assert_not_awaited()
 


### PR DESCRIPTION
This removes the chance of it being lost by the following execute_remote_patches failing.