### PR TITLE
Fusion: Fixes to Powamp Shaft Logic

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -11893,14 +11893,14 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Gravityless method",
+                                                        "comment": "No Gravity Suit: https://youtu.be/F6iQaCkrbV0",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "StandOnFrozenEnemies",
-                                                                    "amount": 1,
+                                                                    "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -11909,30 +11909,8 @@
                                                                 "data": "Can Freeze Enemies With Any Weapon"
                                                             },
                                                             {
-                                                                "type": "or",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Hi-Jump",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "StandOnFrozenEnemies",
-                                                                                "amount": 3,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Have Any Jump Upgrade"
                                                             }
                                                         ]
                                                     }
@@ -11940,7 +11918,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "Gravity method",
+                                                        "comment": null,
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -11959,7 +11937,7 @@
                                                                         {
                                                                             "type": "and",
                                                                             "data": {
-                                                                                "comment": "Shinespark",
+                                                                                "comment": "Shinespark: https://youtu.be/zDXCR7HINss",
                                                                                 "items": [
                                                                                     {
                                                                                         "type": "resource",
@@ -12021,7 +11999,7 @@
                                                                         {
                                                                             "type": "and",
                                                                             "data": {
-                                                                                "comment": "Single walljump on the side and kill the powamps",
+                                                                                "comment": "Single Wall Jump: https://youtu.be/6iSEl5LF6aU",
                                                                                 "items": [
                                                                                     {
                                                                                         "type": "template",
@@ -12044,6 +12022,27 @@
                                                                                             "amount": 2,
                                                                                             "negate": false
                                                                                         }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Stand On Frozen Enemies: https://youtu.be/eoniGf8_j70",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "StandOnFrozenEnemies",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Can Freeze Enemies With Any Weapon"
                                                                                     }
                                                                                 ]
                                                                             }

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -1708,19 +1708,18 @@ Extra - room_id: [35]
       Gravity Suit and Screw Attack
   > Upper Ladder
       Any of the following:
+          # No Gravity Suit: https://youtu.be/F6iQaCkrbV0
+          Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies With Any Weapon and Have Any Jump Upgrade
           All of the following:
-              # Gravityless method
-              Stand On Frozen Enemies (Beginner) and Can Freeze Enemies With Any Weapon
-              Hi-Jump or Stand On Frozen Enemies (Advanced)
-          All of the following:
-              # Gravity method
               Gravity Suit
               Any of the following:
                   Space Jump
-                  # Shinespark
+                  # Shinespark: https://youtu.be/zDXCR7HINss
                   Level 0 Keycard and Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
-                  # Single walljump on the side and kill the powamps
+                  # Single Wall Jump: https://youtu.be/6iSEl5LF6aU
                   Screw Attack and Wall Jump (Intermediate) and Can Single Walljump
+                  # Stand On Frozen Enemies: https://youtu.be/eoniGf8_j70
+                  Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies With Any Weapon
 
 > Door to Glass Tube to Sector 2 (TRO); Heals? False
   * Layers: default


### PR DESCRIPTION
The logic for this connection was impossible. It allowed to reach upper ladder gravless and no jump upgrade which ran by multiple people and the community, seems to be undoable by only Frozen Enemies advanced. I did enounter this in testing a seed and it was noncontinuable. 

- Fixed logic with what is possible
- Adjusted the difficulty level to reflect the tricks better
- Added in the videos