### PR TITLE
increase DLR attempts for echoes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Legacy multiworld sessions where an Echoes hint points to a Cave Story item may have very slightly altered wording.
 - Changed: A legacy relative hint pointing to a Nothing will now always refer to it by name.
 - Changed: Keybearer hints may refer to pickups using different categories than before.
+- Fixed: Seeds with individual Door Lock Randomizer enabled should see more door variety in the lategame.
 - Fixed: When using the new experimental generator setting to consider possible unsafe resources, the Starter Preset can once again see Missile Launcher placed in the GFMC Compound crate.
 - Fixed: Translators will no longer be hinted by hints of their own color.
 

--- a/randovania/games/prime2/logic_database/header.json
+++ b/randovania/games/prime2/logic_database/header.json
@@ -2974,7 +2974,7 @@
         },
         "dock_rando": {
             "force_change_two_way": false,
-            "resolver_attempts": 200,
+            "resolver_attempts": 600,
             "to_shuffle_proportion": 1.0
         }
     },

--- a/randovania/generator/dock_weakness_distributor.py
+++ b/randovania/generator/dock_weakness_distributor.py
@@ -257,7 +257,8 @@ async def _run_dock_resolver(
         new_state = None
         result = f"Timeout ({logic.get_attempts()} attempts)"
     else:
-        result = f"Finished resolver ({logic.get_attempts()} attempts)"
+        success = "success" if new_state is not None else "failure"
+        result = f"Finished resolver ({success} in {logic.get_attempts()} attempts)"
 
     debug.debug_print(result)
 


### PR DESCRIPTION
on my preset, most doors are solved in under 300 attempts, and all are solved in under 500 attempts. the 600 is just a little bit of leeway in case of weird presets. critically, this means the doors in Sky Temple can actually be non-blue, which is an important part of my intended design for echoes DLR and hasn't been working for a while