### PR TITLE
prevent translators from hinting themselves in echoes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: A legacy relative hint pointing to a Nothing will now always refer to it by name.
 - Changed: Keybearer hints may refer to pickups using different categories than before.
 - Fixed: When using the new experimental generator setting to consider possible unsafe resources, the Starter Preset can once again see Missile Launcher placed in the GFMC Compound crate.
+- Fixed: Translators will no longer be hinted by hints of their own color.
 
 #### Logic Database
 

--- a/randovania/games/am2r/generator/hint_distributor.py
+++ b/randovania/games/am2r/generator/hint_distributor.py
@@ -6,14 +6,15 @@ from randovania.game_description.hint import HintItemPrecision, HintLocationPrec
 from randovania.generator.hint_distributor import HintDistributor
 
 if TYPE_CHECKING:
-    from randovania.game_description.pickup.pickup_entry import PickupEntry
+    from randovania.game_description.assignment import PickupTarget
+    from randovania.game_description.db.hint_node import HintNode
 
 
 class AM2RHintDistributor(HintDistributor):
     # Makes DNA less likely to be hinted since gaurunteed hints already exist on Wisdom Septoggs
     @override
-    def is_pickup_interesting(self, pickup: PickupEntry) -> bool:
-        return not pickup.has_hint_feature("dna")
+    def is_pickup_interesting(self, target: PickupTarget, player_id: int, hint_node: HintNode) -> bool:
+        return not target.pickup.has_hint_feature("dna")
 
     @override
     @property

--- a/randovania/games/dread/generator/hint_distributor.py
+++ b/randovania/games/dread/generator/hint_distributor.py
@@ -13,8 +13,9 @@ from randovania.games.dread.layout.dread_configuration import DreadConfiguration
 from randovania.generator.hint_distributor import HintDistributor
 
 if TYPE_CHECKING:
+    from randovania.game_description.assignment import PickupTarget
+    from randovania.game_description.db.hint_node import HintNode
     from randovania.game_description.game_patches import GamePatches
-    from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.generator.pre_fill_params import PreFillParams
 
 
@@ -25,8 +26,8 @@ class DreadHintDistributor(HintDistributor):
         return PrecisionPair(HintLocationPrecision.REGION_ONLY, HintItemPrecision.DETAILED, True)
 
     @override
-    def is_pickup_interesting(self, pickup: PickupEntry) -> bool:
-        return not pickup.has_hint_feature("dna")
+    def is_pickup_interesting(self, target: PickupTarget, player_id: int, hint_node: HintNode) -> bool:
+        return not target.pickup.has_hint_feature("dna")
 
     @override
     async def assign_specific_location_hints(self, patches: GamePatches, prefill: PreFillParams) -> GamePatches:

--- a/randovania/games/prime1/hint_distributor.py
+++ b/randovania/games/prime1/hint_distributor.py
@@ -6,14 +6,15 @@ from randovania.game_description.hint import HintItemPrecision, HintLocationPrec
 from randovania.generator.hint_distributor import HintDistributor
 
 if TYPE_CHECKING:
-    from randovania.game_description.pickup.pickup_entry import PickupEntry
+    from randovania.game_description.assignment import PickupTarget
+    from randovania.game_description.db.hint_node import HintNode
 
 
 class PrimeHintDistributor(HintDistributor):
     # Makes Artifacts less likely to be hinted since gaurunteed hints already exist in Artifact Temple
     @override
-    def is_pickup_interesting(self, pickup: PickupEntry) -> bool:
-        return not pickup.has_hint_feature("artifact")
+    def is_pickup_interesting(self, target: PickupTarget, player_id: int, hint_node: HintNode) -> bool:
+        return not target.pickup.has_hint_feature("artifact")
 
     @override
     @property

--- a/randovania/games/prime2/generator/hint_distributor.py
+++ b/randovania/games/prime2/generator/hint_distributor.py
@@ -22,8 +22,9 @@ if TYPE_CHECKING:
     from collections.abc import Container
     from random import Random
 
+    from randovania.game_description.assignment import PickupTarget
+    from randovania.game_description.db.hint_node import HintNode
     from randovania.game_description.game_patches import GamePatches
-    from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.generator.filler.filler_configuration import PlayerPool
     from randovania.generator.pre_fill_params import PreFillParams
 
@@ -36,11 +37,14 @@ class EchoesHintDistributor(HintDistributor):
         return 2
 
     @override
-    def is_pickup_interesting(self, pickup: PickupEntry) -> bool:
+    def is_pickup_interesting(self, target: PickupTarget, player_id: int, hint_node: HintNode) -> bool:
         non_interesting_features = ["key", "energy_tank"]
         for feature in non_interesting_features:
-            if pickup.has_hint_feature(feature):
+            if target.pickup.has_hint_feature(feature):
                 return False
+        if target.player == player_id and ("Translator" in target.pickup.name):
+            # don't place a translator hint on its color of lore scan
+            return hint_node.extra.get("translator") not in target.pickup.name
         return True
 
     @override

--- a/randovania/games/samus_returns/generator/hint_distributor.py
+++ b/randovania/games/samus_returns/generator/hint_distributor.py
@@ -6,7 +6,8 @@ from randovania.game_description.hint import HintItemPrecision, HintLocationPrec
 from randovania.generator.hint_distributor import HintDistributor
 
 if TYPE_CHECKING:
-    from randovania.game_description.pickup.pickup_entry import PickupEntry
+    from randovania.game_description.assignment import PickupTarget
+    from randovania.game_description.db.hint_node import HintNode
 
 
 class MSRHintDistributor(HintDistributor):
@@ -16,9 +17,9 @@ class MSRHintDistributor(HintDistributor):
         return PrecisionPair(HintLocationPrecision.REGION_ONLY, HintItemPrecision.DETAILED, True)
 
     @override
-    def is_pickup_interesting(self, pickup: PickupEntry) -> bool:
+    def is_pickup_interesting(self, target: PickupTarget, player_id: int, hint_node: HintNode) -> bool:
         non_interesting_features = ["dna", "energy_tank", "expansion"]
         for feature in non_interesting_features:
-            if pickup.has_hint_feature(feature):
+            if target.pickup.has_hint_feature(feature):
                 return False
         return True

--- a/randovania/generator/hint_distributor.py
+++ b/randovania/generator/hint_distributor.py
@@ -265,6 +265,7 @@ class HintDistributor(ABC):
             player_state.game.region_list,
             rng,
             player_state.hint_state,
+            player_state.index,
             player_pools,
         )
         return await self.assign_precision_to_hints(full_hints_patches, rng, player_pool, player_pools)
@@ -289,7 +290,9 @@ class HintDistributor(ABC):
 
     @final
     @staticmethod
-    def hint_suitability_for_target(target: PickupTarget, player_pools: list[PlayerPool]) -> HintSuitability:
+    def hint_suitability_for_target(
+        target: PickupTarget, player_id: int, hint_node: HintNode, player_pools: list[PlayerPool]
+    ) -> HintSuitability:
         """
         Determines the HintSuitability for the given target,
         according to the criteria of its *owner's* HintDistributor.
@@ -299,17 +302,17 @@ class HintDistributor(ABC):
         """
         hint_distributor = player_pools[target.player].game_generator.hint_distributor
 
-        if not hint_distributor.is_pickup_interesting(target.pickup):
+        if not hint_distributor.is_pickup_interesting(target, player_id, hint_node):
             return HintSuitability.LEAST_INTERESTING
-        if not hint_distributor.is_pickup_more_interesting(target.pickup):
+        if not hint_distributor.is_pickup_more_interesting(target, player_id, hint_node):
             return HintSuitability.INTERESTING
         return HintSuitability.MORE_INTERESTING
 
-    def is_pickup_more_interesting(self, pickup: PickupEntry) -> bool:
+    def is_pickup_more_interesting(self, target: PickupTarget, player_id: int, hint_node: HintNode) -> bool:
         """Pickups which don't satisfy this check are lower priority for hinting than those that do."""
-        return pickup.show_in_credits_spoiler
+        return target.pickup.show_in_credits_spoiler
 
-    def is_pickup_interesting(self, pickup: PickupEntry) -> bool:
+    def is_pickup_interesting(self, target: PickupTarget, player_id: int, hint_node: HintNode) -> bool:
         """Pickups which don't satisfy this check are only hinted as a last resort."""
         return True
 
@@ -319,6 +322,7 @@ class HintDistributor(ABC):
         region_list: RegionList,
         rng: Random,
         hint_state: HintState,
+        player_id: int,
         player_pools: list[PlayerPool],
     ) -> GamePatches:
         """
@@ -344,7 +348,9 @@ class HintDistributor(ABC):
             real_potential_targets = {
                 target
                 for target in sorted(potential_targets)
-                if self.hint_suitability_for_target(patches.pickup_assignment[target], player_pools)
+                if HintDistributor.hint_suitability_for_target(
+                    patches.pickup_assignment[target], player_id, node, player_pools
+                )
                 >= HintSuitability.MORE_INTERESTING
             }
             # don't hint things twice
@@ -355,7 +361,8 @@ class HintDistributor(ABC):
                 real_potential_targets = {
                     pickup
                     for pickup, entry in patches.pickup_assignment.items()
-                    if self.hint_suitability_for_target(entry, player_pools) >= HintSuitability.INTERESTING
+                    if HintDistributor.hint_suitability_for_target(entry, player_id, node, player_pools)
+                    >= HintSuitability.INTERESTING
                 }
                 real_potential_targets -= hinted_locations
                 debug.debug_print(

--- a/test/generator/filler/test_runner.py
+++ b/test/generator/filler/test_runner.py
@@ -98,6 +98,7 @@ async def test_fill_unassigned_hints_empty_assignment(echoes_game_description, e
         echoes_game_description.region_list,
         rng,
         hint_state,
+        0,
         player_pools,
     )
 


### PR DESCRIPTION
fixes #723 (save for some extremely unlikely edge cases)

you can still get hints for an item *required* to get a translator, but that's not as immediately offensive to players as a violet hint telling you where to find violet translator