### PR TITLE
Fusion: Fix Sub Zero Damage Run Logic

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -7990,7 +7990,7 @@
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
@@ -8060,7 +8060,7 @@
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -1348,7 +1348,9 @@ Extra - room_id: [46]
   * L3 Hatch to Dark Stairwell/Door to Sub-Zero Containment
   * Extra - door_idx: (103,)
   > Pickup (Frozen Ridley)
-      Varia Suit or Damage Runs (Intermediate) or Cold Damage ≥ 80
+      Any of the following:
+          Varia Suit
+          Damage Runs (Intermediate) and Cold Damage ≥ 80
 
 > Pickup (Frozen Ridley); Heals? False
   * Layers: default
@@ -1359,7 +1361,9 @@ Extra - room_id: [46]
   * Extra - blocky: 8
   * Extra - infant_weight: 0.4
   > Door to Dark Stairwell
-      Varia Suit or Damage Runs (Intermediate) or Cold Damage ≥ 69
+      Any of the following:
+          Varia Suit
+          Damage Runs (Intermediate) and Cold Damage ≥ 69
 
 ----------------
 Genesis Speedway


### PR DESCRIPTION
Hotdogged the "and" in the logic for the damage run on subzero containment.