### PR TITLE
Fusion: add check to not hint a keycard behind self

### DIFF
--- a/randovania/games/fusion/generator/hint_distributor.py
+++ b/randovania/games/fusion/generator/hint_distributor.py
@@ -33,7 +33,10 @@ class FusionHintDistributor(HintDistributor):
         for feature in non_interesting_features:
             if target.pickup.has_hint_feature(feature):
                 return False
-        return True
+        if target.player == player_id and ("Keycard" in target.pickup.name):
+            # don't place a keycard hint on a navigation pad locked by itself
+            return target.pickup.name not in str(hint_node.requirement_to_collect())
+        return super().is_pickup_interesting(target, player_id, hint_node)
 
     # Set default precision for hints
     @override


### PR DESCRIPTION
roughly the same as #8038 but using the requirement to collect vs extra data