### PR TITLE
Gitignore bulk generation folder

### DIFF
--- a/tools/bulk-generation/.gitignore
+++ b/tools/bulk-generation/.gitignore
@@ -1,0 +1,3 @@
+# Ignore everything but this file
+*
+!.gitignore


### PR DESCRIPTION
For bulk-generation it's useful to have an ignored output folder in the repo folder.