### PR TITLE
skip resolving in DLR for impossible to reach doors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Door Lock Randomizer
 
+- Changed: When checking doors that are completely unreachable (such as uncrashed Frigate in most Metroid Prime presets), the resolver is no longer run. This should improve generation time slightly.
 - Fixed: Bug in the revised door solver that would result in permanently locked doors being placed when they shouldn't.
 
 ### Resolver


### PR DESCRIPTION
this should affect all games with DLR in some fashion, but it most noticeably improves the performance of DLR generation in prime 1, where anything in uncrashed frigate now gets skipped (unless those elevators are shuffled ofc) rather than very slowly calculated in failure. I would suggest looking into increasing the max attempts and/or to_shuffle proprtions in prime 1 now that there aren't so many slow impossible doors to consider