### PR TITLE
fusion(sector3): Add morph-ball checks in Alcove

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -1940,10 +1940,12 @@
                     "hint_features": [],
                     "connections": {
                         "Other to Entrance Lobby": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "MorphBall",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Above E-Tank": {
@@ -2192,6 +2194,15 @@
                             "data": {
                                 "comment": "Store shinespark from adjacent room: https://youtu.be/OzwrRjDZKXs",
                                 "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
                                     {
                                         "type": "resource",
                                         "data": {
@@ -2805,6 +2816,15 @@
                             "data": {
                                 "comment": null,
                                 "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
                                     {
                                         "type": "template",
                                         "data": "Can Break Single Bomb Blocks"

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -310,7 +310,7 @@ Hint Features - Pillar
   * Extra - blockx: 9
   * Extra - blocky: 9
   > Other to Entrance Lobby
-      Trivial
+      Morph Ball
   > Above E-Tank
       Can Use Power Bombs
 
@@ -350,7 +350,7 @@ Hint Features - Pillar
   > Below E-Tank
       All of the following:
           # Store shinespark from adjacent room: https://youtu.be/OzwrRjDZKXs
-          Level 0 Keycard and Speed Booster and Knowledge (Intermediate) and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
+          Level 0 Keycard and Morph Ball and Speed Booster and Knowledge (Intermediate) and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
           # Deal with Sidehopper
           Combat (Advanced) or Can Kill Tough Beam-Resistant Enemy
   > Bottom Right
@@ -429,7 +429,7 @@ Hint Features - Pillar
           Wall Jump (Intermediate) and Can Single Walljump
   > Below E-Tank
       All of the following:
-          Can Break Single Bomb Blocks
+          Morph Ball and Can Break Single Bomb Blocks
           Any of the following:
               # Get through Sidehoppers
               Can Kill Tough Beam-Resistant Enemy


### PR DESCRIPTION
Adds morph ball checks where "can break single bomb block" template is used for morph tunnels and the missing morph ball check from the Power Bomb tank pickup.