### PR TITLE
Add 4 lines tracker for dread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
+- Added: A 4 line non-progressive tracker layout.
+
 #### Logic Database
 
 - Changed: All instances of the Cross Bomb Skip trick that were previously rated as Beginner or Intermediate are now rated one level higher.

--- a/randovania/data/gui_assets/tracker/dread-game-four-lines.json
+++ b/randovania/data/gui_assets/tracker/dread-game-four-lines.json
@@ -1,0 +1,39 @@
+{
+    "game": "dread",
+    "elements": [
+        { "row": 1, "column": 0, "resources": ["Wide Beam"], "image_path": "gui_assets/tracker/game-images/dread/Wide Beam.png"},
+        { "row": 1, "column": 1, "resources": ["Plasma Beam"], "image_path": "gui_assets/tracker/game-images/dread/Plasma Beam.png"},
+        { "row": 1, "column": 2, "resources": ["Wave Beam"], "image_path": "gui_assets/tracker/game-images/dread/Wave Beam.png"},
+        { "row": 1, "column": 3, "resources": ["Charge Beam"], "image_path": "gui_assets/tracker/game-images/dread/Charge Beam.png"},
+        { "row": 1, "column": 4, "resources": ["Diffusion Beam"], "image_path": "gui_assets/tracker/game-images/dread/Diffusion Beam.png"},
+        { "row": 1, "column": 5, "resources": ["Grapple Beam"], "image_path": "gui_assets/tracker/game-images/dread/Grapple Beam.png"},
+	
+        { "row": 2, "column": 0, "resources": ["Morph Ball"], "image_path": "gui_assets/tracker/game-images/dread/Morph Ball.png"},
+        { "row": 2, "column": 1, "resources": ["Bomb"], "image_path": "gui_assets/tracker/game-images/dread/Bomb.png"},
+        { "row": 2, "column": 2, "resources": ["Cross Bomb"], "image_path": "gui_assets/tracker/game-images/dread/Cross Bomb.png"},
+        { "row": 2, "column": 3, "resources": ["Main Power Bomb"], "image_path": "gui_assets/tracker/game-images/dread/Power Bomb.png"},
+        { "row": 2, "column": 4, "resources": ["Varia Suit"], "image_path": "gui_assets/tracker/game-images/dread/Varia Suit.png"},
+        { "row": 2, "column": 5, "resources": ["Gravity Suit"], "image_path": "gui_assets/tracker/game-images/dread/Gravity Suit.png"},
+
+        { "row": 3, "column": 0, "resources": ["Super Missile"], "image_path": "gui_assets/tracker/game-images/dread/Super Missile.png"},
+        { "row": 3, "column": 1, "resources": ["Ice Missile"], "image_path": "gui_assets/tracker/game-images/dread/Ice Missile.png"},
+        { "row": 3, "column": 2, "resources": ["Storm Missile"], "image_path": "gui_assets/tracker/game-images/dread/Storm Missile.png"},
+        { "row": 3, "column": 3, "resources": ["Phantom Cloak"], "image_path": "gui_assets/tracker/game-images/dread/Phantom Cloak.png"},
+        { "row": 3, "column": 4, "resources": ["Flash Shift"], "image_path": "gui_assets/tracker/game-images/dread/Flash Shift.png"},
+        { "row": 3, "column": 5, "resources": ["Pulse Radar"], "image_path": "gui_assets/tracker/game-images/dread/Pulse Radar.png"},
+
+        { "row": 4, "column": 0, "resources": ["Spin Boost"], "image_path": "gui_assets/tracker/game-images/dread/Spin Boost.png"},
+        { "row": 4, "column": 1, "resources": ["Space Jump"], "image_path": "gui_assets/tracker/game-images/dread/Space Jump.png"},
+        { "row": 4, "column": 2, "resources": ["Spider Magnet"], "image_path": "gui_assets/tracker/game-images/dread/Spider Magnet.png"},
+        { "row": 4, "column": 3, "resources": ["Screw Attack"], "image_path": "gui_assets/tracker/game-images/dread/Screw Attack.png"},
+        { "row": 4, "column": 4, "resources": ["Speed Booster"], "image_path": "gui_assets/tracker/game-images/dread/Speed Booster.png" },
+
+        { "row": 4, "column": 5, "resources": [], "image_path": "gui_assets/tracker/game-images/dread/DNA.png" },
+        { "row": 5, "column": 5, "label": "x {capacity}/{max_capacity}", "resources": [
+            "Metroid DNA 1", "Metroid DNA 2", "Metroid DNA 3",
+            "Metroid DNA 4", "Metroid DNA 5", "Metroid DNA 6",
+            "Metroid DNA 7", "Metroid DNA 8", "Metroid DNA 9",
+            "Metroid DNA 10", "Metroid DNA 11", "Metroid DNA 12"
+        ]}
+    ]
+}

--- a/randovania/data/gui_assets/tracker/trackers.json
+++ b/randovania/data/gui_assets/tracker/trackers.json
@@ -30,7 +30,8 @@
         },
         "dread": {
             "Game Art": "dread-game.json",
-            "Game Art (Progressive)": "dread-game-progressive.json"
+            "Game Art (Progressive)": "dread-game-progressive.json",
+            "Game Art (4 Lines)": "dread-game-four-lines.json"
         },
         "blank": {
             "Official Art": "blank.json"


### PR DESCRIPTION
Adds a tracker layout for dread with no progressive items that fits more nicely in the stream layout I usually use.
Mostly this is to have a tracker layout with split beams that isn't as wide as the default one, which fits neither in my screen nor in my stream layout.