### PR TITLE
Fusion More Joke Hints

### DIFF
--- a/randovania/games/fusion/exporter/joke_hints.py
+++ b/randovania/games/fusion/exporter/joke_hints.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from randovania.exporter.hints.joke_hints import GENERIC_JOKE_HINTS
 
 FUSION_JOKE_HINTS = GENERIC_JOKE_HINTS + [
-    "Adam has not yet authorized the use of this hint.",
     "Space Pirates, strangely, dislike theft.",
     "We've been trying to contact you about your ship's extended warranty.",
     "Did you know Yellow X are lemon flavoured?",
@@ -11,8 +10,7 @@ FUSION_JOKE_HINTS = GENERIC_JOKE_HINTS + [
     "Did you know Red X are strawberry flavoured?",
     "Did you know Blue X are blueberry flavoured?",
     "I would tell you a hint, but Aran out of them.",
-    "WARNING: No hint without authorization.",
-    "If you do not know where you are going, you are playing METROID conFUSION.",
+    "If you do not know where you are going, you are playing METROID CONFUSION.",
     "Someone who looked just like you already claimed this hint.",
     "The electrified water is quite shocking.",
     "Did Gary touch the thermostat again?",

--- a/randovania/games/fusion/exporter/joke_hints.py
+++ b/randovania/games/fusion/exporter/joke_hints.py
@@ -11,9 +11,9 @@ FUSION_JOKE_HINTS = GENERIC_JOKE_HINTS + [
     "Did you know Red X are strawberry flavoured?",
     "Did you know Blue X are blueberry flavoured?",
     "I would tell you a hint, but Aran out of them.",
-    "WARNING: No hint without authorization",
-    "If you do not know where you are going, you are playing Metroid conFUSION",
-    "Someone who looked just like you already claimed this hint",
-    "The electrified water is quite shocking",
+    "WARNING: No hint without authorization.",
+    "If you do not know where you are going, you are playing METROID conFUSION.",
+    "Someone who looked just like you already claimed this hint.",
+    "The electrified water is quite shocking.",
     "Did Gary touch the thermostat again?",
 ]

--- a/randovania/games/fusion/exporter/joke_hints.py
+++ b/randovania/games/fusion/exporter/joke_hints.py
@@ -11,4 +11,9 @@ FUSION_JOKE_HINTS = GENERIC_JOKE_HINTS + [
     "Did you know Red X are strawberry flavoured?",
     "Did you know Blue X are blueberry flavoured?",
     "I would tell you a hint, but Aran out of them.",
+    "WARNING: No hint without authorization",
+    "If you do not know where you are going, you are playing Metroid conFUSION",
+    "Someone who looked just like you already claimed this hint",
+    "The electrified water is quite shocking",
+    "Did Gary touch the thermostat again?",
 ]


### PR DESCRIPTION
Most Important PR, added in some joke hints. If some didnt land, I can remove them

- "WARNING: No hint without authorization"
- "If you do not know where you are going, you are playing Metroid conFUSION"
- "Someone who looked just like you already claimed this hint"
- "The electrified water is quite shocking"
- "Did Gary touch the thermostat again?"