### PR TITLE
Resolver: Fix resources from wrong node when rolling back dangerous items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet
 
+### Resolver
+
+- Fixed: Bug that could lead to timeouts or longer resolving time in some cases.
+
 ## [9.1.0] - 2025-05-01
 
 - Added: After clicking the "Login with Discord" button, a link and a QR Code are displayed instead of opening the default browser directly.

--- a/randovania/resolver/resolver.py
+++ b/randovania/resolver/resolver.py
@@ -301,7 +301,11 @@ async def _inner_advance_depth(
                 if new_result[0] is None:
                     additional = logic.get_additional_requirements(action).alternatives
 
-                    resources = [x for x, _ in action.resource_gain_on_collect(state.node_context())]
+                    resources = (
+                        [x for x, _ in state.node.resource_gain_on_collect(state.node_context())]
+                        if isinstance(state.node, ResourceNode)
+                        else []
+                    )
 
                     progressive_chain_info = _progressive_chain_info(state.node, state.node_context())
 


### PR DESCRIPTION
In fast branch of the resolver, fix using the wrong node when determining which dangerous resources the node gives. This is used to remove these resources from the additional requirements we set on the node.