### PR TITLE
Fusion Puyo Palace Trick and Video Updates

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -10225,7 +10225,7 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": "Use Wave Beam: https://youtu.be/xd5-5I8YFwM",
+                                                        "comment": "Screw Attack: https://youtu.be/CEmsUhfUjCc or Use Wave Beam: https://youtu.be/xd5-5I8YFwM",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -10260,6 +10260,15 @@
                                                                             }
                                                                         }
                                                                     ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "ScrewAttack",
+                                                                    "amount": 1,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -9952,7 +9952,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "High Jump: https://youtu.be/ft3NsBF8cOM",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -9995,7 +9995,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "WJ off of left wall: https://youtu.be/PQwCkP1QNC4?t=26",
+                                            "comment": "Wall Jump off of left wall: https://youtu.be/PQwCkP1QNC4?t=26",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -10197,17 +10197,8 @@
                         "Pickup (Power Bomb Tank)": {
                             "type": "or",
                             "data": {
-                                "comment": "Space Jump, or don't fall down: https://youtu.be/yEFbN8WOEBU",
+                                "comment": "Space Jump or Movement: https://youtu.be/yEFbN8WOEBU",
                                 "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Movement",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    },
                                     {
                                         "type": "resource",
                                         "data": {
@@ -10215,6 +10206,75 @@
                                             "name": "SpaceJump",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Movement",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Use Wave Beam: https://youtu.be/xd5-5I8YFwM",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "WaveBeam",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Use Diffusion Missiles: https://youtu.be/i1R77y4hQs0",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Missiles",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "DiffusionMissileData",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -10225,7 +10225,7 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": "Screw Attack: https://youtu.be/CEmsUhfUjCc or Use Wave Beam: https://youtu.be/xd5-5I8YFwM",
+                                                        "comment": "Screw Attack: https://youtu.be/CEmsUhfUjCc or Destroy Blocks from Above: https://youtu.be/xd5-5I8YFwM",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -10270,6 +10270,10 @@
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Power Bombs"
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1587,8 +1587,8 @@ Extra - room_id: [47]
           All of the following:
               Movement (Intermediate)
               Any of the following:
-                  # Screw Attack: https://youtu.be/CEmsUhfUjCc or Use Wave Beam: https://youtu.be/xd5-5I8YFwM
-                  Screw Attack or Wave Beam
+                  # Screw Attack: https://youtu.be/CEmsUhfUjCc or Destroy Blocks from Above: https://youtu.be/xd5-5I8YFwM
+                  Screw Attack or Wave Beam or Can Use Power Bombs
                   # Use Diffusion Missiles: https://youtu.be/i1R77y4hQs0
                   Diffusion Missile Data and Missiles
   > Door to Cloister

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1549,10 +1549,11 @@ Extra - room_id: [47]
   > Door to Nettori Save Room
       Any of the following:
           Space Jump
+          # High Jump: https://youtu.be/ft3NsBF8cOM
           Hi-Jump and Movement (Intermediate)
           # Requires you to only shoot upper block on way in: https://youtu.be/bmge53Vxg5w
           Movement (Advanced)
-          # WJ off of left wall: https://youtu.be/PQwCkP1QNC4?t=26
+          # Wall Jump off of left wall: https://youtu.be/PQwCkP1QNC4?t=26
           Wall Jump (Intermediate)
 
 > Door to Cloister; Heals? False
@@ -1580,8 +1581,16 @@ Extra - room_id: [47]
   * Open Hatch to Nettori Save Room/Door to Puyo Palace
   * Extra - door_idx: (115,)
   > Pickup (Power Bomb Tank)
-      # Space Jump, or don't fall down: https://youtu.be/yEFbN8WOEBU
-      Space Jump or Movement (Intermediate)
+      Any of the following:
+          # Space Jump or Movement: https://youtu.be/yEFbN8WOEBU
+          Space Jump or Movement (Advanced)
+          All of the following:
+              Movement (Intermediate)
+              Any of the following:
+                  # Use Wave Beam: https://youtu.be/xd5-5I8YFwM
+                  Wave Beam
+                  # Use Diffusion Missiles: https://youtu.be/i1R77y4hQs0
+                  Diffusion Missile Data and Missiles
   > Door to Cloister
       # Shinespark diagonally on the bottom at the door: https://youtu.be/fvu8Jlvg_Vw
       Speed Booster and Shinespark Tricks (Advanced) and Disabled Entrance Rando and Disabled Open Hatch Lock Rando

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1587,8 +1587,8 @@ Extra - room_id: [47]
           All of the following:
               Movement (Intermediate)
               Any of the following:
-                  # Use Wave Beam: https://youtu.be/xd5-5I8YFwM
-                  Wave Beam
+                  # Screw Attack: https://youtu.be/CEmsUhfUjCc or Use Wave Beam: https://youtu.be/xd5-5I8YFwM
+                  Screw Attack or Wave Beam
                   # Use Diffusion Missiles: https://youtu.be/i1R77y4hQs0
                   Diffusion Missile Data and Missiles
   > Door to Cloister


### PR DESCRIPTION
### Pickup (Power Bomb Tank) -> Door to Nettori Save Room

Made and added new video that was requested from trick spreadsheet


### Door to Nettori Save Room -> Pickup (Power Bomb Tank)

I increased the initial movement trick with no upgrades from intermediate to advanced

Reasons:
- If you fail any of the below you are punished heavily esp in alternate start
- Hanging, jumping, holding L, aiming down, shooting and then holding right was pretty tough to do quickly
- If you pressed "b" or did the sequence too late, you shoot the block below ruining your chances of getting out with no upgrades (which that movement trick is set to advanced. IMO this trick should match that trick since it ties to and impacts the ability to do that advanced trick at all)

In addition I also found and added in some easier methods

- You can shoot the blocks with Wave Beam or Diffusion from above making the movement much easier to get in
- Or you can use SA and just jump through
- I left this at intermedate since if you still fail the jump you are heavily punished

I dont know if I did the logic right for what items requires Diffusion Missiles in this case, please double check me there

Edit: I forgot last night to add in the SA method too, that is what the second commit is there. 
