### PR TITLE
Fusion Remove the export is unsupported text

### DIFF
--- a/randovania/games/fusion/gui/ui_files/fusion_game_export_dialog.ui
+++ b/randovania/games/fusion/gui/ui_files/fusion_game_export_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>508</width>
-    <height>295</height>
+    <height>309</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -66,10 +66,10 @@
       </size>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Exporting is currently not supported for Fusion! Please be patient, as we are still very early in development :)&lt;/p&gt;&lt;p&gt;In order to create the randomized game, a copy of the US version of Fusion.gba is necessary.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In order to create the randomized game, a copy of the US version of Fusion.gba is necessary.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="textFormat">
-      <enum>Qt::RichText</enum>
+      <enum>Qt::TextFormat::RichText</enum>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -96,7 +96,7 @@
    <item row="1" column="0" colspan="2">
     <widget class="Line" name="line">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -110,7 +110,7 @@
    <item row="7" column="0" colspan="2">
     <widget class="Line" name="line_2">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Jeff pointed out in the discord to have this fixed

I did not see an open issue for this, but here is the PR

Here is screenshot of how it looks with the export is unsupported text removed:

![image](https://github.com/user-attachments/assets/55a653f9-dc94-4594-b5c4-5892409424c6)
