### PR TITLE
Prime: pre-placement of artifacts and phazon suit

### DIFF
--- a/randovania/games/prime1/gui/preset_settings/prime_generation_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_generation_tab.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import typing
 from typing import TYPE_CHECKING
 
 from PySide6 import QtWidgets
 
 from randovania.games.prime1.layout.prime_configuration import PrimeConfiguration
+from randovania.gui.lib import signal_handling
 from randovania.gui.preset_settings.generation_tab import PresetGeneration
 
 if TYPE_CHECKING:
@@ -15,15 +17,22 @@ if TYPE_CHECKING:
     from randovania.interface_common.preset_editor import PresetEditor
     from randovania.layout.preset import Preset
 
+_CHECKBOX_FIELDS = ["pre_place_artifact", "pre_place_phazon"]
+
 
 class PresetPrimeGeneration(PresetGeneration):
     min_progression_label: QtWidgets.QLabel
     min_progression_spin: QtWidgets.QSpinBox
+    pre_place_label: QtWidgets.QLabel
+    pre_place_artifact_check: QtWidgets.QCheckBox
+    pre_place_phazon_check: QtWidgets.QCheckBox
 
     def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
         super().__init__(editor, game_description, window_manager)
 
         self.min_progression_spin.valueChanged.connect(self._on_spin_changed)
+        for f in _CHECKBOX_FIELDS:
+            self._add_checkbox_persist_option(getattr(self, f"{f}_check"), f)
 
     def setupUi(self, obj: QtWidgets.QWidget) -> None:
         super().setupUi(obj)
@@ -33,21 +42,35 @@ class PresetPrimeGeneration(PresetGeneration):
         )
         self.min_progression_spin = QtWidgets.QSpinBox()
 
+        self.pre_place_label = QtWidgets.QLabel("Choose which items are pre-placed before generation occurs.")
+        self.pre_place_artifact_check = QtWidgets.QCheckBox("Pre-place Artifacts")
+        self.pre_place_phazon_check = QtWidgets.QCheckBox("Pre-place Phazon Suit")
+
     @property
     def game_specific_widgets(self) -> Iterable[QtWidgets.QWidget]:
         yield self.min_progression_label
         yield self.min_progression_spin
+        yield self.pre_place_label
+        yield self.pre_place_artifact_check
+        yield self.pre_place_phazon_check
 
     @property
     def experimental_settings(self) -> Iterable[QtWidgets.QWidget]:
         yield from super().experimental_settings
         yield self.min_progression_label
         yield self.min_progression_spin
+        yield self.pre_place_label
+        yield self.pre_place_artifact_check
+        yield self.pre_place_phazon_check
 
     def on_preset_changed(self, preset: Preset) -> None:
         assert isinstance(preset.configuration, PrimeConfiguration)
         super().on_preset_changed(preset)
         self.min_progression_spin.setValue(preset.configuration.artifact_minimum_progression)
+        for f in _CHECKBOX_FIELDS:
+            typing.cast("QtWidgets.QCheckBox", getattr(self, f"{f}_check")).setChecked(getattr(preset.configuration, f))
+        self.min_progression_label.setEnabled(not self.pre_place_artifact_check.isChecked())
+        self.min_progression_spin.setEnabled(not self.pre_place_artifact_check.isChecked())
 
     def _on_spin_changed(self) -> None:
         with self._editor as editor:
@@ -55,3 +78,10 @@ class PresetPrimeGeneration(PresetGeneration):
                 "artifact_minimum_progression",
                 self.min_progression_spin.value(),
             )
+
+    def _add_checkbox_persist_option(self, check: QtWidgets.QCheckBox, attribute_name: str) -> None:
+        def persist(value: bool) -> None:
+            with self._editor as editor:
+                editor.set_configuration_field(attribute_name, value)
+
+        signal_handling.on_checked(check, persist)

--- a/randovania/games/prime1/layout/prime_configuration.py
+++ b/randovania/games/prime1/layout/prime_configuration.py
@@ -88,6 +88,8 @@ class PrimeConfiguration(BaseConfiguration):
     artifact_target: LayoutArtifactMode
     artifact_required: LayoutArtifactMode
     artifact_minimum_progression: int = dataclasses.field(metadata={"min": 0, "max": 99})
+    pre_place_artifact: bool
+    pre_place_phazon: bool
     heat_damage: float = dataclasses.field(metadata={"min": 0.1, "max": 99.9, "precision": 3.0})
     warp_to_start: bool
     damage_reduction: DamageReduction

--- a/randovania/games/prime1/logic_database/Chozo Ruins.json
+++ b/randovania/games/prime1/logic_database/Chozo Ruins.json
@@ -1089,7 +1089,8 @@
                         "default"
                     ],
                     "extra": {
-                        "position_required": false,
+                        "position_required": false, 
+                        "regional_weight": 0.60, 
                         "world_position": [
                             148.244965,
                             86.584686,
@@ -1124,6 +1125,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60, 
                         "world_position": [
                             125.546928,
                             25.281984,
@@ -1158,6 +1160,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60, 
                         "world_position": [
                             115.710464,
                             -13.073902,
@@ -1192,6 +1195,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60, 
                         "world_position": [
                             69.797874,
                             -35.624599,
@@ -2555,6 +2559,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             246.626495,
                             -47.550934,
@@ -3081,6 +3086,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             -93.537979,
                             2.516589,
@@ -3115,6 +3121,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60, 
                         "world_position": [
                             -54.394249,
                             -36.025082,
@@ -3149,6 +3156,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60, 
                         "world_position": [
                             -68.224518,
                             40.722778,
@@ -4031,6 +4039,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             179.68869,
                             175.07019,
@@ -4339,6 +4348,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             137.860794,
                             -166.334442,
@@ -5305,6 +5315,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             -24.978611,
                             109.534653,
@@ -5623,6 +5634,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             94.323715,
                             -187.592346,
@@ -6615,6 +6627,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             181.427887,
                             -226.236923,
@@ -7234,6 +7247,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             -144.555801,
                             -40.385406,
@@ -8115,6 +8129,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             -144.519394,
                             -103.535721,
@@ -8393,6 +8408,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             -10.856061,
                             241.918289,
@@ -8427,6 +8443,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60, 
                         "world_position": [
                             29.546309,
                             209.553467,
@@ -9235,6 +9252,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             94.214615,
                             349.062347,
@@ -9861,6 +9879,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             429.458893,
                             -101.40741,
@@ -10667,6 +10686,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             94.744514,
                             318.042358,
@@ -10887,6 +10907,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             284.118408,
                             199.247131,
@@ -10921,6 +10942,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60, 
                         "world_position": [
                             284.242889,
                             137.159592,
@@ -11741,6 +11763,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             396.773163,
                             -43.946041,
@@ -12505,6 +12528,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             467.240417,
                             7.778633,
@@ -12539,6 +12563,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60, 
                         "world_position": [
                             447.610901,
                             113.443604,
@@ -13500,6 +13525,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             456.425171,
                             -73.568268,
@@ -13534,6 +13560,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60, 
                         "world_position": [
                             475.830994,
                             -63.177143,
@@ -14082,6 +14109,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             577.172974,
                             -13.816566,
@@ -14116,6 +14144,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60, 
                         "world_position": [
                             588.54895,
                             39.530502,
@@ -14645,6 +14674,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             692.474731,
                             -184.133575,
@@ -14679,6 +14709,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60, 
                         "world_position": [
                             692.218811,
                             -187.948959,
@@ -15811,6 +15842,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             754.202576,
                             -158.538727,
@@ -17635,6 +17667,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             753.550171,
                             -86.031303,
@@ -18202,6 +18235,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             801.440308,
                             -199.651062,
@@ -19215,6 +19249,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60, 
                         "world_position": [
                             805.732178,
                             -303.459869,

--- a/randovania/games/prime1/logic_database/Magmoor Caverns.json
+++ b/randovania/games/prime1/logic_database/Magmoor Caverns.json
@@ -1496,6 +1496,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 1.30,
                         "world_position": [
                             -45.342251,
                             -6.963963,
@@ -4474,6 +4475,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 1.30,
                         "world_position": [
                             70.219917,
                             -181.831757,
@@ -5330,6 +5332,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 1.30,
                         "world_position": [
                             -54.526352,
                             -271.64035,
@@ -8572,6 +8575,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 1.30,
                         "world_position": [
                             113.437225,
                             -274.008148,
@@ -8839,6 +8843,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 1.30,
                         "world_position": [
                             309.482086,
                             -286.583984,
@@ -9358,6 +9363,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 1.30,
                         "world_position": [
                             290.438843,
                             -298.137726,
@@ -10539,6 +10545,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 1.30,
                         "world_position": [
                             318.356445,
                             -286.376343,
@@ -10726,6 +10733,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 1.30,
                         "world_position": [
                             351.999908,
                             -333.726166,
@@ -16526,6 +16534,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 1.30,
                         "world_position": [
                             367.575012,
                             -762.284241,
@@ -17574,6 +17583,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 1.30,
                         "world_position": [
                             439.013092,
                             -933.172424,

--- a/randovania/games/prime1/logic_database/Phazon Mines.json
+++ b/randovania/games/prime1/logic_database/Phazon Mines.json
@@ -718,6 +718,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             100.425362,
                             14.960495,
@@ -1677,6 +1678,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             98.35289,
                             -18.84465,
@@ -4012,6 +4014,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             101.39048,
                             224.6465,
@@ -4566,6 +4569,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             -5.591609,
                             89.700455,
@@ -5018,6 +5022,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             -25.555389,
                             199.580185,
@@ -5152,6 +5157,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.80,
                         "world_position": [
                             -25.636387,
                             166.72522,
@@ -5899,6 +5905,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             73.956299,
                             186.725922,
@@ -6952,6 +6959,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             7.79607,
                             61.914818,
@@ -7849,6 +7857,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             -27.314747,
                             126.756615,
@@ -8942,6 +8951,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             -152.71756,
                             87.637535,
@@ -9728,6 +9738,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             -158.250366,
                             47.763702,
@@ -10278,6 +10289,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             164.61319,
                             21.420218,
@@ -12068,6 +12080,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             -82.999771,
                             -72.115097,
@@ -12832,6 +12845,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             224.916901,
                             255.70929,
@@ -14684,6 +14698,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             113.364304,
                             -34.201637,
@@ -15383,6 +15398,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             120.13559,
                             147.160461,
@@ -15827,6 +15843,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.80,
                         "world_position": [
                             161.045975,
                             352.397278,

--- a/randovania/games/prime1/logic_database/Phendrana Drifts.json
+++ b/randovania/games/prime1/logic_database/Phendrana Drifts.json
@@ -965,6 +965,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             -20.831432,
                             -183.894196,
@@ -999,6 +1000,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60,
                         "world_position": [
                             -104.062393,
                             -159.39328,
@@ -2168,6 +2170,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             -239.734421,
                             -204.550858,
@@ -3176,6 +3179,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             -11.066862,
                             -292.232971,
@@ -3846,6 +3850,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             168.178024,
                             -197.075714,
@@ -3880,6 +3885,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60,
                         "world_position": [
                             105.327614,
                             -217.844681,
@@ -4648,6 +4654,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             -403.054199,
                             -172.594421,
@@ -5396,6 +5403,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             -62.021873,
                             -466.702515,
@@ -5910,6 +5918,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             -300.481262,
                             -400.498779,
@@ -7929,6 +7938,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             213.966217,
                             -637.852051,
@@ -9453,6 +9463,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             -17.227148,
                             -785.52771,
@@ -9723,6 +9734,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             322.953705,
                             -607.551331,
@@ -11034,6 +11046,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             -70.945717,
                             -897.34259,
@@ -11310,6 +11323,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             178.570648,
                             -923.859863,
@@ -13395,6 +13409,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             23.058327,
                             -814.237671,
@@ -14569,6 +14584,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             52.230732,
                             -997.426697,
@@ -15063,6 +15079,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             143.877838,
                             -1257.665894,
@@ -17758,6 +17775,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             58.196442,
                             -877.153748,
@@ -17792,6 +17810,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60,
                         "world_position": [
                             61.745659,
                             -874.357239,
@@ -19335,6 +19354,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             368.142609,
                             -1152.306763,
@@ -19571,6 +19591,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.60,
                         "world_position": [
                             369.00705,
                             -1178.608154,
@@ -19704,6 +19725,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             214.03186,
                             -1400.925171,
@@ -19816,6 +19838,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.60,
                         "world_position": [
                             163.003754,
                             -1462.253052,

--- a/randovania/games/prime1/logic_database/Tallon Overworld.json
+++ b/randovania/games/prime1/logic_database/Tallon Overworld.json
@@ -293,6 +293,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             -368.295319,
                             410.005371,
@@ -1163,6 +1164,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             -331.809967,
                             451.500092,
@@ -2999,6 +3001,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             -140.0578,
                             483.41925,
@@ -3722,6 +3725,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             -105.899132,
                             588.58606,
@@ -4380,6 +4384,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             -665.231873,
                             315.721283,
@@ -4952,6 +4957,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             -373.291595,
                             46.95195,
@@ -5524,6 +5530,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             -659.070007,
                             257.203003,
@@ -5633,6 +5640,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             -723.697693,
                             339.113556,
@@ -7474,6 +7482,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             -49.282471,
                             362.910492,
@@ -7975,6 +7984,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             -149.136124,
                             247.778046,
@@ -9780,6 +9790,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             -70.580711,
                             137.163437,
@@ -10970,6 +10981,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             79.739098,
                             149.134735,
@@ -11369,6 +11381,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             17.830425,
                             72.339661,
@@ -12004,6 +12017,7 @@
                     ],
                     "extra": {
                         "position_required": false,
+                        "regional_weight": 0.85,
                         "world_position": [
                             18.346603,
                             -0.424441,
@@ -12038,6 +12052,7 @@
                         "default"
                     ],
                     "extra": {
+                        "regional_weight": 0.85,
                         "world_position": [
                             17.674232,
                             -63.688828,

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1175,6 +1175,13 @@ def _migrate_v103(preset: dict, game: RandovaniaGame) -> None:
         preset["configuration"]["blue_save_doors"] = True
 
 
+def _migrate_v104(preset: dict, game: RandovaniaGame) -> None:
+    if game == RandovaniaGame.METROID_PRIME:
+        preset["configuration"]["pre_place_artifact"] = False
+        preset["configuration"]["pre_place_phazon"] = False
+
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -1279,6 +1286,7 @@ _MIGRATIONS = [
     _migrate_v101,
     _migrate_v102,  # removal of in_dark_aether
     _migrate_v103,  # prime1 blast-shield lockon
+    _migrate_v104,  # add pre-placement to prime
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/test/games/prime1/generator/test_prime_bootstrap.py
+++ b/test/games/prime1/generator/test_prime_bootstrap.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import dataclasses
+from random import Random
+
 import pytest
 
 from randovania.game.game_enum import RandovaniaGame
+from randovania.game_description.game_patches import GamePatches
+from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.game_description.resources.resource_collection import ResourceCollection
-from randovania.games.prime1.generator.bootstrap import PrimeBootstrap
+from randovania.games.prime1.generator.bootstrap import PrimeBootstrap, is_pickup_to_pre_place
+from randovania.generator.pickup_pool import pool_creator
 
 
 @pytest.mark.parametrize(
@@ -89,3 +95,39 @@ def test_prime1_additive_damage_reduction(prime1_resource_database, expected, su
 
     # Assert
     assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("pre_place_artifact", "pre_place_phazon", "expected"),
+    [
+        (False, False, []),
+        (True, False, [84, 89, 135, 159, 180, 226]),
+        (True, True, [84, 89, 135, 159, 180, 226, 237]),
+        (False, True, [84]),
+    ],
+)
+def test_assign_pool_results(
+    prime_game_description, default_prime_configuration, pre_place_artifact, pre_place_phazon, expected
+):
+    default_prime_configuration = dataclasses.replace(
+        default_prime_configuration, pre_place_artifact=pre_place_artifact
+    )
+    default_prime_configuration = dataclasses.replace(default_prime_configuration, pre_place_phazon=pre_place_phazon)
+    patches = GamePatches.create_from_game(prime_game_description, 0, default_prime_configuration)
+    pool_results = pool_creator.calculate_pool_results(default_prime_configuration, patches.game)
+
+    # Run
+    result = PrimeBootstrap().assign_pool_results(
+        Random(8000),
+        default_prime_configuration,
+        patches,
+        pool_results,
+    )
+    # Assert
+    shuffled_pickups = [
+        pickup for pickup in pool_results.to_place if is_pickup_to_pre_place(pickup, default_prime_configuration)
+    ]
+
+    assert result.starting_equipment == pool_results.starting
+    assert set(result.pickup_assignment.keys()) == {PickupIndex(i) for i in expected}
+    assert shuffled_pickups == []


### PR DESCRIPTION
Allows pre-placement of Artifacts and Phazon Suit.

Data was gathered here: https://docs.google.com/spreadsheets/d/17mac3-c2I5fyqSZ1H7YKfTrnRSMGR6Zx8NAA4UhhhHc/edit?usp=sharing

![image](https://github.com/user-attachments/assets/542a6f5d-b052-458f-a607-b29ffcb8b712)
(checking pre-place artifacts disables minimum actions spinbox)

Final values can be adjusted later, but in game testing will be important on the future of this setting so want to get it out.