### PR TITLE
Changed Options in Multi-World Client

### DIFF
--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -370,10 +370,15 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         self.update_multiworld_client_status()
         self.everyone_can_claim_check.setChecked(session.allow_everyone_claim_world)
         self.everyone_can_claim_check.setEnabled(self.users_widget.is_admin())
+        self.everyone_can_claim_check.setToolTip("By default, only admins can assign unclaimed worlds.")
         self.allow_coop_check.setChecked(session.allow_coop)
         self.allow_coop_check.setEnabled(self.users_widget.is_admin() and not_genned_yet)
         self.allow_coop_check.setText(
-            "Enable Co-Op" + ("" if not_genned_yet else " (can only be changed before generation)")
+            "Enable Co-Op Worlds" + ("" if not_genned_yet else " (can only be changed before generation)")
+        )
+        self.allow_coop_check.setToolTip(
+            ("" if not_genned_yet else "(Can only be changed before generation.)\n")
+            + "By default, worlds can only be assigned to a single player.\n"
         )
 
     @asyncSlot(MultiplayerSessionActions)

--- a/randovania/gui/ui_files/multiplayer_session.ui
+++ b/randovania/gui/ui_files/multiplayer_session.ui
@@ -146,14 +146,20 @@
            <item row="2" column="0">
             <widget class="QCheckBox" name="everyone_can_claim_check">
              <property name="text">
-              <string>Everyone can claim worlds</string>
+              <string>Enable All Players to Claim Worlds</string>
+             </property>
+             <property name="toolTip">
+              <string>By default, only admins can assign unclaimed worlds.&lt;br/&gt;Enabling this allows any player to claim an unclaimed world.</string>
              </property>
             </widget>
            </item>
            <item row="3" column="0">
             <widget class="QCheckBox" name="allow_coop_check">
              <property name="text">
-              <string>Enable Co-Op</string>
+              <string>Enable Co-Op Worlds</string>
+             </property>
+             <property name="toolTip">
+              <string>By default, worlds can only be assigned to a single player.&lt;br/&gt;Enabling this allows multiple players to claim and participate in world progress.</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Changed:
- Former "Everyone can claim worlds" to "Enable All Players to Claim Worlds"
- Former "Enable Co-Op" to "Enable Co-Op Worlds"
- File `multiplayer_session.ui`
- File `multiplater_session_window.py`

Added:
- Tool Tip for "Enable All Players to Claim Worlds"
- Tool Tip for "Enable Co-Op Worlds"