### PR TITLE
echoes: increase hint action weight

### DIFF
--- a/randovania/games/prime2/game_data.py
+++ b/randovania/games/prime2/game_data.py
@@ -52,7 +52,7 @@ def _generator() -> randovania.game.generator.GameGenerator:
         bootstrap=EchoesBootstrap(),
         base_patches_factory=EchoesBasePatchesFactory(),
         hint_distributor=EchoesHintDistributor(),
-        action_weights=ActionWeights(),
+        action_weights=ActionWeights(hints_weight=2.0),
     )
 
 


### PR DESCRIPTION
should make translators significantly more common in echoes, which helps make up for hints being less powerful overall