### PR TITLE
JBJ Overhaul

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -6799,6 +6799,36 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "KCBJ: https://youtu.be/fc2X5ko1onQ",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Bombs"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "WallJump",
+                                                                    "amount": 5,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "JBJ",
+                                                                    "amount": 5,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -1028,6 +1028,8 @@ Hint Features - Boss
               Space Jump
               # Single wall jump out - https://youtu.be/trYxYGq7PMs
               Wall Jump (Advanced) and Can Single Walljump
+              # KCBJ: https://youtu.be/fc2X5ko1onQ
+              Jump Bombjump (Ludicrous) and Wall Jump (Ludicrous) and Can Use Bombs
   > Event - Neo-Ridley
       All of the following:
           All of the following:

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -1755,7 +1755,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "JBJ",
-                                                                    "amount": 5,
+                                                                    "amount": 4,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -1987,17 +1987,25 @@
                                                         "comment": "JBJ: https://youtu.be/WSEOa-Ke16g",
                                                         "items": [
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "JBJ",
-                                                                    "amount": 3,
-                                                                    "negate": false
+                                                                    "comment": "TODO: replace vid using arguably easier to time bombjumping from the ground",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "JBJ",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Use Springball"
+                                                                        }
+                                                                    ]
                                                                 }
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Can Use Springball"
                                                             }
                                                         ]
                                                     }
@@ -2245,7 +2253,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "JBJ",
-                                                                    "amount": 4,
+                                                                    "amount": 3,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -2688,7 +2696,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "WallJump",
-                                                        "amount": 5,
+                                                        "amount": 4,
                                                         "negate": false
                                                     }
                                                 },
@@ -2697,7 +2705,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "JBJ",
-                                                        "amount": 5,
+                                                        "amount": 4,
                                                         "negate": false
                                                     }
                                                 },
@@ -3856,6 +3864,36 @@
                                                                     "type": "tricks",
                                                                     "name": "WallJump",
                                                                     "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "KCBJ: https://youtu.be/jcV-y3iVvPQ",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Bombs"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "WallJump",
+                                                                    "amount": 5,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "JBJ",
+                                                                    "amount": 5,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -7274,12 +7312,20 @@
                                                                                 "comment": "JBJ: https://youtu.be/Fs10I7_LjRY",
                                                                                 "items": [
                                                                                     {
-                                                                                        "type": "resource",
+                                                                                        "type": "and",
                                                                                         "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "JBJ",
-                                                                                            "amount": 3,
-                                                                                            "negate": false
+                                                                                            "comment": "TODO: replace vid using arguably easier to time bombjumping from the ground",
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "tricks",
+                                                                                                        "name": "JBJ",
+                                                                                                        "amount": 2,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
                                                                                         }
                                                                                     }
                                                                                 ]

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -309,7 +309,7 @@ Hint Features - Pillar
               Can Use Power Bombs
               Screw Attack and Knowledge (Beginner) and Can Use Bombs
               # JBJ Method: https://youtu.be/Cqf5mZg1NZc
-              Hi-Jump and Jump Bombjump (Ludicrous) and Mid-Air Morph (Intermediate) and Can Use Bombs and Can Use Springball
+              Hi-Jump and Jump Bombjump (Expert) and Mid-Air Morph (Intermediate) and Can Use Bombs and Can Use Springball
 
 > Event - Break Bomb Blocks; Heals? False
   * Layers: default
@@ -352,8 +352,10 @@ Extra - room_id: [10]
           Can Use Power Bombs
           All of the following:
               Can Use Bombs
-              # JBJ: https://youtu.be/WSEOa-Ke16g
-              Jump Bombjump (Advanced) or Can Use Springball
+              Any of the following:
+                  # JBJ: https://youtu.be/WSEOa-Ke16g
+                  # TODO: replace vid using arguably easier to time bombjumping from the ground
+                  Jump Bombjump (Intermediate) and Can Use Springball
           # Break with Screw
           Screw Attack and Knowledge (Beginner)
 
@@ -387,7 +389,7 @@ Extra - room_id: [11]
               # Freeze Puyos: https://youtu.be/efHh9Hd00RQ?t=31
               Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies With Any Weapon
               # JBJ: https://youtu.be/xwUXVRBf3_4
-              Jump Bombjump (Expert) and Can Use Bombs
+              Jump Bombjump (Advanced) and Can Use Bombs
               # SWJ
               Wall Jump (Beginner) and Can Single Walljump
 
@@ -458,7 +460,7 @@ Extra - room_id: [13, 46]
                           # With diffusion: https://youtu.be/l0h-9oyqEsA
                           Stand On Frozen Enemies (Expert) and Can Freeze Enemies With Diffusion
           # JBJ then buffer wall jump https://clips.twitch.tv/GrotesqueYummyGerbilChefFrank-5OKlWbe3ooKrkuFE
-          Jump Bombjump (Ludicrous) and Wall Jump (Ludicrous) and Can Use Bombs
+          Jump Bombjump (Expert) and Wall Jump (Expert) and Can Use Bombs
           # SWJ to middle platform, then do a normal walljump
           Wall Jump (Intermediate) and Can Single Walljump
 
@@ -673,6 +675,8 @@ Hint Features - Boss
           Any of the following:
               Have Any Jump Upgrade
               Wall Jump (Beginner) and Can Single Walljump
+              # KCBJ: https://youtu.be/jcV-y3iVvPQ
+              Jump Bombjump (Ludicrous) and Wall Jump (Ludicrous) and Can Use Bombs
   > Door to Zazabi Speedway
       All of the following:
           Screw Attack and After Boss Zazabi Defeated
@@ -1168,8 +1172,10 @@ Extra - room_id: [31, 7]
                   Can Use Bombs
                   Any of the following:
                       Can Use Springball
-                      # JBJ: https://youtu.be/Fs10I7_LjRY
-                      Jump Bombjump (Advanced)
+                      All of the following:
+                          # JBJ: https://youtu.be/Fs10I7_LjRY
+                          # TODO: replace vid using arguably easier to time bombjumping from the ground
+                          Jump Bombjump (Intermediate)
 
 > Door to Courtyard Access; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -8914,7 +8914,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "JBJ",
-                                                                    "amount": 4,
+                                                                    "amount": 3,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -9017,7 +9017,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "JBJ",
-                                                                    "amount": 4,
+                                                                    "amount": 3,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -9642,7 +9642,7 @@
                                                                             "data": {
                                                                                 "type": "tricks",
                                                                                 "name": "JBJ",
-                                                                                "amount": 4,
+                                                                                "amount": 3,
                                                                                 "negate": false
                                                                             }
                                                                         }
@@ -10733,12 +10733,20 @@
                                                                     "comment": "JBJ: https://youtu.be/xyR9PAwAMYM",
                                                                     "items": [
                                                                         {
-                                                                            "type": "resource",
+                                                                            "type": "and",
                                                                             "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "JBJ",
-                                                                                "amount": 4,
-                                                                                "negate": false
+                                                                                "comment": "TODO: replace vid using arguably easier to time bombjumping from the ground",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "JBJ",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         }
                                                                     ]

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -1289,7 +1289,7 @@ Extra - room_id: [30]
           Any of the following:
               Have Any Jump Upgrade
               # Same height as grabbing item: https://youtu.be/T8CZbxC6r6Y
-              Jump Bombjump (Expert) and Can Use Bombs
+              Jump Bombjump (Advanced) and Can Use Bombs
               # SWJ up
               Wall Jump (Beginner) and Can Single Walljump
 
@@ -1303,7 +1303,7 @@ Extra - room_id: [30]
           Any of the following:
               Can Freeze Enemies With Any Weapon or Have Any Jump Upgrade
               # Kill Namihe then JBJ to ledge: https://youtu.be/T8CZbxC6r6Y
-              Jump Bombjump (Expert) and Can Kill Tough Beam-Resistant Enemy and Can Use Bombs
+              Jump Bombjump (Advanced) and Can Kill Tough Beam-Resistant Enemy and Can Use Bombs
               # Grab ledge with SWJ
               Wall Jump (Intermediate) and Can Kill Tough Beam-Resistant Enemy and Can Single Walljump
 
@@ -1427,7 +1427,7 @@ Extra - room_id: [34]
               Any of the following:
                   Can Freeze Enemies With Any Weapon
                   # JBJ: https://youtu.be/o_0zrFKKkoo
-                  Jump Bombjump (Expert) and Can Use Bombs
+                  Jump Bombjump (Advanced) and Can Use Bombs
 
 > Door to Red Tower; Heals? False
   * Layers: default
@@ -1585,8 +1585,10 @@ Extra - room_id: [37]
               Can Use Bombs
               Any of the following:
                   Can Use Springball
-                  # JBJ: https://youtu.be/xyR9PAwAMYM
-                  Jump Bombjump (Expert)
+                  All of the following:
+                      # JBJ: https://youtu.be/xyR9PAwAMYM
+                      # TODO: replace vid using arguably easier to time bombjumping from the ground
+                      Jump Bombjump (Intermediate)
           # Get up with Screw
           Screw Attack and Knowledge (Beginner)
   > Area Transition to Sector 5 (ARC)

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -11617,7 +11617,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "JBJ",
-                                                                    "amount": 4,
+                                                                    "amount": 3,
                                                                     "negate": false
                                                                 }
                                                             },

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -1688,7 +1688,7 @@ Extra - room_id: [34]
                   Gravity Suit
                   Any of the following:
                       Screw Attack and Knowledge (Beginner)
-                      Jump Bombjump (Expert) and Can Use Bombs
+                      Jump Bombjump (Advanced) and Can Use Bombs
           Any of the following:
               # Get up to the higher level
               Underwater Wall Jump (Advanced)

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -4609,7 +4609,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "JBJ",
-                                                                    "amount": 4,
+                                                                    "amount": 3,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -8438,7 +8438,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "JBJ",
-                                                                    "amount": 5,
+                                                                    "amount": 4,
                                                                     "negate": false
                                                                 }
                                                             }

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -715,7 +715,7 @@ Extra - room_id: [19]
           Any of the following:
               Space Jump or Wall Jump (Beginner)
               # Freeze and JBJ off of Zeela: https://youtu.be/P5SrdfcDN9A
-              Hi-Jump and Jump Bombjump (Expert) and Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies With Any Weapon and Can Use Bombs
+              Hi-Jump and Jump Bombjump (Advanced) and Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies With Any Weapon and Can Use Bombs
 
 > Door to Nightmare Nook; Heals? False
   * Layers: default
@@ -1308,7 +1308,7 @@ Hint Features - 1-way Shutter
               # Shinespark from sector shortcuts: https://youtu.be/JChKb_XpMlw
               Level 0 Keycard and Speed Booster and Knowledge (Intermediate) and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
               # Get second JBJ before first block reforms: https://youtu.be/154gQQseqvk
-              Hi-Jump and Jump Bombjump (Ludicrous) and Can Use Bombs and Can Use Springball
+              Hi-Jump and Jump Bombjump (Expert) and Can Use Bombs and Can Use Springball
           Any of the following:
               # Get past pirates
               Can Kill Tough Beam-Resistant Enemy

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -340,7 +340,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "JBJ",
-                                                                    "amount": 4,
+                                                                    "amount": 3,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -5142,7 +5142,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "JBJ",
-                                                                    "amount": 4,
+                                                                    "amount": 3,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -8463,7 +8463,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "JBJ",
-                                                        "amount": 4,
+                                                        "amount": 3,
                                                         "negate": false
                                                     }
                                                 },

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -53,7 +53,7 @@ Extra - room_id: [0]
               Screw Attack and Knowledge (Beginner)
               All of the following:
                   # Jump Bomb Jump to break the blocks: https://youtu.be/mZe9Ht3o19w
-                  Jump Bombjump (Expert) and Can Use Bombs
+                  Jump Bombjump (Advanced) and Can Use Bombs
                   # Jump with HJ for JBJ, or breaking the top 2 Screw blocks
                   Hi-Jump or Movement (Advanced)
               # Break the blocks with Power Bombs
@@ -698,7 +698,7 @@ Extra - room_id: [15]
                   # Freeze with Diffusion
                   Stand On Frozen Enemies (Advanced) and Can Freeze Enemies With Diffusion
               # JBJ: https://youtu.be/oXu_rBiyO6E
-              Jump Bombjump (Expert) and Can Use Bombs
+              Jump Bombjump (Advanced) and Can Use Bombs
 
 ----------------
 X-B.O.X. Arena
@@ -1238,7 +1238,7 @@ Hint Features - Multiple Pickups
       Any of the following:
           Space Jump
           # JBJ: https://youtu.be/M_bad6jxMRk
-          Hi-Jump and Jump Bombjump (Expert) and Can Use Bombs
+          Hi-Jump and Jump Bombjump (Advanced) and Can Use Bombs
           # Freeze Bull: https://youtu.be/JDSabpkP9qo&t=43
           Stand On Frozen Enemies (Intermediate) and Can Freeze Enemies With Any Weapon
           # Damage boost off of bull: https://youtu.be/o3SWYYDnbe4


### PR DESCRIPTION
- Reduced all jumpball and grounded bombjump timed JBJs to Intermediate. Grounded bomb JBJ videos needed for:
  - Sector 2 Cultivation Station
  - Sector 2 Data Courtyard
  - Sector 3 Glass Tube to Sector 5
- All other Expert JBJs reduced to Advanced
- All Ludicrous JBJs reduced to Expert
- Added Ridley and Zazabi escapes as Ludicrous tricks, including videos