### PR TITLE
Fusion: Launcher Adjustments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ exporters = [
     "open-dread-rando>=2.16.0",
 
     # Metroid fusion
-    "mars-patcher>=0.4.1",
+    "mars-patcher>=0.5.0",
 
     # Metroid Planets
     "planets-yapr>=1.0.0",

--- a/randovania/games/fusion/exporter/patch_data_factory.py
+++ b/randovania/games/fusion/exporter/patch_data_factory.py
@@ -156,19 +156,9 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
             tank_dict[definition.extra["TankIncrementName"]] = state.ammo_count[0]
         tank_dict["EnergyTank"] = self.configuration.energy_per_tank
 
-        missile_launcher = next(
-            state
-            for defi, state in self.configuration.standard_pickup_configuration.pickups_state.items()
-            if defi.name == "Missile Launcher Data"
-        )
-        tank_dict["MissileData"] = missile_launcher.included_ammo[0]
-
-        pb_launcher = next(
-            state
-            for defi, state in self.configuration.standard_pickup_configuration.pickups_state.items()
-            if defi.name == "Power Bomb Data"
-        )
-        tank_dict["PowerBombData"] = pb_launcher.included_ammo[0]
+        for definition, state in self.configuration.standard_pickup_configuration.pickups_state.items():
+            if "LauncherIncrementName" in definition.extra:
+                tank_dict[definition.extra["LauncherIncrementName"]] = state.included_ammo[0]
 
         return tank_dict
 

--- a/randovania/games/fusion/exporter/patch_data_factory.py
+++ b/randovania/games/fusion/exporter/patch_data_factory.py
@@ -152,13 +152,13 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
 
     def _create_tank_increments(self) -> dict:
         tank_dict = {}
-        for definition, state in self.patches.configuration.ammo_pickup_configuration.pickups_state.items():
-            tank_dict[definition.extra["TankIncrementName"]] = state.ammo_count[0]
+        for ammo_definition, ammo_state in self.patches.configuration.ammo_pickup_configuration.pickups_state.items():
+            tank_dict[ammo_definition.extra["TankIncrementName"]] = ammo_state.ammo_count[0]
         tank_dict["EnergyTank"] = self.configuration.energy_per_tank
 
-        for definition, state in self.configuration.standard_pickup_configuration.pickups_state.items():
-            if "LauncherIncrementName" in definition.extra:
-                tank_dict[definition.extra["LauncherIncrementName"]] = state.included_ammo[0]
+        for stand_definition, stand_state in self.configuration.standard_pickup_configuration.pickups_state.items():
+            if "LauncherIncrementName" in stand_definition.extra:
+                tank_dict[stand_definition.extra["LauncherIncrementName"]] = stand_state.included_ammo[0]
 
         return tank_dict
 

--- a/randovania/games/fusion/exporter/patch_data_factory.py
+++ b/randovania/games/fusion/exporter/patch_data_factory.py
@@ -127,26 +127,18 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
             "Abilities": [],
             "SecurityLevels": [],
             "DownloadedMaps": [0, 1, 2, 3, 4, 5, 6],
+            "Missiles": 0,
+            "PowerBombs": 0,
         }
-        missile_launcher = next(
-            state
-            for defi, state in self.configuration.standard_pickup_configuration.pickups_state.items()
-            if defi.name == "Missile Launcher Data"
-        )
-        # Fusion always starts with launchers ammo, even if launcher is not a starting item
-        starting_dict["Missiles"] = missile_launcher.included_ammo[0]
-
-        pb_launcher = next(
-            state
-            for defi, state in self.configuration.standard_pickup_configuration.pickups_state.items()
-            if defi.name == "Power Bomb Data"
-        )
-        starting_dict["PowerBombs"] = pb_launcher.included_ammo[0]
 
         for item, quantity in self.patches.starting_resources().as_resource_gain():
             match item.extra["StartingItemCategory"]:
-                case "Missiles" | "PowerBombs" | "Metroids":
+                case "Metroids":
                     continue
+                case "Missiles":
+                    starting_dict["Missiles"] += quantity
+                case "PowerBombs":
+                    starting_dict["PowerBombs"] += quantity
                 case "Energy":
                     starting_dict["Energy"] += self.configuration.energy_per_tank * quantity
                 case "SecurityLevels":
@@ -163,6 +155,21 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
         for definition, state in self.patches.configuration.ammo_pickup_configuration.pickups_state.items():
             tank_dict[definition.extra["TankIncrementName"]] = state.ammo_count[0]
         tank_dict["EnergyTank"] = self.configuration.energy_per_tank
+
+        missile_launcher = next(
+            state
+            for defi, state in self.configuration.standard_pickup_configuration.pickups_state.items()
+            if defi.name == "Missile Launcher Data"
+        )
+        tank_dict["MissileData"] = missile_launcher.included_ammo[0]
+
+        pb_launcher = next(
+            state
+            for defi, state in self.configuration.standard_pickup_configuration.pickups_state.items()
+            if defi.name == "Power Bomb Data"
+        )
+        tank_dict["PowerBombData"] = pb_launcher.included_ammo[0]
+
         return tank_dict
 
     def _create_door_locks(self) -> list[dict]:

--- a/randovania/games/fusion/pickup_database/pickup-database.json
+++ b/randovania/games/fusion/pickup_database/pickup-database.json
@@ -272,7 +272,8 @@
             "preferred_location_category": "major",
             "extra": {
                 "StartingItemCategory": "Abilities",
-                "StartingItemName": "Missiles"
+                "StartingItemName": "Missiles",
+                "LauncherIncrementName": "MissileData"
             },
             "progression": [
                 "MissileData"
@@ -434,7 +435,8 @@
             "preferred_location_category": "major",
             "extra": {
                 "StartingItemCategory": "Abilities",
-                "StartingItemName": "PowerBombs"
+                "StartingItemName": "PowerBombs",
+                "LauncherIncrementName": "PowerBombData"
             },
             "progression": [
                 "PowerBombData"

--- a/test/test_files/log_files/fusion/starting_items.rdvgame
+++ b/test/test_files/log_files/fusion/starting_items.rdvgame
@@ -123,8 +123,8 @@
                             }
                         },
                         "default_pickups": {},
-                        "minimum_random_starting_pickups": 0,
-                        "maximum_random_starting_pickups": 0
+                        "minimum_random_starting_pickups": 2,
+                        "maximum_random_starting_pickups": 2
                     },
                     "ammo_pickup_configuration": {
                         "pickups_state": {
@@ -132,14 +132,14 @@
                                 "ammo_count": [
                                     5
                                 ],
-                                "pickup_count": 48,
+                                "pickup_count": 49,
                                 "requires_main_item": true
                             },
                             "Power Bomb Tank": {
                                 "ammo_count": [
                                     2
                                 ],
-                                "pickup_count": 25,
+                                "pickup_count": 26,
                                 "requires_main_item": true
                             }
                         }
@@ -210,7 +210,9 @@
                     "Charge Beam",
                     "Wave Beam",
                     "Missile Launcher Data",
+                    "Missile Tank",
                     "Power Bomb Data",
+                    "Power Bomb Tank",
                     "Energy Tank",
                     "Level 0 Keycard",
                     "Infant Metroid 1",

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
@@ -21,8 +21,8 @@
             5,
             6
         ],
-        "Missiles": 10,
-        "PowerBombs": 10
+        "Missiles": 0,
+        "PowerBombs": 0
     },
     "Locations": {
         "MajorLocations": [
@@ -2462,7 +2462,9 @@
     "TankIncrements": {
         "MissileTank": 5,
         "PowerBombTank": 2,
-        "EnergyTank": 100
+        "EnergyTank": 100,
+        "MissileData": 10,
+        "PowerBombData": 10
     },
     "MissileLimit": 3,
     "DoorLocks": [],

--- a/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
@@ -21,8 +21,8 @@
             5,
             6
         ],
-        "Missiles": 10,
-        "PowerBombs": 10
+        "Missiles": 0,
+        "PowerBombs": 0
     },
     "Locations": {
         "MajorLocations": [
@@ -2402,7 +2402,9 @@
     "TankIncrements": {
         "MissileTank": 5,
         "PowerBombTank": 2,
-        "EnergyTank": 100
+        "EnergyTank": 100,
+        "MissileData": 10,
+        "PowerBombData": 10
     },
     "MissileLimit": 3,
     "DoorLocks": [],

--- a/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
@@ -21,8 +21,8 @@
             5,
             6
         ],
-        "Missiles": 10,
-        "PowerBombs": 10
+        "Missiles": 0,
+        "PowerBombs": 0
     },
     "Locations": {
         "MajorLocations": [
@@ -2402,7 +2402,9 @@
     "TankIncrements": {
         "MissileTank": 5,
         "PowerBombTank": 2,
-        "EnergyTank": 100
+        "EnergyTank": 100,
+        "MissileData": 10,
+        "PowerBombData": 10
     },
     "MissileLimit": 3,
     "DoorLocks": [],

--- a/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
@@ -26,8 +26,8 @@
             5,
             6
         ],
-        "Missiles": 10,
-        "PowerBombs": 10
+        "Missiles": 15,
+        "PowerBombs": 12
     },
     "Locations": {
         "MajorLocations": [
@@ -3096,7 +3096,7 @@
                 "Sector6Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
+                "InitialText": "Starting items: Missile Tank, Power Bomb Tank. Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
@@ -3115,7 +3115,7 @@
                 "Sector6Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
+                "InitialText": "Starting items: Missile Tank, Power Bomb Tank. Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
@@ -3134,7 +3134,7 @@
                 "Sector6Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
+                "InitialText": "Starting items: Missile Tank, Power Bomb Tank. Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
@@ -3153,7 +3153,7 @@
                 "Sector6Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
+                "InitialText": "Starting items: Missile Tank, Power Bomb Tank. Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
@@ -3172,7 +3172,7 @@
                 "Sector6Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
+                "InitialText": "Starting items: Missile Tank, Power Bomb Tank. Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
@@ -3191,7 +3191,7 @@
                 "Sector6Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
+                "InitialText": "Starting items: Missile Tank, Power Bomb Tank. Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
@@ -3210,7 +3210,7 @@
                 "Sector6Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
+                "InitialText": "Starting items: Missile Tank, Power Bomb Tank. Equip yourself to battle the [COLOR=3]SA-X[/COLOR].",
                 "ConfirmText": "Any Objections, Lady?"
             }
         }

--- a/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
@@ -2467,7 +2467,9 @@
     "TankIncrements": {
         "MissileTank": 5,
         "PowerBombTank": 2,
-        "EnergyTank": 100
+        "EnergyTank": 100,
+        "MissileData": 10,
+        "PowerBombData": 10
     },
     "MissileLimit": 3,
     "DoorLocks": [

--- a/uv.lock
+++ b/uv.lock
@@ -1006,15 +1006,15 @@ wheels = [
 
 [[package]]
 name = "mars-patcher"
-version = "0.4.1"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozendict" },
     { name = "jsonschema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/60/f72676dd62777401b4f9ec6a3ec98e556a584ba963811f84bb7961c5d930/mars_patcher-0.4.1.tar.gz", hash = "sha256:edd5557747673fd0625decbe23272e7cde9eb35430eff88d26e7dafd0be0d951", size = 192812 }
+sdist = { url = "https://files.pythonhosted.org/packages/de/14/131b45c2c7fee624eab3e07468427d4007c246d9373b3a47887fb6ce3eda/mars_patcher-0.5.0.tar.gz", hash = "sha256:c80635aa8ae820d79b7135b11882fca14119948be25189430435a58efce9ef46", size = 193767 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/af/6e843b5e72f4ec30013b73369cad5899246d63d05d1775200c3b615c1802/mars_patcher-0.4.1-py3-none-any.whl", hash = "sha256:0d140da10b5516130bbe7a5ec12dc1b51124258b52088219b78f2b4de7794dce", size = 186079 },
+    { url = "https://files.pythonhosted.org/packages/af/a4/a0fd8f5f13e4ccb1000970b1a6d3409097e6d9998c103d94a9bb87532cd4/mars_patcher-0.5.0-py3-none-any.whl", hash = "sha256:d05f6cecb15890102ffe80357fd63d6c11b7bf0f1ea9ea0a267493bc5f362643", size = 187050 },
 ]
 
 [[package]]
@@ -2042,7 +2042,7 @@ requires-dist = [
     { name = "humanize", marker = "extra == 'gui'" },
     { name = "json-delta" },
     { name = "markdown", marker = "extra == 'gui'" },
-    { name = "mars-patcher", marker = "extra == 'exporters'", specifier = ">=0.4.1" },
+    { name = "mars-patcher", marker = "extra == 'exporters'", specifier = ">=0.5.0" },
     { name = "matplotlib", marker = "extra == 'gui'", specifier = ">=3.6.2" },
     { name = "mp2hudcolor", marker = "extra == 'exporters'", specifier = ">=1.0.10" },
     { name = "natsort", marker = "extra == 'gui'" },


### PR DESCRIPTION
Issues reported:
- Launchers did not give ammo with multiple copies shuffled
- Starting with ammo tanks was not considered

With the new changes on the patcher/asm side for how launcher is handled, adjusted the RDV side to match and address the two issues above.

- Updated mars to patcher 0.5.0 in the reqs
- Initialized missiles and pbs to `0` since that is now possible/intended depending on settings
- Adjusted the cases to now consider launcher amount and ammos together as intented for starting
- Added MissileData and PowerBombData to match new patcher/asm changes
- Updated test files to reflect new chaanges

Tested (includes other stuff in the patcher/asm update)
- A bunch of starting ammo/launcher configs
- With starting ammo, checked it out in the status screen, worked good
- Increments of launchers
- New Color variations (Got a really cool emerald green SAX I haven't seen before)
- Color variations seem fixed for new locations tanks
- Credits updates  worked good
- Revealed Pillars (reported bug)
- Glass tube indicators
