### PR TITLE
Add GameDatabaseView and use it in a few places

### DIFF
--- a/randovania/exporter/item_names.py
+++ b/randovania/exporter/item_names.py
@@ -7,7 +7,7 @@ from randovania.game_description.resources.resource_collection import ResourceCo
 from randovania.generator.pickup_pool.pool_creator import calculate_pool_results
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.game_description.game_patches import GamePatches
     from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.game_description.resources.resource_info import ResourceInfo
@@ -56,7 +56,7 @@ def _pickups_count_by_name(pickups: list[PickupEntry]) -> dict[str, int]:
 
 
 def additional_starting_pickups(
-    layout_configuration: BaseConfiguration, game: GameDescription, starting_pickups: list[PickupEntry]
+    layout_configuration: BaseConfiguration, game: GameDatabaseView, starting_pickups: list[PickupEntry]
 ) -> list[str]:
     initial_pickups = _pickups_count_by_name(calculate_pool_results(layout_configuration, game).starting)
     final_pickups = _pickups_count_by_name(starting_pickups)
@@ -69,9 +69,9 @@ def additional_starting_pickups(
 
 
 def additional_starting_items(
-    layout_configuration: BaseConfiguration, game: GameDescription, starting_items: ResourceCollection
+    layout_configuration: BaseConfiguration, game: GameDatabaseView, starting_items: ResourceCollection
 ) -> list[str]:
-    initial_items = ResourceCollection.with_database(game.resource_database)
+    initial_items = game.create_resource_collection()
     for pickup in calculate_pool_results(layout_configuration, game).starting:
         initial_items.add_resource_gain(pickup.resource_gain(initial_items))
 
@@ -83,7 +83,7 @@ def additional_starting_items(
 
 
 def additional_starting_equipment(
-    layout_configuration: BaseConfiguration, game: GameDescription, patches: GamePatches
+    layout_configuration: BaseConfiguration, game: GameDatabaseView, patches: GamePatches
 ) -> list[str]:
     if isinstance(patches.starting_equipment, ResourceCollection):
         return additional_starting_items(layout_configuration, game, patches.starting_equipment)

--- a/randovania/game/game_enum.py
+++ b/randovania/game/game_enum.py
@@ -20,6 +20,7 @@ if typing.TYPE_CHECKING:
     from randovania.game.generator import GameGenerator
     from randovania.game.gui import GameGui
     from randovania.game.hints import GameHints
+    from randovania.game_description.game_description import GameDescription
     from randovania.interface_common.options import PerGameOptions
 
 
@@ -108,3 +109,9 @@ class RandovaniaGame(BitPackEnum, Enum):
     @cached_property
     def exporter(self) -> GameExporter:
         return self.data.exporter()
+
+    @cached_property
+    def game_description(self) -> GameDescription:
+        from randovania.game_description import default_database
+
+        return default_database.game_description_for(self)

--- a/randovania/game/generator.py
+++ b/randovania/game/generator.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.generator.base_patches_factory import BasePatchesFactory
     from randovania.generator.filler.weights import ActionWeights
     from randovania.generator.pickup_pool import PoolResults
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class GameGenerator:
-    pickup_pool_creator: Callable[[PoolResults, BaseConfiguration, GameDescription], None]
+    pickup_pool_creator: Callable[[PoolResults, BaseConfiguration, GameDatabaseView], None]
     """Extends the base pickup pools with any specific item pools such as Artifacts."""
 
     bootstrap: Bootstrap

--- a/randovania/game_description/filtered_game_database_view.py
+++ b/randovania/game_description/filtered_game_database_view.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import typing
+
+from randovania.game_description.game_database_view import GameDatabaseView, GameDatabaseViewProxy
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from randovania.game_description.db.area import Area
+    from randovania.game_description.db.node import Node
+    from randovania.game_description.db.region import Region
+    from randovania.layout.base.base_configuration import BaseConfiguration
+
+
+class LayerFilteredGameDatabaseView(GameDatabaseViewProxy):
+    def __init__(self, original: GameDatabaseView, enabled_layers: set[str]):
+        super().__init__(original)
+        self.enabled_layers = enabled_layers
+
+    @typing.override
+    def node_iterator(self) -> Iterable[tuple[Region, Area, Node]]:
+        for entry in super().node_iterator():
+            if self.enabled_layers.intersection(entry[2].layers):
+                yield entry
+
+
+def filter_view_for_configuration(view: GameDatabaseView, configuration: BaseConfiguration) -> GameDatabaseView:
+    """
+    Creates a new GameDatabaseView that filters
+    :param view:
+    :param configuration:
+    :return:
+    """
+    return LayerFilteredGameDatabaseView(
+        view,
+        configuration.active_layers(),
+    )

--- a/randovania/game_description/game_database_view.py
+++ b/randovania/game_description/game_database_view.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import abc
+from abc import ABC
+from typing import TYPE_CHECKING, override
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence
+
+    from randovania.game_description.db.area import Area
+    from randovania.game_description.db.dock import DockType, DockWeakness
+    from randovania.game_description.db.node import Node
+    from randovania.game_description.db.node_identifier import NodeIdentifier
+    from randovania.game_description.db.pickup_node import PickupNode
+    from randovania.game_description.db.region import Region
+    from randovania.game_description.hint_features import HintFeature
+    from randovania.game_description.pickup.pickup_database import PickupDatabase
+    from randovania.game_description.pickup.pickup_entry import PickupModel
+    from randovania.game_description.requirements.base import Requirement
+    from randovania.game_description.resources.item_resource_info import ItemResourceInfo
+    from randovania.game_description.resources.pickup_index import PickupIndex
+    from randovania.game_description.resources.resource_collection import ResourceCollection
+    from randovania.game_description.resources.resource_database import NamedRequirementTemplate
+    from randovania.game_description.resources.resource_info import ResourceInfo
+    from randovania.game_description.resources.resource_type import ResourceType
+    from randovania.game_description.resources.simple_resource_info import SimpleResourceInfo
+    from randovania.game_description.resources.trick_resource_info import TrickResourceInfo
+
+
+class ResourceDatabaseView(ABC):
+    """
+    An interface for giving access to a database of resources.
+    """
+
+    def get_item(self, short_name: str) -> ItemResourceInfo:
+        """
+        Gets a ItemResourceInfo, using internal name
+        Raises KeyError if it doesn't exist.
+        """
+        raise NotImplementedError
+
+    def get_event(self, short_name: str) -> SimpleResourceInfo:
+        """
+        Gets a ResourceInfo of type Event, using internal name
+        Raises KeyError if it doesn't exist.
+        """
+        raise NotImplementedError
+
+    def get_trick(self, short_name: str) -> TrickResourceInfo:
+        """
+        Gets a TrickResourceInfo using internal name
+        Raises KeyError if it doesn't exist.
+        """
+        raise NotImplementedError
+
+    def get_all_tricks(self) -> Sequence[TrickResourceInfo]:
+        """
+        Gets a list of all TrickResourceInfo
+        """
+        raise NotImplementedError
+
+    def get_damage(self, short_name: str) -> SimpleResourceInfo:
+        """
+        Gets a ResourceInfo of type Damage, using internal name
+        Raises KeyError if it doesn't exist.
+        """
+        raise NotImplementedError
+
+    def get_damage_reduction(self, resource: SimpleResourceInfo, current_resources: ResourceCollection) -> float:
+        """
+        Gets the damage reduction for given resource with the given current resources.
+        """
+        raise NotImplementedError
+
+    def get_template_requirement(self, name: str) -> NamedRequirementTemplate:
+        """
+        Gets a RequirementTemplate, using internal name.
+        Raises KeyError if it doesn't exist.
+        """
+        raise NotImplementedError
+
+    def get_all_resources_of_type(self, resource_type: ResourceType) -> Sequence[ResourceInfo]:
+        """
+        Gets a list of all resources of the given type.
+        """
+        raise NotImplementedError
+
+    def get_pickup_model(self, name: str) -> PickupModel:
+        """
+        Gets a model with the given name.
+        """
+        raise NotImplementedError
+
+
+class ResourceDatabaseViewProxy(ResourceDatabaseView):
+    """
+    A ResourceDatabaseView, implemented by delegating all calls to another ResourceDatabaseView.
+    Intended to be used to overwrite specific functions.
+    """
+
+    def __init__(self, original: ResourceDatabaseView):
+        self._original = original
+
+    @override
+    def get_item(self, short_name: str) -> ItemResourceInfo:
+        return self._original.get_item(short_name)
+
+    @override
+    def get_event(self, short_name: str) -> SimpleResourceInfo:
+        return self._original.get_event(short_name)
+
+    @override
+    def get_trick(self, short_name: str) -> TrickResourceInfo:
+        return self._original.get_trick(short_name)
+
+    @override
+    def get_all_tricks(self) -> Sequence[TrickResourceInfo]:
+        return self._original.get_all_tricks()
+
+    @override
+    def get_damage(self, short_name: str) -> SimpleResourceInfo:
+        return self._original.get_damage(short_name)
+
+    @override
+    def get_damage_reduction(self, resource: SimpleResourceInfo, current_resources: ResourceCollection) -> float:
+        return self._original.get_damage_reduction(resource, current_resources)
+
+    @override
+    def get_template_requirement(self, name: str) -> NamedRequirementTemplate:
+        return self._original.get_template_requirement(name)
+
+    @override
+    def get_all_resources_of_type(self, resource_type: ResourceType) -> Sequence[ResourceInfo]:
+        return self._original.get_all_resources_of_type(resource_type)
+
+
+class GameDatabaseView(ABC):
+    """
+    Provides access to the GameDescription and nested, with support for being filtered for Preset settings.
+
+    These APIs are all expected to be slow and shouldn't be used in any performance sensitive code.
+    """
+
+    @abc.abstractmethod
+    def node_iterator(self) -> Iterable[tuple[Region, Area, Node]]:
+        """
+        Iterates over all nodes in the database, including the region and area they belong to
+        """
+
+    @abc.abstractmethod
+    def iterate_nodes_of_type[NodeT: Node](self, node_type: type[NodeT]) -> Iterator[tuple[Region, Area, NodeT]]:
+        """
+        Iterates over only the nodes that are of the given type.
+        """
+
+    @abc.abstractmethod
+    def node_by_identifier(self, identifier: NodeIdentifier) -> Node:
+        """
+        Find a node with the given NodeIdentifier.
+        Raises KeyError if no node could be found.
+        """
+
+    @abc.abstractmethod
+    def assert_pickup_index_exists(self, index: PickupIndex) -> None:
+        """
+        If the PickupIndex does not exist, this function raises an Exception
+        """
+
+    @abc.abstractmethod
+    def create_resource_collection(self) -> ResourceCollection:
+        """
+        Creates a new ResourceCollection
+        """
+
+    @abc.abstractmethod
+    def default_starting_location(self) -> NodeIdentifier:
+        """
+        The default starting location for the game. Not really used since the preset starting location replaces this...
+        """
+
+    @abc.abstractmethod
+    def get_dock_types(self) -> list[DockType]:
+        """
+        List all available DockTypes
+        """
+
+    @abc.abstractmethod
+    def get_dock_weakness(self, dock_type_name: str, weakness_name: str) -> DockWeakness:
+        """
+        Gets a DockWeakness via names
+        """
+
+    @abc.abstractmethod
+    def get_resource_database_view(self) -> ResourceDatabaseView:
+        """
+        Gets a view for the ResourceDatabase
+        """
+
+    @abc.abstractmethod
+    def get_pickup_database(self) -> PickupDatabase:
+        """
+        Gets the PickupDatabase for this game.
+        """
+
+    @abc.abstractmethod
+    def get_victory_condition(self) -> Requirement:
+        """
+        Gets the requirement that determines if the player has won.
+        """
+
+    @abc.abstractmethod
+    def pickup_nodes_with_feature(self, feature: HintFeature) -> tuple[PickupNode, ...]:
+        """
+        Returns an iterable tuple of PickupNodes with the given feature (either directly or in their area)
+        """
+
+    @abc.abstractmethod
+    def node_from_pickup_index(self, index: PickupIndex) -> PickupNode:
+        """
+        Returns the PickupNode with the given index.
+        :raises: KeyError if it doesn't exist
+        """
+
+    @abc.abstractmethod
+    def area_from_node(self, node: Node) -> Area:
+        """
+        Returns the Area that contains the given node.
+        :raises: KeyError if it doesn't exist
+        """
+
+
+class GameDatabaseViewProxy(GameDatabaseView):
+    """
+    A GameDatabaseView, implemented by delegating all calls to another GameDatabaseView.
+    Intended to be used to overwrite specific functions.
+    """
+
+    def __init__(self, original: GameDatabaseView):
+        self._original = original
+
+    @override
+    def node_iterator(self) -> Iterable[tuple[Region, Area, Node]]:
+        return self._original.node_iterator()
+
+    @override
+    def iterate_nodes_of_type[NodeT: Node](self, node_type: type[NodeT]) -> Iterator[tuple[Region, Area, NodeT]]:
+        return self._original.iterate_nodes_of_type(node_type)
+
+    @override
+    def node_by_identifier(self, identifier: NodeIdentifier) -> Node:
+        return self._original.node_by_identifier(identifier)
+
+    @override
+    def assert_pickup_index_exists(self, index: PickupIndex) -> None:
+        return self._original.assert_pickup_index_exists(index)
+
+    @override
+    def create_resource_collection(self) -> ResourceCollection:
+        return self._original.create_resource_collection()
+
+    @override
+    def default_starting_location(self) -> NodeIdentifier:
+        return self._original.default_starting_location()
+
+    @override
+    def get_dock_types(self) -> list[DockType]:
+        return self._original.get_dock_types()
+
+    @override
+    def get_dock_weakness(self, dock_type_name: str, weakness_name: str) -> DockWeakness:
+        return self._original.get_dock_weakness(dock_type_name, weakness_name)
+
+    @override
+    def get_resource_database_view(self) -> ResourceDatabaseView:
+        return self._original.get_resource_database_view()
+
+    @override
+    def get_pickup_database(self) -> PickupDatabase:
+        return self._original.get_pickup_database()
+
+    @override
+    def get_victory_condition(self) -> Requirement:
+        return self._original.get_victory_condition()
+
+    @override
+    def pickup_nodes_with_feature(self, feature: HintFeature) -> tuple[PickupNode, ...]:
+        return self._original.pickup_nodes_with_feature(feature)
+
+    @override
+    def node_from_pickup_index(self, index: PickupIndex) -> PickupNode:
+        return self._original.node_from_pickup_index(index)
+
+    @override
+    def area_from_node(self, node: Node) -> Area:
+        return self._original.area_from_node(node)
+
+
+def typed_node_by_identifier[NodeT: Node](game: GameDatabaseView, i: NodeIdentifier, t: type[NodeT]) -> NodeT:
+    """
+    Wrapper for calling game.node_by_identifier, followed by an isinstance.
+    """
+    result = game.node_by_identifier(i)
+    assert isinstance(result, t)
+    return result

--- a/randovania/game_description/pickup/pickup_definition/ammo_pickup.py
+++ b/randovania/game_description/pickup/pickup_definition/ammo_pickup.py
@@ -11,7 +11,7 @@ from randovania.game_description.pickup.pickup_definition.base_pickup import (
 from randovania.game_description.pickup.pickup_entry import ResourceLock
 
 if TYPE_CHECKING:
-    from randovania.game_description.resources.resource_database import ResourceDatabase
+    from randovania.game_description.game_database_view import ResourceDatabaseView
 
 
 @dataclass(frozen=True, kw_only=True, order=True)
@@ -67,7 +67,7 @@ class AmmoPickupDefinition(BasePickupDefinition):
         elif self.unlocked_by is not None:
             raise ValueError("If temporary is not set, unlocked_by must not be set.")
 
-    def create_resource_lock(self, resource_database: ResourceDatabase) -> ResourceLock | None:
+    def create_resource_lock(self, resource_database: ResourceDatabaseView) -> ResourceLock | None:
         if self.unlocked_by is not None:
             assert self.temporary is not None
             return ResourceLock(

--- a/randovania/game_description/resources/resource_database.py
+++ b/randovania/game_description/resources/resource_database.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import dataclasses
 import typing
+from typing import override
 
+from randovania.game_description.game_database_view import ResourceDatabaseView
 from randovania.game_description.pickup.pickup_entry import PickupModel
 from randovania.game_description.resources import search
 from randovania.game_description.resources.resource_info import ResourceInfo
@@ -41,7 +43,7 @@ class NamedRequirementTemplate:
 
 
 @dataclasses.dataclass(frozen=True)
-class ResourceDatabase:
+class ResourceDatabase(ResourceDatabaseView):
     game_enum: RandovaniaGame
     item: list[ItemResourceInfo]
     event: list[SimpleResourceInfo]
@@ -109,6 +111,7 @@ class ResourceDatabase:
     def get_item_by_name(self, name: str) -> ItemResourceInfo:
         return search.find_resource_info_with_long_name(self.item, name)
 
+    @override
     def get_pickup_model(self, name: str) -> PickupModel:
         return PickupModel(
             game=self.game_enum,

--- a/randovania/games/am2r/generator/pool_creator.py
+++ b/randovania/games/am2r/generator/pool_creator.py
@@ -8,18 +8,18 @@ from randovania.generator.pickup_pool.pickup_creator import create_generated_pic
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_description import GameDatabaseView
     from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
+def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDatabaseView) -> None:
     assert isinstance(configuration, AM2RConfiguration)
 
     results.extend_with(artifact_pool(game, configuration.artifacts))
 
 
-def artifact_pool(game: GameDescription, config: AM2RArtifactConfig) -> PoolResults:
+def artifact_pool(game: GameDatabaseView, config: AM2RArtifactConfig) -> PoolResults:
     # Check whether we have valid artifact requirements in configuration
     max_artifacts = 0
     if config.prefer_anywhere:
@@ -32,7 +32,7 @@ def artifact_pool(game: GameDescription, config: AM2RArtifactConfig) -> PoolResu
         raise InvalidConfiguration("More Metroid DNA than allowed!")
 
     keys: list[PickupEntry] = [
-        create_generated_pickup("Metroid DNA", game.resource_database, game.get_pickup_database(), i=i + 1)
+        create_generated_pickup("Metroid DNA", game.get_resource_database_view(), game.get_pickup_database(), i=i + 1)
         for i in range(46)
     ]
     keys_to_shuffle = keys[: config.placed_artifacts]

--- a/randovania/games/blank/generator/pool_creator.py
+++ b/randovania/games/blank/generator/pool_creator.py
@@ -6,12 +6,14 @@ from randovania.games.blank.layout.blank_configuration import BlankConfiguration
 from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.generator.pickup_pool import PoolResults
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
+def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDatabaseView) -> None:
     assert isinstance(configuration, BlankConfiguration)
 
-    results.to_place.append(create_generated_pickup("Victory Key", game.resource_database, game.get_pickup_database()))
+    results.to_place.append(
+        create_generated_pickup("Victory Key", game.get_resource_database_view(), game.get_pickup_database())
+    )

--- a/randovania/games/cave_story/generator/pool_creator.py
+++ b/randovania/games/cave_story/generator/pool_creator.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING
 from randovania.games.cave_story.layout.cs_configuration import CSConfiguration
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.generator.pickup_pool import PoolResults
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
+def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDatabaseView) -> None:
     assert isinstance(configuration, CSConfiguration)

--- a/randovania/games/dread/generator/pool_creator.py
+++ b/randovania/games/dread/generator/pool_creator.py
@@ -7,19 +7,19 @@ from randovania.generator.pickup_pool import PoolResults
 from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
+def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDatabaseView) -> None:
     assert isinstance(configuration, DreadConfiguration)
 
     results.extend_with(artifact_pool(game, configuration.artifacts))
 
 
-def artifact_pool(game: GameDescription, config: DreadArtifactConfig) -> PoolResults:
+def artifact_pool(game: GameDatabaseView, config: DreadArtifactConfig) -> PoolResults:
     keys = [
-        create_generated_pickup("Metroid DNA", game.resource_database, game.get_pickup_database(), i=i + 1)
+        create_generated_pickup("Metroid DNA", game.get_resource_database_view(), game.get_pickup_database(), i=i + 1)
         for i in range(12)
     ]
     keys_to_shuffle = keys[: config.required_artifacts]

--- a/randovania/games/fusion/generator/pool_creator.py
+++ b/randovania/games/fusion/generator/pool_creator.py
@@ -8,18 +8,18 @@ from randovania.generator.pickup_pool.pickup_creator import create_generated_pic
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
+def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDatabaseView) -> None:
     assert isinstance(configuration, FusionConfiguration)
 
     results.extend_with(artifact_pool(game, configuration.artifacts))
 
 
-def artifact_pool(game: GameDescription, config: FusionArtifactConfig) -> PoolResults:
+def artifact_pool(game: GameDatabaseView, config: FusionArtifactConfig) -> PoolResults:
     # Check whether we have valid artifact requirements in configuration
     max_artifacts = 0
     if config.prefer_anywhere:
@@ -30,7 +30,9 @@ def artifact_pool(game: GameDescription, config: FusionArtifactConfig) -> PoolRe
         raise InvalidConfiguration("More Infant Metroids than allowed!")
 
     keys: list[PickupEntry] = [
-        create_generated_pickup("Infant Metroid", game.resource_database, game.get_pickup_database(), i=i + 1)
+        create_generated_pickup(
+            "Infant Metroid", game.get_resource_database_view(), game.get_pickup_database(), i=i + 1
+        )
         for i in range(20)
     ]
     keys_to_shuffle = keys[: config.placed_artifacts]

--- a/randovania/games/planets_zebeth/generator/pool_creator.py
+++ b/randovania/games/planets_zebeth/generator/pool_creator.py
@@ -12,20 +12,20 @@ from randovania.generator.pickup_pool.pickup_creator import create_generated_pic
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
+def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDatabaseView) -> None:
     assert isinstance(configuration, PlanetsZebethConfiguration)
 
     results.extend_with(artifact_pool(game, configuration.artifacts))
 
 
-def artifact_pool(game: GameDescription, config: PlanetsZebethArtifactConfig) -> PoolResults:
+def artifact_pool(game: GameDatabaseView, config: PlanetsZebethArtifactConfig) -> PoolResults:
     keys: list[PickupEntry] = [
-        create_generated_pickup("Tourian Key", game.resource_database, game.get_pickup_database(), i=i + 1)
+        create_generated_pickup("Tourian Key", game.get_resource_database_view(), game.get_pickup_database(), i=i + 1)
         for i in range(9)
     ]
 

--- a/randovania/games/prime1/generator/pickup_pool/artifacts.py
+++ b/randovania/games/prime1/generator/pickup_pool/artifacts.py
@@ -7,14 +7,14 @@ from randovania.generator.pickup_pool import PoolResults
 from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 if TYPE_CHECKING:
+    from randovania.game_description.game_database_view import ResourceDatabaseView
     from randovania.game_description.pickup.pickup_database import PickupDatabase
     from randovania.game_description.pickup.pickup_entry import PickupEntry
-    from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.games.prime1.layout.artifact_mode import LayoutArtifactMode
 
 
 def add_artifacts(
-    resource_database: ResourceDatabase,
+    resource_database: ResourceDatabaseView,
     pickup_database: PickupDatabase,
     total: LayoutArtifactMode,
     artifact_minimum_progression: int,

--- a/randovania/games/prime1/generator/pickup_pool/pool_creator.py
+++ b/randovania/games/prime1/generator/pickup_pool/pool_creator.py
@@ -6,16 +6,16 @@ from randovania.games.prime1.generator.pickup_pool.artifacts import add_artifact
 from randovania.games.prime1.layout.prime_configuration import PrimeConfiguration
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.generator.pickup_pool import PoolResults
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def prime1_specific_pool(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
+def prime1_specific_pool(results: PoolResults, configuration: BaseConfiguration, game: GameDatabaseView) -> None:
     assert isinstance(configuration, PrimeConfiguration)
     results.extend_with(
         add_artifacts(
-            game.resource_database,
+            game.get_resource_database_view(),
             game.get_pickup_database(),
             configuration.artifact_target,
             configuration.artifact_minimum_progression,

--- a/randovania/games/prime2/generator/pickup_pool/dark_temple_keys.py
+++ b/randovania/games/prime2/generator/pickup_pool/dark_temple_keys.py
@@ -6,13 +6,13 @@ from randovania.generator.pickup_pool import PoolResults
 from randovania.generator.pickup_pool.pickup_creator import create_generated_pickup
 
 if TYPE_CHECKING:
+    from randovania.game_description.game_database_view import ResourceDatabaseView
     from randovania.game_description.pickup.pickup_database import PickupDatabase
     from randovania.game_description.pickup.pickup_entry import PickupEntry
-    from randovania.game_description.resources.resource_database import ResourceDatabase
 
 
 def add_dark_temple_keys(
-    resource_database: ResourceDatabase,
+    resource_database: ResourceDatabaseView,
     pickup_database: PickupDatabase,
 ) -> PoolResults:
     """

--- a/randovania/games/prime2/generator/pickup_pool/pool_creator.py
+++ b/randovania/games/prime2/generator/pickup_pool/pool_creator.py
@@ -7,15 +7,15 @@ from randovania.games.prime2.generator.pickup_pool.sky_temple_keys import add_sk
 from randovania.games.prime2.layout.echoes_configuration import EchoesConfiguration
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.generator.pickup_pool import PoolResults
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def echoes_specific_pool(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
+def echoes_specific_pool(results: PoolResults, configuration: BaseConfiguration, game: GameDatabaseView) -> None:
     assert isinstance(configuration, EchoesConfiguration)
     # Adding Dark Temple Keys to pool
-    results.extend_with(add_dark_temple_keys(game.resource_database, game.get_pickup_database()))
+    results.extend_with(add_dark_temple_keys(game.get_resource_database_view(), game.get_pickup_database()))
 
     # Adding Sky Temple Keys to pool
     results.extend_with(add_sky_temple_key_distribution_logic(game, configuration.sky_temple_keys))

--- a/randovania/games/prime2/generator/pickup_pool/sky_temple_keys.py
+++ b/randovania/games/prime2/generator/pickup_pool/sky_temple_keys.py
@@ -9,15 +9,15 @@ from randovania.generator.pickup_pool.pickup_creator import create_generated_pic
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.game_description.pickup.pickup_entry import PickupEntry
 
 
-def pickup_nodes_for_stk_mode(game: GameDescription, mode: LayoutSkyTempleKeyMode) -> list[PickupNode]:
+def pickup_nodes_for_stk_mode(game: GameDatabaseView, mode: LayoutSkyTempleKeyMode) -> list[PickupNode]:
     locations = []
 
     if mode == LayoutSkyTempleKeyMode.ALL_BOSSES or mode == LayoutSkyTempleKeyMode.ALL_GUARDIANS:
-        for node in game.region_list.iterate_nodes_of_type(PickupNode):
+        for _, _, node in game.iterate_nodes_of_type(PickupNode):
             boss = node.extra.get("boss")
             if boss is not None:
                 if boss == "guardian" or mode == LayoutSkyTempleKeyMode.ALL_BOSSES:
@@ -27,14 +27,14 @@ def pickup_nodes_for_stk_mode(game: GameDescription, mode: LayoutSkyTempleKeyMod
 
 
 def add_sky_temple_key_distribution_logic(
-    game: GameDescription,
+    game: GameDatabaseView,
     mode: LayoutSkyTempleKeyMode,
 ) -> PoolResults:
     """
     Adds the given Sky Temple Keys to the item pool
     :return:
     """
-    resource_database = game.resource_database
+    resource_database = game.get_resource_database_view()
     pickup_db = game.get_pickup_database()
     item_pool: list[PickupEntry] = []
     keys_to_place: int

--- a/randovania/games/samus_returns/generator/pool_creator.py
+++ b/randovania/games/samus_returns/generator/pool_creator.py
@@ -8,18 +8,18 @@ from randovania.generator.pickup_pool.pickup_creator import create_generated_pic
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription) -> None:
+def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDatabaseView) -> None:
     assert isinstance(configuration, MSRConfiguration)
 
     results.extend_with(artifact_pool(game, configuration.artifacts))
 
 
-def artifact_pool(game: GameDescription, config: MSRArtifactConfig) -> PoolResults:
+def artifact_pool(game: GameDatabaseView, config: MSRArtifactConfig) -> PoolResults:
     # Check whether we have valid artifact requirements in configuration
     max_artifacts = 0
     if config.prefer_anywhere:
@@ -34,7 +34,7 @@ def artifact_pool(game: GameDescription, config: MSRArtifactConfig) -> PoolResul
         raise InvalidConfiguration("More Metroid DNA than allowed!")
 
     keys: list[PickupEntry] = [
-        create_generated_pickup("Metroid DNA", game.resource_database, game.get_pickup_database(), i=i + 1)
+        create_generated_pickup("Metroid DNA", game.get_resource_database_view(), game.get_pickup_database(), i=i + 1)
         for i in range(39)
     ]
     keys_to_shuffle = keys[: config.placed_artifacts]

--- a/randovania/generator/pickup_pool/ammo_pickup.py
+++ b/randovania/generator/pickup_pool/ammo_pickup.py
@@ -5,13 +5,13 @@ from typing import TYPE_CHECKING
 from randovania.generator.pickup_pool.pickup_creator import create_ammo_pickup
 
 if TYPE_CHECKING:
+    from randovania.game_description.game_database_view import ResourceDatabaseView
     from randovania.game_description.pickup.pickup_entry import PickupEntry
-    from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.layout.base.ammo_pickup_configuration import AmmoPickupConfiguration
 
 
 def add_ammo_pickups(
-    resource_database: ResourceDatabase,
+    resource_database: ResourceDatabaseView,
     ammo_configuration: AmmoPickupConfiguration,
 ) -> list[PickupEntry]:
     """

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -13,18 +13,18 @@ if TYPE_CHECKING:
     from typing import Any
 
     from randovania.game.game_enum import RandovaniaGame
+    from randovania.game_description.game_database_view import ResourceDatabaseView
     from randovania.game_description.pickup.pickup_database import PickupDatabase
     from randovania.game_description.pickup.pickup_definition.ammo_pickup import AmmoPickupDefinition
     from randovania.game_description.pickup.pickup_definition.standard_pickup import StandardPickupDefinition
     from randovania.game_description.resources.item_resource_info import ItemResourceInfo
-    from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.layout.base.standard_pickup_state import StandardPickupState
 
 
 def create_standard_pickup(
     pickup: StandardPickupDefinition,
     state: StandardPickupState,
-    resource_database: ResourceDatabase,
+    resource_database: ResourceDatabaseView,
     ammo: AmmoPickupDefinition | None,
     ammo_requires_main_item: bool,
 ) -> PickupEntry:
@@ -75,7 +75,7 @@ def create_ammo_pickup(
     ammo: AmmoPickupDefinition,
     ammo_count: Sequence[int],
     requires_main_item: bool,
-    resource_database: ResourceDatabase,
+    resource_database: ResourceDatabaseView,
 ) -> PickupEntry:
     """
     Creates a PickupEntry for an expansion of the given ammo.
@@ -111,7 +111,7 @@ def create_ammo_pickup(
 
 def create_generated_pickup(
     pickup_group: str,
-    resource_database: ResourceDatabase,
+    resource_database: ResourceDatabaseView,
     pickup_database: PickupDatabase,
     *,
     minimum_progression: int = 0,
@@ -160,7 +160,7 @@ USELESS_PICKUP_CATEGORY = hint_features.HintFeature(
 )
 
 
-def create_nothing_pickup(resource_database: ResourceDatabase, model_name: str = "Nothing") -> PickupEntry:
+def create_nothing_pickup(resource_database: ResourceDatabaseView, model_name: str = "Nothing") -> PickupEntry:
     """
     Creates a Nothing pickup.
     :param resource_database:

--- a/randovania/generator/pickup_pool/pool_creator.py
+++ b/randovania/generator/pickup_pool/pool_creator.py
@@ -2,23 +2,23 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 
+from randovania.game_description import filtered_game_database_view
 from randovania.game_description.db.pickup_node import PickupNode
 from randovania.game_description.resources.location_category import LocationCategory
 from randovania.generator.pickup_pool import PoolResults
 from randovania.generator.pickup_pool.ammo_pickup import add_ammo_pickups
 from randovania.generator.pickup_pool.standard_pickup import add_standard_pickups
-from randovania.layout import filtered_database
 
 if TYPE_CHECKING:
-    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_database_view import GameDatabaseView
     from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def calculate_pool_results(layout_configuration: BaseConfiguration, game: GameDescription) -> PoolResults:
+def calculate_pool_results(configuration: BaseConfiguration, game: GameDatabaseView) -> PoolResults:
     """
     Creates a PoolResults with all starting items and pickups in fixed locations, as well as a list of
     pickups we should shuffle.
-    :param layout_configuration:
+    :param configuration:
     :param game:
     :return:
     """
@@ -27,19 +27,19 @@ def calculate_pool_results(layout_configuration: BaseConfiguration, game: GameDe
     # Adding standard pickups to the pool
     base_results.extend_with(
         add_standard_pickups(
-            game.resource_database,
-            layout_configuration.standard_pickup_configuration,
-            layout_configuration.ammo_pickup_configuration,
+            game.get_resource_database_view(),
+            configuration.standard_pickup_configuration,
+            configuration.ammo_pickup_configuration,
         )
     )
 
     # Adding ammo to the pool
     base_results.to_place.extend(
-        add_ammo_pickups(game.resource_database, layout_configuration.ammo_pickup_configuration)
+        add_ammo_pickups(game.get_resource_database_view(), configuration.ammo_pickup_configuration)
     )
 
     # Add game-specific entries to the pool
-    layout_configuration.game.generator.pickup_pool_creator(base_results, layout_configuration, game)
+    configuration.game.generator.pickup_pool_creator(base_results, configuration, game)
 
     return base_results
 
@@ -49,21 +49,25 @@ class PoolCount(NamedTuple):
     locations: int
 
 
-def calculate_pool_pickup_count(layout: BaseConfiguration) -> dict[LocationCategory | str, PoolCount]:
+def calculate_pool_pickup_count(configuration: BaseConfiguration) -> dict[LocationCategory | str, PoolCount]:
     """
     Calculate how many pickups are needed for given layout, with how many spots are there.
-    :param layout:
+    :param configuration:
     :return:
     """
-    game_description = filtered_database.game_description_for_layout(layout)
+
+    view = filtered_game_database_view.filter_view_for_configuration(
+        configuration.game_enum().game_description,
+        configuration,
+    )
 
     result: dict[LocationCategory | str, list[int]] = {cat: [0, 0] for cat in LocationCategory}
 
-    for node in game_description.region_list.iterate_nodes_of_type(PickupNode):
+    for _, _, node in view.iterate_nodes_of_type(PickupNode):
         result[node.location_category][1] += 1
 
-    pool_results = calculate_pool_results(layout, game_description)
-    result["Starting"] = [0, layout.standard_pickup_configuration.minimum_random_starting_pickups]
+    pool_results = calculate_pool_results(configuration, view)
+    result["Starting"] = [0, configuration.standard_pickup_configuration.minimum_random_starting_pickups]
 
     all_pickups = pool_results.to_place + list(pool_results.assignment.values())
     for pickup in all_pickups:

--- a/randovania/generator/pickup_pool/standard_pickup.py
+++ b/randovania/generator/pickup_pool/standard_pickup.py
@@ -7,10 +7,10 @@ from randovania.generator.pickup_pool.pickup_creator import create_standard_pick
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
+    from randovania.game_description.game_database_view import ResourceDatabaseView
     from randovania.game_description.pickup.pickup_definition.ammo_pickup import AmmoPickupDefinition
     from randovania.game_description.pickup.pickup_entry import PickupEntry
     from randovania.game_description.resources.pickup_index import PickupIndex
-    from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.layout.base.ammo_pickup_configuration import AmmoPickupConfiguration
     from randovania.layout.base.standard_pickup_configuration import StandardPickupConfiguration
 
@@ -27,7 +27,7 @@ def _find_ammo_for(
 
 
 def add_standard_pickups(
-    resource_database: ResourceDatabase,
+    resource_database: ResourceDatabaseView,
     standard_pickup_configuration: StandardPickupConfiguration,
     ammo_pickup_configuration: AmmoPickupConfiguration,
 ) -> PoolResults:


### PR DESCRIPTION
This is my solution for the mess that is `filtered_database.py`, `patch_requirements` and all the stuff in [FactorioBootstrap](https://github.com/randovania/randovania/blob/main/randovania/games/factorio/generator/bootstrap.py#L37).

Everything that'd use a GameDescription/RegionList now instead uses a `GameDatabaseView`, which you can put a bunch of proxies in front, such as `LayerFilteredGameDatabaseView` or whatever else to handle the `patch_requirements`.

Of course, using these views during the generator/resolver can likely impact performance massively. This inpact is avoided via the [world-graph branch](https://github.com/randovania/randovania/tree/feature/world-graph), which actually depends on this PR in order to decently handle `Bootstrap.apply_game_specific`.

In this PR I've added the view and used it in a few places. Let me know what you think of the API. Still need to figure out certain things, like how `RegionList.node_name` and similar works.