### PR TITLE
fusion(sector6): Add alternate room id for Clogged Cavern

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -3253,7 +3253,8 @@
             "extra": {
                 "map_name": "Sector 69",
                 "room_id": [
-                    9
+                    9,
+                    33
                 ]
             },
             "nodes": {

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -437,7 +437,7 @@ Extra - room_id: [8]
 ----------------
 Clogged Cavern
 Extra - map_name: Sector 69
-Extra - room_id: [9]
+Extra - room_id: [9, 33]
 > Door to Nocturnal Playground; Heals? False
   * Layers: default
   * L0 Hatch to Nocturnal Playground/Door to Clogged Cavern

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
@@ -4487,6 +4487,11 @@
         },
         {
             "Area": 6,
+            "Room": 33,
+            "Name": "Clogged Cavern"
+        },
+        {
+            "Area": 6,
             "Room": 10,
             "Name": "Warehouse"
         },

--- a/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
@@ -4432,6 +4432,11 @@
         },
         {
             "Area": 6,
+            "Room": 33,
+            "Name": "Clogged Cavern"
+        },
+        {
+            "Area": 6,
             "Room": 10,
             "Name": "Warehouse"
         },

--- a/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
@@ -4432,6 +4432,11 @@
         },
         {
             "Area": 6,
+            "Room": 33,
+            "Name": "Clogged Cavern"
+        },
+        {
+            "Area": 6,
             "Room": 10,
             "Name": "Warehouse"
         },


### PR DESCRIPTION
Fixes a missing room name in sector 6 after you defeat Varia Core boss.