### PR TITLE
Hints: if specific locations are off, fill with joke hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [9.2.x] - 2025-06-??
 
 - Fixed: A rare division-by-zero error during generation when placing hints.
+- Fixed: An error where turning off specific location hints would still consume that locations pickup as a viable hint target for regular hints.
 - Fixed: The experimental option called Logical Pickup Placement is now respected by the resolver. It also now checks for items configured to be placed in their vanilla location.
 
 ### Resolver

--- a/randovania/generator/hint_distributor.py
+++ b/randovania/generator/hint_distributor.py
@@ -223,7 +223,9 @@ class HintDistributor(ABC):
                     LocationHint(
                         specific_location_precisions[identifier],
                         PickupIndex(node.extra["hint_index"]),
-                    ),
+                    )
+                    if patches.configuration.hints.enable_specific_location_hints
+                    else JokeHint(),
                 )
 
         return patches


### PR DESCRIPTION
this fixes an issue where hint targets for specific hint locations were not being freed

sample seed shows a pickup being hinted on a specific location hint
![image](https://github.com/user-attachments/assets/dcd1bc90-648e-4cf1-bfbb-be52068e843a)

supersedes #8313 