### PR TITLE
Fusion: Update Preset Item Pool Numbers

### DIFF
--- a/randovania/games/fusion/presets/open_sector_hub.rdvpreset
+++ b/randovania/games/fusion/presets/open_sector_hub.rdvpreset
@@ -120,7 +120,7 @@
                     "ammo_count": [
                         2
                     ],
-                    "pickup_count": 25,
+                    "pickup_count": 32,
                     "requires_main_item": true
                 }
             }

--- a/randovania/games/fusion/presets/vanilla_start.rdvpreset
+++ b/randovania/games/fusion/presets/vanilla_start.rdvpreset
@@ -119,7 +119,7 @@
                     "ammo_count": [
                         2
                     ],
-                    "pickup_count": 25,
+                    "pickup_count": 31,
                     "requires_main_item": true
                 }
             }

--- a/test/games/fusion/layout/test_fusion_describer.py
+++ b/test/games/fusion/layout/test_fusion_describer.py
@@ -44,7 +44,7 @@ def test_fusion_format_params(artifacts):
         ),
         "Hints": ["Infant Metroids Hint: Region and area", "Charge Beam Hint: Region only"],
         "Item Pool": [
-            f"Size: {114 + artifacts.placed_artifacts} of 127",
+            f"Size: {121 + artifacts.placed_artifacts} of 127",
             "1 random starting items",
             "Starts with Energy Tank",
             "Shuffles 19x Energy Tank",


### PR DESCRIPTION
As requested by Jeff and Duncathan this will adjust OSH to the vanilla amount of PBs to where everything is vanilla total numbers and there is 1 nothing instead of many

I also added PBs in the vanilla start item pool until it was full as well to try and keep things consistent.

Updated the preset description as well to match the numbers for test validation