### PR TITLE
Generator: Fix not accounting for dangerous resource when evaluating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Generator
 
 - Fixed: Bugs where the generator would collect dangerous resources too early, leading to generation failure in some cases.
+- Fixed: Bug where the requirements that apply beyond a point of no return weren't considered correctly.
 - Improved: Try a little harder to check if seemingly unsafe options are actually safe.
 
 ### AM2R

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Generator
 
-- Fixed: Bug where the generator would collect dangerous resources too early, leading to generation failure in some cases.
+- Fixed: Bugs where the generator would collect dangerous resources too early, leading to generation failure in some cases.
 
 ### AM2R
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Generator
 
 - Fixed: Bugs where the generator would collect dangerous resources too early, leading to generation failure in some cases.
+- Improved: Try a little harder to check if seemingly unsafe options are actually safe.
 
 ### AM2R
 

--- a/randovania/generator/old_generator_reach.py
+++ b/randovania/generator/old_generator_reach.py
@@ -364,10 +364,11 @@ class OldGeneratorReach(GeneratorReach):
             (all_nodes[node_index], requirement) for node_index, requirement in self._uncollectable_nodes.items()
         ]
 
-        for (_, node_index), requirement in self._unreachable_paths.items():
-            node = all_nodes[node_index]
-            if not self.is_reachable_node(node):
-                to_check.append((node, requirement))
+        for (source_node_index, target_node_index), requirement in self._unreachable_paths.items():
+            source_node = all_nodes[source_node_index]
+            target_node = all_nodes[target_node_index]
+            if self.is_reachable_node(source_node) and not self.is_reachable_node(target_node):
+                to_check.append((target_node, requirement))
 
         for node, requirement in to_check:
             requirements = requirement.patch_requirements(context)

--- a/randovania/generator/reach_lib.py
+++ b/randovania/generator/reach_lib.py
@@ -137,14 +137,12 @@ def advance_reach_with_possible_unsafe_resources(previous_reach: GeneratorReach)
             # print("Non-safe {} was good".format(logic.game.node_name(action)))
             return advance_reach_with_possible_unsafe_resources(next_reach)
 
-        if next_reach.is_reachable_node(initial_state.node):
-            next_next_state = next_reach.state.copy()
-            next_next_state.node = initial_state.node
+        next_next_state = next_reach.state.copy()
 
-            next_reach = reach_with_all_safe_resources(game, next_next_state, previous_reach.filler_config)
-            if previous_safe_nodes <= set(next_reach.safe_nodes):
-                # print("Non-safe {} could reach back to where we were".format(logic.game.node_name(action)))
-                return advance_reach_with_possible_unsafe_resources(next_reach)
+        next_reach = reach_with_all_safe_resources(game, next_next_state, previous_reach.filler_config)
+        if next_reach.is_reachable_node(initial_state.node) and previous_safe_nodes <= set(next_reach.safe_nodes):
+            # print("Non-safe {} could reach back to where we were".format(logic.game.node_name(action)))
+            return advance_reach_with_possible_unsafe_resources(next_reach)
         else:
             pass
 

--- a/randovania/generator/reach_lib.py
+++ b/randovania/generator/reach_lib.py
@@ -154,9 +154,9 @@ def advance_reach_with_possible_unsafe_resources(previous_reach: GeneratorReach)
 
 def advance_after_action(potential_reach: GeneratorReach) -> GeneratorReach:
     """
-    Collect all possible resources.
-    :param potential_reach:
-    :return:
+    Advances the reach after performing an action, collecting unlocked resources.
+    :param potential_reach: Reach after collecting action
+    :return: Reach after collecting resources
     """
 
     if potential_reach.filler_config.consider_possible_unsafe_resources:

--- a/randovania/generator/reach_lib.py
+++ b/randovania/generator/reach_lib.py
@@ -152,15 +152,12 @@ def advance_reach_with_possible_unsafe_resources(previous_reach: GeneratorReach)
     return previous_reach
 
 
-def advance_to_with_reach_copy(base_reach: GeneratorReach, state: State) -> GeneratorReach:
+def advance_after_action(potential_reach: GeneratorReach) -> GeneratorReach:
     """
-    Copies the given Reach, advances to the given State and collect all possible resources.
-    :param base_reach:
-    :param state:
+    Collect all possible resources.
+    :param potential_reach:
     :return:
     """
-    potential_reach = copy.deepcopy(base_reach)
-    potential_reach.advance_to(state)
 
     if potential_reach.filler_config.consider_possible_unsafe_resources:
         return advance_reach_with_possible_unsafe_resources(potential_reach)


### PR DESCRIPTION
When evaluating an action that gives a dangerous action, use reach.act_on, because this function accounts for the new dangerous resource in terms of removing nodes as safe in the reach.