### PR TITLE
MSR - Rename/Fix Gamma Arena in Area 4 Crystal Mines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed: Starting in Spazer Beam Chamber now places Samus in the correct room.
 
+#### Area 4 Crystal Mines
+
+- Fixed: A typo in the room name "Gamma+ Arena" has been changed from "Gamma Arena".
+- Fixed: The Gamma+ Metroid being classified as a Gamma Metroid, thus having the wrong requirements.
+
 #### Area 5 Tower Exterior
 
 - Fixed: Starting in Screw Attack Chamber or Zeta Arena Access now places Samus in the correct room.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Area 4 Crystal Mines
 
-- Fixed: A typo in the room name "Gamma+ Arena" has been changed from "Gamma Arena".
+- Fixed: Renamed the room "Gamma Arena" to "Gamma+ Arena".
 - Fixed: The Gamma+ Metroid being classified as a Gamma Metroid, thus having the wrong requirements.
 
 #### Area 5 Tower Exterior

--- a/randovania/games/samus_returns/assets/migration_data.json
+++ b/randovania/games/samus_returns/assets/migration_data.json
@@ -1458,7 +1458,13 @@
         }
     },
     "a4_crystal_mines_typo": {
-        "Area 4 Crystal Mines/Gamma Arena/Tunnel to Gawron Groove": "Area 4 Crystal Mines/Gamma+ Arena/Tunnel to Gawron Groove",
-        "Area 4 Crystal Mines/Gawron Groove/Tunnel to Gamma Arena": "Area 4 Crystal Mines/Gawron Groove/Tunnel to Gamma+ Arena"
+        "nodes": {
+            "Area 4 Crystal Mines/Gawron Groove/Tunnel to Gamma Arena": "Area 4 Crystal Mines/Gawron Groove/Tunnel to Gamma+ Arena"
+        },
+        "area": {
+            "Area 4 Crystal Mines": {
+                "Gamma Arena/Pickup (DNA)": "Gamma+ Arena/Pickup (DNA)"
+            }
+        }
     }
 }

--- a/randovania/games/samus_returns/assets/migration_data.json
+++ b/randovania/games/samus_returns/assets/migration_data.json
@@ -1458,9 +1458,6 @@
         }
     },
     "a4_crystal_mines_typo": {
-        "nodes": {
-            "Area 4 Crystal Mines/Gawron Groove/Tunnel to Gamma Arena": "Area 4 Crystal Mines/Gawron Groove/Tunnel to Gamma+ Arena"
-        },
         "area": {
             "Area 4 Crystal Mines": {
                 "Gamma Arena/Pickup (DNA)": "Gamma+ Arena/Pickup (DNA)"

--- a/randovania/games/samus_returns/assets/migration_data.json
+++ b/randovania/games/samus_returns/assets/migration_data.json
@@ -1456,5 +1456,9 @@
             "region": "Surface West",
             "area_and_node": "Transport to Area 8/Pickup (Missile Tank)"
         }
+    },
+    "a4_crystal_mines_typo": {
+        "Area 4 Crystal Mines/Gamma Arena/Tunnel to Gawron Groove": "Area 4 Crystal Mines/Gamma+ Arena/Tunnel to Gawron Groove",
+        "Area 4 Crystal Mines/Gawron Groove/Tunnel to Gamma Arena": "Area 4 Crystal Mines/Gawron Groove/Tunnel to Gamma+ Arena"
     }
 }

--- a/randovania/games/samus_returns/generator/bootstrap.py
+++ b/randovania/games/samus_returns/generator/bootstrap.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 def is_dna_node(node: PickupNode, config: BaseConfiguration) -> bool:
     assert isinstance(config, MSRConfiguration)
     artifact_config = config.artifacts
-    _stronger_metroid_indices = [177, 178, 181, 185, 186, 187, 188, 192, 193, 199, 200, 202, 205, 209]
+    _stronger_metroid_indices = [177, 178, 181, 185, 186, 187, 188, 192, 193, 198, 199, 200, 202, 205, 209]
     _boss_indices = [37, 99, 139, 171, 211]
     _boss_mapping = {
         FinalBossConfiguration.ARACHNUS: 0,

--- a/randovania/games/samus_returns/generator/pool_creator.py
+++ b/randovania/games/samus_returns/generator/pool_creator.py
@@ -25,9 +25,9 @@ def artifact_pool(game: GameDescription, config: MSRArtifactConfig) -> PoolResul
     if config.prefer_anywhere:
         max_artifacts = 39
     if config.prefer_metroids:
-        max_artifacts += 25
+        max_artifacts += 24
     if config.prefer_stronger_metroids:
-        max_artifacts += 14
+        max_artifacts += 15
     if config.prefer_bosses and max_artifacts < 36:
         max_artifacts += 4
     if config.required_artifacts > max_artifacts:

--- a/randovania/games/samus_returns/gui/preset_settings/msr_goal_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_goal_tab.py
@@ -73,9 +73,9 @@ class PresetMSRGoal(PresetTab, Ui_PresetMSRGoal):
             preferred = 39
         else:
             if self.prefer_metroids_check.isChecked():
-                preferred += 25
+                preferred += 24
             if self.prefer_stronger_metroids_check.isChecked():
-                preferred += 14
+                preferred += 15
             if self.prefer_bosses_check.isChecked() and preferred < 36:
                 preferred += 4
         return preferred

--- a/randovania/games/samus_returns/gui/ui_files/preset_msr_goal.ui
+++ b/randovania/games/samus_returns/gui/ui_files/preset_msr_goal.ui
@@ -43,8 +43,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>846</width>
-         <height>793</height>
+         <width>844</width>
+         <height>791</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -238,7 +238,7 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>Prefer Standard Metroids (10 Alphas, 9 Gammas, 3 Zetas, 3 Omegas)</string>
+                <string>Prefer Standard Metroids (10 Alphas, 8 Gammas, 3 Zetas, 3 Omegas)</string>
                </property>
               </widget>
              </item>
@@ -251,7 +251,7 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>Prefer Stronger Metroids (7 Alpha+, 5 Gamma+, 1 Zeta+, 1 Omega+)</string>
+                <string>Prefer Stronger Metroids (7 Alpha+, 6 Gamma+, 1 Zeta+, 1 Omega+)</string>
                </property>
               </widget>
              </item>

--- a/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.json
+++ b/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.json
@@ -3955,7 +3955,7 @@
                         }
                     }
                 },
-                "Event - Gamma+ Metroid": {
+                "Event - Gamma Metroid+": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -4092,7 +4092,7 @@
                                 ]
                             }
                         },
-                        "Event - Gamma+ Metroid": {
+                        "Event - Gamma Metroid+": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.json
+++ b/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.json
@@ -3869,7 +3869,7 @@
                 }
             }
         },
-        "Gamma Arena": {
+        "Gamma+ Arena": {
             "default_node": "Start Point",
             "hint_features": [],
             "extra": {
@@ -3918,7 +3918,7 @@
                     "default_connection": {
                         "region": "Area 4 Crystal Mines",
                         "area": "Gawron Groove",
-                        "node": "Tunnel to Gamma Arena"
+                        "node": "Tunnel to Gamma+ Arena"
                     },
                     "default_dock_weakness": "Tunnel",
                     "exclude_from_dock_rando": false,
@@ -3955,12 +3955,12 @@
                         }
                     }
                 },
-                "Event - Gamma Metroid": {
+                "Event - Gamma+ Metroid": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 16148.772087451332,
-                        "y": 9788.349805330938,
+                        "x": 16148.77,
+                        "y": 9788.35,
                         "z": 0.0
                     },
                     "description": "",
@@ -4014,8 +4014,8 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 15091.115171200434,
-                        "y": 9236.642306130736,
+                        "x": 15091.12,
+                        "y": 9236.64,
                         "z": 0.0
                     },
                     "description": "",
@@ -4092,7 +4092,7 @@
                                 ]
                             }
                         },
-                        "Event - Gamma Metroid": {
+                        "Event - Gamma+ Metroid": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4108,7 +4108,7 @@
                                     },
                                     {
                                         "type": "template",
-                                        "data": "Defeat Gamma Metroid"
+                                        "data": "Defeat Gamma Metroid+"
                                     }
                                 ]
                             }
@@ -4470,7 +4470,7 @@
                         }
                     }
                 },
-                "Tunnel to Gamma Arena": {
+                "Tunnel to Gamma+ Arena": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4487,7 +4487,7 @@
                     "dock_type": "tunnel",
                     "default_connection": {
                         "region": "Area 4 Crystal Mines",
-                        "area": "Gamma Arena",
+                        "area": "Gamma+ Arena",
                         "node": "Tunnel to Gawron Groove"
                     },
                     "default_dock_weakness": "Tunnel",
@@ -4691,7 +4691,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Tunnel to Gamma Arena": {
+                        "Tunnel to Gamma+ Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4803,7 +4803,7 @@
                                 ]
                             }
                         },
-                        "Tunnel to Gamma Arena": {
+                        "Tunnel to Gamma+ Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.txt
+++ b/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.txt
@@ -545,19 +545,19 @@ Extra - asset_id: collision_camera_008
       Trivial
 
 ----------------
-Gamma Arena
+Gamma+ Arena
 Extra - total_boundings: {'x1': 14400.0, 'x2': 18000.0, 'y1': 8550.0, 'y2': 11000.0}
 Extra - polygon: [[14400.0, 11000.0], [14400.0, 8550.0], [18000.0, 8550.0], [18000.0, 11000.0]]
 Extra - asset_id: collision_camera_015
 > Tunnel to Gawron Groove; Heals? False
   * Layers: default
-  * Tunnel to Gawron Groove/Tunnel to Gamma Arena
+  * Tunnel to Gawron Groove/Tunnel to Gamma+ Arena
   > Start Point
       Morph Ball and Varia Suit
 
-> Event - Gamma Metroid; Heals? False
+> Event - Gamma+ Metroid; Heals? False
   * Layers: default
-  * Event Area 4 (Crystal Mines) - Gamma Metroid
+  * Event Area 4 (Crystal Mines) - Gamma+ Metroid
   > Pickup (DNA)
       Trivial
 
@@ -576,8 +576,8 @@ Extra - asset_id: collision_camera_015
       All of the following:
           Morph Ball and Varia Suit
           Single-wall Wall Jump (Beginner) or Super Jump (Beginner) or Unmorph Extend (Beginner) or Climb Rooms Vertically (High Jump)
-  > Event - Gamma Metroid
-      Varia Suit and Defeat Gamma Metroid
+  > Event - Gamma+ Metroid
+      Varia Suit and Defeat Gamma Metroid+
 
 ----------------
 Gawron Groove
@@ -620,9 +620,9 @@ Extra - asset_id: collision_camera_009
       # Unmorph exiting tunnel and jump left
       Morph Ball and Varia Suit and Movement (Beginner)
 
-> Tunnel to Gamma Arena; Heals? False
+> Tunnel to Gamma+ Arena; Heals? False
   * Layers: default
-  * Tunnel to Gamma Arena/Tunnel to Gawron Groove
+  * Tunnel to Gamma+ Arena/Tunnel to Gawron Groove
   > Tunnel to Basalt Basin (Right)
       All of the following:
           Super Missile and Varia Suit
@@ -647,7 +647,7 @@ Extra - asset_id: collision_camera_009
 > Tunnel to Basalt Basin (Right); Heals? False
   * Layers: default
   * Tunnel with Bomb Block to Basalt Basin/Tunnel to Gawron Groove (Right)
-  > Tunnel to Gamma Arena
+  > Tunnel to Gamma+ Arena
       All of the following:
           Varia Suit and Lay Any Bomb
           # Get up
@@ -659,7 +659,7 @@ Extra - asset_id: collision_camera_009
       Varia Suit
   > Pickup (Super Missile Tank)
       Morph Ball and Super Missile and Varia Suit
-  > Tunnel to Gamma Arena
+  > Tunnel to Gamma+ Arena
       Morph Ball and Varia Suit
 
 > TODO: future dock; Heals? False

--- a/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.txt
+++ b/randovania/games/samus_returns/logic_database/Area 4 Crystal Mines.txt
@@ -555,9 +555,9 @@ Extra - asset_id: collision_camera_015
   > Start Point
       Morph Ball and Varia Suit
 
-> Event - Gamma+ Metroid; Heals? False
+> Event - Gamma Metroid+; Heals? False
   * Layers: default
-  * Event Area 4 (Crystal Mines) - Gamma+ Metroid
+  * Event Area 4 (Crystal Mines) - Gamma Metroid+
   > Pickup (DNA)
       Trivial
 
@@ -576,7 +576,7 @@ Extra - asset_id: collision_camera_015
       All of the following:
           Morph Ball and Varia Suit
           Single-wall Wall Jump (Beginner) or Super Jump (Beginner) or Unmorph Extend (Beginner) or Climb Rooms Vertically (High Jump)
-  > Event - Gamma+ Metroid
+  > Event - Gamma Metroid+
       Varia Suit and Defeat Gamma Metroid+
 
 ----------------

--- a/randovania/games/samus_returns/logic_database/header.json
+++ b/randovania/games/samus_returns/logic_database/header.json
@@ -655,7 +655,7 @@
                 "extra": {}
             },
             "Gamma 10": {
-                "long_name": "Area 4 (Crystal Mines) - Gamma+ Metroid",
+                "long_name": "Area 4 (Crystal Mines) - Gamma Metroid+",
                 "extra": {}
             },
             "Zeta 1": {

--- a/randovania/games/samus_returns/logic_database/header.json
+++ b/randovania/games/samus_returns/logic_database/header.json
@@ -655,7 +655,7 @@
                 "extra": {}
             },
             "Gamma 10": {
-                "long_name": "Area 4 (Crystal Mines) - Gamma Metroid",
+                "long_name": "Area 4 (Crystal Mines) - Gamma+ Metroid",
                 "extra": {}
             },
             "Zeta 1": {

--- a/randovania/layout/description_migration.py
+++ b/randovania/layout/description_migration.py
@@ -601,6 +601,22 @@ def _migrate_v31(data: dict) -> None:
     _migrate_hint_precision(data, {"broad-category"})
 
 
+def _migrate_v32(data: dict) -> None:
+    game_modifications = data["game_modifications"]
+
+    for game in game_modifications:
+        game_name = game["game"]
+        if game_name != "samus_returns":
+            continue
+        locations = game.get("locations")
+
+        old_new_name = migration_data.get_raw_data(RandovaniaGame(game_name))["a4_crystal_mines_typo"]
+        for old_name, new_name in old_new_name.items():
+            for area, nodes in locations.items():
+                if old_name in area:
+                    nodes[new_name] = nodes.pop(old_name)
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v2.2.0-6-gbfd37022
     _migrate_v2,  # v2.4.2-16-g735569fd
@@ -633,6 +649,7 @@ _MIGRATIONS = [
     _migrate_v29,  # hint type refactor
     _migrate_v30,  # migrate some HintLocationPrecision and HintItemPrecision to HintFeature
     _migrate_v31,  # remove HintLocationPrecision.BROAD_CATEGORY
+    _migrate_v32,  # MSR Rename Area 4 Crystal Mines - Gamma Arena to Gamma+ Arena
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/randovania/layout/description_migration.py
+++ b/randovania/layout/description_migration.py
@@ -610,12 +610,6 @@ def _migrate_v32(data: dict) -> None:
             continue
 
         migration = migration_data.get_raw_data(RandovaniaGame(game_name))["a4_crystal_mines_typo"]
-        dock_weakness = game.get("dock_weakness")
-        if dock_weakness is not None:
-            for old_node, new_node in migration["nodes"].items():
-                if old_node in dock_weakness:
-                    dock_weakness[new_node] = dock_weakness.pop(old_node)
-
         for region, area_data in migration["area"].items():
             for old_area_name, new_area_name in area_data.items():
                 region_location = game["locations"][region]

--- a/randovania/layout/description_migration.py
+++ b/randovania/layout/description_migration.py
@@ -608,13 +608,19 @@ def _migrate_v32(data: dict) -> None:
         game_name = game["game"]
         if game_name != "samus_returns":
             continue
-        locations = game.get("locations")
 
-        old_new_name = migration_data.get_raw_data(RandovaniaGame(game_name))["a4_crystal_mines_typo"]
-        for old_name, new_name in old_new_name.items():
-            for area, nodes in locations.items():
-                if old_name in area:
-                    nodes[new_name] = nodes.pop(old_name)
+        migration = migration_data.get_raw_data(RandovaniaGame(game_name))["a4_crystal_mines_typo"]
+        dock_weakness = game.get("dock_weakness")
+        if dock_weakness is not None:
+            for old_node, new_node in migration["nodes"].items():
+                if old_node in dock_weakness:
+                    dock_weakness[new_node] = dock_weakness.pop(old_node)
+
+        for region, area_data in migration["area"].items():
+            for old_area_name, new_area_name in area_data.items():
+                region_location = game["locations"][region]
+                if old_area_name in region_location:
+                    region_location[new_area_name] = region_location.pop(old_area_name)
 
 
 _MIGRATIONS = [

--- a/test/games/samus_returns/generator/test_msr_bootstrap.py
+++ b/test/games/samus_returns/generator/test_msr_bootstrap.py
@@ -21,7 +21,7 @@ from randovania.generator.pickup_pool import pool_creator
         (MSRArtifactConfig(False, False, False, False, 0, 0), []),
         (MSRArtifactConfig(False, False, True, False, 4, 4), [37, 99, 139, 171]),
         (MSRArtifactConfig(True, False, False, False, 1, 1), [183]),
-        (MSRArtifactConfig(False, True, False, False, 2, 2), [178, 187]),
+        (MSRArtifactConfig(False, True, False, False, 2, 2), [178, 185]),
         (MSRArtifactConfig(True, True, True, False, 1, 1), [197]),
     ],
 )

--- a/test/games/samus_returns/generator/test_msr_pool_creator.py
+++ b/test/games/samus_returns/generator/test_msr_pool_creator.py
@@ -27,7 +27,7 @@ def test_msr_pool_creator(msr_game_description, required_dna, placed_dna):
     ("metroids", "stronger_metroids", "bosses", "anywhere", "required_dna", "placed_dna"),
     [
         (False, False, True, False, 5, 5),
-        (False, True, False, False, 15, 15),
+        (False, True, False, False, 16, 16),
         (True, False, True, False, 40, 40),
         (True, True, True, False, 40, 40),
         (False, False, False, True, 40, 40),

--- a/test/games/samus_returns/gui/preset_settings/test_msr_goal_tab.py
+++ b/test/games/samus_returns/gui/preset_settings/test_msr_goal_tab.py
@@ -15,12 +15,12 @@ from randovania.interface_common.preset_editor import PresetEditor
     ("prefer_metroids", "prefer_stronger_metroids", "prefer_bosses", "expected_max_slider"),
     [
         (False, False, False, 0),
-        (True, False, False, 25),
-        (False, True, False, 14),
+        (True, False, False, 24),
+        (False, True, False, 15),
         (False, False, True, 4),
         (True, True, False, 39),
-        (True, False, True, 29),
-        (False, True, True, 18),
+        (True, False, True, 28),
+        (False, True, True, 19),
         (True, True, True, 39),
     ],
 )

--- a/test/test_files/patcher_data/samus_returns/multi-am2r+cs+dread+prime1+prime2+msr/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/multi-am2r+cs+dread+prime1+prime2+msr/world_1.json
@@ -4344,7 +4344,7 @@
                 "collision_camera_006": "Lava Reservoir",
                 "collision_camera_007": "Dual Pond Alcove",
                 "collision_camera_008": "Zeta Arena",
-                "collision_camera_015": "Gamma Arena",
+                "collision_camera_015": "Gamma+ Arena",
                 "collision_camera_009": "Gawron Groove",
                 "collision_camera_017": "Basalt Basin",
                 "collision_camera_010": "Mines Entrance",

--- a/test/test_files/patcher_data/samus_returns/multi_coop_am2r+bdg+cs+dread+prime1+echoes+msr/world_7.json
+++ b/test/test_files/patcher_data/samus_returns/multi_coop_am2r+bdg+cs+dread+prime1+echoes+msr/world_7.json
@@ -4344,7 +4344,7 @@
                 "collision_camera_006": "Lava Reservoir",
                 "collision_camera_007": "Dual Pond Alcove",
                 "collision_camera_008": "Zeta Arena",
-                "collision_camera_015": "Gamma Arena",
+                "collision_camera_015": "Gamma+ Arena",
                 "collision_camera_009": "Gawron Groove",
                 "collision_camera_017": "Basalt Basin",
                 "collision_camera_010": "Mines Entrance",

--- a/test/test_files/patcher_data/samus_returns/samus_returns/arachnus_boss_start_inventory/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/arachnus_boss_start_inventory/world_1.json
@@ -4442,7 +4442,7 @@
                 "collision_camera_006": "Lava Reservoir",
                 "collision_camera_007": "Dual Pond Alcove",
                 "collision_camera_008": "Zeta Arena",
-                "collision_camera_015": "Gamma Arena",
+                "collision_camera_015": "Gamma+ Arena",
                 "collision_camera_009": "Gawron Groove",
                 "collision_camera_017": "Basalt Basin",
                 "collision_camera_010": "Mines Entrance",

--- a/test/test_files/patcher_data/samus_returns/samus_returns/diggernaut_boss_free_placement_dna/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/diggernaut_boss_free_placement_dna/world_1.json
@@ -4090,7 +4090,7 @@
         "Metroid DNA 5": "Area 2 Dam Exterior - Metroid Caverns Alpha Arena North West",
         "Metroid DNA 6": "Area 3 Factory Exterior - Gamma Arena",
         "Metroid DNA 7": "Area 6 - Omega Arena",
-        "Metroid DNA 8": "Area 4 Crystal Mines - Gamma Arena",
+        "Metroid DNA 8": "Area 4 Crystal Mines - Gamma+ Arena",
         "Metroid DNA 9": "Area 6 - Zeta Arena"
     },
     "hints": [
@@ -4183,7 +4183,7 @@
                 "scenario": "s033_area3b",
                 "actor": "LE_RandoDNA"
             },
-            "text": "DNA is located in Area 2 Dam Exterior - Inner Alpha Arena.\nDNA is located in Area 4 Crystal Mines - Gamma Arena.\nDNA is located in Area 3 Metroid Caverns - Gamma Arena South.\n"
+            "text": "DNA is located in Area 2 Dam Exterior - Inner Alpha Arena.\nDNA is located in Area 4 Crystal Mines - Gamma+ Arena.\nDNA is located in Area 3 Metroid Caverns - Gamma Arena South.\n"
         },
         {
             "accesspoint_actor": {
@@ -4430,7 +4430,7 @@
                 "collision_camera_006": "Lava Reservoir",
                 "collision_camera_007": "Dual Pond Alcove",
                 "collision_camera_008": "Zeta Arena",
-                "collision_camera_015": "Gamma Arena",
+                "collision_camera_015": "Gamma+ Arena",
                 "collision_camera_009": "Gawron Groove",
                 "collision_camera_017": "Basalt Basin",
                 "collision_camera_010": "Mines Entrance",

--- a/test/test_files/patcher_data/samus_returns/samus_returns/door_lock/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/door_lock/world_1.json
@@ -4430,7 +4430,7 @@
                 "collision_camera_006": "Lava Reservoir",
                 "collision_camera_007": "Dual Pond Alcove",
                 "collision_camera_008": "Zeta Arena",
-                "collision_camera_015": "Gamma Arena",
+                "collision_camera_015": "Gamma+ Arena",
                 "collision_camera_009": "Gawron Groove",
                 "collision_camera_017": "Basalt Basin",
                 "collision_camera_010": "Mines Entrance",

--- a/test/test_files/patcher_data/samus_returns/samus_returns/door_lock_access_open/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/door_lock_access_open/world_1.json
@@ -4430,7 +4430,7 @@
                 "collision_camera_006": "Lava Reservoir",
                 "collision_camera_007": "Dual Pond Alcove",
                 "collision_camera_008": "Zeta Arena",
-                "collision_camera_015": "Gamma Arena",
+                "collision_camera_015": "Gamma+ Arena",
                 "collision_camera_009": "Gawron Groove",
                 "collision_camera_017": "Basalt Basin",
                 "collision_camera_010": "Mines Entrance",

--- a/test/test_files/patcher_data/samus_returns/samus_returns/progressive_beams_and_suits/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/progressive_beams_and_suits/world_1.json
@@ -4083,7 +4083,7 @@
         "Aeion Reserve Tank": "Area 3 Metroid Caverns - Transport to Factory Exterior North",
         "Missile Reserve Tank": "Area 5 Tower Lobby - Lobby Teleporter West",
         "Metroid DNA 1": "Area 7 - Omega+ Arena",
-        "Metroid DNA 10": "Area 4 Crystal Mines - Gamma Arena",
+        "Metroid DNA 10": "Area 4 Crystal Mines - Gamma+ Arena",
         "Metroid DNA 2": "Area 1 - Metroid Caverns Alpha Arena South West",
         "Metroid DNA 3": "Area 3 Factory Exterior - Gamma Arena",
         "Metroid DNA 4": "Area 4 Central Caves - Alpha+ Arena",
@@ -4183,7 +4183,7 @@
                 "scenario": "s033_area3b",
                 "actor": "LE_RandoDNA"
             },
-            "text": "DNA is located in Area 4 Crystal Mines - Gamma Arena.\nDNA is located in Area 7 - Omega Arena South.\n"
+            "text": "DNA is located in Area 4 Crystal Mines - Gamma+ Arena.\nDNA is located in Area 7 - Omega Arena South.\n"
         },
         {
             "accesspoint_actor": {
@@ -4430,7 +4430,7 @@
                 "collision_camera_006": "Lava Reservoir",
                 "collision_camera_007": "Dual Pond Alcove",
                 "collision_camera_008": "Zeta Arena",
-                "collision_camera_015": "Gamma Arena",
+                "collision_camera_015": "Gamma+ Arena",
                 "collision_camera_009": "Gawron Groove",
                 "collision_camera_017": "Basalt Basin",
                 "collision_camera_010": "Mines Entrance",

--- a/test/test_files/patcher_data/samus_returns/samus_returns/queen_boss_custom_required_dna/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/queen_boss_custom_required_dna/world_1.json
@@ -4074,7 +4074,7 @@
         "Metroid DNA 2": "Area 4 Central Caves - Gamma Arena",
         "Metroid DNA 20": "Area 3 Factory Interior - Gamma Arena & Transport to Metroid Caverns East",
         "Metroid DNA 21": "Surface East - Alpha Arena",
-        "Metroid DNA 22": "Area 4 Crystal Mines - Gamma Arena",
+        "Metroid DNA 22": "Area 4 Crystal Mines - Gamma+ Arena",
         "Metroid DNA 23": "Area 2 Dam Exterior - Inner Alpha Arena",
         "Metroid DNA 24": "Area 4 Crystal Mines - Zeta Arena",
         "Metroid DNA 25": "Area 3 Metroid Caverns - Alpha+ Arena West",
@@ -4216,7 +4216,7 @@
                 "scenario": "s090_area9",
                 "actor": "LE_RandoDNA"
             },
-            "text": "DNA is located in Surface East - Alpha Arena.\nDNA is located in Area 1 - Metroid Caverns Alpha Arena North East.\nDNA is located in Area 4 Crystal Mines - Gamma Arena.\n"
+            "text": "DNA is located in Surface East - Alpha Arena.\nDNA is located in Area 1 - Metroid Caverns Alpha Arena North East.\nDNA is located in Area 4 Crystal Mines - Gamma+ Arena.\n"
         },
         {
             "accesspoint_actor": {
@@ -4428,7 +4428,7 @@
                 "collision_camera_006": "Lava Reservoir",
                 "collision_camera_007": "Dual Pond Alcove",
                 "collision_camera_008": "Zeta Arena",
-                "collision_camera_015": "Gamma Arena",
+                "collision_camera_015": "Gamma+ Arena",
                 "collision_camera_009": "Gawron Groove",
                 "collision_camera_017": "Basalt Basin",
                 "collision_camera_010": "Mines Entrance",

--- a/test/test_files/patcher_data/samus_returns/samus_returns/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/samus_returns/samus_returns/starter_preset/world_1.json
@@ -4377,7 +4377,7 @@
                 "collision_camera_006": "Lava Reservoir",
                 "collision_camera_007": "Dual Pond Alcove",
                 "collision_camera_008": "Zeta Arena",
-                "collision_camera_015": "Gamma Arena",
+                "collision_camera_015": "Gamma+ Arena",
                 "collision_camera_009": "Gawron Groove",
                 "collision_camera_017": "Basalt Basin",
                 "collision_camera_010": "Mines Entrance",


### PR DESCRIPTION
As mentioned in the issue, the room was misnamed and thus the logic/event is also wrong. This PR fixes that.

Fixes #7884 