### PR TITLE
fusion: update underwater walljump logic in sector 4

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -8984,7 +8984,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "UnderwaterWallJump",
-                                                        "amount": 4,
+                                                        "amount": 5,
                                                         "negate": false
                                                     }
                                                 },
@@ -9117,7 +9117,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "UnderwaterWallJump",
-                                                        "amount": 4,
+                                                        "amount": 5,
                                                         "negate": false
                                                     }
                                                 }

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -8977,7 +8977,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Long sequence (15-20) of Underwater Wall Jumps TODO: video",
+                                            "comment": "Long sequence (30+) of Underwater Wall Jumps: https://youtu.be/BYdBjECAoAM",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -9105,7 +9105,7 @@
                         "Door to Cheddar Bay": {
                             "type": "or",
                             "data": {
-                                "comment": "Long sequence (15-20) of Underwater Wall Jumps TODO: video",
+                                "comment": "Long sequence (30+) of Underwater Wall Jumps: https://youtu.be/n9Z_Ywet4WE",
                                 "items": [
                                     {
                                         "type": "and",

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -1275,7 +1275,7 @@ Extra - room_id: [25]
                   # Wall Jump: https://youtu.be/TDwTWYNa_F8
                   Wall Jump (Beginner)
           # Long sequence (15-20) of Underwater Wall Jumps TODO: video
-          Hi-Jump and Underwater Wall Jump (Expert)
+          Hi-Jump and Underwater Wall Jump (Hypermode)
 
 > Other to Security Bypass; Heals? False
   * Layers: default
@@ -1296,7 +1296,7 @@ Extra - room_id: [25]
   > Door to Cheddar Bay
       Any of the following:
           # Long sequence (15-20) of Underwater Wall Jumps TODO: video
-          Underwater Wall Jump (Expert)
+          Underwater Wall Jump (Hypermode)
           All of the following:
               Gravity Suit
               Any of the following:

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -1274,7 +1274,7 @@ Extra - room_id: [25]
                   Space Jump
                   # Wall Jump: https://youtu.be/TDwTWYNa_F8
                   Wall Jump (Beginner)
-          # Long sequence (15-20) of Underwater Wall Jumps TODO: video
+          # Long sequence (30+) of Underwater Wall Jumps: https://youtu.be/BYdBjECAoAM
           Hi-Jump and Underwater Wall Jump (Ludicrous)
 
 > Other to Security Bypass; Heals? False
@@ -1295,7 +1295,7 @@ Extra - room_id: [25]
   * Layers: default
   > Door to Cheddar Bay
       Any of the following:
-          # Long sequence (15-20) of Underwater Wall Jumps TODO: video
+          # Long sequence (30+) of Underwater Wall Jumps: https://youtu.be/n9Z_Ywet4WE
           Underwater Wall Jump (Ludicrous)
           All of the following:
               Gravity Suit

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -1275,7 +1275,7 @@ Extra - room_id: [25]
                   # Wall Jump: https://youtu.be/TDwTWYNa_F8
                   Wall Jump (Beginner)
           # Long sequence (15-20) of Underwater Wall Jumps TODO: video
-          Hi-Jump and Underwater Wall Jump (Hypermode)
+          Hi-Jump and Underwater Wall Jump (Ludicrous)
 
 > Other to Security Bypass; Heals? False
   * Layers: default
@@ -1296,7 +1296,7 @@ Extra - room_id: [25]
   > Door to Cheddar Bay
       Any of the following:
           # Long sequence (15-20) of Underwater Wall Jumps TODO: video
-          Underwater Wall Jump (Hypermode)
+          Underwater Wall Jump (Ludicrous)
           All of the following:
               Gravity Suit
               Any of the following:


### PR DESCRIPTION
Community feedback suggests that long underwater walljump tricks should be hypermode/ludicrous.
Additionally, I think they should be hypermode/ludicrous so we do not give players who chose expert repetitive strain injury.

Changed:
Sector 4
* Security Access
  * Door to Security -> Beside Hole
  * Beside Hole -> Door to Cheddar Bay