### PR TITLE
Fusion: DB Fix Aquairum Speedway and Kago Storage Requirements 

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -3636,7 +3636,7 @@
                                                                             "data": {
                                                                                 "type": "tricks",
                                                                                 "name": "StandOnFrozenEnemies",
-                                                                                "amount": 2,
+                                                                                "amount": 1,
                                                                                 "negate": false
                                                                             }
                                                                         },
@@ -3716,7 +3716,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "StandOnFrozenEnemies",
-                                                        "amount": 2,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
@@ -14119,7 +14119,7 @@
                                                                                                                 "data": {
                                                                                                                     "type": "tricks",
                                                                                                                     "name": "StandOnFrozenEnemies",
-                                                                                                                    "amount": 2,
+                                                                                                                    "amount": 1,
                                                                                                                     "negate": false
                                                                                                                 }
                                                                                                             },
@@ -14184,7 +14184,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "StandOnFrozenEnemies",
-                                                                    "amount": 2,
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -3691,7 +3691,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "TODO: vid",
+                                            "comment": "Underwater Wall Jump: https://youtu.be/UEsvsxt9CgY",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -3710,6 +3710,19 @@
                                                         "amount": 5,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "StandOnFrozenEnemies",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Freeze Enemies With Any Weapon"
                                                 }
                                             ]
                                         }
@@ -14146,7 +14159,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "TODO: vid",
+                                                        "comment": "Underwater Wall Jump: https://youtu.be/UEsvsxt9CgY",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -14165,6 +14178,19 @@
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "StandOnFrozenEnemies",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Freeze Enemies With Any Weapon"
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -550,8 +550,8 @@ Extra - room_id: [12]
                   Stand On Frozen Enemies (Intermediate) and Wall Jump (Intermediate) and Can Freeze Enemies With Any Weapon
                   # HJ: https://youtu.be/ncBn4hyjC-A
                   Hi-Jump and Wall Jump (Beginner)
-          # TODO: vid
-          Hi-Jump and Underwater Wall Jump (Ludicrous)
+          # Underwater Wall Jump: https://youtu.be/UEsvsxt9CgY
+          Hi-Jump and Stand On Frozen Enemies (Intermediate) and Underwater Wall Jump (Ludicrous) and Can Freeze Enemies With Any Weapon
 
 > Other to Aquarium Kago Storage; Heals? False
   * Layers: default
@@ -1985,8 +1985,8 @@ Hint Features - Multiple Pickups
                               Speed Booster
                               # Freeze Yard from room below and wall jump https://youtu.be/AWajsYrYgbA
                               Stand On Frozen Enemies (Intermediate) and Wall Jump (Intermediate) and Can Freeze Enemies With Any Weapon
-              # TODO: vid
-              Hi-Jump and Underwater Wall Jump (Ludicrous)
+              # Underwater Wall Jump: https://youtu.be/UEsvsxt9CgY
+              Hi-Jump and Stand On Frozen Enemies (Intermediate) and Underwater Wall Jump (Ludicrous) and Can Freeze Enemies With Any Weapon
 
 > After Kago; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -547,11 +547,11 @@ Extra - room_id: [12]
               Any of the following:
                   Space Jump
                   # NHJ freeze Yard: https://youtu.be/AWajsYrYgbA
-                  Stand On Frozen Enemies (Intermediate) and Wall Jump (Intermediate) and Can Freeze Enemies With Any Weapon
+                  Stand On Frozen Enemies (Beginner) and Wall Jump (Intermediate) and Can Freeze Enemies With Any Weapon
                   # HJ: https://youtu.be/ncBn4hyjC-A
                   Hi-Jump and Wall Jump (Beginner)
           # Underwater Wall Jump: https://youtu.be/UEsvsxt9CgY
-          Hi-Jump and Stand On Frozen Enemies (Intermediate) and Underwater Wall Jump (Ludicrous) and Can Freeze Enemies With Any Weapon
+          Hi-Jump and Stand On Frozen Enemies (Beginner) and Underwater Wall Jump (Ludicrous) and Can Freeze Enemies With Any Weapon
 
 > Other to Aquarium Kago Storage; Heals? False
   * Layers: default
@@ -1984,9 +1984,9 @@ Hint Features - Multiple Pickups
                               # Spark to item then jump down
                               Speed Booster
                               # Freeze Yard from room below and wall jump https://youtu.be/AWajsYrYgbA
-                              Stand On Frozen Enemies (Intermediate) and Wall Jump (Intermediate) and Can Freeze Enemies With Any Weapon
+                              Stand On Frozen Enemies (Beginner) and Wall Jump (Intermediate) and Can Freeze Enemies With Any Weapon
               # Underwater Wall Jump: https://youtu.be/UEsvsxt9CgY
-              Hi-Jump and Stand On Frozen Enemies (Intermediate) and Underwater Wall Jump (Ludicrous) and Can Freeze Enemies With Any Weapon
+              Hi-Jump and Stand On Frozen Enemies (Beginner) and Underwater Wall Jump (Ludicrous) and Can Freeze Enemies With Any Weapon
 
 > After Kago; Heals? False
   * Layers: default


### PR DESCRIPTION
Thanks to Raddley Vance for pointing this out and the video

Aquarium Speedway to Kago Storage
- Gravless impossible wihout freezing the Yard to get enough height to start the UWJ
- Added Raddley's Video
- Updated the Kago Storage room to reflect the changes

Made the stand on enemies intermediate to follow the same standard that was the stand on frozen enemy in this same room. Not sure why it was intermiedate or if it should all get changed to beginner, but left at intermediate to make it consistent with what was there currently.

Testing from Raddley: 

> Yeah, just high without grav puts you about half a hitbox short of having to get a frame perfect walljump. Ice is required.

In a quick verification, I also could not reach enough high with HJ and No Grav