### PR TITLE
Fusion Hide Required Main Fixes

### DIFF
--- a/randovania/game_description/pickup/pickup_definition/ammo_pickup.py
+++ b/randovania/game_description/pickup/pickup_definition/ammo_pickup.py
@@ -40,6 +40,9 @@ class AmmoPickupDefinition(BasePickupDefinition):
     allows_negative: bool = dataclasses.field(default=False, metadata=EXCLUDE_DEFAULT)
     """Determines whether the user can configure this expansion to remove maximum ammo rather than provide it."""
 
+    hide_requires_main: bool = dataclasses.field(default=False, metadata=EXCLUDE_DEFAULT)
+    """Determines whether to hide the option of requiring mains for the ammo pickup."""
+
     include_expected_counts: bool = dataclasses.field(default=True, metadata=EXCLUDE_DEFAULT)
     """Whether to indicate the maximum ammo from this source in the item pool tab."""
     explain_other_sources: bool = dataclasses.field(default=True, metadata=EXCLUDE_DEFAULT)
@@ -90,6 +93,7 @@ class AmmoPickupDefinition(BasePickupDefinition):
             "unlocked_by",
             "temporary",
             "allows_negative",
+            "hide_requires_main",
             "include_expected_counts",
             "explain_other_sources",
             "mention_limit",

--- a/randovania/games/fusion/pickup_database/pickup-database.json
+++ b/randovania/games/fusion/pickup_database/pickup-database.json
@@ -752,7 +752,8 @@
             "preferred_location_category": "minor",
             "probability_offset": 1.5,
             "extra": {
-                "TankIncrementName": "MissileTank"
+                "TankIncrementName": "MissileTank",
+                "hide_requires_main": true
             },
             "items": [
                 "Missiles"
@@ -776,7 +777,8 @@
             },
             "preferred_location_category": "minor",
             "extra": {
-                "TankIncrementName": "PowerBombTank"
+                "TankIncrementName": "PowerBombTank",
+                "hide_requires_main": true
             },
             "items": [
                 "PowerBombs"

--- a/randovania/games/fusion/pickup_database/pickup-database.json
+++ b/randovania/games/fusion/pickup_database/pickup-database.json
@@ -752,15 +752,15 @@
             "preferred_location_category": "minor",
             "probability_offset": 1.5,
             "extra": {
-                "TankIncrementName": "MissileTank",
-                "hide_requires_main": true
+                "TankIncrementName": "MissileTank"
             },
             "items": [
                 "Missiles"
             ],
             "unlocked_by": "MissileData",
             "temporary": "LockedMissiles",
-            "allows_negative": true
+            "allows_negative": true,
+            "hide_requires_main": true
         },
         "Power Bomb Tank": {
             "gui_category": "morph_ball",
@@ -777,15 +777,15 @@
             },
             "preferred_location_category": "minor",
             "extra": {
-                "TankIncrementName": "PowerBombTank",
-                "hide_requires_main": true
+                "TankIncrementName": "PowerBombTank"
             },
             "items": [
                 "PowerBombs"
             ],
             "unlocked_by": "PowerBombData",
             "temporary": "LockedPowerBombs",
-            "allows_negative": true
+            "allows_negative": true,
+            "hide_requires_main": true
         }
     },
     "default_pickups": {},

--- a/randovania/games/prime1/pickup_database/pickup-database.json
+++ b/randovania/games/prime1/pickup_database/pickup-database.json
@@ -724,7 +724,8 @@
             ],
             "unlocked_by": "MissileLauncher",
             "temporary": "LockedMissile",
-            "allows_negative": true
+            "allows_negative": true,
+            "hide_requires_main": true
         },
         "Power Bomb Expansion": {
             "gui_category": "morph_ball",
@@ -745,7 +746,8 @@
             ],
             "unlocked_by": "MainPB",
             "temporary": "LockedPB",
-            "allows_negative": true
+            "allows_negative": true,
+            "hide_requires_main": true
         },
         "Energy Refill": {
             "gui_category": "misc",

--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -388,10 +388,8 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
                 require_main_item_check.stateChanged.connect(partial(self._on_update_ammo_require_main_item, ammo))
                 if self.game == RandovaniaGame.METROID_PRIME:
                     require_main_item_check.setVisible(False)
-                for extra, value in ammo.extra.items():
-                    if "hide_requires_main" in extra:
-                        if value:
-                            require_main_item_check.setVisible(False)
+                if ammo.hide_requires_main:
+                    require_main_item_check.setVisible(False)
                 layout.addWidget(require_main_item_check, current_row, 0, 1, -1)
                 current_row += 1
             else:

--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -388,6 +388,10 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
                 require_main_item_check.stateChanged.connect(partial(self._on_update_ammo_require_main_item, ammo))
                 if self.game == RandovaniaGame.METROID_PRIME:
                     require_main_item_check.setVisible(False)
+                for extra, value in ammo.extra.items():
+                    if "hide_requires_main" in extra:
+                        if value:
+                            require_main_item_check.setVisible(False)
                 layout.addWidget(require_main_item_check, current_row, 0, 1, -1)
                 current_row += 1
             else:

--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -381,13 +381,10 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
             add_column(pickup_spinbox)
             current_row += 1
 
-            # FIXME: hardcoded check to hide required mains for Prime 1
             if ammo.temporary:
                 require_main_item_check = QtWidgets.QCheckBox(pickup_box)
                 require_main_item_check.setText("Requires the main item to work?")
                 require_main_item_check.stateChanged.connect(partial(self._on_update_ammo_require_main_item, ammo))
-                if self.game == RandovaniaGame.METROID_PRIME:
-                    require_main_item_check.setVisible(False)
                 if ammo.hide_requires_main:
                     require_main_item_check.setVisible(False)
                 layout.addWidget(require_main_item_check, current_row, 0, 1, -1)


### PR DESCRIPTION
Fixes https://github.com/randovania/randovania/issues/7959

Felt this implementation was the best middle ground. There is no nice way to add in a check for hiding the required mains in the item pool gui for ammo. In fact, there is a "fix me" for prime 1 that just hard checks if the game is prime 1 and then hides required mains.

Trying to add anything into the definitions/properties for ammo_pickups blew everything sky high. Changing ammo being not temporary (so item pool gui doesnt even do required mains) blew up logic and other stuff.

In the end, I decided to add in a value to extra for the ammo in the pickup database instead. Then added a check in the item pool gui for this value. This also safely didnt hurt other games.

I could probably fix the prime 1 hardcode as well by adding this extra value for the ammo in the pickup database for prime 1 in a seperate PR if this is a acceptable fix.

I also looked around and didnt see any mention of required mains in the difference tab or otherwise in the Fusion gui. Not sure if I missed something, but hopefully this should be it.