### PR TITLE
Separate static base game patches from non-static.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Generator action weights were being incorrectly calculated.
 - Fixed: When calculating reach with unsafe resources, the generator no longer ignores some valid options.
 - Fixed: Typo in dialog about generated game hash being different from expected.
+- Fixed: Tracker now knows about doors overridden by the game configuration that aren't randomized
 
 ### Door Lock Randomizer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Generator action weights were being incorrectly calculated.
 - Fixed: When calculating reach with unsafe resources, the generator no longer ignores some valid options.
 - Fixed: Typo in dialog about generated game hash being different from expected.
-- Fixed: Tracker now knows about doors overridden by the game configuration that aren't randomized
+- Fixed: The map tracker now correctly accounts for door locks that have been modified statically by settings such as unlocked Save Station doors.
 
 ### Door Lock Randomizer
 

--- a/randovania/games/am2r/generator/base_patches_factory.py
+++ b/randovania/games/am2r/generator/base_patches_factory.py
@@ -24,6 +24,8 @@ class AM2RBasePatchesFactory(BasePatchesFactory[AM2RConfiguration]):
     def assign_static_dock_weakness(
         self, configuration: AM2RConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
+        parent = super().assign_static_dock_weakness(configuration, game, initial_patches)
+
         get_node = game.region_list.typed_node_by_identifier
 
         dock_weakness: list[tuple[DockNode, DockWeakness]] = []
@@ -49,7 +51,7 @@ class AM2RBasePatchesFactory(BasePatchesFactory[AM2RConfiguration]):
                                 # TODO: This is not correct in entrance rando
                                 dock_weakness.append((get_node(node.default_connection, DockNode), blue_door))
 
-        return initial_patches.assign_dock_weakness(dock_weakness)
+        return parent.assign_dock_weakness(dock_weakness)
 
     def dock_connections_assignment(
         self, configuration: AM2RConfiguration, game: GameDescription, rng: Random

--- a/randovania/games/am2r/generator/base_patches_factory.py
+++ b/randovania/games/am2r/generator/base_patches_factory.py
@@ -21,17 +21,9 @@ if TYPE_CHECKING:
 
 
 class AM2RBasePatchesFactory(BasePatchesFactory[AM2RConfiguration]):
-    def create_base_patches(
-        self,
-        configuration: AM2RConfiguration,
-        rng: Random,
-        game: GameDescription,
-        is_multiworld: bool,
-        player_index: int,
-        rng_required: bool = True,
+    def apply_static_configuration_patches(
+        self, configuration: AM2RConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
-        parent = super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)
-
         get_node = game.region_list.typed_node_by_identifier
 
         dock_weakness: list[tuple[DockNode, DockWeakness]] = []
@@ -57,7 +49,23 @@ class AM2RBasePatchesFactory(BasePatchesFactory[AM2RConfiguration]):
                                 # TODO: This is not correct in entrance rando
                                 dock_weakness.append((get_node(node.default_connection, DockNode), blue_door))
 
-        return parent.assign_dock_weakness(dock_weakness)
+        return initial_patches.assign_dock_weakness(dock_weakness)
+
+    def create_base_patches(
+        self,
+        configuration: AM2RConfiguration,
+        rng: Random,
+        game: GameDescription,
+        is_multiworld: bool,
+        player_index: int,
+        rng_required: bool = True,
+    ) -> GamePatches:
+        return super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)
+
+    def create_static_base_patches(
+        self, configuration: AM2RConfiguration, game: GameDescription, player_index: int
+    ) -> GamePatches:
+        return super().create_static_base_patches(configuration, game, player_index)
 
     def dock_connections_assignment(
         self, configuration: AM2RConfiguration, game: GameDescription, rng: Random

--- a/randovania/games/am2r/generator/base_patches_factory.py
+++ b/randovania/games/am2r/generator/base_patches_factory.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 class AM2RBasePatchesFactory(BasePatchesFactory[AM2RConfiguration]):
-    def apply_static_configuration_patches(
+    def assign_static_dock_weakness(
         self, configuration: AM2RConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
         get_node = game.region_list.typed_node_by_identifier
@@ -50,22 +50,6 @@ class AM2RBasePatchesFactory(BasePatchesFactory[AM2RConfiguration]):
                                 dock_weakness.append((get_node(node.default_connection, DockNode), blue_door))
 
         return initial_patches.assign_dock_weakness(dock_weakness)
-
-    def create_base_patches(
-        self,
-        configuration: AM2RConfiguration,
-        rng: Random,
-        game: GameDescription,
-        is_multiworld: bool,
-        player_index: int,
-        rng_required: bool = True,
-    ) -> GamePatches:
-        return super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)
-
-    def create_static_base_patches(
-        self, configuration: AM2RConfiguration, game: GameDescription, player_index: int
-    ) -> GamePatches:
-        return super().create_static_base_patches(configuration, game, player_index)
 
     def dock_connections_assignment(
         self, configuration: AM2RConfiguration, game: GameDescription, rng: Random

--- a/randovania/games/dread/generator/base_patches_factory.py
+++ b/randovania/games/dread/generator/base_patches_factory.py
@@ -24,6 +24,8 @@ class DreadBasePatchesFactory(BasePatchesFactory[DreadConfiguration]):
     def assign_static_dock_weakness(
         self, configuration: DreadConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
+        parent = super().assign_static_dock_weakness(configuration, game, initial_patches)
+
         dock_weakness = []
         if configuration.hanubia_easier_path_to_itorash:
             nic = NodeIdentifier.create
@@ -36,7 +38,7 @@ class DreadBasePatchesFactory(BasePatchesFactory[DreadConfiguration]):
                 ]
             )
 
-        return initial_patches.assign_dock_weakness(
+        return parent.assign_dock_weakness(
             (
                 (game.region_list.typed_node_by_identifier(identifier, DockNode), target)
                 for identifier, target in dock_weakness

--- a/randovania/games/dread/generator/base_patches_factory.py
+++ b/randovania/games/dread/generator/base_patches_factory.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 class DreadBasePatchesFactory(BasePatchesFactory[DreadConfiguration]):
-    def apply_static_dock_weakness(
+    def assign_static_dock_weakness(
         self, configuration: DreadConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
         dock_weakness = []

--- a/randovania/games/dread/generator/base_patches_factory.py
+++ b/randovania/games/dread/generator/base_patches_factory.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 class DreadBasePatchesFactory(BasePatchesFactory[DreadConfiguration]):
-    def apply_static_configuration_patches(
+    def apply_static_dock_weakness(
         self, configuration: DreadConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
         dock_weakness = []
@@ -42,22 +42,6 @@ class DreadBasePatchesFactory(BasePatchesFactory[DreadConfiguration]):
                 for identifier, target in dock_weakness
             )
         )
-
-    def create_static_base_patches(
-        self, configuration: DreadConfiguration, game: GameDescription, player_index: int
-    ) -> GamePatches:
-        return super().create_static_base_patches(configuration, game, player_index)
-
-    def create_base_patches(
-        self,
-        configuration: DreadConfiguration,
-        rng: Random,
-        game: GameDescription,
-        is_multiworld: bool,
-        player_index: int,
-        rng_required: bool = True,
-    ) -> GamePatches:
-        return super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)
 
     def dock_connections_assignment(
         self, configuration: DreadConfiguration, game: GameDescription, rng: Random

--- a/randovania/games/fusion/generator/base_patches_factory.py
+++ b/randovania/games/fusion/generator/base_patches_factory.py
@@ -15,17 +15,9 @@ if TYPE_CHECKING:
 
 
 class FusionBasePatchesFactory(BasePatchesFactory[FusionConfiguration]):
-    def create_base_patches(
-        self,
-        configuration: FusionConfiguration,
-        rng: Random,
-        game: GameDescription,
-        is_multiworld: bool,
-        player_index: int,
-        rng_required: bool = True,
+    def apply_static_configuration_patches(
+        self, configuration: FusionConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
-        parent = super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)
-
         get_node = game.region_list.typed_node_by_identifier
 
         dock_weakness: list[tuple[DockNode, DockWeakness]] = []
@@ -48,4 +40,20 @@ class FusionBasePatchesFactory(BasePatchesFactory[FusionConfiguration]):
                                     (get_node(node.default_connection, DockNode), open_transition_door)
                                 )
 
-        return parent.assign_dock_weakness(dock_weakness)
+        return initial_patches.assign_dock_weakness(dock_weakness)
+
+    def create_static_base_patches(
+        self, configuration: FusionConfiguration, game: GameDescription, player_index: int
+    ) -> GamePatches:
+        return super().create_static_base_patches(configuration, game, player_index)
+
+    def create_base_patches(
+        self,
+        configuration: FusionConfiguration,
+        rng: Random,
+        game: GameDescription,
+        is_multiworld: bool,
+        player_index: int,
+        rng_required: bool = True,
+    ) -> GamePatches:
+        return super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)

--- a/randovania/games/fusion/generator/base_patches_factory.py
+++ b/randovania/games/fusion/generator/base_patches_factory.py
@@ -7,15 +7,13 @@ from randovania.games.fusion.layout.fusion_configuration import FusionConfigurat
 from randovania.generator.base_patches_factory import BasePatchesFactory
 
 if TYPE_CHECKING:
-    from random import Random
-
     from randovania.game_description.db.dock import DockWeakness
     from randovania.game_description.game_description import GameDescription
     from randovania.game_description.game_patches import GamePatches
 
 
 class FusionBasePatchesFactory(BasePatchesFactory[FusionConfiguration]):
-    def apply_static_configuration_patches(
+    def apply_static_dock_weakness(
         self, configuration: FusionConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
         get_node = game.region_list.typed_node_by_identifier
@@ -41,19 +39,3 @@ class FusionBasePatchesFactory(BasePatchesFactory[FusionConfiguration]):
                                 )
 
         return initial_patches.assign_dock_weakness(dock_weakness)
-
-    def create_static_base_patches(
-        self, configuration: FusionConfiguration, game: GameDescription, player_index: int
-    ) -> GamePatches:
-        return super().create_static_base_patches(configuration, game, player_index)
-
-    def create_base_patches(
-        self,
-        configuration: FusionConfiguration,
-        rng: Random,
-        game: GameDescription,
-        is_multiworld: bool,
-        player_index: int,
-        rng_required: bool = True,
-    ) -> GamePatches:
-        return super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)

--- a/randovania/games/fusion/generator/base_patches_factory.py
+++ b/randovania/games/fusion/generator/base_patches_factory.py
@@ -16,6 +16,8 @@ class FusionBasePatchesFactory(BasePatchesFactory[FusionConfiguration]):
     def assign_static_dock_weakness(
         self, configuration: FusionConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
+        parent = super().assign_static_dock_weakness(configuration, game, initial_patches)
+
         get_node = game.region_list.typed_node_by_identifier
 
         dock_weakness: list[tuple[DockNode, DockWeakness]] = []
@@ -38,4 +40,4 @@ class FusionBasePatchesFactory(BasePatchesFactory[FusionConfiguration]):
                                     (get_node(node.default_connection, DockNode), open_transition_door)
                                 )
 
-        return initial_patches.assign_dock_weakness(dock_weakness)
+        return parent.assign_dock_weakness(dock_weakness)

--- a/randovania/games/fusion/generator/base_patches_factory.py
+++ b/randovania/games/fusion/generator/base_patches_factory.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 class FusionBasePatchesFactory(BasePatchesFactory[FusionConfiguration]):
-    def apply_static_dock_weakness(
+    def assign_static_dock_weakness(
         self, configuration: FusionConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
         get_node = game.region_list.typed_node_by_identifier

--- a/randovania/games/prime1/generator/base_patches_factory.py
+++ b/randovania/games/prime1/generator/base_patches_factory.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 
 class PrimeBasePatchesFactory(BasePatchesFactory[PrimeConfiguration]):
-    def apply_static_configuration_patches(
+    def apply_static_dock_weakness(
         self, configuration: PrimeConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
         nic = NodeIdentifier.create
@@ -46,22 +46,6 @@ class PrimeBasePatchesFactory(BasePatchesFactory[PrimeConfiguration]):
                             dock_weakness.append((get_node(node.default_connection, DockNode), power_weak))
 
         return initial_patches.assign_dock_weakness(dock_weakness)
-
-    def create_base_patches(
-        self,
-        configuration: PrimeConfiguration,
-        rng: Random,
-        game: GameDescription,
-        is_multiworld: bool,
-        player_index: int,
-        rng_required: bool = True,
-    ) -> GamePatches:
-        return super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)
-
-    def create_static_base_patches(
-        self, configuration: PrimeConfiguration, game: GameDescription, player_index: int
-    ) -> GamePatches:
-        return super().create_static_base_patches(configuration, game, player_index)
 
     def dock_connections_assignment(
         self, configuration: PrimeConfiguration, game: GameDescription, rng: Random

--- a/randovania/games/prime1/generator/base_patches_factory.py
+++ b/randovania/games/prime1/generator/base_patches_factory.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 
 class PrimeBasePatchesFactory(BasePatchesFactory[PrimeConfiguration]):
-    def apply_static_dock_weakness(
+    def assign_static_dock_weakness(
         self, configuration: PrimeConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
         nic = NodeIdentifier.create

--- a/randovania/games/prime1/generator/base_patches_factory.py
+++ b/randovania/games/prime1/generator/base_patches_factory.py
@@ -22,17 +22,9 @@ if TYPE_CHECKING:
 
 
 class PrimeBasePatchesFactory(BasePatchesFactory[PrimeConfiguration]):
-    def create_base_patches(
-        self,
-        configuration: PrimeConfiguration,
-        rng: Random,
-        game: GameDescription,
-        is_multiworld: bool,
-        player_index: int,
-        rng_required: bool = True,
+    def apply_static_configuration_patches(
+        self, configuration: PrimeConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
-        parent = super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)
-
         nic = NodeIdentifier.create
         get_node = game.region_list.typed_node_by_identifier
 
@@ -53,7 +45,23 @@ class PrimeBasePatchesFactory(BasePatchesFactory[PrimeConfiguration]):
                             # TODO: This is not correct in entrance rando
                             dock_weakness.append((get_node(node.default_connection, DockNode), power_weak))
 
-        return parent.assign_dock_weakness(dock_weakness)
+        return initial_patches.assign_dock_weakness(dock_weakness)
+
+    def create_base_patches(
+        self,
+        configuration: PrimeConfiguration,
+        rng: Random,
+        game: GameDescription,
+        is_multiworld: bool,
+        player_index: int,
+        rng_required: bool = True,
+    ) -> GamePatches:
+        return super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)
+
+    def create_static_base_patches(
+        self, configuration: PrimeConfiguration, game: GameDescription, player_index: int
+    ) -> GamePatches:
+        return super().create_static_base_patches(configuration, game, player_index)
 
     def dock_connections_assignment(
         self, configuration: PrimeConfiguration, game: GameDescription, rng: Random

--- a/randovania/games/prime1/generator/base_patches_factory.py
+++ b/randovania/games/prime1/generator/base_patches_factory.py
@@ -25,6 +25,8 @@ class PrimeBasePatchesFactory(BasePatchesFactory[PrimeConfiguration]):
     def assign_static_dock_weakness(
         self, configuration: PrimeConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
+        parent = super().assign_static_dock_weakness(configuration, game, initial_patches)
+
         nic = NodeIdentifier.create
         get_node = game.region_list.typed_node_by_identifier
 
@@ -45,7 +47,7 @@ class PrimeBasePatchesFactory(BasePatchesFactory[PrimeConfiguration]):
                             # TODO: This is not correct in entrance rando
                             dock_weakness.append((get_node(node.default_connection, DockNode), power_weak))
 
-        return initial_patches.assign_dock_weakness(dock_weakness)
+        return parent.assign_dock_weakness(dock_weakness)
 
     def dock_connections_assignment(
         self, configuration: PrimeConfiguration, game: GameDescription, rng: Random

--- a/randovania/games/prime2/generator/base_patches_factory.py
+++ b/randovania/games/prime2/generator/base_patches_factory.py
@@ -66,7 +66,7 @@ WORLDS = [
 
 
 class EchoesBasePatchesFactory(BasePatchesFactory[EchoesConfiguration]):
-    def apply_static_dock_weakness(
+    def assign_static_dock_weakness(
         self, configuration: EchoesConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
         if not configuration.blue_save_doors:

--- a/randovania/games/prime2/generator/base_patches_factory.py
+++ b/randovania/games/prime2/generator/base_patches_factory.py
@@ -71,9 +71,6 @@ class EchoesBasePatchesFactory(BasePatchesFactory[EchoesConfiguration]):
     ) -> GamePatches:
         parent = super().assign_static_dock_weakness(configuration, game, initial_patches)
 
-        if not configuration.blue_save_doors:
-            return initial_patches
-
         get_node = game.region_list.typed_node_by_identifier
         power_weak = game.dock_weakness_database.get_by_weakness("door", "Normal Door (Forced)")
         dock_weakness: list[tuple[DockNode, DockWeakness]] = []

--- a/randovania/games/prime2/generator/base_patches_factory.py
+++ b/randovania/games/prime2/generator/base_patches_factory.py
@@ -66,6 +66,11 @@ WORLDS = [
 
 
 class EchoesBasePatchesFactory(BasePatchesFactory[EchoesConfiguration]):
+    def apply_static_configuration_patches(
+        self, configuration: EchoesConfiguration, game: GameDescription, initial_patches: GamePatches
+    ) -> GamePatches:
+        return self.assign_save_door_weaknesses(initial_patches, configuration, game)
+
     def create_base_patches(
         self,
         configuration: EchoesConfiguration,
@@ -75,8 +80,12 @@ class EchoesBasePatchesFactory(BasePatchesFactory[EchoesConfiguration]):
         player_index: int,
         rng_required: bool = True,
     ) -> GamePatches:
-        parent = super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)
-        return self.assign_save_door_weaknesses(parent, configuration, game)
+        return super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)
+
+    def create_static_base_patches(
+        self, configuration: EchoesConfiguration, game: GameDescription, player_index: int
+    ) -> GamePatches:
+        return super().create_static_base_patches(configuration, game, player_index)
 
     def dock_connections_assignment(
         self, configuration: EchoesConfiguration, game: GameDescription, rng: Random

--- a/randovania/games/prime2/generator/base_patches_factory.py
+++ b/randovania/games/prime2/generator/base_patches_factory.py
@@ -69,6 +69,8 @@ class EchoesBasePatchesFactory(BasePatchesFactory[EchoesConfiguration]):
     def assign_static_dock_weakness(
         self, configuration: EchoesConfiguration, game: GameDescription, initial_patches: GamePatches
     ) -> GamePatches:
+        parent = super().assign_static_dock_weakness(configuration, game, initial_patches)
+
         if not configuration.blue_save_doors:
             return initial_patches
 
@@ -85,7 +87,7 @@ class EchoesBasePatchesFactory(BasePatchesFactory[EchoesConfiguration]):
                             # TODO: This is not correct in entrance rando
                             dock_weakness.append((get_node(node.default_connection, DockNode), power_weak))
 
-        return initial_patches.assign_dock_weakness(dock_weakness)
+        return parent.assign_dock_weakness(dock_weakness)
 
     def dock_connections_assignment(
         self, configuration: EchoesConfiguration, game: GameDescription, rng: Random

--- a/randovania/generator/base_patches_factory.py
+++ b/randovania/generator/base_patches_factory.py
@@ -27,6 +27,29 @@ HintTargetPrecision = tuple[PickupIndex, HintLocationPrecision, HintItemPrecisio
 
 
 class BasePatchesFactory[Configuration: BaseConfiguration]:
+    def apply_static_configuration_patches(
+        self, configuration: Configuration, game: GameDescription, initial_patches: GamePatches
+    ) -> GamePatches:
+        """
+        Allows games to apply their own static (non-randomized) patches based on the configuration.
+        """
+        return initial_patches
+
+    def create_static_base_patches(
+        self, configuration: Configuration, game: GameDescription, player_index: int
+    ) -> GamePatches:
+        """
+        Creates game patches that are intrinsic to the game's configuration, before any randomization
+        has been applied.
+
+        This can be used by trackers to ensure they have the same information about a generated game
+        that the player would have based on the preset itself, before actually playing the seed.
+        """
+        patches = GamePatches.create_from_game(game, player_index, configuration)
+        patches = self.apply_static_configuration_patches(configuration, game, patches)
+
+        return patches
+
     def create_base_patches(
         self,
         configuration: Configuration,
@@ -37,7 +60,7 @@ class BasePatchesFactory[Configuration: BaseConfiguration]:
         rng_required: bool = True,
     ) -> GamePatches:
         """ """
-        patches = GamePatches.create_from_game(game, player_index, configuration)
+        patches = self.create_static_base_patches(configuration, game, player_index)
 
         # Teleporters
         try:

--- a/randovania/generator/base_patches_factory.py
+++ b/randovania/generator/base_patches_factory.py
@@ -27,26 +27,15 @@ HintTargetPrecision = tuple[PickupIndex, HintLocationPrecision, HintItemPrecisio
 
 
 class BasePatchesFactory[Configuration: BaseConfiguration]:
-    def apply_static_configuration_patches(
-        self, configuration: Configuration, game: GameDescription, initial_patches: GamePatches
-    ) -> GamePatches:
-        """
-        Allows games to apply their own static (non-randomized) patches based on the configuration.
-        """
-        return initial_patches
-
     def create_static_base_patches(
         self, configuration: Configuration, game: GameDescription, player_index: int
     ) -> GamePatches:
         """
         Creates game patches that are intrinsic to the game's configuration, before any randomization
         has been applied.
-
-        This can be used by trackers to ensure they have the same information about a generated game
-        that the player would have based on the preset itself, before actually playing the seed.
         """
         patches = GamePatches.create_from_game(game, player_index, configuration)
-        patches = self.apply_static_configuration_patches(configuration, game, patches)
+        patches = self.assign_static_dock_weakness(configuration, game, patches)
 
         return patches
 
@@ -88,6 +77,12 @@ class BasePatchesFactory[Configuration: BaseConfiguration]:
         self.check_item_pool(configuration)
 
         return patches
+
+    def assign_static_dock_weakness(
+        self, configuration: Configuration, game: GameDescription, initial_patches: GamePatches
+    ) -> GamePatches:
+        """Add/Update dock weaknesses that don't depend on RNG."""
+        return initial_patches
 
     def check_item_pool(self, configuration: Configuration) -> None:
         """

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -145,11 +145,6 @@ class TrackerWindow(QtWidgets.QMainWindow, Ui_TrackerWindow):
         )
 
         pool_results = pool_creator.calculate_pool_results(self.game_configuration, game)
-        # patches = (
-        #     GamePatches.create_from_game(game, 0, self.game_configuration)
-        #     .assign_new_pickups((index, PickupTarget(pickup, 0)) for index, pickup in pool_results.assignment.items())
-        #     .assign_extra_starting_pickups(pool_results.starting)
-        # )
         patches = (
             game.game.generator.base_patches_factory.create_static_base_patches(self.game_configuration, game, 0)
             .assign_new_pickups((index, PickupTarget(pickup, 0)) for index, pickup in pool_results.assignment.items())

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -15,7 +15,6 @@ from randovania.game_description.db.configurable_node import ConfigurableNode
 from randovania.game_description.db.dock_node import DockNode
 from randovania.game_description.db.node_identifier import NodeIdentifier
 from randovania.game_description.db.resource_node import ResourceNode
-from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.requirements.base import Requirement
 from randovania.game_description.requirements.requirement_and import RequirementAnd
 from randovania.game_description.requirements.resource_requirement import ResourceRequirement
@@ -46,6 +45,7 @@ if typing.TYPE_CHECKING:
     from randovania.game_description.db.node import Node
     from randovania.game_description.db.region import Region
     from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_patches import GamePatches
     from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.layout.base.base_configuration import BaseConfiguration
     from randovania.layout.preset import Preset
@@ -136,7 +136,7 @@ class TrackerWindow(QtWidgets.QMainWindow, Ui_TrackerWindow):
         self.game_configuration = preset.configuration
         self.persistence_path = persistence_path
 
-    async def configure(self):
+    async def configure(self) -> None:
         game = filtered_database.game_description_for_layout(self.game_configuration).get_mutable()
         game_generator = game.game.generator
         game.resource_database = game_generator.bootstrap.patch_resource_database(
@@ -145,8 +145,13 @@ class TrackerWindow(QtWidgets.QMainWindow, Ui_TrackerWindow):
         )
 
         pool_results = pool_creator.calculate_pool_results(self.game_configuration, game)
+        # patches = (
+        #     GamePatches.create_from_game(game, 0, self.game_configuration)
+        #     .assign_new_pickups((index, PickupTarget(pickup, 0)) for index, pickup in pool_results.assignment.items())
+        #     .assign_extra_starting_pickups(pool_results.starting)
+        # )
         patches = (
-            GamePatches.create_from_game(game, 0, self.game_configuration)
+            game.game.generator.base_patches_factory.create_static_base_patches(self.game_configuration, game, 0)
             .assign_new_pickups((index, PickupTarget(pickup, 0)) for index, pickup in pool_results.assignment.items())
             .assign_extra_starting_pickups(pool_results.starting)
         )

--- a/test/games/prime2/generator/test_echoes_base_patches_factory.py
+++ b/test/games/prime2/generator/test_echoes_base_patches_factory.py
@@ -49,7 +49,7 @@ def test_save_stations_not_unlocked(echoes_game_patches, default_echoes_configur
     factory = EchoesBasePatchesFactory()
 
     # Run
-    result = factory.assign_save_door_weaknesses(
+    result = factory.assign_static_dock_weakness(
         echoes_game_patches, default_echoes_configuration, echoes_game_description
     )
 
@@ -62,7 +62,7 @@ def test_save_stations_unlocked(echoes_game_patches, default_echoes_configuratio
     config = dataclasses.replace(default_echoes_configuration, blue_save_doors=True)
 
     # Run
-    result = factory.assign_save_door_weaknesses(echoes_game_patches, config, echoes_game_description)
+    result = factory.assign_static_dock_weakness(echoes_game_patches, config, echoes_game_description)
 
     # Result
     assert len(list(result.all_dock_weaknesses())) == 18 * 2

--- a/test/games/prime2/generator/test_echoes_base_patches_factory.py
+++ b/test/games/prime2/generator/test_echoes_base_patches_factory.py
@@ -50,7 +50,7 @@ def test_save_stations_not_unlocked(echoes_game_patches, default_echoes_configur
 
     # Run
     result = factory.assign_static_dock_weakness(
-        echoes_game_patches, default_echoes_configuration, echoes_game_description
+        default_echoes_configuration, echoes_game_description, echoes_game_patches
     )
 
     # Result
@@ -62,7 +62,7 @@ def test_save_stations_unlocked(echoes_game_patches, default_echoes_configuratio
     config = dataclasses.replace(default_echoes_configuration, blue_save_doors=True)
 
     # Run
-    result = factory.assign_static_dock_weakness(echoes_game_patches, config, echoes_game_description)
+    result = factory.assign_static_dock_weakness(config, echoes_game_description, echoes_game_patches)
 
     # Result
     assert len(list(result.all_dock_weaknesses())) == 18 * 2

--- a/test/test_files/prime2_small.json
+++ b/test/test_files/prime2_small.json
@@ -1759,6 +1759,19 @@
                         },
                         "lock": null
                     },
+                    "Normal Door (Forced)": {
+                        "extra": {
+                            "door_type": "Normal"
+                        },
+                        "requirement": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "lock": null
+                    },
                     "Dark Door": {
                         "extra": {},
                         "requirement": {


### PR DESCRIPTION
This allows the tracker to have information that would be available to the player based on the game's configuration without "cheating" by knowing the results of the randomization.