### PR TITLE
Fusion Change Keycards Order in GUI

### DIFF
--- a/randovania/games/fusion/pickup_database/pickup-database.json
+++ b/randovania/games/fusion/pickup_database/pickup-database.json
@@ -38,6 +38,13 @@
                 "suit"
             ]
         },
+        "keycard": {
+            "long_name": "Keycards",
+            "hint_details": [
+                "a ",
+                "Keycard"
+            ]
+        },
         "energy_tank": {
             "long_name": "Energy Tanks",
             "hint_details": [
@@ -64,13 +71,6 @@
             "hint_details": [
                 "a ",
                 "life support system"
-            ]
-        },
-        "keycard": {
-            "long_name": "Keycards",
-            "hint_details": [
-                "a ",
-                "Keycard"
             ]
         },
         "InfantMetroid": {


### PR DESCRIPTION
Fixes https://github.com/randovania/randovania/issues/8049

Moved the Keycards in the pickup databasae JSON in the categories section

Tested the gui still worked and changed a few of the items and exported to make sure stuff was still working

![image](https://github.com/user-attachments/assets/d7481f71-8148-4812-aa22-88e341a749cf)
