### PR TITLE
clarify branch name in discord post

### DIFF
--- a/tools/post_discord_webhook.py
+++ b/tools/post_discord_webhook.py
@@ -65,7 +65,7 @@ async def post_to_discord():
         "embeds": [
             {
                 "color": 0x2ECC71,
-                "title": f"{current_branch} - Randovania {version}",
+                "title": f"Branch {current_branch} - Randovania {version}",
                 "url": f"https://github.com/randovania/randovania/commit/{commit_hash}",
                 "description": message.strip(),
                 "fields": fields,


### PR DESCRIPTION
sometimes we post stuff from the stable branch, which could then get confused for a dev build even though it doesnt use the staging environment