### PR TITLE
Fusion: force infants as non-starting

### DIFF
--- a/randovania/games/fusion/pickup_database/pickup-database.json
+++ b/randovania/games/fusion/pickup_database/pickup-database.json
@@ -126,7 +126,8 @@
             "progression": [
                 "Infant Metroid {i}"
             ],
-            "expected_case_for_describer": "shuffled"
+            "expected_case_for_describer": "shuffled",
+            "starting_condition": "never_start"
         }
     },
     "standard_pickups": {


### PR DESCRIPTION
game breaks if we start with a required metroid so don't do that