### PR TITLE
Fix Speed Booster Upgrades being included as hintable items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
+- Changed: The maximum number of Speed Booster Upgrade items that will have an effect is now 4 instead of 5 (any further upgrades have no effect). This is to prevent a quirk with inconsistent Speed Booster activation with very short charge times.
 - Fixed: The patching data being exported on race seeds.
+- Fixed: Speed Booster Upgrade items will no longer be hinted or included in the credits.
 
 #### Logic Database
 

--- a/randovania/games/dread/pickup_database/pickup-database.json
+++ b/randovania/games/dread/pickup_database/pickup-database.json
@@ -892,7 +892,7 @@
                 "am2r": "sItemSpeedBoosterUpgradeDread"
             },
             "preferred_location_category": "minor",
-            "description": "Each Speed Booster Upgrade reduces the amount of time Speed Booster takes to charge by one quarter of a second.\nDue to game limitations, the minimum allowed charge time is approximately half a second.",
+            "description": "Each Speed Booster Upgrade reduces the amount of time Speed Booster takes to charge by ~0.25 seconds.\nDue to game limitations, the minimum allowed charge time is approximately 0.5 seconds.",
             "progression": [
                 "SpeedBoostUpgrade"
             ],

--- a/randovania/games/dread/pickup_database/pickup-database.json
+++ b/randovania/games/dread/pickup_database/pickup-database.json
@@ -884,7 +884,7 @@
         "Speed Booster Upgrade": {
             "gui_category": "misc",
             "hint_features": [
-                "major",
+                "expansion",
                 "misc"
             ],
             "model_name": "item_speedboostupgrade",
@@ -892,10 +892,11 @@
                 "am2r": "sItemSpeedBoosterUpgradeDread"
             },
             "preferred_location_category": "minor",
-            "description": "Speed Booster Upgrades reduce the amount of time it takes Speed Booster to activate by 0.25 seconds (for each upgrade collected).\nThe minimum charge time is 0.25s.",
+            "description": "Each Speed Booster Upgrade reduces the amount of time Speed Booster takes to charge by one quarter of a second.\nDue to game limitations, the minimum allowed charge time is approximately half a second.",
             "progression": [
                 "SpeedBoostUpgrade"
             ],
+            "show_in_credits_spoiler": false,
             "expected_case_for_describer": "missing"
         }
     },

--- a/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
@@ -3826,7 +3826,6 @@
         "Speed Booster": "Burenia - Flash Shift Room",
         "Progressive Spin": "Burenia - Main Hub Tower Top\nGhavoran - Super Missile Room Access",
         "Screw Attack": "Burenia - Early Gravity Speedboost Room 1",
-        "Speed Booster Upgrade": "Artaria - EMMI Zone First Entrance\nArtaria - Screw Attack Room\nBurenia - Gravity Suit Room\nGhavoran - Spin Boost Tower",
         "Metroid DNA 1": "Dairon - Central Unit Access",
         "Metroid DNA 10": "Cataris - Kraid Arena",
         "Metroid DNA 11": "Ghavoran - Golzuna Arena",

--- a/test/test_files/patcher_data/dread/dread/crazy_settings/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/crazy_settings/world_1.json
@@ -3542,7 +3542,6 @@
         "Speed Booster": "Cataris - Teleport to Dairon",
         "Progressive Spin": "Artaria - Teleport to Cataris\nBurenia - Early Gravity Speedboost Room 1",
         "Screw Attack": "Hanubia - Orange EMMI Introduction",
-        "Speed Booster Upgrade": "Artaria - Proto EMMI Introduction\nCataris - Above Z-57 Fight\nDairon - Bomb Room\nFerenia - Pitfall Puzzle Room",
         "Metroid DNA 1": "Artaria - Central Unit Access",
         "Metroid DNA 2": "Burenia - Drogyga Arena",
         "Metroid DNA 3": "Cataris - Central Unit Access"

--- a/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_4.json
@@ -3745,7 +3745,6 @@
         "Speed Booster": "{c3}World 4{c0}'s Artaria - Waterfall",
         "Progressive Spin": "{c3}World 1{c0}'s The Tower - Tower Exterior South East\n{c3}World 4{c0}'s Burenia - Gravity Suit Tower",
         "Screw Attack": "{c3}World 1{c0}'s The Tower - Inner Zeta Nest",
-        "Speed Booster Upgrade": "{c3}World 1{c0}'s Main Caves - Fat Crocomire Room\n{c3}World 1{c0}'s The Tower - Exterior Zeta Nest East",
         "Metroid DNA 1": "{c3}World 4{c0}'s Cataris - Central Unit Access",
         "Metroid DNA 2": "{c3}World 4{c0}'s Cataris - Kraid Arena",
         "Metroid DNA 3": "{c3}World 4{c0}'s Dairon - Central Unit Access",


### PR DESCRIPTION
SBUs are now excluded from the credits (and thus the hinted item pool). The description was also changed to take randovania/open-dread-rando#398 into account, and to be less precise about the times since the minimum charge time is no longer exactly a multiple of 0.25 seconds.