### PR TITLE
add extra to pickupentry

### DIFF
--- a/randovania/game_connection/connector/cs_remote_connector.py
+++ b/randovania/game_connection/connector/cs_remote_connector.py
@@ -198,7 +198,7 @@ class CSRemoteConnector(RemoteConnector):
 
         message = f"Received item from ={provider_name}=!"
         message = wrap_msg_text(message, False)
-        pickup_script = self.pickup_db.get_pickup_with_name(pickup.name).extra.get("script", NOTHING_ITEM_SCRIPT)
+        pickup_script = pickup.extra.get("script", NOTHING_ITEM_SCRIPT)
         script = f"<MSG<TUR{message}<FL+{ITEM_RECEIVED_FLAG}{pickup_script}"
         await self.executor.exec_script(script)
 

--- a/randovania/game_description/pickup/pickup_entry.py
+++ b/randovania/game_description/pickup/pickup_entry.py
@@ -96,6 +96,7 @@ class PickupEntry:
     )
     show_in_credits_spoiler: bool = True  # TODO: rename. this is effectively an "is important item" flag
     is_expansion: bool = False
+    extra: frozendict = dataclasses.field(default_factory=frozendict)
 
     def __post_init__(self) -> None:
         if not isinstance(self.progression, tuple):

--- a/randovania/games/cave_story/exporter/patch_data_factory.py
+++ b/randovania/games/cave_story/exporter/patch_data_factory.py
@@ -133,9 +133,7 @@ class CSPatchDataFactory(PatchDataFactory[CSConfiguration, CSCosmeticPatches]):
             elif target == nothing_item:
                 pickup_script = NOTHING_ITEM_SCRIPT
             else:
-                pickup_script = self.pickup_db.get_pickup_with_name(target.pickup.name).extra.get(
-                    "script", NOTHING_ITEM_SCRIPT
-                )
+                pickup_script = target.pickup.extra.get("script", NOTHING_ITEM_SCRIPT)
             pickups[mapname][event] = pickup_script
 
         return pickups

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -68,6 +68,7 @@ def create_standard_pickup(
             index_age_impact=pickup.index_age_impact,
         ),
         show_in_credits_spoiler=pickup.show_in_credits_spoiler,
+        extra=pickup.extra,
     )
 
 
@@ -106,6 +107,7 @@ def create_ammo_pickup(
         ),
         show_in_credits_spoiler=False,
         is_expansion=True,
+        extra=ammo.extra,
     )
 
 
@@ -150,6 +152,7 @@ def create_generated_pickup(
             index_age_impact=pickup.index_age_impact,
             required_progression=minimum_progression,
         ),
+        extra=pickup.extra,
     )
 
 
@@ -177,6 +180,7 @@ def create_nothing_pickup(resource_database: ResourceDatabase, model_name: str =
             preferred_location_category=LocationCategory.MAJOR,  # TODO
         ),
         show_in_credits_spoiler=False,
+        extra=frozendict(),
     )
 
 
@@ -201,4 +205,5 @@ def create_visual_nothing(game: RandovaniaGame, model_name: str, pickup_name: st
             preferred_location_category=LocationCategory.MAJOR,  # TODO
         ),
         show_in_credits_spoiler=False,
+        extra=frozendict(),
     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -473,6 +473,7 @@ def cs_panties_pickup(default_generator_params: PickupGeneratorParams) -> Pickup
         generator_params=default_generator_params,
         resource_lock=None,
         unlocks_resource=False,
+        extra=frozendict({"script": "<EVE0085"}),
     )
 
 


### PR DESCRIPTION
this makes it a lot more convenient to access in the PDF and in connectors, where this is the most relevant. especially helpful for generated pickups, where the old pattern of getting a pickup definition by name wasn't possible