### PR TITLE
Resolver: Fix unmet damage requirement chain disregarded as additional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed: Some seeds being considered impossible when finding a progressive item in an area where a later item in the progressive chain is required to leave.
 - Fixed: Minor edge case where a seed might be considered impossible due to missing consideration of damage.
+- Fixed: Some seeds being considered impossible in cases where damage requirements are spread between multiple connections.
 
 ### Metroid Prime 2: Echoes
 

--- a/randovania/game_description/requirements/base.py
+++ b/randovania/game_description/requirements/base.py
@@ -40,6 +40,15 @@ class Requirement:
         """
         raise NotImplementedError
 
+    def isolate_damage_requirements(self, context: NodeContext) -> Requirement:
+        """
+        Strips away requirements not related to damage. For requirements that aren't damage related: unsatisfied
+        requirements are replaced with impossible, satisfied ones are replaced with trivial.
+        :param context:
+        :return:
+        """
+        raise NotImplementedError
+
     def as_set(self, context: NodeContext) -> RequirementSet:
         raise NotImplementedError
 

--- a/randovania/game_description/requirements/node_requirement.py
+++ b/randovania/game_description/requirements/node_requirement.py
@@ -48,6 +48,9 @@ class NodeRequirement(Requirement):
     def simplify(self, keep_comments: bool = False) -> Requirement:
         return self
 
+    def isolate_damage_requirements(self, context: NodeContext) -> Requirement:
+        return Requirement.trivial() if self.satisfied(context, 0) else Requirement.impossible()
+
     @property
     def pretty_text(self) -> str:
         return str(self.node_identifier)

--- a/randovania/game_description/requirements/requirement_and.py
+++ b/randovania/game_description/requirements/requirement_and.py
@@ -38,6 +38,16 @@ class RequirementAnd(RequirementArrayBase):
 
         return RequirementAnd(new_items, comment=self.comment)
 
+    def isolate_damage_requirements(self, context: NodeContext) -> Requirement:
+        isolated_items = []
+        for item in self.items:
+            potential_item = item.isolate_damage_requirements(context)
+            if potential_item == Requirement.impossible():
+                return Requirement.impossible()
+            if potential_item != Requirement.trivial():
+                isolated_items.append(potential_item)
+        return isolated_items[0] if len(isolated_items) == 1 else RequirementAnd(isolated_items)
+
     def as_set(self, context: NodeContext) -> RequirementSet:
         result = RequirementSet.trivial()
         for item in self.items:

--- a/randovania/game_description/requirements/requirement_or.py
+++ b/randovania/game_description/requirements/requirement_or.py
@@ -88,7 +88,7 @@ class RequirementOr(RequirementArrayBase):
                 return Requirement.trivial()
             if potential_item != Requirement.impossible():
                 isolated_items.append(potential_item)
-        return isolated_items[0] if len(isolated_items) == 1 else RequirementAnd(isolated_items)
+        return isolated_items[0] if len(isolated_items) == 1 else RequirementOr(isolated_items)
 
     def as_set(self, context: NodeContext) -> RequirementSet:
         alternatives: set[RequirementList] = set()

--- a/randovania/game_description/requirements/requirement_or.py
+++ b/randovania/game_description/requirements/requirement_or.py
@@ -80,6 +80,16 @@ class RequirementOr(RequirementArrayBase):
 
         return RequirementOr(final_items, comment=self.comment)
 
+    def isolate_damage_requirements(self, context: NodeContext) -> Requirement:
+        isolated_items = []
+        for item in self.items:
+            potential_item = item.isolate_damage_requirements(context)
+            if potential_item == Requirement.trivial():
+                return Requirement.trivial()
+            if potential_item != Requirement.impossible():
+                isolated_items.append(potential_item)
+        return isolated_items[0] if len(isolated_items) == 1 else RequirementAnd(isolated_items)
+
     def as_set(self, context: NodeContext) -> RequirementSet:
         alternatives: set[RequirementList] = set()
         for item in self.items:

--- a/randovania/game_description/requirements/requirement_template.py
+++ b/randovania/game_description/requirements/requirement_template.py
@@ -41,6 +41,9 @@ class RequirementTemplate(Requirement):
     def simplify(self, keep_comments: bool = False) -> Requirement:
         return self
 
+    def isolate_damage_requirements(self, context: NodeContext) -> Requirement:
+        return self.template_requirement(context.database).isolate_damage_requirements(context)
+
     def as_set(self, context: NodeContext) -> RequirementSet:
         return self.template_requirement(context.database).as_set(context)
 

--- a/randovania/game_description/requirements/resource_requirement.py
+++ b/randovania/game_description/requirements/resource_requirement.py
@@ -82,6 +82,9 @@ class ResourceRequirement(Requirement):
     def simplify(self, keep_comments: bool = False) -> Requirement:
         return self
 
+    def isolate_damage_requirements(self, context: NodeContext) -> Requirement:
+        return Requirement.trivial() if self.satisfied(context, 0) else Requirement.impossible()
+
     def __repr__(self) -> str:
         return "{} {} {}".format(self.resource, "<" if self.negate else "≥", self.amount)
 
@@ -151,6 +154,9 @@ class DamageResourceRequirement(ResourceRequirement):
 
     def satisfied(self, context: NodeContext, current_energy: int) -> bool:
         return current_energy > self.damage(context)
+
+    def isolate_damage_requirements(self, context: NodeContext) -> Requirement:
+        return self
 
     def multiply_amount(self, multiplier: float) -> ResourceRequirement:
         return DamageResourceRequirement(

--- a/randovania/resolver/resolver_reach.py
+++ b/randovania/resolver/resolver_reach.py
@@ -165,9 +165,9 @@ class ResolverReach:
                     # If we can't go to this node, store the reason in order to build the satisfiable requirements.
                     # Note we ignore the 'additional requirements' here because it'll be added on the end.
                     if not requirement.satisfied(context, damage_health):
-                        full_requirement_for_target = _combine_damage_requirements(
-                            node.heal, requirement, satisfied_requirement_on_node[node.node_index], context
-                        )
+                        full_requirement_for_target = RequirementAnd(
+                            [requirement, satisfied_requirement_on_node[node.node_index]]
+                        ).simplify()
                         requirements_excluding_leaving_by_node[target_node_index].append(full_requirement_for_target)
 
         # Discard satisfiable requirements of nodes reachable by other means

--- a/randovania/resolver/resolver_reach.py
+++ b/randovania/resolver/resolver_reach.py
@@ -150,6 +150,8 @@ class ResolverReach:
                         else RequirementAnd(
                             [requirement_including_leaving, satisfied_requirement_on_node[node.node_index]]
                         )
+                        .isolate_damage_requirements(context)
+                        .simplify()
                     )
 
                 elif target_node:
@@ -160,6 +162,8 @@ class ResolverReach:
                             requirement
                             if node.heal
                             else RequirementAnd([requirement, satisfied_requirement_on_node[node.node_index]])
+                            .isolate_damage_requirements(context)
+                            .simplify()
                         )
                         requirements_excluding_leaving_by_node[target_node_index].append(full_requirement_for_target)
 

--- a/randovania/resolver/resolver_reach.py
+++ b/randovania/resolver/resolver_reach.py
@@ -49,6 +49,16 @@ def _is_requirement_viable_as_additional(requirement: Requirement) -> bool:
 def _combine_damage_requirements(
     heal: bool, requirement: Requirement, satisfied_requirement: Requirement, context: NodeContext
 ) -> Requirement:
+    """
+    Helper function combining damage requirements from requirement and satisfied_requirement. Other requirements are
+    considered either trivial or impossible. The heal argument can be used to ignore the damage requirements from the
+    satisfied requirement, which is relevant when requirement comes from a connection out of a heal node.
+    :param heal:
+    :param requirement:
+    :param satisfied_requirement:
+    :param context:
+    :return:
+    """
     return (
         requirement
         if heal


### PR DESCRIPTION
When a chain of requirements is unsatisfied, use all requirements between heal nodes to form additional requirements, in order to capture the accumulated damage requirements.