### PR TITLE
Async Race: Make clearer that proof url is not required when submission notes were given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: After clicking the "Login with Discord" button, a link and a QR Code are displayed instead of opening the default browser directly.
 - Changed: The relative time to start/finish in Async Race rooms now update as time passes, and the window reacts appropriately when the race starts and finishes.
+- Fixed: When submitting proof for an async race, it is now clearer that it's only providing a proof URL is not required if submission notes were given.
 - Removed: The initial Randovania screen no longer contains the list of supported games.
 
 ### AM2R

--- a/randovania/gui/dialog/async_race_proof_popup.py
+++ b/randovania/gui/dialog/async_race_proof_popup.py
@@ -26,15 +26,25 @@ class AsyncRaceProofPopup(QtWidgets.QDialog):
         self.ui.button_box.accepted.connect(self.accept)
         self.ui.button_box.rejected.connect(self.reject)
         self.ui.proof_edit.textChanged.connect(self._on_proof_updated)
+        self.ui.notes_edit.textChanged.connect(self._on_proof_updated)
 
     def _on_proof_updated(self) -> None:
-        """Validate that the proof URL at least looks like a URL"""
+        """Validate that either a proof URL which looks like a URL was given, or that submission notes were given."""
+
+        # Mark proof url as error only if one was given that does not look like a url
         common_qt_lib.set_error_border_stylesheet(
             self.ui.proof_edit,
             self.proof_url and self._proof_re.match(self.proof_url) is None,
         )
+
+        # Mark submission notes as error only if none were given and no proof url was given
+        common_qt_lib.set_error_border_stylesheet(
+            self.ui.notes_edit, not bool(self.submission_notes) and not bool(self.proof_url)
+        )
+
+        # Only let user submit if either proof url or submission notes were given
         self.ui.button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Save).setEnabled(
-            not self.ui.proof_edit.has_error
+            not (self.ui.proof_edit.has_error or self.ui.notes_edit.has_error)
         )
 
     @property


### PR DESCRIPTION
fixes #8238 