### PR TITLE
place hints with no valid targets at the end instead of the start

### DIFF
--- a/randovania/generator/hint_distributor.py
+++ b/randovania/generator/hint_distributor.py
@@ -318,8 +318,11 @@ class HintDistributor(ABC):
 
         hinted_locations = {hint.target for hint in patches.hints.values() if isinstance(hint, LocationHint)}
 
-        def sort_hints(item: tuple[NodeIdentifier, set[PickupIndex]]) -> tuple[int, NodeIdentifier]:
-            return (len(item[1] - hinted_locations), item[0])
+        def sort_hints(item: tuple[NodeIdentifier, set[PickupIndex]]) -> tuple[bool, int, NodeIdentifier]:
+            identifier, targets = item
+            num_targets = len(targets - hinted_locations)
+            has_targets = bool(num_targets)  # place hints with NO targets last instead of first
+            return (not has_targets, num_targets, identifier)
 
         # assign hints with fewest potential targets first to help ensure none of them run out of options
         for hint_node, potential_targets in sorted(hint_state.hint_valid_targets.items(), key=sort_hints):


### PR DESCRIPTION
this prevents completely non-logical hints from taking potential logical targets from other hints