### PR TITLE
Further improvements to playthrough tab

### DIFF
--- a/randovania/game_description/pickup/pickup_entry.py
+++ b/randovania/game_description/pickup/pickup_entry.py
@@ -87,7 +87,7 @@ class PickupEntry:
     offworld_models: frozendict[RandovaniaGame, str] = dataclasses.field(
         default_factory=typing.cast(typing.Callable[[], frozendict[RandovaniaGame, str]], frozendict),
     )
-    show_in_credits_spoiler: bool = True
+    show_in_credits_spoiler: bool = True  # TODO: rename. this is effectively an "is important item" flag
     is_expansion: bool = False
 
     def __post_init__(self) -> None:

--- a/randovania/gui/ui_files/game_validator_widget.ui
+++ b/randovania/gui/ui_files/game_validator_widget.ui
@@ -115,10 +115,17 @@
        <item>
         <widget class="QCheckBox" name="show_pickups_check">
          <property name="text">
-          <string>Pickups</string>
+          <string>Majors</string>
          </property>
          <property name="checked">
           <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="show_minors_check">
+         <property name="text">
+          <string>Minors</string>
          </property>
         </widget>
        </item>

--- a/randovania/gui/widgets/game_validator_widget.py
+++ b/randovania/gui/widgets/game_validator_widget.py
@@ -240,7 +240,7 @@ class GameValidatorWidget(QtWidgets.QWidget, Ui_GameValidatorWidget):
                     player = int(pickup_match.group("world_num"))
                     pickup = pickup_match.group("pickup_name")
 
-                    if self.layout_description.generator_parameters.world_count == 1:
+                    if self.layout_description.world_count == 1:
                         action_text = pickup
                     else:
                         action_text = f"{self.players.player_names[player]}'s {pickup}"

--- a/randovania/gui/widgets/game_validator_widget.py
+++ b/randovania/gui/widgets/game_validator_widget.py
@@ -37,15 +37,21 @@ COMMENT_CHAR = "#"
 SKIP_ROLLBACK_CHAR = "*"
 
 action_re = re.compile(
-    r"^(?P<node>.+?) (?:\[(?P<energy>\d+?/\d+?) Energy] )?for (?:\[action (?P<action>.*?)] )?(?P<resources>\[.*?])$"
+    r"^(?P<region>.+?)/(?P<area>.+?)/(?P<node>.+?) "
+    r"(?:\[(?P<energy>\d+?/\d+?) Energy] )?for (?:\[action (?P<action>.*?)] )?(?P<resources>\[.*?])$"
 )
 pickup_action_re = re.compile(r"^World (?P<world_num>\d+?)'s (?P<pickup_name>.*?)$")
 action_type_re = re.compile(r"^(?P<type>.*?) - (?P<action>.*?)$")
+rollback_skip_re = re.compile(
+    r"^(?P<action>.*?) (?P<region>.+?)/(?P<area>.+?)/(?P<node>.+?)(?:, (?P<additional>.*?))?$"
+)
 
 
 def get_brush_for_action(action_type: str | None) -> QtGui.QBrush:
     ACTION_COLORS = {
         "Pickup": QtGui.QColorConstants.Cyan,
+        "Major": QtGui.QColorConstants.Cyan,
+        "Minor": QtGui.QColorConstants.DarkCyan,
         "Event": QtGui.QColorConstants.Magenta,
         "Lock": QtGui.QColorConstants.Green,
         "Hint": QtGui.QColorConstants.Yellow,
@@ -95,7 +101,8 @@ class GameValidatorWidget(QtWidgets.QWidget, Ui_GameValidatorWidget):
 
         configs: list[BaseConfiguration] = [preset.configuration for preset in layout.all_presets]
         self._action_filters = {
-            "Pickup": True,
+            "Major": True,
+            "Minor": False,
             "Event": True,
             "Hint": False,
             "Lock": configs[players.player_index].dock_rando.is_enabled(),
@@ -106,7 +113,8 @@ class GameValidatorWidget(QtWidgets.QWidget, Ui_GameValidatorWidget):
             check.setChecked(self._action_filters[action_type])
             signal_handling.on_checked(check, self._set_action_filter(action_type))
 
-        init_filter(self.show_pickups_check, "Pickup")
+        init_filter(self.show_pickups_check, "Major")
+        init_filter(self.show_minors_check, "Minor")
         init_filter(self.show_events_check, "Event")
         init_filter(self.show_hints_check, "Hint")
         init_filter(self.show_locks_check, "Lock")
@@ -144,10 +152,13 @@ class GameValidatorWidget(QtWidgets.QWidget, Ui_GameValidatorWidget):
         self._verbosity = value
         self._update_needs_refresh()
 
-    def update_item_visibility(self, widget: IndentedWidget) -> None:
+    def should_item_be_visible(self, widget: IndentedWidget) -> bool:
         if widget.action_type is None:
-            return
-        hide = not self._action_filters.get(widget.action_type, True)
+            return True
+        return self._action_filters.get(widget.action_type, True)
+
+    def update_item_visibility(self, widget: IndentedWidget) -> None:
+        hide = not self.should_item_be_visible(widget)
         widget.item.setHidden(hide)
 
     @asyncSlot()
@@ -170,7 +181,7 @@ class GameValidatorWidget(QtWidgets.QWidget, Ui_GameValidatorWidget):
         self.log_widget.setColumnHidden(LABEL_IDS["Energy"], self._verbosity < 2)
         self.log_widget.setColumnHidden(LABEL_IDS["Resources"], self._verbosity < 2)
 
-        self._current_tree = [IndentedWidget(-1, self.log_widget)]
+        self._current_tree = [IndentedWidget(-3, self.log_widget)]
 
         def write_to_log(*a: Any) -> None:
             scrollbar = self.log_widget.verticalScrollBar()
@@ -200,45 +211,45 @@ class GameValidatorWidget(QtWidgets.QWidget, Ui_GameValidatorWidget):
             while self._current_tree[-1].indent >= indent:
                 self._current_tree.pop().item.setExpanded(False)
 
-            if indent == 0:
-                parent = self.log_widget
-            else:
-                parent = self._current_tree[-1].item
-
-            item = QtWidgets.QTreeWidgetItem(parent)
+            item = QtWidgets.QTreeWidgetItem()
+            region, area, node = ("", "", "")
 
             if leading_char == ACTION_CHAR:
                 match = action_re.match(stripped)
                 assert match is not None
                 groups = match.groupdict()
 
-                item.setText(LABEL_IDS["Node"], groups["node"])
+                region = groups["region"]
+                area = groups["area"]
+                node = groups["node"]
+
+                item.setText(LABEL_IDS["Node"], node)
                 item.setText(LABEL_IDS["Resources"], groups["resources"])
                 item.setText(LABEL_IDS["Energy"], groups.get("energy", ""))
 
                 action = groups["action"]
                 if action is not None:
-                    if action.startswith("World"):
-                        pickup_match = pickup_action_re.match(action)
-                        assert pickup_match is not None
-
-                        player = int(pickup_match.group("world_num"))
-                        pickup = pickup_match.group("pickup_name")
-
-                        if self.layout_description.generator_parameters.world_count == 1:
-                            action = pickup
-                        else:
-                            action = f"{self.players.player_names[player]}'s {pickup}"
-
-                        action = f"Pickup - {action}"
-
                     action_type_match = action_type_re.match(action)
                     if action_type_match is None:
                         item.setText(LABEL_IDS["Action"], action)
                         action_type = "Other"
                     else:
-                        item.setText(LABEL_IDS["Action"], action_type_match.group("action"))
+                        action_text = action_type_match.group("action")
                         action_type = action_type_match.group("type")
+
+                        if (action_type in {"Major", "Minor", "Pickup"}) and action_text != "Nothing":
+                            pickup_match = pickup_action_re.match(action_text)
+                            assert pickup_match is not None
+
+                            player = int(pickup_match.group("world_num"))
+                            pickup = pickup_match.group("pickup_name")
+
+                            if self.layout_description.generator_parameters.world_count == 1:
+                                action_text = pickup
+                            else:
+                                action_text = f"{self.players.player_names[player]}'s {pickup}"
+
+                        item.setText(LABEL_IDS["Action"], action_text)
 
                     item.setText(LABEL_IDS["Type"], action_type)
                     widget = IndentedWidget(indent, item, action_type)
@@ -246,15 +257,53 @@ class GameValidatorWidget(QtWidgets.QWidget, Ui_GameValidatorWidget):
                     item.setText(LABEL_IDS["Type"], "Start")
                     widget = IndentedWidget(indent, item)
             elif leading_char == SKIP_ROLLBACK_CHAR:
-                action_type = stripped.split(" ")[0]
-                item.setText(LABEL_IDS["Node"], stripped)
+                rollback_skip_match = rollback_skip_re.match(stripped)
+                assert rollback_skip_match is not None
+                groups = rollback_skip_match.groupdict()
+
+                region = groups["region"]
+                area = groups["area"]
+                node = groups["node"]
+
+                action_type = groups["action"]
+
+                item.setText(LABEL_IDS["Node"], f"{action_type} {node}")
                 item.setText(LABEL_IDS["Type"], action_type)
+                if (extra := groups.get("additional")) is not None:
+                    item.setText(LABEL_IDS["Action"], extra.capitalize())
                 widget = IndentedWidget(indent, item, action_type)
             else:
                 item.setText(0, stripped)
                 widget = IndentedWidget(indent, item)
 
-            item.setExpanded(indent == 0)
+            if self.should_item_be_visible(widget) and node:
+                if len(self._current_tree) == 3:
+                    region_item = self._current_tree[-2].item
+                    area_item = self._current_tree[-1].item
+
+                    if region_item.text(LABEL_IDS["Node"]) != region:
+                        self._current_tree.pop()
+                        self._current_tree.pop()
+                    elif area_item.text(LABEL_IDS["Node"]) != area:
+                        self._current_tree.pop()
+
+                if len(self._current_tree) == 1:
+                    region_item = QtWidgets.QTreeWidgetItem(self._current_tree[-1].item)
+                    region_item.setText(LABEL_IDS["Node"], region)
+                    self._current_tree.append(IndentedWidget(-2, region_item))
+
+                    region_item.setExpanded(True)
+
+                if len(self._current_tree) == 2:
+                    area_item = QtWidgets.QTreeWidgetItem(region_item)
+                    area_item.setText(LABEL_IDS["Node"], area)
+                    self._current_tree.append(IndentedWidget(-1, area_item))
+
+                    area_item.setExpanded(True)
+
+            parent = self._current_tree[-1].item
+            parent.addChild(item)
+
             item.setForeground(LABEL_IDS["Type"], get_brush_for_action(widget.action_type))
             item.setBackground(LABEL_IDS["Type"], QtGui.QColor(32, 33, 36))  # ugly in light mode, but visible
 

--- a/randovania/gui/widgets/game_validator_widget.py
+++ b/randovania/gui/widgets/game_validator_widget.py
@@ -37,16 +37,24 @@ SATISFIABLE_CHAR = "="
 COMMENT_CHAR = "#"
 SKIP_ROLLBACK_CHAR = "*"
 
+location_pattern = r"(?P<region>.+?)/(?P<area>.+?)/(?P<node>.+?)"
+action_pattern = r"\[action (?P<action>.*?)]"
+
 action_re = re.compile(
-    r"^(?P<region>.+?)/(?P<area>.+?)/(?P<node>.+?) "
-    r"(?:\[(?P<energy>\d+?/\d+?) Energy] )?for (?:\[action (?P<action>.*?)] )?(?P<resources>\[.*?])$"
+    f"^{location_pattern} "
+    r"(?:\[(?P<energy>\d+?/\d+?) Energy] )?"
+    f"for (?:{action_pattern} )?"
+    r"(?P<resources>\[.*?])$"
 )
+rollback_skip_re = re.compile(
+    r"^(?P<action_type>.*?) "
+    f"{location_pattern} "
+    f"{action_pattern}"
+    r"(?:, (?P<additional>.*?))?$"
+)
+
 pickup_action_re = re.compile(r"^World (?P<world_num>\d+?)'s (?P<pickup_name>.*?)$")
 action_type_re = re.compile(r"^(?P<type>.*?) - (?P<action>.*?)$")
-rollback_skip_re = re.compile(
-    r"^(?P<action_type>.*?) (?P<region>.+?)/(?P<area>.+?)/(?P<node>.+?) "
-    r"\[action (?P<action>.*?)(?:, (?P<additional>.*?))?$"
-)
 
 
 def get_brush_for_action(action_type: str | None) -> QtGui.QBrush:

--- a/randovania/gui/widgets/game_validator_widget.py
+++ b/randovania/gui/widgets/game_validator_widget.py
@@ -181,7 +181,7 @@ class GameValidatorWidget(QtWidgets.QWidget, Ui_GameValidatorWidget):
         self.log_widget.setColumnHidden(LABEL_IDS["Energy"], self._verbosity < 2)
         self.log_widget.setColumnHidden(LABEL_IDS["Resources"], self._verbosity < 2)
 
-        self._current_tree = [IndentedWidget(-3, self.log_widget)]
+        self._current_tree = [IndentedWidget(-2, self.log_widget)]
 
         def write_to_log(*a: Any) -> None:
             scrollbar = self.log_widget.verticalScrollBar()
@@ -223,7 +223,7 @@ class GameValidatorWidget(QtWidgets.QWidget, Ui_GameValidatorWidget):
                 area = groups["area"]
                 node = groups["node"]
 
-                item.setText(LABEL_IDS["Node"], node)
+                item.setText(LABEL_IDS["Node"], f"{area}/{node}")
                 item.setText(LABEL_IDS["Resources"], groups["resources"])
                 item.setText(LABEL_IDS["Energy"], groups.get("energy", ""))
 
@@ -267,7 +267,7 @@ class GameValidatorWidget(QtWidgets.QWidget, Ui_GameValidatorWidget):
 
                 action_type = groups["action"]
 
-                item.setText(LABEL_IDS["Node"], f"{action_type} {node}")
+                item.setText(LABEL_IDS["Node"], f"{action_type} {area}/{node}")
                 item.setText(LABEL_IDS["Type"], action_type)
                 if (extra := groups.get("additional")) is not None:
                     item.setText(LABEL_IDS["Action"], extra.capitalize())
@@ -277,29 +277,18 @@ class GameValidatorWidget(QtWidgets.QWidget, Ui_GameValidatorWidget):
                 widget = IndentedWidget(indent, item)
 
             if self.should_item_be_visible(widget) and node:
-                if len(self._current_tree) == 3:
-                    region_item = self._current_tree[-2].item
-                    area_item = self._current_tree[-1].item
+                if len(self._current_tree) == 2:
+                    region_item = self._current_tree[-1].item
 
                     if region_item.text(LABEL_IDS["Node"]) != region:
-                        self._current_tree.pop()
-                        self._current_tree.pop()
-                    elif area_item.text(LABEL_IDS["Node"]) != area:
                         self._current_tree.pop()
 
                 if len(self._current_tree) == 1:
                     region_item = QtWidgets.QTreeWidgetItem(self._current_tree[-1].item)
                     region_item.setText(LABEL_IDS["Node"], region)
-                    self._current_tree.append(IndentedWidget(-2, region_item))
+                    self._current_tree.append(IndentedWidget(-1, region_item))
 
                     region_item.setExpanded(True)
-
-                if len(self._current_tree) == 2:
-                    area_item = QtWidgets.QTreeWidgetItem(region_item)
-                    area_item.setText(LABEL_IDS["Node"], area)
-                    self._current_tree.append(IndentedWidget(-1, area_item))
-
-                    area_item.setExpanded(True)
 
             parent = self._current_tree[-1].item
             parent.addChild(item)

--- a/randovania/resolver/logic.py
+++ b/randovania/resolver/logic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from randovania.game_description.assignment import PickupTarget
 from randovania.game_description.db.event_pickup import EventPickupNode
 from randovania.game_description.db.hint_node import HintNode
 from randovania.game_description.db.pickup_node import PickupNode
@@ -20,8 +21,8 @@ if TYPE_CHECKING:
     from randovania.resolver.state import State
 
 
-def n(node: Node, region_list: RegionList, with_region: bool = False) -> str:
-    return region_list.node_name(node, with_region) if node is not None else "None"
+def n(node: Node, region_list: RegionList, with_region: bool = True) -> str:
+    return region_list.node_name(node, with_region, True) if node is not None else "None"
 
 
 def energy_string(state: State) -> str:
@@ -39,8 +40,11 @@ def action_string(state: State) -> str:
         action = node.name
 
     if isinstance(node, PickupNode):
-        target = state.patches.pickup_assignment.get(node.pickup_index, "Pickup - Nothing")
-        action = str(target)
+        target = state.patches.pickup_assignment.get(node.pickup_index, "Nothing")
+        if isinstance(target, PickupTarget) and target.pickup.show_in_credits_spoiler:
+            action = f"Major - {target}"
+        else:
+            action = f"Minor - {target}"
 
     elif isinstance(node, HintNode):
         if not action.startswith("Hint - "):

--- a/randovania/resolver/logic.py
+++ b/randovania/resolver/logic.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from randovania.game_description.db.node import Node
     from randovania.game_description.db.region_list import RegionList
     from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_patches import GamePatches
     from randovania.game_description.requirements.base import Requirement
     from randovania.layout.base.base_configuration import BaseConfiguration
     from randovania.resolver.damage_state import DamageState
@@ -29,9 +30,8 @@ def energy_string(state: State) -> str:
     return f" [{state.game_state_debug_string()}]" if debug.debug_level() >= 2 else ""
 
 
-def action_string(state: State) -> str:
+def action_string(node: Node, patches: GamePatches) -> str:
     action = ""
-    node = state.node
 
     if isinstance(node, EventPickupNode):
         node = node.pickup_node
@@ -40,7 +40,7 @@ def action_string(state: State) -> str:
         action = node.name
 
     if isinstance(node, PickupNode):
-        target = state.patches.pickup_assignment.get(node.pickup_index, "Nothing")
+        target = patches.pickup_assignment.get(node.pickup_index, "Nothing")
         if isinstance(target, PickupTarget) and target.pickup.show_in_credits_spoiler:
             action = f"Major - {target}"
         else:
@@ -125,9 +125,8 @@ class Logic:
                     debug.print_function(f"{self._indent(1)}: {n(node, region_list=region_list)}")
 
             node_str = n(state.node, region_list=region_list)
-            debug.print_function(
-                f"{self._indent(1)}> {node_str}{energy_string(state)} for {action_string(state)}{resources}"
-            )
+            action_text = action_string(state.node, state.patches)
+            debug.print_function(f"{self._indent(1)}> {node_str}{energy_string(state)} for {action_text}{resources}")
 
     def log_checking_satisfiable_actions(self, state: State, actions: list[tuple[ResourceNode, DamageState]]):
         if debug.debug_level() > 1:
@@ -143,7 +142,10 @@ class Logic:
     ):
         if debug.debug_level() > 0:
             show_reqs = debug.debug_level() > 1 and additional_requirements is not None
-            debug.print_function(f"{self._indent()}* Rollback {n(state.node, region_list=state.region_list)}")
+            action_text = action_string(state.node, state.patches)
+            debug.print_function(
+                f"{self._indent()}* Rollback {n(state.node, region_list=state.region_list)} {action_text}"
+            )
             debug.print_function(
                 "{}Had action? {}; Possible Action? {}{}".format(
                     self._indent(-1),
@@ -157,15 +159,14 @@ class Logic:
         if self.increment_indent:
             self._current_indent -= 1
 
-    def log_skip_action_missing_requirement(self, node: Node, game: GameDescription):
+    def log_skip_action_missing_requirement(self, node: Node, patches: GamePatches, game: GameDescription):
         if debug.debug_level() > 1:
             requirement_set = self.get_additional_requirements(node)
+            base_log = f"{self._indent()}* Skip {n(node, region_list=game.region_list)} {action_string(node, patches)}"
             if node in self._last_printed_additional and self._last_printed_additional[node] == requirement_set:
-                debug.print_function(f"{self._indent()}* Skip {n(node, region_list=game.region_list)}, same additional")
+                debug.print_function(f"{base_log}, same additional")
             else:
-                debug.print_function(
-                    f"{self._indent()}* Skip {n(node, region_list=game.region_list)}, missing additional:"
-                )
+                debug.print_function(f"{base_log}, missing additional:")
                 self.print_requirement_set(requirement_set, -1)
                 self._last_printed_additional[node] = requirement_set
 

--- a/randovania/resolver/resolver.py
+++ b/randovania/resolver/resolver.py
@@ -325,7 +325,7 @@ async def _inner_advance_depth(
     for action, damage_state in actions:
         action_additional_requirements = logic.get_additional_requirements(action)
         if not action_additional_requirements.satisfied(context, damage_state.health_for_damage_requirements()):
-            logic.log_skip_action_missing_requirement(action, logic.game)
+            logic.log_skip_action_missing_requirement(action, state.patches, logic.game)
             continue
         new_state = state.act_on_node(action, path=reach.path_to_node(action), new_damage_state=damage_state)
         _assign_hint_available_locations(new_state, action, logic)

--- a/randovania/resolver/resolver_reach.py
+++ b/randovania/resolver/resolver_reach.py
@@ -175,7 +175,7 @@ class ResolverReach:
                 self._satisfiable_requirements_for_additionals = self._satisfiable_requirements_for_additionals.union(
                     additional_requirements.alternatives
                 )
-                self._logic.log_skip_action_missing_requirement(node, self._logic.game)
+                self._logic.log_skip_action_missing_requirement(node, state.patches, self._logic.game)
 
     def collectable_resource_nodes(self, context: NodeContext) -> Iterator[ResourceNode]:
         for node in self.nodes:

--- a/test/gui/widgets/test_game_validator_widget.py
+++ b/test/gui/widgets/test_game_validator_widget.py
@@ -105,22 +105,22 @@ async def test_on_start_button_no_task(widget, mocker, cancel: bool, verbosity: 
         assert widget.start_button.text() == "Stop"
         assert widget.status_label.text() == "Running..."
         if verbosity:
-            write_to_log("> Starting Area/Spawn Point for []")
+            write_to_log("> Intro/Starting Area/Spawn Point for []")
             write_to_log(
-                "> Starting Area/Pickup (Weapon) [100/100 Energy] for "
+                "> Intro/Starting Area/Pickup (Weapon) [100/100 Energy] for "
                 "[action Major - World 0's Blue Key] ['N: Pickup (Weapon)', 'I: Blue Key']"
             )
             if verbosity > 1:
                 write_to_log(" # Satisfiable Actions")
-                write_to_log("  = Starting Area/Lock - Door to Boss Arena")
+                write_to_log("  = Intro/Starting Area/Lock - Door to Boss Arena")
             if verbosity > 2:
-                write_to_log(": Back-Only Lock Room/Door to Starting Area")
+                write_to_log(": Intro/Back-Only Lock Room/Door to Starting Area")
             write_to_log(
-                "> Starting Area/Spawn Point [100/100 Energy] for [action Some weird action] ['N: Spawn Point']"
+                "> Intro/Starting Area/Spawn Point [100/100 Energy] for [action Some weird action] ['N: Spawn Point']"
             )
-            write_to_log(" * Rollback weird action")
+            write_to_log(" * Rollback Intro/Starting Area/Spawn Point [action Some weird action]")
             write_to_log(
-                "> Back-Only Lock Room/Event - Key Switch 1 [100/100 Energy] for "
+                "> Intro/Back-Only Lock Room/Event - Key Switch 1 [100/100 Energy] for "
                 "[action Event - Key Switch 1] ['E: Key Switch 1']"
             )
         if cancel:
@@ -139,31 +139,35 @@ async def test_on_start_button_no_task(widget, mocker, cancel: bool, verbosity: 
 
     # Assert
     mock_run_validator.assert_awaited_once_with(ANY, verbosity, widget.layout_description)
-    assert widget.log_widget.topLevelItemCount() == (5 if verbosity else 0)
+    assert widget.log_widget.topLevelItemCount() == (1 if verbosity else 0)
 
     if verbosity:
-        assert not widget.log_widget.topLevelItem(0).isExpanded()
+        region_item = widget.log_widget.topLevelItem(0)
+        assert region_item.childCount() == 5
+        assert region_item.text(LABEL_IDS["Node"]) == "Intro"
 
-        pickup_action = widget.log_widget.topLevelItem(1)
+        assert not region_item.child(0).isExpanded()
+
+        pickup_action = region_item.child(1)
         assert pickup_action.text(LABEL_IDS["Type"]) == "Major"
         assert pickup_action.text(LABEL_IDS["Action"]) == "Blue Key"
 
-        other_action = widget.log_widget.topLevelItem(2)
+        other_action = region_item.child(2)
         assert other_action.text(LABEL_IDS["Type"]) == "Other"
         assert other_action.text(LABEL_IDS["Action"]) == "Some weird action"
 
-        rollback = widget.log_widget.topLevelItem(3)
-        assert rollback.text(LABEL_IDS["Node"]) == "Rollback weird action"
+        rollback = region_item.child(3)
+        assert rollback.text(LABEL_IDS["Node"]) == "Rollback Starting Area/Spawn Point"
         assert rollback.text(LABEL_IDS["Type"]) == "Rollback"
 
     if verbosity > 1:
         child = pickup_action.child(0)
         assert child.text(0) == "# Satisfiable Actions"
-        assert child.child(0).text(LABEL_IDS["Node"]) == "Starting Area/Lock - Door to Boss Arena"
+        assert child.child(0).text(LABEL_IDS["Node"]) == "Intro/Starting Area/Lock - Door to Boss Arena"
 
     if verbosity > 2:
         child = pickup_action.child(1)
-        assert child.text(LABEL_IDS["Node"]) == "Back-Only Lock Room/Door to Starting Area"
+        assert child.text(LABEL_IDS["Node"]) == "Intro/Back-Only Lock Room/Door to Starting Area"
 
     for column in (LABEL_IDS["Energy"], LABEL_IDS["Resources"]):
         assert widget.log_widget.isColumnHidden(column) == (verbosity < 2)

--- a/test/gui/widgets/test_game_validator_widget.py
+++ b/test/gui/widgets/test_game_validator_widget.py
@@ -12,7 +12,7 @@ from randovania.resolver import debug
 @pytest.fixture
 def widget(skip_qtbot):
     layout = MagicMock()
-    layout.generator_parameters.world_count = 1
+    layout.world_count = 1
     layout.all_presets = [MagicMock()]
     players = MagicMock()
     players.player_names = {0: "Player"}

--- a/test/gui/widgets/test_game_validator_widget.py
+++ b/test/gui/widgets/test_game_validator_widget.py
@@ -108,7 +108,7 @@ async def test_on_start_button_no_task(widget, mocker, cancel: bool, verbosity: 
             write_to_log("> Starting Area/Spawn Point for []")
             write_to_log(
                 "> Starting Area/Pickup (Weapon) [100/100 Energy] for "
-                "[action World 0's Blue Key] ['N: Pickup (Weapon)', 'I: Blue Key']"
+                "[action Major - World 0's Blue Key] ['N: Pickup (Weapon)', 'I: Blue Key']"
             )
             if verbosity > 1:
                 write_to_log(" # Satisfiable Actions")
@@ -145,7 +145,7 @@ async def test_on_start_button_no_task(widget, mocker, cancel: bool, verbosity: 
         assert not widget.log_widget.topLevelItem(0).isExpanded()
 
         pickup_action = widget.log_widget.topLevelItem(1)
-        assert pickup_action.text(LABEL_IDS["Type"]) == "Pickup"
+        assert pickup_action.text(LABEL_IDS["Type"]) == "Major"
         assert pickup_action.text(LABEL_IDS["Action"]) == "Blue Key"
 
         other_action = widget.log_widget.topLevelItem(2)


### PR DESCRIPTION
at this point I think I actually find the playthrough tab *more* readable than the generation order tab, which is a massive success imo

- adds region name
- splits major and minor pickups and allows them to be filtered separately
- filters rollbacks based on the type of action being rolled back

the big remaining issue is that EventPickup names are soooo long but idk what can be done about that lmao

![image](https://github.com/user-attachments/assets/edf75c5b-9412-4827-af50-e12f73b4fee7)
![image](https://github.com/user-attachments/assets/5480da79-ec23-4e0d-a1e9-f1f169d2a853)
