### PR TITLE
Replace Qt `Signal` with own implementation

### DIFF
--- a/randovania/game_connection/connector/debug_remote_connector.py
+++ b/randovania/game_connection/connector/debug_remote_connector.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import Signal
-
 from randovania.game_connection.connector.remote_connector import RemoteConnector
 from randovania.game_description import default_database
 from randovania.game_description.resources.inventory import Inventory
 from randovania.game_description.resources.resource_collection import ResourceCollection
+from randovania.gui.lib.signal import RdvSignal
 
 if TYPE_CHECKING:
     import uuid
@@ -22,15 +21,16 @@ class DebugRemoteConnector(RemoteConnector):
     _finished: bool = False
     _last_inventory_event: Inventory
     item_collection: ResourceCollection
-
-    RemotePickupsUpdated = Signal()
-    MessagesUpdated = Signal()
+    RemotePickupsUpdated: RdvSignal
+    MessagesUpdated: RdvSignal
 
     def __init__(self, game: RandovaniaGame, layout_uuid: uuid.UUID):
         super().__init__()
         self._game = game
         self._layout_uuid = layout_uuid
         self._last_inventory_event = Inventory({})
+        self.RemotePickupsUpdated = RdvSignal()
+        self.MessagesUpdated = RdvSignal()
 
         self.messages = []
         self.item_collection = ResourceCollection.with_database(default_database.resource_database_for(game))

--- a/randovania/game_connection/connector/remote_connector.py
+++ b/randovania/game_connection/connector/remote_connector.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import enum
 import typing
 
-from PySide6 import QtCore
-
-from randovania.game_description.resources.inventory import Inventory
-from randovania.game_description.resources.pickup_index import PickupIndex
+from randovania.gui.lib.signal import RdvSignal
 from randovania.lib import enum_lib
 
 if typing.TYPE_CHECKING:
@@ -15,6 +12,8 @@ if typing.TYPE_CHECKING:
     from randovania.game.game_enum import RandovaniaGame
     from randovania.game_description.db.area import Area
     from randovania.game_description.db.region import Region
+    from randovania.game_description.resources.inventory import Inventory
+    from randovania.game_description.resources.pickup_index import PickupIndex
     from randovania.network_common.remote_pickup import RemotePickup
 
 
@@ -41,12 +40,16 @@ enum_lib.add_long_name(
 )
 
 
-class RemoteConnector(QtCore.QObject):
+class RemoteConnector:
     _layout_uuid: uuid.UUID
+    PlayerLocationChanged: RdvSignal[PlayerLocationEvent]
+    PickupIndexCollected: RdvSignal[PickupIndex]
+    InventoryUpdated: RdvSignal[Inventory]
 
-    PlayerLocationChanged = QtCore.Signal(PlayerLocationEvent)
-    PickupIndexCollected = QtCore.Signal(PickupIndex)
-    InventoryUpdated = QtCore.Signal(Inventory)
+    def __init__(self) -> None:
+        self.PlayerLocationChanged = RdvSignal()
+        self.PickupIndexCollected = RdvSignal()
+        self.InventoryUpdated = RdvSignal()
 
     @property
     def game_enum(self) -> RandovaniaGame:

--- a/randovania/game_connection/executor/executor_to_connector_signals.py
+++ b/randovania/game_connection/executor/executor_to_connector_signals.py
@@ -1,9 +1,16 @@
-from PySide6.QtCore import QObject, Signal
+from randovania.gui.lib.signal import RdvSignal
 
 
-class ExecutorToConnectorSignals(QObject):
-    new_inventory = Signal(str)
-    new_collected_locations = Signal(bytes)
-    new_received_pickups = Signal(str)
-    new_player_location = Signal(str)
-    connection_lost = Signal()
+class ExecutorToConnectorSignals:
+    new_inventory: RdvSignal[str]
+    new_collected_locations: RdvSignal[bytes]
+    new_received_pickups: RdvSignal[str]
+    new_player_location: RdvSignal[str]
+    connection_lost: RdvSignal
+
+    def __init__(self) -> None:
+        self.new_inventory = RdvSignal()
+        self.new_collected_locations = RdvSignal()
+        self.new_received_pickups = RdvSignal()
+        self.new_player_location = RdvSignal()
+        self.connection_lost = RdvSignal()

--- a/randovania/gui/lib/signal.py
+++ b/randovania/gui/lib/signal.py
@@ -1,0 +1,17 @@
+import typing
+from collections.abc import Callable
+from typing import Generic, TypeVarTuple
+
+FuncArgs = TypeVarTuple("FuncArgs")
+
+
+class RdvSignal(Generic[*FuncArgs]):
+    def __init__(self) -> None:
+        self.subscribers: list = []
+
+    def emit(self, *func_args: *FuncArgs) -> None:
+        for x in self.subscribers:
+            x(*func_args)
+
+    def connect(self, func: Callable[[*FuncArgs], typing.Any]) -> None:
+        self.subscribers.append(func)

--- a/test/game_connection/connector/test_am2r_remote_connector.py
+++ b/test/game_connection/connector/test_am2r_remote_connector.py
@@ -19,7 +19,7 @@ from randovania.network_common.remote_pickup import RemotePickup
 def am2r_remote_connector():
     executor_mock = MagicMock(AM2RExecutor)
     executor_mock.layout_uuid_str = "00000000-0000-1111-0000-000000000000"
-    executor_mock.signals = MagicMock(ExecutorToConnectorSignals)
+    executor_mock.signals = ExecutorToConnectorSignals()
     connector = AM2RRemoteConnector(executor_mock)
     return connector
 

--- a/test/game_connection/connector/test_dread_remote_connector.py
+++ b/test/game_connection/connector/test_dread_remote_connector.py
@@ -18,7 +18,7 @@ from randovania.network_common.remote_pickup import RemotePickup
 def dread_remote_connector():
     executor_mock = MagicMock(DreadExecutor)
     executor_mock.layout_uuid_str = "00000000-0000-1111-0000-000000000000"
-    executor_mock.signals = MagicMock(ExecutorToConnectorSignals)
+    executor_mock.signals = ExecutorToConnectorSignals()
     executor_mock.version = "2.1.0"
     connector = DreadRemoteConnector(executor_mock)
     return connector

--- a/test/game_connection/connector/test_msr_remote_connector.py
+++ b/test/game_connection/connector/test_msr_remote_connector.py
@@ -18,7 +18,7 @@ from randovania.network_common.remote_pickup import RemotePickup
 def msr_remote_connector():
     executor_mock = MagicMock(MSRExecutor)
     executor_mock.layout_uuid_str = "00000000-0000-1111-0000-000000000000"
-    executor_mock.signals = MagicMock(ExecutorToConnectorSignals)
+    executor_mock.signals = ExecutorToConnectorSignals()
     connector = MSRRemoteConnector(executor_mock)
     return connector
 


### PR DESCRIPTION
Regarding: https://github.com/randovania/randovania/pull/8128#discussion_r1999699537

I have the feeling that I simplified it too much but would this be a solution?
(I skipped replacing all the signals for now and just did it for a few one)
At least it shows a type error for the `ExecutorToConnectorSignals` in AM2R 🙃