### PR TITLE
Fusion Traning Grounds Video and Clean Up Comments

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -803,7 +803,7 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": "Freeze Chute Leeches (No Wall Jump): https://youtu.be/XeE_DkCnuGI",
+                                                        "comment": "Freeze Chute Leeches (No Wall Jump, No High Jump): https://youtu.be/XeE_DkCnuGI",
                                                         "items": [
                                                             {
                                                                 "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -550,7 +550,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "https://youtu.be/Qe9eMPmoUcU",
+                                            "comment": "Shinespark: https://youtu.be/Qe9eMPmoUcU",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -631,7 +631,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "WJ off of door hatch: https://youtu.be/weMdKWzp31g",
+                                            "comment": "Wall Jump off of door hatch: https://youtu.be/weMdKWzp31g",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -794,7 +794,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Freeze Chute Leeches: https://youtu.be/XeE_DkCnuGI",
+                                            "comment": null,
                                             "items": [
                                                 {
                                                     "type": "template",
@@ -803,7 +803,7 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Freeze Chute Leeches (No Wall Jump): https://youtu.be/XeE_DkCnuGI",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -826,7 +826,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": null,
+                                                                    "comment": "Freeze Chute Leeches (Wall Jump): https://youtu.be/c9ZXNaw35MA",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -100,14 +100,14 @@ Extra - room_id: [3, 6]
   * L3 Hatch to Gerubus Gully/Door to Training Grounds
   * Extra - door_idx: (7,)
   > Door to Training Aerie
-      # https://youtu.be/Qe9eMPmoUcU
+      # Shinespark: https://youtu.be/Qe9eMPmoUcU
       Level 3 Keycard and Speed Booster and Shinespark Tricks (Intermediate) and Wall Jump (Advanced) and Disabled Door Lock Rando and Disabled Entrance Rando
   > Door to Arctic Containment
       Trivial
   > Door to Entrance Lobby
       Any of the following:
           Have Any Jump Upgrade
-          # WJ off of door hatch: https://youtu.be/weMdKWzp31g
+          # Wall Jump off of door hatch: https://youtu.be/weMdKWzp31g
           Wall Jump (Intermediate) and Disabled Door Lock Rando
 
 > Door to Training Aerie; Heals? False
@@ -134,10 +134,11 @@ Extra - room_id: [3, 6]
       Any of the following:
           Space Jump
           All of the following:
-              # Freeze Chute Leeches: https://youtu.be/XeE_DkCnuGI
               Can Freeze Enemies With Any Weapon
               Any of the following:
+                  # Freeze Chute Leeches (No Wall Jump): https://youtu.be/XeE_DkCnuGI
                   Hi-Jump or Stand On Frozen Enemies (Intermediate)
+                  # Freeze Chute Leeches (Wall Jump): https://youtu.be/c9ZXNaw35MA
                   Stand On Frozen Enemies (Beginner) and Wall Jump (Beginner)
 
 ----------------

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -136,7 +136,7 @@ Extra - room_id: [3, 6]
           All of the following:
               Can Freeze Enemies With Any Weapon
               Any of the following:
-                  # Freeze Chute Leeches (No Wall Jump): https://youtu.be/XeE_DkCnuGI
+                  # Freeze Chute Leeches (No Wall Jump, No High Jump): https://youtu.be/XeE_DkCnuGI
                   Hi-Jump or Stand On Frozen Enemies (Intermediate)
                   # Freeze Chute Leeches (Wall Jump): https://youtu.be/c9ZXNaw35MA
                   Stand On Frozen Enemies (Beginner) and Wall Jump (Beginner)


### PR DESCRIPTION
Added

- The trick video for the beginner logic frozen enemies and wall jump

Changed

- Adjusted comments on other tricks to match and be consistent with what I was seeing in the rest of the db
- Adjusted the existing Frozen Enemies No Wall Jump video comment to the intermediate trick it was meant for (this should also fix the trick report)

I understand the tricks are close, but had a seed where only beginner logic was required and thought the intermedate was the beginner. Made a new video and adjustments in hopes this clears it all up