### PR TITLE
fusion: add item jingles and infant metroid automessage

### DIFF
--- a/randovania/games/fusion/exporter/patch_data_factory.py
+++ b/randovania/games/fusion/exporter/patch_data_factory.py
@@ -68,8 +68,9 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
             if text != self._placeholder_metroid_message:
                 item_message = {"Languages": dict.fromkeys(self._lang_list, text), "Kind": "CustomMessage"}
             else:
-                if message_id is not None:
-                    item_message = {"Kind": "MessageID", "MessageID": message_id}
+                if message_id is None:
+                    raise ValueError("Suppossed to use a message id but none given?")
+                item_message = {"Kind": "MessageID", "MessageID": message_id}
 
             # Shiny easter eggs
             if (

--- a/randovania/games/fusion/exporter/patch_data_factory.py
+++ b/randovania/games/fusion/exporter/patch_data_factory.py
@@ -64,13 +64,12 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
             sprite = pickup.model.name
 
             item_message = {}
-            # Special case where we ignore metroid dna right now, because that needs more patcher work.
+            # Handles special case for infant metroids which use ASM to automatically determine message via a MessageID
             if text != self._placeholder_metroid_message:
                 item_message = {"Languages": dict.fromkeys(self._lang_list, text), "Kind": "CustomMessage"}
-
-            # Resources we want to specify a generic Message ID if we have not already provided custom messaging
-            if resource in ["InfantMetroid"] and not item_message and message_id is not None:
-                item_message = {"Kind": "MessageID", "MessageID": message_id}
+            else:
+                if message_id is not None:
+                    item_message = {"Kind": "MessageID", "MessageID": message_id}
 
             # Shiny easter eggs
             if (

--- a/randovania/games/fusion/exporter/patch_data_factory.py
+++ b/randovania/games/fusion/exporter/patch_data_factory.py
@@ -444,6 +444,7 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
             "CreditsText": self._create_credits_text(),
             "DisableDemos": True,
             "RoomNames": self._create_room_names(),
+            "AccessibilityPatches": True,
             "AntiSoftlockRoomEdits": self.configuration.anti_softlock,
             "PowerBombsWithoutBombs": True,
             "SkipDoorTransitions": self.configuration.instant_transitions,

--- a/randovania/games/fusion/exporter/patch_data_factory.py
+++ b/randovania/games/fusion/exporter/patch_data_factory.py
@@ -54,6 +54,8 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
                 is_major = True
             if not pickup.is_for_remote_player and pickup.conditional_resources[0].resources:
                 resource = pickup.conditional_resources[0].resources[-1][0].extra["item"]
+                jingle = pickup.conditional_resources[0].resources[-1][0].extra.get("Jingle", "Minor")
+                message_id = pickup.conditional_resources[0].resources[-1][0].extra.get("MessageID", None)
             else:
                 resource = "None"
 
@@ -92,9 +94,12 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
                 major_pickup = {
                     "Source": node.extra["source"],
                     "Item": resource,
+                    "Jingle": jingle,
                 }
                 if custom_message:
                     major_pickup["ItemMessages"] = custom_message
+                elif message_id is not None:
+                    major_pickup["ItemMessages"] = {"Kind": "MessageID", "MessageID": message_id}
                 major_pickup_list.append(major_pickup)
             else:
                 minor_pickup = {
@@ -104,9 +109,12 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
                     "BlockY": node.extra["blocky"],
                     "Item": resource,
                     "ItemSprite": sprite,
+                    "Jingle": jingle,
                 }
                 if custom_message:
                     minor_pickup["ItemMessages"] = custom_message
+                elif message_id is not None:
+                    minor_pickup["ItemMessages"] = {"Kind": "MessageID", "MessageID": message_id}
                 minor_pickup_list.append(minor_pickup)
         pickup_map_dict = {"MajorLocations": major_pickup_list, "MinorLocations": minor_pickup_list}
         return pickup_map_dict

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -586,9 +586,7 @@
             },
             "LowerWaterLevel": {
                 "long_name": "Sector 4 Water Level Lowered",
-                "extra": {
-                    "MessageID": 38
-                }
+                "extra": {}
             },
             "Wide X": {
                 "long_name": "Boss Wide Core-X Defeated",

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -9,7 +9,9 @@
                 "extra": {
                     "item": "ChargeBeam",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "ChargeBeam"
+                    "StartingItemName": "ChargeBeam",
+                    "Jingle": "Major",
+                    "MessageID": 18
                 }
             },
             "WideBeam": {
@@ -18,7 +20,9 @@
                 "extra": {
                     "item": "WideBeam",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "WideBeam"
+                    "StartingItemName": "WideBeam",
+                    "Jingle": "Major",
+                    "MessageID": 19
                 }
             },
             "PlasmaBeam": {
@@ -27,7 +31,9 @@
                 "extra": {
                     "item": "PlasmaBeam",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "PlasmaBeam"
+                    "StartingItemName": "PlasmaBeam",
+                    "Jingle": "Major",
+                    "MessageID": 21
                 }
             },
             "WaveBeam": {
@@ -36,7 +42,9 @@
                 "extra": {
                     "item": "WaveBeam",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "WaveBeam"
+                    "StartingItemName": "WaveBeam",
+                    "Jingle": "Major",
+                    "MessageID": 20
                 }
             },
             "IceBeam": {
@@ -45,7 +53,9 @@
                 "extra": {
                     "item": "IceBeam",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "IceBeam"
+                    "StartingItemName": "IceBeam",
+                    "Jingle": "Major",
+                    "MessageID": 22
                 }
             },
             "MissileData": {
@@ -54,7 +64,9 @@
                 "extra": {
                     "item": "Missiles",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "Missiles"
+                    "StartingItemName": "Missiles",
+                    "Jingle": "Major",
+                    "MessageID": 5
                 }
             },
             "Missiles": {
@@ -63,7 +75,9 @@
                 "extra": {
                     "item": "MissileTank",
                     "StartingItemCategory": "Missiles",
-                    "StartingItemName": "MissileTank"
+                    "StartingItemName": "MissileTank",
+                    "Jingle": "Minor",
+                    "MessageID": 51
                 }
             },
             "SuperMissileData": {
@@ -72,7 +86,9 @@
                 "extra": {
                     "item": "SuperMissiles",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "SuperMissiles"
+                    "StartingItemName": "SuperMissiles",
+                    "Jingle": "Major",
+                    "MessageID": 6
                 }
             },
             "IceMissileData": {
@@ -81,7 +97,9 @@
                 "extra": {
                     "item": "IceMissiles",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "IceMissiles"
+                    "StartingItemName": "IceMissiles",
+                    "Jingle": "Major",
+                    "MessageID": 9
                 }
             },
             "DiffusionMissileData": {
@@ -90,7 +108,9 @@
                 "extra": {
                     "item": "DiffusionMissiles",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "DiffusionMissiles"
+                    "StartingItemName": "DiffusionMissiles",
+                    "Jingle": "Major",
+                    "MessageID": 10
                 }
             },
             "MorphBall": {
@@ -99,7 +119,9 @@
                 "extra": {
                     "item": "MorphBall",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "MorphBall"
+                    "StartingItemName": "MorphBall",
+                    "Jingle": "Major",
+                    "MessageID": 11
                 }
             },
             "MorphBallBombData": {
@@ -108,7 +130,9 @@
                 "extra": {
                     "item": "Bombs",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "Bombs"
+                    "StartingItemName": "Bombs",
+                    "Jingle": "Major",
+                    "MessageID": 7
                 }
             },
             "PowerBombData": {
@@ -117,7 +141,9 @@
                 "extra": {
                     "item": "PowerBombs",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "PowerBombs"
+                    "StartingItemName": "PowerBombs",
+                    "Jingle": "Major",
+                    "MessageID": 8
                 }
             },
             "PowerBombs": {
@@ -126,7 +152,9 @@
                 "extra": {
                     "item": "PowerBombTank",
                     "StartingItemCategory": "PowerBombs",
-                    "StartingItemName": "PowerBombTank"
+                    "StartingItemName": "PowerBombTank",
+                    "Jingle": "Minor",
+                    "MessageID": 52
                 }
             },
             "Hi-Jump": {
@@ -135,7 +163,9 @@
                 "extra": {
                     "item": "HiJump",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "HiJump"
+                    "StartingItemName": "HiJump",
+                    "Jingle": "Major",
+                    "MessageID": 12
                 }
             },
             "SpaceJump": {
@@ -144,7 +174,9 @@
                 "extra": {
                     "item": "SpaceJump",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "SpaceJump"
+                    "StartingItemName": "SpaceJump",
+                    "Jingle": "Major",
+                    "MessageID": 14
                 }
             },
             "SpeedBooster": {
@@ -153,7 +185,9 @@
                 "extra": {
                     "item": "SpeedBooster",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "SpeedBooster"
+                    "StartingItemName": "SpeedBooster",
+                    "Jingle": "Major",
+                    "MessageID": 15
                 }
             },
             "ScrewAttack": {
@@ -162,7 +196,9 @@
                 "extra": {
                     "item": "ScrewAttack",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "ScrewAttack"
+                    "StartingItemName": "ScrewAttack",
+                    "Jingle": "Major",
+                    "MessageID": 13
                 }
             },
             "VariaSuit": {
@@ -171,7 +207,9 @@
                 "extra": {
                     "item": "VariaSuit",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "VariaSuit"
+                    "StartingItemName": "VariaSuit",
+                    "Jingle": "Major",
+                    "MessageID": 16
                 }
             },
             "GravitySuit": {
@@ -180,7 +218,9 @@
                 "extra": {
                     "item": "GravitySuit",
                     "StartingItemCategory": "Abilities",
-                    "StartingItemName": "GravitySuit"
+                    "StartingItemName": "GravitySuit",
+                    "Jingle": "Major",
+                    "MessageID": 17
                 }
             },
             "EnergyTank": {
@@ -189,7 +229,9 @@
                 "extra": {
                     "item": "EnergyTank",
                     "StartingItemCategory": "Energy",
-                    "StartingItemName": "EnergyTank"
+                    "StartingItemName": "EnergyTank",
+                    "Jingle": "Minor",
+                    "MessageID": 50
                 }
             },
             "LockedMissiles": {
@@ -198,7 +240,9 @@
                 "extra": {
                     "item": "MissileTank",
                     "StartingItemCategory": "Missiles",
-                    "StartingItemName": "MissileTank"
+                    "StartingItemName": "MissileTank",
+                    "Jingle": "Minor",
+                    "MessageID": 51
                 }
             },
             "LockedPowerBombs": {
@@ -207,7 +251,9 @@
                 "extra": {
                     "item": "PowerBombTank",
                     "StartingItemCategory": "PowerBombs",
-                    "StartingItemName": "PowerBombTank"
+                    "StartingItemName": "PowerBombTank",
+                    "Jingle": "Minor",
+                    "MessageID": 52
                 }
             },
             "Nothing": {
@@ -216,7 +262,9 @@
                 "extra": {
                     "item": "None",
                     "StartingItemCategory": "None",
-                    "StartingItemName": "None"
+                    "StartingItemName": "None",
+                    "Jingle": "Minor",
+                    "MessageID": 55
                 }
             },
             "L0Locks": {
@@ -225,7 +273,9 @@
                 "extra": {
                     "item": "Level0",
                     "StartingItemCategory": "SecurityLevels",
-                    "StartingItemName": 0
+                    "StartingItemName": 0,
+                    "Jingle": "Major",
+                    "MessageID": 0
                 }
             },
             "L1Locks": {
@@ -234,7 +284,9 @@
                 "extra": {
                     "item": "Level1",
                     "StartingItemCategory": "SecurityLevels",
-                    "StartingItemName": 1
+                    "StartingItemName": 1,
+                    "Jingle": "Major",
+                    "MessageID": 1
                 }
             },
             "L2Locks": {
@@ -243,7 +295,9 @@
                 "extra": {
                     "item": "Level2",
                     "StartingItemCategory": "SecurityLevels",
-                    "StartingItemName": 2
+                    "StartingItemName": 2,
+                    "Jingle": "Major",
+                    "MessageID": 2
                 }
             },
             "L3Locks": {
@@ -252,7 +306,9 @@
                 "extra": {
                     "item": "Level3",
                     "StartingItemCategory": "SecurityLevels",
-                    "StartingItemName": 3
+                    "StartingItemName": 3,
+                    "Jingle": "Major",
+                    "MessageID": 3
                 }
             },
             "L4Locks": {
@@ -261,7 +317,9 @@
                 "extra": {
                     "item": "Level4",
                     "StartingItemCategory": "SecurityLevels",
-                    "StartingItemName": 4
+                    "StartingItemName": 4,
+                    "Jingle": "Major",
+                    "MessageID": 4
                 }
             },
             "Infant Metroid 1": {
@@ -270,7 +328,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 2": {
@@ -279,7 +339,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 3": {
@@ -288,7 +350,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 4": {
@@ -297,7 +361,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 5": {
@@ -306,7 +372,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 6": {
@@ -315,7 +383,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 7": {
@@ -324,7 +394,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 8": {
@@ -333,7 +405,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 9": {
@@ -342,7 +416,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 10": {
@@ -351,7 +427,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 11": {
@@ -360,7 +438,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 12": {
@@ -369,7 +449,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 13": {
@@ -378,7 +460,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 14": {
@@ -387,7 +471,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 15": {
@@ -396,7 +482,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 16": {
@@ -405,7 +493,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 17": {
@@ -414,7 +504,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 18": {
@@ -423,7 +515,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 19": {
@@ -432,7 +526,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             },
             "Infant Metroid 20": {
@@ -441,7 +537,9 @@
                 "extra": {
                     "item": "InfantMetroid",
                     "StartingItemCategory": "Metroids",
-                    "StartingItemName": "InfantMetroid"
+                    "StartingItemName": "InfantMetroid",
+                    "Jingle": "Major",
+                    "MessageID": 56
                 }
             }
         },
@@ -488,7 +586,9 @@
             },
             "LowerWaterLevel": {
                 "long_name": "Sector 4 Water Level Lowered",
-                "extra": {}
+                "extra": {
+                    "MessageID": 38
+                }
             },
             "Wide X": {
                 "long_name": "Boss Wide Core-X Defeated",

--- a/test/games/fusion/exporter/test_fusion_game_exporter.py
+++ b/test/games/fusion/exporter/test_fusion_game_exporter.py
@@ -13,7 +13,10 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.parametrize("patch_data_name", ["starter_preset"])
+@pytest.mark.parametrize(
+    "patch_data_name",
+    ["starter_preset", "starting_items", "short_intro", "all_hidden_with_nothing", "all_hidden_with_random"],
+)
 def test_export_game(test_files_dir, mocker, patch_data_name: str, tmp_path):
     # Setup
     def validate_schema(input_path: Path, output_path: Path, configuration: dict, status_update):

--- a/test/games/test_log_file_export.py
+++ b/test/games/test_log_file_export.py
@@ -108,6 +108,7 @@ def pytest_generate_tests(metafunc: _pytest.python.Metafunc) -> None:
         "fusion/starter_preset.rdvgame",
         "fusion/short_intro.rdvgame",
         "fusion/all_hidden_with_nothing.rdvgame",
+        "fusion/all_hidden_with_random.rdvgame",
         "fusion/starting_items.rdvgame",
         # Dread
         "dread/starter_preset.rdvgame",  # starter preset

--- a/test/test_files/log_files/fusion/all_hidden_with_random.rdvgame
+++ b/test/test_files/log_files/fusion/all_hidden_with_random.rdvgame
@@ -1,0 +1,499 @@
+{
+    "schema_version": 37,
+    "info": {
+        "randovania_version": "9.4.0.dev51-dirty",
+        "randovania_version_git": "0ddc5f52",
+        "permalink": "DekrURz80A3cX1ISl456cse2g13xvIj1hTsP8fpyAFOY",
+        "has_spoiler": true,
+        "seed": 789574574,
+        "hash": "FNIRZ7GQ",
+        "word_hash": "Yakuza Omega Bob",
+        "presets": [
+            {
+                "schema_version": 107,
+                "base_preset_uuid": null,
+                "name": "Vanilla Start Copy",
+                "uuid": "4b36b72c-c90f-4515-be14-bcd1d2fde5f1",
+                "description": "A copy version of Vanilla Start.",
+                "game": "fusion",
+                "configuration": {
+                    "trick_level": {
+                        "minimal_logic": false,
+                        "specific_levels": {}
+                    },
+                    "starting_location": [
+                        {
+                            "region": "Main Deck",
+                            "area": "Docking Bay Hangar",
+                            "node": "Ship"
+                        }
+                    ],
+                    "available_locations": {
+                        "randomization_mode": "full",
+                        "excluded_indices": []
+                    },
+                    "standard_pickup_configuration": {
+                        "pickups_state": {
+                            "Charge Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Wide Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Plasma Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Wave Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Ice Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Missile Launcher Data": {
+                                "num_shuffled_pickups": 1,
+                                "included_ammo": [
+                                    10
+                                ]
+                            },
+                            "Super Missile Data": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Ice Missile Data": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Diffusion Missile Data": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Morph Ball": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Morph Ball Bomb Data": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Power Bomb Data": {
+                                "num_shuffled_pickups": 1,
+                                "included_ammo": [
+                                    10
+                                ]
+                            },
+                            "Hi-Jump": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Space Jump": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Speed Booster": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Screw Attack": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Varia Suit": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Gravity Suit": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Energy Tank": {
+                                "num_shuffled_pickups": 20
+                            },
+                            "Level 0 Keycard": {
+                                "num_included_in_starting_pickups": 1
+                            },
+                            "Level 1 Keycard": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Level 2 Keycard": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Level 3 Keycard": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Level 4 Keycard": {
+                                "num_shuffled_pickups": 1
+                            }
+                        },
+                        "default_pickups": {},
+                        "minimum_random_starting_pickups": 0,
+                        "maximum_random_starting_pickups": 0
+                    },
+                    "ammo_pickup_configuration": {
+                        "pickups_state": {
+                            "Missile Tank": {
+                                "ammo_count": [
+                                    5
+                                ],
+                                "pickup_count": 48,
+                                "requires_main_item": true
+                            },
+                            "Power Bomb Tank": {
+                                "ammo_count": [
+                                    2
+                                ],
+                                "pickup_count": 31,
+                                "requires_main_item": true
+                            }
+                        }
+                    },
+                    "damage_strictness": 1.5,
+                    "pickup_model_style": "hide-all",
+                    "pickup_model_data_source": "random",
+                    "logical_resource_action": "randomly",
+                    "first_progression_must_be_local": false,
+                    "two_sided_door_lock_search": false,
+                    "dock_rando": {
+                        "mode": "vanilla",
+                        "types_state": {
+                            "Door": {
+                                "can_change_from": [
+                                    "L0 Hatch",
+                                    "L1 Hatch",
+                                    "L2 Hatch",
+                                    "L3 Hatch",
+                                    "L4 Hatch"
+                                ],
+                                "can_change_to": [
+                                    "L0 Hatch",
+                                    "L1 Hatch",
+                                    "L2 Hatch",
+                                    "L3 Hatch",
+                                    "L4 Hatch",
+                                    "Open Hatch"
+                                ]
+                            }
+                        }
+                    },
+                    "single_set_for_pickups_that_solve": true,
+                    "staggered_multi_pickup_placement": true,
+                    "check_if_beatable_after_base_patches": false,
+                    "logical_pickup_placement": "minimal",
+                    "consider_possible_unsafe_resources": false,
+                    "hints": {
+                        "enable_random_hints": true,
+                        "enable_specific_location_hints": true,
+                        "specific_pickup_hints": {
+                            "artifacts": "precise",
+                            "charge_beam": "hide-area"
+                        },
+                        "minimum_available_locations_for_hint_placement": 5,
+                        "minimum_location_weight_for_hint_placement": 0.1,
+                        "use_resolver_hints": false
+                    },
+                    "anti_softlock": true,
+                    "instant_transitions": false,
+                    "energy_per_tank": 100,
+                    "artifacts": {
+                        "required_artifacts": 5,
+                        "placed_artifacts": 5
+                    },
+                    "open_save_recharge_hatches": false,
+                    "unlock_sector_hub": false,
+                    "short_intro_text": false
+                }
+            }
+        ]
+    },
+    "game_modifications": [
+        {
+            "game": "fusion",
+            "starting_equipment": {
+                "pickups": [
+                    "Level 0 Keycard",
+                    "Infant Metroid 6",
+                    "Infant Metroid 7",
+                    "Infant Metroid 8",
+                    "Infant Metroid 9",
+                    "Infant Metroid 10",
+                    "Infant Metroid 11",
+                    "Infant Metroid 12",
+                    "Infant Metroid 13",
+                    "Infant Metroid 14",
+                    "Infant Metroid 15",
+                    "Infant Metroid 16",
+                    "Infant Metroid 17",
+                    "Infant Metroid 18",
+                    "Infant Metroid 19",
+                    "Infant Metroid 20"
+                ]
+            },
+            "starting_location": "Main Deck/Docking Bay Hangar/Ship",
+            "dock_connections": {},
+            "dock_weakness": {
+                "Sector 2 (TRO)/Cathedral/Door to Ripper Tower": {
+                    "type": "Door",
+                    "name": "Open Hatch"
+                },
+                "Sector 2 (TRO)/Ripper Tower/Door to Cathedral": {
+                    "type": "Door",
+                    "name": "Open Hatch"
+                },
+                "Sector 5 (ARC)/Arctic Containment/Door to Ripper Road": {
+                    "type": "Door",
+                    "name": "Open Hatch"
+                },
+                "Sector 5 (ARC)/Ripper Road/Door to Arctic Containment": {
+                    "type": "Door",
+                    "name": "Open Hatch"
+                }
+            },
+            "locations": {
+                "Main Deck": {
+                    "Arachnus Arena/Pickup (Energy Tank)": "Power Bomb Tank",
+                    "Arachnus Arena/Pickup (Morph Ball)": "Missile Tank",
+                    "Attic/Pickup (Energy Tank)": "Missile Tank",
+                    "Auxiliary Power Station/Pickup (Reactor Control)": "Missile Tank",
+                    "Cubby Hole/Pickup (Missile Tank)": "Missile Launcher Data",
+                    "Genesis Speedway/Pickup (Hidden Power Bomb Tank)": "Power Bomb Tank",
+                    "Habitation Deck/Pickup (Missile Tank)": "Missile Tank",
+                    "Habitation Deck/Pickup (Save the Animals)": "Missile Tank",
+                    "Main Elevator Cache/Pickup (Missile Tank)": "Power Bomb Tank",
+                    "Nexus Storage/Pickup (Power Bomb Tank)": "Diffusion Missile Data",
+                    "Operations Deck Data Room/Pickup (Missile Launcher)": "Morph Ball",
+                    "Operations Ventilation Storage/Pickup (Hidden Missile Tank)": "Missile Tank",
+                    "Operations Ventilation/Pickup (Missile Tank)": "Power Bomb Data",
+                    "Quarantine Bay/Pickup (Hornoad)": "Missile Tank",
+                    "Restricted Airlock/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Silo Catwalk/Pickup (Energy Tank)": "Energy Tank",
+                    "Silo Scaffolding/Pickup (Missile Tank)": "Power Bomb Tank",
+                    "Station Entrance/Pickup (Hidden Missile Tank)": "Level 1 Keycard",
+                    "Sub-Zero Containment/Pickup (Frozen Ridley)": "Missile Tank",
+                    "Yakuza Arena/Pickup (Space Jump)": "Missile Tank"
+                },
+                "Sector 1 (SRX)": {
+                    "Animorphs Cache/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Antechamber/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Atmospheric Stabilizer Northeast/Pickup (NE Stabilizer)": "Missile Tank",
+                    "Charge Core Arena/Pickup (Charge Beam)": "Missile Tank",
+                    "Charge Core Arena/Pickup (Energy Tank)": "Level 2 Keycard",
+                    "Crab Rave/Pickup (Missile Tank)": "Missile Tank",
+                    "Hornoad Hole/Pickup (Energy Tank)": "Power Bomb Tank",
+                    "Lava Lake/Pickup (Missile Tank in Lava)": "Energy Tank",
+                    "Lava Lake/Pickup (Missile Tank on Cliffside)": "Missile Tank",
+                    "Lava Lake/Pickup (Missile Tank on Platform)": "Hi-Jump",
+                    "Ridley Arena/Pickup (Screw Attack)": "Infant Metroid 3",
+                    "Ripper Maze/Pickup (Hidden Energy Tank)": "Missile Tank",
+                    "Stabilizer Storage/Pickup (Missile Tank)": "Missile Tank",
+                    "Wall Jump Tutorial/Pickup (Missile Tank)": "Level 4 Keycard",
+                    "Watering Hole/Pickup (Hidden Power Bomb Tank)": "Missile Tank"
+                },
+                "Sector 2 (TRO)": {
+                    "Crumble City/Pickup (Energy Tank)": "Energy Tank",
+                    "Crumble City/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Cultivation Station/Pickup (Missile Tank)": "Energy Tank",
+                    "Data Courtyard/Pickup (Missile Tank)": "Power Bomb Tank",
+                    "Data Room/Pickup (Morph Ball Bombs)": "Missile Tank",
+                    "Dessgeega Dorm/Pickup (Missile Tank)": "Space Jump",
+                    "Kago Room/Pickup (Missile Tank)": "Missile Tank",
+                    "Level 1 Security Room/Pickup (L1 Locks)": "Missile Tank",
+                    "Lobby Cache/Pickup (Missile Tank)": "Missile Tank",
+                    "Nettori Arena/Pickup (Plasma Beam)": "Infant Metroid 4",
+                    "Oasis Storage/Pickup (Missile Tank)": "Energy Tank",
+                    "Oasis/Pickup (Missile Tank)": "Power Bomb Tank",
+                    "Overgrown Cache/Pickup (Hidden Energy Tank)": "Missile Tank",
+                    "Puyo Palace/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Ripper Tower/Pickup (Hidden Power Bomb Tank)": "Charge Beam",
+                    "Ripper Tower/Pickup (Power Bomb Tank)": "Wave Beam",
+                    "Zazabi Arena Access/Pickup (Energy Tank)": "Missile Tank",
+                    "Zazabi Arena/Pickup (High Jump)": "Ice Beam",
+                    "Zazabi Speedway/Pickup (Hidden Missile Tank)": "Missile Tank",
+                    "Zazabi Speedway/Pickup (Power Bomb Tank)": "Energy Tank",
+                    "Zoro Zig-Zag/Pickup (Missile Tank)": "Missile Tank"
+                },
+                "Sector 3 (PYR)": {
+                    "Alcove/Pickup (Hidden Energy Tank)": "Power Bomb Tank",
+                    "Alcove/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Bob's Abode/Pickup (Missile Tank)": "Energy Tank",
+                    "Data Room/Pickup (Super Missiles)": "Level 3 Keycard",
+                    "Deserted Runway/Pickup (Missile Tank)": "Energy Tank",
+                    "Fiery Storage/Pickup (Energy Tank)": "Missile Tank",
+                    "Fiery Storage/Pickup (Missile Tank)": "Missile Tank",
+                    "Garbage Chute/Pickup (Power Bomb Tank in Cave)": "Missile Tank",
+                    "Garbage Chute/Pickup (Power Bomb Tank in Shaft)": "Power Bomb Tank",
+                    "Geron's Treasure/Pickup (Missile Tank)": "Gravity Suit",
+                    "Glass Tube to Sector 5 (ARC)/Pickup (Hidden Power Bomb Tank)": "Missile Tank",
+                    "Lava Maze/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Level 2 Security Room/Pickup (L2 Locks)": "Power Bomb Tank",
+                    "Main Boiler Control Room/Pickup (Cooling Unit)": "Power Bomb Tank",
+                    "Main Boiler Control Room/Pickup (Wide Beam)": "Missile Tank",
+                    "Namihe's Lair/Pickup (Power Bomb Tank)": "Ice Missile Data",
+                    "Processing Access/Pickup (Hidden Missile Tank)": "Power Bomb Tank",
+                    "Security Access/Pickup (Hidden Missile Tank)": "Varia Suit",
+                    "Sova Processing/Pickup (Energy Tank)": "Power Bomb Tank",
+                    "Sova Processing/Pickup (Missile Tank)": "Energy Tank"
+                },
+                "Sector 4 (AQA)": {
+                    "Aquarium Kago Storage/Pickup (Missile Tank)": "Missile Tank",
+                    "Aquarium Kago Storage/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Aquarium Pirate Tank/Pickup (Missile Tank)": "Energy Tank",
+                    "Broken Bridge/Pickup (Energy Tank)": "Missile Tank",
+                    "C-Cache/Pickup (Underwater Missile Tank)": "Energy Tank",
+                    "Cargo Hold to Sector 5 (ARC)/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Cheddar Bay/Pickup (Power Bomb Tank)": "Infant Metroid 5",
+                    "Data Room/Pickup (Diffusion Missiles)": "Power Bomb Tank",
+                    "Drain Pipe/Pickup (Hidden Missile Tank)": "Energy Tank",
+                    "Level 4 Security Room/Pickup (L4 Locks)": "Energy Tank",
+                    "Pump Control Unit/Pickup (Missile Tank)": "Energy Tank",
+                    "Reservoir East/Pickup (Hidden Power Bomb Tank)": "Power Bomb Tank",
+                    "Reservoir Vault/Pickup (Lower Missile Tank)": "Power Bomb Tank",
+                    "Reservoir Vault/Pickup (Upper Missile Tank)": "Speed Booster",
+                    "Sanctuary Cache/Pickup (Hidden Energy Tank)": "Missile Tank",
+                    "Serris Arena/Pickup (Speed Booster)": "Infant Metroid 1",
+                    "Waterway/Pickup (Underwater Missile Tank)": "Power Bomb Tank",
+                    "Yard Firing Range/Pickup (Missile Tank)": "Missile Tank"
+                },
+                "Sector 5 (ARC)": {
+                    "Crow's Nest/Pickup (Hidden Power Bomb Tank)": "Power Bomb Tank",
+                    "Data Room/Pickup (Power Bomb Data)": "Energy Tank",
+                    "E-Tank Mimic Den/Pickup (Hidden Energy Tank)": "Missile Tank",
+                    "Flooded Airlock to Sector 4 (AQA)/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Gerubus Gully/Pickup (Hidden Missile Tank)": "Morph Ball Bomb Data",
+                    "Level 3 Security Room/Pickup (L3 Locks)": "Infant Metroid 2",
+                    "Magic Box/Pickup (Missile Tank)": "Missile Tank",
+                    "Mini-Fridge/Pickup (Energy Tank)": "Power Bomb Tank",
+                    "Nightmare Arena/Pickup (Gravity Suit)": "Power Bomb Tank",
+                    "Nightmare Hub/Pickup (Hidden Power Bomb Tank)": "Power Bomb Tank",
+                    "Nightmare Nook/Pickup (Energy Tank)": "Missile Tank",
+                    "Ripper Road/Pickup (Power Bomb Tank)": "Super Missile Data",
+                    "Ripper's Treasure/Pickup (Power Bomb Tank)": "Energy Tank",
+                    "Ruined Break Room/Pickup (Hidden Power Bomb Tank)": "Power Bomb Tank",
+                    "Security Shaft East/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Training Aerie/Pickup (Missile Tank)": "Power Bomb Tank",
+                    "Training Aerie/Pickup (Power Bomb Tank)": "Screw Attack",
+                    "Transmutation Trial/Pickup (Hidden Missile Tank)": "Missile Tank"
+                },
+                "Sector 6 (NOC)": {
+                    "Catacombs/Pickup (Energy Tank)": "Missile Tank",
+                    "Entrance Lobby/Pickup (Missile Tank)": "Energy Tank",
+                    "Missile Mimic Lodge/Pickup (Missile Tank)": "Missile Tank",
+                    "Pillar Highway/Pickup (Energy Tank)": "Power Bomb Tank",
+                    "Spaceboost Alley/Pickup (Power Bomb Tank 2)": "Energy Tank",
+                    "Spaceboost Alley/Pickup (Power Bomb Tank)": "Missile Tank",
+                    "Twin Caverns West/Pickup (Hidden Missile Tank)": "Power Bomb Tank",
+                    "Twin Caverns West/Pickup (Missile Tank)": "Missile Tank",
+                    "Varia Core-X Arena/Pickup (Varia Suit)": "Missile Tank",
+                    "Vault/Pickup (Energy Tank)": "Energy Tank",
+                    "X-B.O.X. Arena/Pickup (Wave Beam)": "Energy Tank",
+                    "X-B.O.X. Garage/Pickup (Hidden Power Bomb Tank)": "Missile Tank",
+                    "X-B.O.X. Garage/Pickup (Missile Tank)": "Plasma Beam",
+                    "Zozoro Wine Cellar/Pickup (Hidden Missile Tank)": "Wide Beam"
+                }
+            },
+            "hints": {
+                "Main Deck/Auxiliary Navigation Room/Navigation Terminal": {
+                    "hint_type": "joke"
+                },
+                "Main Deck/Restricted Navigation Room/Navigation Terminal": {
+                    "hint_type": "joke"
+                },
+                "Main Deck/Operations Deck Navigation Room/Navigation Terminal": {
+                    "hint_type": "joke"
+                },
+                "Sector 4 (AQA)/Entrance Navigation Room/Navigation Terminal": {
+                    "hint_type": "joke"
+                },
+                "Sector 3 (PYR)/Entrance Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null
+                    },
+                    "target": 89,
+                    "hint_type": "location"
+                },
+                "Sector 1 (SRX)/Entrance Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null
+                    },
+                    "target": 91,
+                    "hint_type": "location"
+                },
+                "Sector 2 (TRO)/Entrance Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null
+                    },
+                    "target": 80,
+                    "hint_type": "location"
+                },
+                "Sector 5 (ARC)/Entrance Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "include_owner": false,
+                        "relative": null,
+                        "item_feature": "suit"
+                    },
+                    "target": 53,
+                    "hint_type": "location"
+                },
+                "Sector 6 (NOC)/Entrance Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null
+                    },
+                    "target": 19,
+                    "hint_type": "location"
+                },
+                "Main Deck/Crew Quarters Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null
+                    },
+                    "target": 52,
+                    "hint_type": "location"
+                },
+                "Main Deck/Nexus Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null
+                    },
+                    "target": 31,
+                    "hint_type": "location"
+                }
+            },
+            "game_specific": {}
+        }
+    ],
+    "item_order": [
+        "Morph Ball at Main Deck/Operations Deck Data Room/Pickup (Missile Launcher)",
+        "Missile Launcher Data at Main Deck/Cubby Hole/Pickup (Missile Tank)",
+        "Hi-Jump at Sector 1 (SRX)/Lava Lake/Pickup (Missile Tank on Platform)",
+        "Level 4 Keycard at Sector 1 (SRX)/Wall Jump Tutorial/Pickup (Missile Tank)",
+        "Power Bomb Data at Main Deck/Operations Ventilation/Pickup (Missile Tank)",
+        "Space Jump at Sector 2 (TRO)/Dessgeega Dorm/Pickup (Missile Tank)",
+        "Level 1 Keycard at Main Deck/Station Entrance/Pickup (Hidden Missile Tank)",
+        "Speed Booster at Sector 4 (AQA)/Reservoir Vault/Pickup (Upper Missile Tank)",
+        "Ice Missile Data at Sector 3 (PYR)/Namihe's Lair/Pickup (Power Bomb Tank)",
+        "Wave Beam at Sector 2 (TRO)/Ripper Tower/Pickup (Power Bomb Tank)",
+        "Energy Tank at Sector 4 (AQA)/Drain Pipe/Pickup (Hidden Missile Tank)",
+        "Charge Beam at Sector 2 (TRO)/Ripper Tower/Pickup (Hidden Power Bomb Tank)",
+        "Level 2 Keycard at Sector 1 (SRX)/Charge Core Arena/Pickup (Energy Tank)",
+        "Energy Tank at Sector 6 (NOC)/Entrance Lobby/Pickup (Missile Tank)",
+        "Diffusion Missile Data at Main Deck/Nexus Storage/Pickup (Power Bomb Tank)",
+        "Screw Attack at Sector 5 (ARC)/Training Aerie/Pickup (Power Bomb Tank)",
+        "Energy Tank at Sector 2 (TRO)/Crumble City/Pickup (Energy Tank)",
+        "Energy Tank at Sector 6 (NOC)/Vault/Pickup (Energy Tank)",
+        "Level 3 Keycard at Sector 3 (PYR)/Data Room/Pickup (Super Missiles)",
+        "Morph Ball Bomb Data at Sector 5 (ARC)/Gerubus Gully/Pickup (Hidden Missile Tank)",
+        "Energy Tank at Sector 2 (TRO)/Zazabi Speedway/Pickup (Power Bomb Tank)",
+        "Ice Beam at Sector 2 (TRO)/Zazabi Arena/Pickup (High Jump)",
+        "Varia Suit at Sector 3 (PYR)/Security Access/Pickup (Hidden Missile Tank)",
+        "Wide Beam at Sector 6 (NOC)/Zozoro Wine Cellar/Pickup (Hidden Missile Tank)",
+        "Super Missile Data at Sector 5 (ARC)/Ripper Road/Pickup (Power Bomb Tank)",
+        "Gravity Suit at Sector 3 (PYR)/Geron's Treasure/Pickup (Missile Tank)",
+        "Energy Tank at Sector 4 (AQA)/Aquarium Pirate Tank/Pickup (Missile Tank)",
+        "Plasma Beam at Sector 6 (NOC)/X-B.O.X. Garage/Pickup (Missile Tank)"
+    ],
+    "checksum": "92df8915d0c3903341dd2780189d5193378ee3ecf88dfff4da69c96dde4a450fa8eebb2ab26f019f22849a9c80e7de50742ea464bb1c355a475a971baad0f103"
+}

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
@@ -425,8 +425,8 @@
                 "BlockX": 13,
                 "BlockY": 14,
                 "Item": "Missiles",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -446,8 +446,8 @@
                 "BlockX": 9,
                 "BlockY": 20,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -467,8 +467,8 @@
                 "BlockX": 14,
                 "BlockY": 65,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -488,8 +488,8 @@
                 "BlockX": 53,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -509,8 +509,8 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -530,8 +530,8 @@
                 "BlockX": 4,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -551,8 +551,8 @@
                 "BlockX": 54,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -572,8 +572,8 @@
                 "BlockX": 5,
                 "BlockY": 29,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -593,8 +593,8 @@
                 "BlockX": 12,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -614,8 +614,8 @@
                 "BlockX": 29,
                 "BlockY": 29,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -635,8 +635,8 @@
                 "BlockX": 13,
                 "BlockY": 9,
                 "Item": "PowerBombs",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -656,8 +656,8 @@
                 "BlockX": 6,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -677,8 +677,8 @@
                 "BlockX": 14,
                 "BlockY": 10,
                 "Item": "Level2",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -698,8 +698,8 @@
                 "BlockX": 27,
                 "BlockY": 10,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -719,8 +719,8 @@
                 "BlockX": 8,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -740,8 +740,8 @@
                 "BlockX": 44,
                 "BlockY": 19,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -761,8 +761,8 @@
                 "BlockX": 15,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -782,8 +782,8 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -803,8 +803,8 @@
                 "BlockX": 12,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -824,8 +824,8 @@
                 "BlockX": 13,
                 "BlockY": 11,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -845,8 +845,8 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -866,8 +866,8 @@
                 "BlockX": 10,
                 "BlockY": 2,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -887,8 +887,8 @@
                 "BlockX": 6,
                 "BlockY": 8,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -908,8 +908,8 @@
                 "BlockX": 13,
                 "BlockY": 7,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -929,8 +929,8 @@
                 "BlockX": 29,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -950,8 +950,8 @@
                 "BlockX": 13,
                 "BlockY": 4,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -971,8 +971,8 @@
                 "BlockX": 19,
                 "BlockY": 35,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -992,8 +992,8 @@
                 "BlockX": 44,
                 "BlockY": 7,
                 "Item": "SpaceJump",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1013,8 +1013,8 @@
                 "BlockX": 29,
                 "BlockY": 4,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1034,8 +1034,8 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1055,8 +1055,8 @@
                 "BlockX": 28,
                 "BlockY": 7,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1076,8 +1076,8 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "Bombs",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1097,8 +1097,8 @@
                 "BlockX": 21,
                 "BlockY": 8,
                 "Item": "Level1",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1118,8 +1118,8 @@
                 "BlockX": 5,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1139,8 +1139,8 @@
                 "BlockX": 29,
                 "BlockY": 16,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1160,8 +1160,8 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "SpeedBooster",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1181,8 +1181,8 @@
                 "BlockX": 3,
                 "BlockY": 24,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1202,8 +1202,8 @@
                 "BlockX": 4,
                 "BlockY": 5,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1223,8 +1223,8 @@
                 "BlockX": 9,
                 "BlockY": 14,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1244,8 +1244,8 @@
                 "BlockX": 7,
                 "BlockY": 4,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1265,8 +1265,8 @@
                 "BlockX": 10,
                 "BlockY": 26,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1286,8 +1286,8 @@
                 "BlockX": 44,
                 "BlockY": 13,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1307,8 +1307,8 @@
                 "BlockX": 5,
                 "BlockY": 17,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1328,8 +1328,8 @@
                 "BlockX": 9,
                 "BlockY": 9,
                 "Item": "GravitySuit",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1349,8 +1349,8 @@
                 "BlockX": 22,
                 "BlockY": 13,
                 "Item": "IceMissiles",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1370,8 +1370,8 @@
                 "BlockX": 42,
                 "BlockY": 8,
                 "Item": "PlasmaBeam",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1391,8 +1391,8 @@
                 "BlockX": 12,
                 "BlockY": 25,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1412,8 +1412,8 @@
                 "BlockX": 43,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1433,8 +1433,8 @@
                 "BlockX": 19,
                 "BlockY": 13,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1454,8 +1454,8 @@
                 "BlockX": 12,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1475,8 +1475,8 @@
                 "BlockX": 36,
                 "BlockY": 27,
                 "Item": "SuperMissiles",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1496,8 +1496,8 @@
                 "BlockX": 4,
                 "BlockY": 13,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1517,8 +1517,8 @@
                 "BlockX": 15,
                 "BlockY": 10,
                 "Item": "Level3",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1538,8 +1538,8 @@
                 "BlockX": 10,
                 "BlockY": 15,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1559,8 +1559,8 @@
                 "BlockX": 4,
                 "BlockY": 27,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1580,8 +1580,8 @@
                 "BlockX": 15,
                 "BlockY": 86,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1601,8 +1601,8 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1622,8 +1622,8 @@
                 "BlockX": 22,
                 "BlockY": 29,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1643,8 +1643,8 @@
                 "BlockX": 12,
                 "BlockY": 29,
                 "Item": "DiffusionMissiles",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1664,8 +1664,8 @@
                 "BlockX": 24,
                 "BlockY": 9,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1685,8 +1685,8 @@
                 "BlockX": 38,
                 "BlockY": 15,
                 "Item": "IceBeam",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1706,8 +1706,8 @@
                 "BlockX": 44,
                 "BlockY": 5,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1727,8 +1727,8 @@
                 "BlockX": 23,
                 "BlockY": 20,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1748,8 +1748,8 @@
                 "BlockX": 57,
                 "BlockY": 19,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1769,8 +1769,8 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "WaveBeam",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1790,8 +1790,8 @@
                 "BlockX": 9,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1811,8 +1811,8 @@
                 "BlockX": 10,
                 "BlockY": 13,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1832,8 +1832,8 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1853,8 +1853,8 @@
                 "BlockX": 42,
                 "BlockY": 5,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1874,8 +1874,8 @@
                 "BlockX": 22,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1895,8 +1895,8 @@
                 "BlockX": 15,
                 "BlockY": 4,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1916,8 +1916,8 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1937,8 +1937,8 @@
                 "BlockX": 5,
                 "BlockY": 5,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1958,8 +1958,8 @@
                 "BlockX": 20,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -1979,8 +1979,8 @@
                 "BlockX": 3,
                 "BlockY": 10,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2000,8 +2000,8 @@
                 "BlockX": 13,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2021,8 +2021,8 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2042,8 +2042,8 @@
                 "BlockX": 3,
                 "BlockY": 48,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2063,8 +2063,8 @@
                 "BlockX": 14,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2084,8 +2084,8 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2105,8 +2105,8 @@
                 "BlockX": 23,
                 "BlockY": 7,
                 "Item": "WideBeam",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2126,8 +2126,8 @@
                 "BlockX": 14,
                 "BlockY": 3,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2147,8 +2147,8 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2168,8 +2168,8 @@
                 "BlockX": 8,
                 "BlockY": 8,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2189,8 +2189,8 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2210,8 +2210,8 @@
                 "BlockX": 13,
                 "BlockY": 8,
                 "Item": "VariaSuit",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2231,8 +2231,8 @@
                 "BlockX": 11,
                 "BlockY": 3,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2252,8 +2252,8 @@
                 "BlockX": 41,
                 "BlockY": 18,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2273,8 +2273,8 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2294,8 +2294,8 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2315,8 +2315,8 @@
                 "BlockX": 29,
                 "BlockY": 20,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2336,8 +2336,8 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2357,8 +2357,8 @@
                 "BlockX": 5,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2378,8 +2378,8 @@
                 "BlockX": 19,
                 "BlockY": 8,
                 "Item": "HiJump",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2399,8 +2399,8 @@
                 "BlockX": 9,
                 "BlockY": 13,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2420,8 +2420,8 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2441,8 +2441,8 @@
                 "BlockX": 45,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2462,8 +2462,8 @@
                 "BlockX": 33,
                 "BlockY": 10,
                 "Item": "ChargeBeam",
-                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2483,8 +2483,8 @@
                 "BlockX": 10,
                 "BlockY": 24,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2504,8 +2504,8 @@
                 "BlockX": 25,
                 "BlockY": 8,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2525,8 +2525,8 @@
                 "BlockX": 9,
                 "BlockY": 8,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2546,8 +2546,8 @@
                 "BlockX": 6,
                 "BlockY": 9,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -2567,8 +2567,8 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -4998,6 +4998,7 @@
             "Name": "Cavern Save Access"
         }
     ],
+    "AccessibilityPatches": true,
     "AntiSoftlockRoomEdits": true,
     "PowerBombsWithoutBombs": true,
     "SkipDoorTransitions": false,

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
@@ -29,6 +29,7 @@
             {
                 "Source": "MainDeckData",
                 "Item": "MorphBall",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -45,6 +46,7 @@
             {
                 "Source": "Arachnus",
                 "Item": "Level4",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -61,6 +63,7 @@
             {
                 "Source": "Serris",
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -77,6 +80,7 @@
             {
                 "Source": "AqaData",
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -93,6 +97,7 @@
             {
                 "Source": "Ridley",
                 "Item": "InfantMetroid",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -109,6 +114,7 @@
             {
                 "Source": "TroData",
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -125,6 +131,7 @@
             {
                 "Source": "Yakuza",
                 "Item": "InfantMetroid",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -141,6 +148,7 @@
             {
                 "Source": "Zazabi",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -157,6 +165,7 @@
             {
                 "Source": "MegaX",
                 "Item": "InfantMetroid",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -173,6 +182,7 @@
             {
                 "Source": "Nightmare",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -189,6 +199,7 @@
             {
                 "Source": "WideCoreX",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -205,6 +216,7 @@
             {
                 "Source": "WaveCoreX",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -221,6 +233,7 @@
             {
                 "Source": "PyrData",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -237,6 +250,7 @@
             {
                 "Source": "ArcData1",
                 "Item": "ScrewAttack",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -253,6 +267,7 @@
             {
                 "Source": "ChargeCoreX",
                 "Item": "InfantMetroid",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -269,6 +284,7 @@
             {
                 "Source": "Nettori",
                 "Item": "InfantMetroid",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -285,6 +301,7 @@
             {
                 "Source": "Level1",
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -301,6 +318,7 @@
             {
                 "Source": "Level2",
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -317,6 +335,7 @@
             {
                 "Source": "Level3",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -333,6 +352,7 @@
             {
                 "Source": "Level4",
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -349,6 +369,7 @@
             {
                 "Source": "Animals",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -365,6 +386,7 @@
             {
                 "Source": "Boiler",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -381,6 +403,7 @@
             {
                 "Source": "AuxiliaryPower",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
@@ -402,6 +425,7 @@
                 "BlockX": 13,
                 "BlockY": 14,
                 "Item": "Missiles",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -422,6 +446,7 @@
                 "BlockX": 9,
                 "BlockY": 20,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -442,6 +467,7 @@
                 "BlockX": 14,
                 "BlockY": 65,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -462,6 +488,7 @@
                 "BlockX": 53,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -482,6 +509,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -502,6 +530,7 @@
                 "BlockX": 4,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -522,6 +551,7 @@
                 "BlockX": 54,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -542,6 +572,7 @@
                 "BlockX": 5,
                 "BlockY": 29,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -562,6 +593,7 @@
                 "BlockX": 12,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -582,6 +614,7 @@
                 "BlockX": 29,
                 "BlockY": 29,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -602,6 +635,7 @@
                 "BlockX": 13,
                 "BlockY": 9,
                 "Item": "PowerBombs",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -622,6 +656,7 @@
                 "BlockX": 6,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -642,6 +677,7 @@
                 "BlockX": 14,
                 "BlockY": 10,
                 "Item": "Level2",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -662,6 +698,7 @@
                 "BlockX": 27,
                 "BlockY": 10,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -682,6 +719,7 @@
                 "BlockX": 8,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -702,6 +740,7 @@
                 "BlockX": 44,
                 "BlockY": 19,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -722,6 +761,7 @@
                 "BlockX": 15,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -742,6 +782,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -762,6 +803,7 @@
                 "BlockX": 12,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -782,6 +824,7 @@
                 "BlockX": 13,
                 "BlockY": 11,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -802,6 +845,7 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -822,6 +866,7 @@
                 "BlockX": 10,
                 "BlockY": 2,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -842,6 +887,7 @@
                 "BlockX": 6,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -862,6 +908,7 @@
                 "BlockX": 13,
                 "BlockY": 7,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -882,6 +929,7 @@
                 "BlockX": 29,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -902,6 +950,7 @@
                 "BlockX": 13,
                 "BlockY": 4,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -922,6 +971,7 @@
                 "BlockX": 19,
                 "BlockY": 35,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -942,6 +992,7 @@
                 "BlockX": 44,
                 "BlockY": 7,
                 "Item": "SpaceJump",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -962,6 +1013,7 @@
                 "BlockX": 29,
                 "BlockY": 4,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -982,6 +1034,7 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1002,6 +1055,7 @@
                 "BlockX": 28,
                 "BlockY": 7,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1022,6 +1076,7 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "Bombs",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1042,6 +1097,7 @@
                 "BlockX": 21,
                 "BlockY": 8,
                 "Item": "Level1",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1062,6 +1118,7 @@
                 "BlockX": 5,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1082,6 +1139,7 @@
                 "BlockX": 29,
                 "BlockY": 16,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1102,6 +1160,7 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "SpeedBooster",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1122,6 +1181,7 @@
                 "BlockX": 3,
                 "BlockY": 24,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1142,6 +1202,7 @@
                 "BlockX": 4,
                 "BlockY": 5,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1162,6 +1223,7 @@
                 "BlockX": 9,
                 "BlockY": 14,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1182,6 +1244,7 @@
                 "BlockX": 7,
                 "BlockY": 4,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1202,6 +1265,7 @@
                 "BlockX": 10,
                 "BlockY": 26,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1222,6 +1286,7 @@
                 "BlockX": 44,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1242,6 +1307,7 @@
                 "BlockX": 5,
                 "BlockY": 17,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1262,6 +1328,7 @@
                 "BlockX": 9,
                 "BlockY": 9,
                 "Item": "GravitySuit",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1282,6 +1349,7 @@
                 "BlockX": 22,
                 "BlockY": 13,
                 "Item": "IceMissiles",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1302,6 +1370,7 @@
                 "BlockX": 42,
                 "BlockY": 8,
                 "Item": "PlasmaBeam",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1322,6 +1391,7 @@
                 "BlockX": 12,
                 "BlockY": 25,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1342,6 +1412,7 @@
                 "BlockX": 43,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1362,6 +1433,7 @@
                 "BlockX": 19,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1382,6 +1454,7 @@
                 "BlockX": 12,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1402,6 +1475,7 @@
                 "BlockX": 36,
                 "BlockY": 27,
                 "Item": "SuperMissiles",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1422,6 +1496,7 @@
                 "BlockX": 4,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1442,6 +1517,7 @@
                 "BlockX": 15,
                 "BlockY": 10,
                 "Item": "Level3",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1462,6 +1538,7 @@
                 "BlockX": 10,
                 "BlockY": 15,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1482,6 +1559,7 @@
                 "BlockX": 4,
                 "BlockY": 27,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1502,6 +1580,7 @@
                 "BlockX": 15,
                 "BlockY": 86,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1522,6 +1601,7 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1542,6 +1622,7 @@
                 "BlockX": 22,
                 "BlockY": 29,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1562,6 +1643,7 @@
                 "BlockX": 12,
                 "BlockY": 29,
                 "Item": "DiffusionMissiles",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1582,6 +1664,7 @@
                 "BlockX": 24,
                 "BlockY": 9,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1602,6 +1685,7 @@
                 "BlockX": 38,
                 "BlockY": 15,
                 "Item": "IceBeam",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1622,6 +1706,7 @@
                 "BlockX": 44,
                 "BlockY": 5,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1642,6 +1727,7 @@
                 "BlockX": 23,
                 "BlockY": 20,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1662,6 +1748,7 @@
                 "BlockX": 57,
                 "BlockY": 19,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1682,6 +1769,7 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "WaveBeam",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1702,6 +1790,7 @@
                 "BlockX": 9,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1722,6 +1811,7 @@
                 "BlockX": 10,
                 "BlockY": 13,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1742,6 +1832,7 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1762,6 +1853,7 @@
                 "BlockX": 42,
                 "BlockY": 5,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1782,6 +1874,7 @@
                 "BlockX": 22,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1802,6 +1895,7 @@
                 "BlockX": 15,
                 "BlockY": 4,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1822,6 +1916,7 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1842,6 +1937,7 @@
                 "BlockX": 5,
                 "BlockY": 5,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1862,6 +1958,7 @@
                 "BlockX": 20,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1882,6 +1979,7 @@
                 "BlockX": 3,
                 "BlockY": 10,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1902,6 +2000,7 @@
                 "BlockX": 13,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1922,6 +2021,7 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1942,6 +2042,7 @@
                 "BlockX": 3,
                 "BlockY": 48,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1962,6 +2063,7 @@
                 "BlockX": 14,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -1982,6 +2084,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2002,6 +2105,7 @@
                 "BlockX": 23,
                 "BlockY": 7,
                 "Item": "WideBeam",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2022,6 +2126,7 @@
                 "BlockX": 14,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2042,6 +2147,7 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2062,6 +2168,7 @@
                 "BlockX": 8,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2082,6 +2189,7 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2102,6 +2210,7 @@
                 "BlockX": 13,
                 "BlockY": 8,
                 "Item": "VariaSuit",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2122,6 +2231,7 @@
                 "BlockX": 11,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2142,6 +2252,7 @@
                 "BlockX": 41,
                 "BlockY": 18,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2162,6 +2273,7 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2182,6 +2294,7 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2202,6 +2315,7 @@
                 "BlockX": 29,
                 "BlockY": 20,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2222,6 +2336,7 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2242,6 +2357,7 @@
                 "BlockX": 5,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2262,6 +2378,7 @@
                 "BlockX": 19,
                 "BlockY": 8,
                 "Item": "HiJump",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2282,6 +2399,7 @@
                 "BlockX": 9,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2302,6 +2420,7 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2322,6 +2441,7 @@
                 "BlockX": 45,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2342,6 +2462,7 @@
                 "BlockX": 33,
                 "BlockY": 10,
                 "Item": "ChargeBeam",
+                "Jingle": "Major",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2362,6 +2483,7 @@
                 "BlockX": 10,
                 "BlockY": 24,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2382,6 +2504,7 @@
                 "BlockX": 25,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2402,6 +2525,7 @@
                 "BlockX": 9,
                 "BlockY": 8,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2422,6 +2546,7 @@
                 "BlockX": 6,
                 "BlockY": 9,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {
@@ -2442,6 +2567,7 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Anonymous",
                 "ItemMessages": {
                     "Languages": {

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
@@ -32,30 +32,38 @@
                 "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "JapaneseHiragana": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "English": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "German": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "French": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "Italian": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "Spanish": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph."
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
             },
             {
                 "Source": "Arachnus",
-                "Item": "InfantMetroid",
-                "Jingle": "Major",
+                "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
-                    "Kind": "MessageID",
-                    "MessageID": 56
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
                 }
             },
             {
                 "Source": "Serris",
-                "Item": "MissileTank",
-                "Jingle": "Minor",
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -71,8 +79,25 @@
             },
             {
                 "Source": "AqaData",
-                "Item": "MissileTank",
+                "Item": "PowerBombTank",
                 "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "JapaneseHiragana": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "English": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "German": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "French": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "Italian": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "Spanish": "Security Level 1 unlocked.\nBlue hatches now active."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Source": "Ridley",
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -87,35 +112,18 @@
                 }
             },
             {
-                "Source": "Ridley",
-                "Item": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
                 "Source": "TroData",
-                "Item": "PowerBombTank",
+                "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -139,26 +147,8 @@
             },
             {
                 "Source": "Zazabi",
-                "Item": "InfantMetroid",
+                "Item": "IceBeam",
                 "Jingle": "Major",
-                "ItemMessages": {
-                    "Kind": "MessageID",
-                    "MessageID": 56
-                }
-            },
-            {
-                "Source": "MegaX",
-                "Item": "InfantMetroid",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Kind": "MessageID",
-                    "MessageID": 56
-                }
-            },
-            {
-                "Source": "Nightmare",
-                "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -168,98 +158,63 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Source": "MegaX",
+                "Item": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "JapaneseHiragana": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "English": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "German": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "French": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "Italian": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "Spanish": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Source": "Nightmare",
+                "Item": "PowerBombTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
             },
             {
                 "Source": "WideCoreX",
-                "Item": "InfantMetroid",
-                "Jingle": "Major",
+                "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
-                    "Kind": "MessageID",
-                    "MessageID": 56
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    },
+                    "Kind": "CustomMessage"
                 }
             },
             {
                 "Source": "WaveCoreX",
-                "Item": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Source": "PyrData",
-                "Item": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Source": "ArcData1",
-                "Item": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Source": "ChargeCoreX",
-                "Item": "InfantMetroid",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Kind": "MessageID",
-                    "MessageID": 56
-                }
-            },
-            {
-                "Source": "Nettori",
-                "Item": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Source": "Level1",
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -276,24 +231,92 @@
                 }
             },
             {
-                "Source": "Level2",
-                "Item": "GravitySuit",
+                "Source": "PyrData",
+                "Item": "Level3",
                 "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "JapaneseHiragana": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "English": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "German": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "French": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "Italian": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "Spanish": "Gravity Suit effect acquired.\nMove freely in liquids."
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
                     },
                     "Kind": "CustomMessage"
                 }
             },
             {
-                "Source": "Level3",
+                "Source": "ArcData1",
+                "Item": "EnergyTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Source": "ChargeCoreX",
+                "Item": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Source": "Nettori",
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Source": "Level1",
+                "Item": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Source": "Level2",
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -310,8 +333,25 @@
                 }
             },
             {
+                "Source": "Level3",
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
                 "Source": "Level4",
-                "Item": "PowerBombTank",
+                "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
@@ -328,51 +368,43 @@
             },
             {
                 "Source": "Animals",
-                "Item": "None",
+                "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Nothing acquired.",
-                        "JapaneseHiragana": "Nothing acquired.",
-                        "English": "Nothing acquired.",
-                        "German": "Nothing acquired.",
-                        "French": "Nothing acquired.",
-                        "Italian": "Nothing acquired.",
-                        "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    "Kind": "MessageID",
+                    "MessageID": 51
                 }
             },
             {
                 "Source": "Boiler",
-                "Item": "None",
+                "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Nothing acquired.",
-                        "JapaneseHiragana": "Nothing acquired.",
-                        "English": "Nothing acquired.",
-                        "German": "Nothing acquired.",
-                        "French": "Nothing acquired.",
-                        "Italian": "Nothing acquired.",
-                        "Spanish": "Nothing acquired."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
             },
             {
                 "Source": "AuxiliaryPower",
-                "Item": "None",
+                "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Nothing acquired.",
-                        "JapaneseHiragana": "Nothing acquired.",
-                        "English": "Nothing acquired.",
-                        "German": "Nothing acquired.",
-                        "French": "Nothing acquired.",
-                        "Italian": "Nothing acquired.",
-                        "Spanish": "Nothing acquired."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -384,6 +416,27 @@
                 "Room": 7,
                 "BlockX": 13,
                 "BlockY": 14,
+                "Item": "Level1",
+                "ItemSprite": "MorphBall",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "JapaneseHiragana": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "English": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "German": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "French": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "Italian": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "Spanish": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 0,
+                "Room": 17,
+                "BlockX": 9,
+                "BlockY": 20,
                 "Item": "PowerBombTank",
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
@@ -402,42 +455,21 @@
             },
             {
                 "Area": 0,
-                "Room": 17,
-                "BlockX": 9,
-                "BlockY": 20,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 0,
                 "Room": 35,
                 "BlockX": 14,
                 "BlockY": 65,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
+                "Item": "PowerBombs",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -448,69 +480,6 @@
                 "BlockX": 53,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 0,
-                "Room": 45,
-                "BlockX": 4,
-                "BlockY": 6,
-                "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 0,
-                "Room": 47,
-                "BlockX": 4,
-                "BlockY": 3,
-                "Item": "Missiles",
-                "ItemSprite": "Missiles",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "JapaneseHiragana": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "English": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "German": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "French": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "Italian": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "Spanish": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 0,
-                "Room": 50,
-                "BlockX": 54,
-                "BlockY": 8,
-                "Item": "EnergyTank",
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -528,9 +497,30 @@
             },
             {
                 "Area": 0,
-                "Room": 51,
-                "BlockX": 5,
-                "BlockY": 29,
+                "Room": 45,
+                "BlockX": 4,
+                "BlockY": 6,
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 0,
+                "Room": 47,
+                "BlockX": 4,
+                "BlockY": 3,
                 "Item": "PowerBombTank",
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
@@ -549,12 +539,54 @@
             },
             {
                 "Area": 0,
+                "Room": 50,
+                "BlockX": 54,
+                "BlockY": 8,
+                "Item": "EnergyTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 0,
+                "Room": 51,
+                "BlockX": 5,
+                "BlockY": 29,
+                "Item": "PowerBombTank",
+                "ItemSprite": "SuperMissiles",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "JapaneseHiragana": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "English": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "German": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "French": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "Italian": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "Spanish": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 0,
                 "Room": 57,
                 "BlockX": 12,
                 "BlockY": 10,
-                "Item": "MissileTank",
+                "Item": "DiffusionMissiles",
                 "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -573,6 +605,132 @@
                 "Room": 69,
                 "BlockX": 29,
                 "BlockY": 29,
+                "Item": "MissileTank",
+                "ItemSprite": "VariaSuit",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
+                        "JapaneseHiragana": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
+                        "English": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
+                        "German": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
+                        "French": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
+                        "Italian": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
+                        "Spanish": "Varia Suit effect acquired.\nSurvive extreme temperatures."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 0,
+                "Room": 72,
+                "BlockX": 13,
+                "BlockY": 9,
+                "Item": "Missiles",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 0,
+                "Room": 73,
+                "BlockX": 6,
+                "BlockY": 10,
+                "Item": "PowerBombTank",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 0,
+                "Room": 84,
+                "BlockX": 14,
+                "BlockY": 10,
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 1,
+                "Room": 5,
+                "BlockX": 27,
+                "BlockY": 10,
+                "Item": "PowerBombTank",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 1,
+                "Room": 17,
+                "BlockX": 8,
+                "BlockY": 6,
+                "Item": "MissileTank",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 1,
+                "Room": 17,
+                "BlockX": 44,
+                "BlockY": 19,
                 "Item": "EnergyTank",
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
@@ -590,137 +748,11 @@
                 }
             },
             {
-                "Area": 0,
-                "Room": 72,
-                "BlockX": 13,
-                "BlockY": 9,
-                "Item": "PowerBombs",
-                "ItemSprite": "PowerBombs",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "JapaneseHiragana": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "English": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "German": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "French": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "Italian": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "Spanish": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 0,
-                "Room": 73,
-                "BlockX": 6,
-                "BlockY": 10,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 0,
-                "Room": 84,
-                "BlockX": 14,
-                "BlockY": 10,
-                "Item": "SpaceJump",
-                "ItemSprite": "SpaceJump",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Space Jump ability acquired.\nSomersault continually in air.",
-                        "JapaneseHiragana": "Space Jump ability acquired.\nSomersault continually in air.",
-                        "English": "Space Jump ability acquired.\nSomersault continually in air.",
-                        "German": "Space Jump ability acquired.\nSomersault continually in air.",
-                        "French": "Space Jump ability acquired.\nSomersault continually in air.",
-                        "Italian": "Space Jump ability acquired.\nSomersault continually in air.",
-                        "Spanish": "Space Jump ability acquired.\nSomersault continually in air."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 1,
-                "Room": 5,
-                "BlockX": 27,
-                "BlockY": 10,
-                "Item": "Level3",
-                "ItemSprite": "Level3",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "JapaneseHiragana": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "English": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "German": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "French": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "Italian": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "Spanish": "Security Level 3 unlocked.\nYellow hatches now active."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 1,
-                "Room": 17,
-                "BlockX": 8,
-                "BlockY": 6,
-                "Item": "ScrewAttack",
-                "ItemSprite": "ScrewAttack",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "JapaneseHiragana": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "English": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "German": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "French": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "Italian": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "Spanish": "Screw Attack ability regained.\nSomersault into enemies."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 1,
-                "Room": 17,
-                "BlockX": 44,
-                "BlockY": 19,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
                 "Area": 1,
                 "Room": 30,
                 "BlockX": 15,
                 "BlockY": 8,
-                "Item": "PowerBombTank",
+                "Item": "MissileTank",
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -741,18 +773,18 @@
                 "Room": 39,
                 "BlockX": 4,
                 "BlockY": 6,
-                "Item": "ChargeBeam",
-                "ItemSprite": "ChargeBeam",
-                "Jingle": "Major",
+                "Item": "PowerBombTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "JapaneseHiragana": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "English": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "German": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "French": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "Italian": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "Spanish": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -762,7 +794,49 @@
                 "Room": 40,
                 "BlockX": 12,
                 "BlockY": 8,
-                "Item": "PowerBombTank",
+                "Item": "Level2",
+                "ItemSprite": "WaveBeam",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "JapaneseHiragana": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "English": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "German": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "French": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "Italian": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "Spanish": "Wave Beam ability acquired.\nBeam now penetrates walls."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 1,
+                "Room": 43,
+                "BlockX": 13,
+                "BlockY": 11,
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 1,
+                "Room": 44,
+                "BlockX": 4,
+                "BlockY": 8,
+                "Item": "MissileTank",
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -774,48 +848,6 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 1,
-                "Room": 43,
-                "BlockX": 13,
-                "BlockY": 11,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 1,
-                "Room": 44,
-                "BlockX": 4,
-                "BlockY": 8,
-                "Item": "Level1",
-                "ItemSprite": "Level1",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Security Level 1 unlocked.\nBlue hatches now active.",
-                        "JapaneseHiragana": "Security Level 1 unlocked.\nBlue hatches now active.",
-                        "English": "Security Level 1 unlocked.\nBlue hatches now active.",
-                        "German": "Security Level 1 unlocked.\nBlue hatches now active.",
-                        "French": "Security Level 1 unlocked.\nBlue hatches now active.",
-                        "Italian": "Security Level 1 unlocked.\nBlue hatches now active.",
-                        "Spanish": "Security Level 1 unlocked.\nBlue hatches now active."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -826,6 +858,48 @@
                 "BlockX": 10,
                 "BlockY": 2,
                 "Item": "MissileTank",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 1,
+                "Room": 50,
+                "BlockX": 6,
+                "BlockY": 8,
+                "Item": "Level4",
+                "ItemSprite": "EnergyTank",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 1,
+                "Room": 52,
+                "BlockX": 13,
+                "BlockY": 7,
+                "Item": "MissileTank",
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -837,48 +911,6 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 1,
-                "Room": 50,
-                "BlockX": 6,
-                "BlockY": 8,
-                "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 1,
-                "Room": 52,
-                "BlockX": 13,
-                "BlockY": 7,
-                "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -889,17 +921,17 @@
                 "BlockX": 29,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -909,18 +941,18 @@
                 "Room": 9,
                 "BlockX": 13,
                 "BlockY": 4,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
+                "Item": "MissileTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -930,18 +962,18 @@
                 "Room": 10,
                 "BlockX": 19,
                 "BlockY": 35,
-                "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
+                "Item": "EnergyTank",
+                "ItemSprite": "Level4",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                        "JapaneseKanji": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "JapaneseHiragana": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "English": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "German": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "French": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "Italian": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "Spanish": "Security Level 4 unlocked.\nRed hatches now active."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -951,18 +983,18 @@
                 "Room": 17,
                 "BlockX": 44,
                 "BlockY": 7,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -972,18 +1004,18 @@
                 "Room": 21,
                 "BlockX": 29,
                 "BlockY": 4,
-                "Item": "IceBeam",
-                "ItemSprite": "IceBeam",
-                "Jingle": "Major",
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "JapaneseHiragana": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "English": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "German": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "French": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "Italian": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "Spanish": "Ice effect added to beam.\nUse beam to freeze enemies."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -993,18 +1025,18 @@
                 "Room": 25,
                 "BlockX": 4,
                 "BlockY": 8,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "Item": "EnergyTank",
+                "ItemSprite": "Level3",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "JapaneseHiragana": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "English": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "German": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "French": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "Italian": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "Spanish": "Security Level 3 unlocked.\nYellow hatches now active."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1014,112 +1046,7 @@
                 "Room": 27,
                 "BlockX": 28,
                 "BlockY": 7,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 31,
-                "BlockX": 40,
-                "BlockY": 7,
-                "Item": "HiJump",
-                "ItemSprite": "HiJump",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Hi-Jump and Jumpball\nabilities acquired.",
-                        "JapaneseHiragana": "Hi-Jump and Jumpball\nabilities acquired.",
-                        "English": "Hi-Jump and Jumpball\nabilities acquired.",
-                        "German": "Hi-Jump and Jumpball\nabilities acquired.",
-                        "French": "Hi-Jump and Jumpball\nabilities acquired.",
-                        "Italian": "Hi-Jump and Jumpball\nabilities acquired.",
-                        "Spanish": "Hi-Jump and Jumpball\nabilities acquired."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 33,
-                "BlockX": 21,
-                "BlockY": 8,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 42,
-                "BlockX": 5,
-                "BlockY": 8,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 47,
-                "BlockX": 29,
-                "BlockY": 16,
-                "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 50,
-                "BlockX": 3,
-                "BlockY": 7,
-                "Item": "SpeedBooster",
+                "Item": "SpaceJump",
                 "ItemSprite": "SpeedBooster",
                 "Jingle": "Major",
                 "ItemMessages": {
@@ -1137,10 +1064,10 @@
             },
             {
                 "Area": 2,
-                "Room": 50,
-                "BlockX": 3,
-                "BlockY": 24,
-                "Item": "EnergyTank",
+                "Room": 31,
+                "BlockX": 40,
+                "BlockY": 7,
+                "Item": "PowerBombTank",
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -1158,93 +1085,30 @@
             },
             {
                 "Area": 2,
-                "Room": 54,
-                "BlockX": 4,
-                "BlockY": 5,
-                "Item": "WaveBeam",
-                "ItemSprite": "WaveBeam",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "JapaneseHiragana": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "English": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "German": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "French": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "Italian": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "Spanish": "Wave Beam ability acquired.\nBeam now penetrates walls."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 54,
-                "BlockX": 9,
-                "BlockY": 14,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
+                "Room": 33,
+                "BlockX": 21,
+                "BlockY": 8,
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
             },
             {
                 "Area": 2,
-                "Room": 55,
-                "BlockX": 7,
-                "BlockY": 4,
-                "Item": "WideBeam",
-                "ItemSprite": "WideBeam",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "JapaneseHiragana": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "English": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "German": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "French": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "Italian": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "Spanish": "Wide Beam ability acquired.\nBeam widens dramatically."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 55,
-                "BlockX": 10,
-                "BlockY": 26,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 3,
-                "Room": 3,
-                "BlockX": 44,
-                "BlockY": 13,
+                "Room": 42,
+                "BlockX": 5,
+                "BlockY": 8,
                 "Item": "PowerBombTank",
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
@@ -1262,11 +1126,95 @@
                 }
             },
             {
-                "Area": 3,
-                "Room": 6,
-                "BlockX": 5,
-                "BlockY": 17,
+                "Area": 2,
+                "Room": 47,
+                "BlockX": 29,
+                "BlockY": 16,
                 "Item": "MissileTank",
+                "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 2,
+                "Room": 50,
+                "BlockX": 3,
+                "BlockY": 7,
+                "Item": "WaveBeam",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 2,
+                "Room": 50,
+                "BlockX": 3,
+                "BlockY": 24,
+                "Item": "ChargeBeam",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 2,
+                "Room": 54,
+                "BlockX": 4,
+                "BlockY": 5,
+                "Item": "EnergyTank",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 2,
+                "Room": 54,
+                "BlockX": 9,
+                "BlockY": 14,
+                "Item": "PowerBombTank",
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -1278,6 +1226,90 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 2,
+                "Room": 55,
+                "BlockX": 7,
+                "BlockY": 4,
+                "Item": "EnergyTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 2,
+                "Room": 55,
+                "BlockX": 10,
+                "BlockY": 26,
+                "Item": "MissileTank",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 3,
+                "Room": 3,
+                "BlockX": 44,
+                "BlockY": 13,
+                "Item": "VariaSuit",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 3,
+                "Room": 6,
+                "BlockX": 5,
+                "BlockY": 17,
+                "Item": "EnergyTank",
+                "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1308,18 +1340,18 @@
                 "Room": 8,
                 "BlockX": 22,
                 "BlockY": 13,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "Item": "PowerBombTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1329,7 +1361,7 @@
                 "Room": 9,
                 "BlockX": 42,
                 "BlockY": 8,
-                "Item": "MissileTank",
+                "Item": "EnergyTank",
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -1351,17 +1383,17 @@
                 "BlockX": 12,
                 "BlockY": 25,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1371,7 +1403,7 @@
                 "Room": 19,
                 "BlockX": 43,
                 "BlockY": 10,
-                "Item": "MissileTank",
+                "Item": "PowerBombTank",
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -1392,18 +1424,18 @@
                 "Room": 19,
                 "BlockX": 19,
                 "BlockY": 13,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "Item": "EnergyTank",
+                "ItemSprite": "ChargeBeam",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "JapaneseHiragana": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "English": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "German": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "French": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "Italian": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "Spanish": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1413,18 +1445,18 @@
                 "Room": 28,
                 "BlockX": 12,
                 "BlockY": 7,
-                "Item": "PlasmaBeam",
-                "ItemSprite": "PlasmaBeam",
-                "Jingle": "Major",
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "JapaneseHiragana": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "English": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "German": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "French": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "Italian": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "Spanish": "Plasma Beam ability acquired.\nBeam now pierces enemies."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1434,20 +1466,12 @@
                 "Room": 28,
                 "BlockX": 36,
                 "BlockY": 27,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
+                "Item": "MissileTank",
+                "ItemSprite": "InfantMetroid",
                 "Jingle": "Minor",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    "Kind": "MessageID",
+                    "MessageID": 51
                 }
             },
             {
@@ -1455,18 +1479,18 @@
                 "Room": 30,
                 "BlockX": 4,
                 "BlockY": 13,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
+                "Item": "IceMissiles",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1476,18 +1500,18 @@
                 "Room": 33,
                 "BlockX": 15,
                 "BlockY": 10,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
+                "Item": "GravitySuit",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1497,18 +1521,18 @@
                 "Room": 34,
                 "BlockX": 10,
                 "BlockY": 15,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "Item": "PowerBombTank",
+                "ItemSprite": "Missiles",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "JapaneseHiragana": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "English": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "German": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "French": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "Italian": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "Spanish": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1518,28 +1542,7 @@
                 "Room": 35,
                 "BlockX": 4,
                 "BlockY": 27,
-                "Item": "Bombs",
-                "ItemSprite": "Bombs",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "JapaneseHiragana": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "English": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "German": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "French": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "Italian": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "Spanish": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 3,
-                "Room": 35,
-                "BlockX": 15,
-                "BlockY": 86,
-                "Item": "EnergyTank",
+                "Item": "MissileTank",
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -1551,6 +1554,27 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 3,
+                "Room": 35,
+                "BlockX": 15,
+                "BlockY": 86,
+                "Item": "PowerBombTank",
+                "ItemSprite": "GravitySuit",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "JapaneseHiragana": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "English": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "German": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "French": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "Italian": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "Spanish": "Gravity Suit effect acquired.\nMove freely in liquids."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1581,9 +1605,30 @@
                 "Room": 6,
                 "BlockX": 22,
                 "BlockY": 29,
-                "Item": "Level2",
+                "Item": "PowerBombTank",
+                "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 4,
+                "Room": 10,
+                "BlockX": 12,
+                "BlockY": 29,
+                "Item": "MissileTank",
                 "ItemSprite": "Level2",
-                "Jingle": "Major",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Security Level 2 unlocked.\nGreen hatches now active.",
@@ -1599,33 +1644,12 @@
             },
             {
                 "Area": 4,
-                "Room": 10,
-                "BlockX": 12,
-                "BlockY": 29,
-                "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 4,
                 "Room": 13,
                 "BlockX": 24,
                 "BlockY": 9,
-                "Item": "MissileTank",
+                "Item": "SpeedBooster",
                 "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1666,19 +1690,11 @@
                 "BlockX": 44,
                 "BlockY": 5,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "InfantMetroid",
                 "Jingle": "Minor",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    "Kind": "MessageID",
+                    "MessageID": 51
                 }
             },
             {
@@ -1686,90 +1702,6 @@
                 "Room": 17,
                 "BlockX": 23,
                 "BlockY": 20,
-                "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 4,
-                "Room": 23,
-                "BlockX": 57,
-                "BlockY": 19,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 4,
-                "Room": 24,
-                "BlockX": 40,
-                "BlockY": 7,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 4,
-                "Room": 28,
-                "BlockX": 9,
-                "BlockY": 6,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 4,
-                "Room": 33,
-                "BlockX": 10,
-                "BlockY": 13,
                 "Item": "EnergyTank",
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
@@ -1788,33 +1720,33 @@
             },
             {
                 "Area": 4,
-                "Room": 36,
-                "BlockX": 3,
-                "BlockY": 7,
-                "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
+                "Room": 23,
+                "BlockX": 57,
+                "BlockY": 19,
+                "Item": "MissileTank",
+                "ItemSprite": "Bombs",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                        "JapaneseKanji": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "JapaneseHiragana": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "English": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "German": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "French": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "Italian": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "Spanish": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right]."
                     },
                     "Kind": "CustomMessage"
                 }
             },
             {
                 "Area": 4,
-                "Room": 38,
-                "BlockX": 42,
-                "BlockY": 5,
-                "Item": "MissileTank",
+                "Room": 24,
+                "BlockX": 40,
+                "BlockY": 7,
+                "Item": "InfantMetroid",
                 "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1830,9 +1762,9 @@
             },
             {
                 "Area": 4,
-                "Room": 38,
-                "BlockX": 22,
-                "BlockY": 10,
+                "Room": 28,
+                "BlockX": 9,
+                "BlockY": 6,
                 "Item": "PowerBombTank",
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
@@ -1845,6 +1777,82 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 4,
+                "Room": 33,
+                "BlockX": 10,
+                "BlockY": 13,
+                "Item": "EnergyTank",
+                "ItemSprite": "HiJump",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "JapaneseHiragana": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "English": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "German": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "French": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "Italian": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "Spanish": "Hi-Jump and Jumpball\nabilities acquired."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 4,
+                "Room": 36,
+                "BlockX": 3,
+                "BlockY": 7,
+                "Item": "EnergyTank",
+                "ItemSprite": "SpaceJump",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "JapaneseHiragana": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "English": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "German": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "French": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "Italian": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "Spanish": "Space Jump ability acquired.\nSomersault continually in air."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 4,
+                "Room": 38,
+                "BlockX": 42,
+                "BlockY": 5,
+                "Item": "PowerBombTank",
+                "ItemSprite": "InfantMetroid",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 52
+                }
+            },
+            {
+                "Area": 4,
+                "Room": 38,
+                "BlockX": 22,
+                "BlockY": 10,
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1875,49 +1883,7 @@
                 "Room": 46,
                 "BlockX": 4,
                 "BlockY": 10,
-                "Item": "IceMissiles",
-                "ItemSprite": "IceMissiles",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "JapaneseHiragana": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "English": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "German": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "French": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "Italian": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "Spanish": "Ice effect added to Missiles.\nUse it to freeze enemies."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 5,
-                "Room": 4,
-                "BlockX": 5,
-                "BlockY": 5,
-                "Item": "VariaSuit",
-                "ItemSprite": "VariaSuit",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
-                        "JapaneseHiragana": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
-                        "English": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
-                        "German": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
-                        "French": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
-                        "Italian": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
-                        "Spanish": "Varia Suit effect acquired.\nSurvive extreme temperatures."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 5,
-                "Room": 4,
-                "BlockX": 20,
-                "BlockY": 8,
-                "Item": "PowerBombTank",
+                "Item": "EnergyTank",
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -1929,6 +1895,48 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 5,
+                "Room": 4,
+                "BlockX": 5,
+                "BlockY": 5,
+                "Item": "ScrewAttack",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
+                "Area": 5,
+                "Room": 4,
+                "BlockX": 20,
+                "BlockY": 8,
+                "Item": "PowerBombTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1959,18 +1967,18 @@
                 "Room": 14,
                 "BlockX": 13,
                 "BlockY": 3,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
+                "Item": "PowerBombTank",
+                "ItemSprite": "PlasmaBeam",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                        "JapaneseKanji": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "JapaneseHiragana": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "English": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "German": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "French": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "Italian": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "Spanish": "Plasma Beam ability acquired.\nBeam now pierces enemies."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -1981,17 +1989,17 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2001,7 +2009,7 @@
                 "Room": 22,
                 "BlockX": 3,
                 "BlockY": 48,
-                "Item": "MissileTank",
+                "Item": "PowerBombTank",
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -2022,7 +2030,7 @@
                 "Room": 23,
                 "BlockX": 14,
                 "BlockY": 6,
-                "Item": "MissileTank",
+                "Item": "EnergyTank",
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -2043,9 +2051,9 @@
                 "Room": 26,
                 "BlockX": 4,
                 "BlockY": 6,
-                "Item": "MissileTank",
+                "Item": "SuperMissiles",
                 "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2064,18 +2072,18 @@
                 "Room": 30,
                 "BlockX": 23,
                 "BlockY": 7,
-                "Item": "SuperMissiles",
-                "ItemSprite": "SuperMissiles",
-                "Jingle": "Major",
+                "Item": "MissileTank",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "JapaneseHiragana": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "English": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "German": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "French": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "Italian": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "Spanish": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2085,9 +2093,9 @@
                 "Room": 33,
                 "BlockX": 14,
                 "BlockY": 3,
-                "Item": "MissileTank",
+                "Item": "Bombs",
                 "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2107,17 +2115,17 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2127,18 +2135,18 @@
                 "Room": 36,
                 "BlockX": 8,
                 "BlockY": 8,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
+                "Item": "PowerBombTank",
+                "ItemSprite": "ScrewAttack",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                        "JapaneseKanji": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "JapaneseHiragana": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "English": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "German": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "French": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "Italian": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "Spanish": "Screw Attack ability regained.\nSomersault into enemies."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2148,18 +2156,18 @@
                 "Room": 47,
                 "BlockX": 4,
                 "BlockY": 10,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
+                "Item": "PowerBombTank",
+                "ItemSprite": "IceBeam",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                        "JapaneseKanji": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "JapaneseHiragana": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "English": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "German": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "French": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "Italian": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "Spanish": "Ice effect added to beam.\nUse beam to freeze enemies."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2169,18 +2177,18 @@
                 "Room": 50,
                 "BlockX": 13,
                 "BlockY": 8,
-                "Item": "Level4",
-                "ItemSprite": "Level4",
-                "Jingle": "Major",
+                "Item": "PowerBombTank",
+                "ItemSprite": "IceMissiles",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "JapaneseHiragana": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "English": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "German": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "French": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "Italian": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "Spanish": "Security Level 4 unlocked.\nRed hatches now active."
+                        "JapaneseKanji": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "JapaneseHiragana": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "English": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "German": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "French": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "Italian": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "Spanish": "Ice effect added to Missiles.\nUse it to freeze enemies."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2190,7 +2198,7 @@
                 "Room": 51,
                 "BlockX": 11,
                 "BlockY": 3,
-                "Item": "PowerBombTank",
+                "Item": "MissileTank",
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -2211,18 +2219,18 @@
                 "Room": 0,
                 "BlockX": 41,
                 "BlockY": 18,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "Item": "EnergyTank",
+                "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2232,9 +2240,9 @@
                 "Room": 15,
                 "BlockX": 3,
                 "BlockY": 3,
-                "Item": "MissileTank",
+                "Item": "WideBeam",
                 "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2254,17 +2262,17 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2274,18 +2282,18 @@
                 "Room": 18,
                 "BlockX": 29,
                 "BlockY": 20,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
+                "Item": "PlasmaBeam",
+                "ItemSprite": "EnergyTank",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2295,18 +2303,18 @@
                 "Room": 24,
                 "BlockX": 29,
                 "BlockY": 9,
-                "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2316,18 +2324,18 @@
                 "Room": 26,
                 "BlockX": 5,
                 "BlockY": 6,
-                "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2337,18 +2345,18 @@
                 "Room": 30,
                 "BlockX": 19,
                 "BlockY": 8,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
+                "Item": "MissileTank",
+                "ItemSprite": "WideBeam",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                        "JapaneseKanji": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "JapaneseHiragana": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "English": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "German": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "French": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "Italian": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "Spanish": "Wide Beam ability acquired.\nBeam widens dramatically."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2358,18 +2366,18 @@
                 "Room": 30,
                 "BlockX": 9,
                 "BlockY": 13,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "Item": "PowerBombTank",
+                "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2379,27 +2387,6 @@
                 "Room": 34,
                 "BlockX": 14,
                 "BlockY": 8,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 6,
-                "Room": 38,
-                "BlockX": 45,
-                "BlockY": 6,
                 "Item": "EnergyTank",
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
@@ -2418,10 +2405,23 @@
             },
             {
                 "Area": 6,
+                "Room": 38,
+                "BlockX": 45,
+                "BlockY": 6,
+                "Item": "PowerBombTank",
+                "ItemSprite": "InfantMetroid",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 52
+                }
+            },
+            {
+                "Area": 6,
                 "Room": 39,
                 "BlockX": 33,
                 "BlockY": 10,
-                "Item": "EnergyTank",
+                "Item": "MissileTank",
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
@@ -2442,27 +2442,6 @@
                 "Room": 39,
                 "BlockX": 10,
                 "BlockY": 24,
-                "Item": "DiffusionMissiles",
-                "ItemSprite": "DiffusionMissiles",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "JapaneseHiragana": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "English": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "German": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "French": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "Italian": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "Spanish": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 1,
-                "Room": 17,
-                "BlockX": 25,
-                "BlockY": 8,
                 "Item": "EnergyTank",
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
@@ -2480,22 +2459,43 @@
                 }
             },
             {
+                "Area": 1,
+                "Room": 17,
+                "BlockX": 25,
+                "BlockY": 8,
+                "Item": "HiJump",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    },
+                    "Kind": "CustomMessage"
+                }
+            },
+            {
                 "Area": 0,
                 "Room": 46,
                 "BlockX": 9,
                 "BlockY": 8,
-                "Item": "None",
-                "ItemSprite": "Empty",
+                "Item": "MissileTank",
+                "ItemSprite": "DiffusionMissiles",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Nothing acquired.",
-                        "JapaneseHiragana": "Nothing acquired.",
-                        "English": "Nothing acquired.",
-                        "German": "Nothing acquired.",
-                        "French": "Nothing acquired.",
-                        "Italian": "Nothing acquired.",
-                        "Spanish": "Nothing acquired."
+                        "JapaneseKanji": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "JapaneseHiragana": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "English": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "German": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "French": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "Italian": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "Spanish": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right]."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2505,18 +2505,18 @@
                 "Room": 71,
                 "BlockX": 6,
                 "BlockY": 9,
-                "Item": "None",
-                "ItemSprite": "Empty",
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Nothing acquired.",
-                        "JapaneseHiragana": "Nothing acquired.",
-                        "English": "Nothing acquired.",
-                        "German": "Nothing acquired.",
-                        "French": "Nothing acquired.",
-                        "Italian": "Nothing acquired.",
-                        "Spanish": "Nothing acquired."
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
                     },
                     "Kind": "CustomMessage"
                 }
@@ -2526,25 +2526,25 @@
                 "Room": 32,
                 "BlockX": 29,
                 "BlockY": 9,
-                "Item": "None",
-                "ItemSprite": "Empty",
+                "Item": "MissileTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
-                        "JapaneseKanji": "Nothing acquired.",
-                        "JapaneseHiragana": "Nothing acquired.",
-                        "English": "Nothing acquired.",
-                        "German": "Nothing acquired.",
-                        "French": "Nothing acquired.",
-                        "Italian": "Nothing acquired.",
-                        "Spanish": "Nothing acquired."
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
                     },
                     "Kind": "CustomMessage"
                 }
             }
         ]
     },
-    "RequiredMetroidCount": 4,
+    "RequiredMetroidCount": 5,
     "TankIncrements": {
         "MissileTank": 5,
         "PowerBombTank": 2,
@@ -2553,144 +2553,165 @@
         "PowerBombData": 10
     },
     "MissileLimit": 3,
-    "DoorLocks": [],
+    "DoorLocks": [
+        {
+            "Area": 2,
+            "Door": 113,
+            "LockType": "Open"
+        },
+        {
+            "Area": 2,
+            "Door": 114,
+            "LockType": "Open"
+        },
+        {
+            "Area": 5,
+            "Door": 56,
+            "LockType": "Open"
+        },
+        {
+            "Area": 5,
+            "Door": 55,
+            "LockType": "Open"
+        }
+    ],
     "HideDoorsOnMinimap": false,
     "Palettes": {
-        "Seed": 1623414567,
+        "Seed": 789574574,
         "Randomize": {},
         "ColorSpace": "Oklab"
     },
     "NavigationText": {
         "JapaneseKanji": {
             "NavigationTerminals": {
-                "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Main Deck - Arachnus Arena[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 6 (NOC) - Varia Core-X Arena[/COLOR].",
-                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
-                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Charge Core Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 3 (PYR) - Main Boiler Control Room[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Zazabi Arena[/COLOR].",
-                "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector2Entrance": "The [COLOR=3]Level 4 Keycard[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector3Entrance": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector4Entrance": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector5Entrance": "The [COLOR=3]Gravity Suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector6Entrance": "The [COLOR=3]Morph Ball[/COLOR] can be found in [COLOR=2]Main Deck[/COLOR]."
+                "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Nettori Arena[/COLOR].",
+                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Serris Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Ridley Arena[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].",
+                "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector4Entrance": "[COLOR=4]Samus can position herself with Zozoros to form a sandwich.[/COLOR]",
+                "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Gather 4/5 Infant Metroids hiding around the B.S.L. to lure out the [COLOR=3]SA-X[/COLOR] and prepare for battle.",
+                "InitialText": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 5 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L.. Find and capture 5 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
         "JapaneseHiragana": {
             "NavigationTerminals": {
-                "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Main Deck - Arachnus Arena[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 6 (NOC) - Varia Core-X Arena[/COLOR].",
-                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
-                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Charge Core Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 3 (PYR) - Main Boiler Control Room[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Zazabi Arena[/COLOR].",
-                "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector2Entrance": "The [COLOR=3]Level 4 Keycard[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector3Entrance": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector4Entrance": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector5Entrance": "The [COLOR=3]Gravity Suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector6Entrance": "The [COLOR=3]Morph Ball[/COLOR] can be found in [COLOR=2]Main Deck[/COLOR]."
+                "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Nettori Arena[/COLOR].",
+                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Serris Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Ridley Arena[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].",
+                "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector4Entrance": "[COLOR=4]Samus can position herself with Zozoros to form a sandwich.[/COLOR]",
+                "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Gather 4/5 Infant Metroids hiding around the B.S.L. to lure out the [COLOR=3]SA-X[/COLOR] and prepare for battle.",
+                "InitialText": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 5 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L.. Find and capture 5 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
         "English": {
             "NavigationTerminals": {
-                "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Main Deck - Arachnus Arena[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 6 (NOC) - Varia Core-X Arena[/COLOR].",
-                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
-                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Charge Core Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 3 (PYR) - Main Boiler Control Room[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Zazabi Arena[/COLOR].",
-                "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector2Entrance": "The [COLOR=3]Level 4 Keycard[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector3Entrance": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector4Entrance": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector5Entrance": "The [COLOR=3]Gravity Suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector6Entrance": "The [COLOR=3]Morph Ball[/COLOR] can be found in [COLOR=2]Main Deck[/COLOR]."
+                "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Nettori Arena[/COLOR].",
+                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Serris Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Ridley Arena[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].",
+                "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector4Entrance": "[COLOR=4]Samus can position herself with Zozoros to form a sandwich.[/COLOR]",
+                "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Gather 4/5 Infant Metroids hiding around the B.S.L. to lure out the [COLOR=3]SA-X[/COLOR] and prepare for battle.",
+                "InitialText": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 5 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L.. Find and capture 5 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
         "German": {
             "NavigationTerminals": {
-                "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Main Deck - Arachnus Arena[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 6 (NOC) - Varia Core-X Arena[/COLOR].",
-                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
-                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Charge Core Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 3 (PYR) - Main Boiler Control Room[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Zazabi Arena[/COLOR].",
-                "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector2Entrance": "The [COLOR=3]Level 4 Keycard[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector3Entrance": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector4Entrance": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector5Entrance": "The [COLOR=3]Gravity Suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector6Entrance": "The [COLOR=3]Morph Ball[/COLOR] can be found in [COLOR=2]Main Deck[/COLOR]."
+                "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Nettori Arena[/COLOR].",
+                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Serris Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Ridley Arena[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].",
+                "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector4Entrance": "[COLOR=4]Samus can position herself with Zozoros to form a sandwich.[/COLOR]",
+                "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Gather 4/5 Infant Metroids hiding around the B.S.L. to lure out the [COLOR=3]SA-X[/COLOR] and prepare for battle.",
+                "InitialText": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 5 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L.. Find and capture 5 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
         "French": {
             "NavigationTerminals": {
-                "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Main Deck - Arachnus Arena[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 6 (NOC) - Varia Core-X Arena[/COLOR].",
-                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
-                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Charge Core Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 3 (PYR) - Main Boiler Control Room[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Zazabi Arena[/COLOR].",
-                "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector2Entrance": "The [COLOR=3]Level 4 Keycard[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector3Entrance": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector4Entrance": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector5Entrance": "The [COLOR=3]Gravity Suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector6Entrance": "The [COLOR=3]Morph Ball[/COLOR] can be found in [COLOR=2]Main Deck[/COLOR]."
+                "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Nettori Arena[/COLOR].",
+                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Serris Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Ridley Arena[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].",
+                "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector4Entrance": "[COLOR=4]Samus can position herself with Zozoros to form a sandwich.[/COLOR]",
+                "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Gather 4/5 Infant Metroids hiding around the B.S.L. to lure out the [COLOR=3]SA-X[/COLOR] and prepare for battle.",
+                "InitialText": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 5 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L.. Find and capture 5 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
         "Italian": {
             "NavigationTerminals": {
-                "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Main Deck - Arachnus Arena[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 6 (NOC) - Varia Core-X Arena[/COLOR].",
-                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
-                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Charge Core Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 3 (PYR) - Main Boiler Control Room[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Zazabi Arena[/COLOR].",
-                "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector2Entrance": "The [COLOR=3]Level 4 Keycard[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector3Entrance": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector4Entrance": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector5Entrance": "The [COLOR=3]Gravity Suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector6Entrance": "The [COLOR=3]Morph Ball[/COLOR] can be found in [COLOR=2]Main Deck[/COLOR]."
+                "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Nettori Arena[/COLOR].",
+                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Serris Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Ridley Arena[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].",
+                "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector4Entrance": "[COLOR=4]Samus can position herself with Zozoros to form a sandwich.[/COLOR]",
+                "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Gather 4/5 Infant Metroids hiding around the B.S.L. to lure out the [COLOR=3]SA-X[/COLOR] and prepare for battle.",
+                "InitialText": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 5 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L.. Find and capture 5 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
                 "ConfirmText": "Any Objections, Lady?"
             }
         },
         "Spanish": {
             "NavigationTerminals": {
-                "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Main Deck - Arachnus Arena[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 6 (NOC) - Varia Core-X Arena[/COLOR].",
-                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
-                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Charge Core Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 3 (PYR) - Main Boiler Control Room[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Zazabi Arena[/COLOR].",
-                "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector2Entrance": "The [COLOR=3]Level 4 Keycard[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
-                "Sector3Entrance": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector4Entrance": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector5Entrance": "The [COLOR=3]Gravity Suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "Sector6Entrance": "The [COLOR=3]Morph Ball[/COLOR] can be found in [COLOR=2]Main Deck[/COLOR]."
+                "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Infant Metroid 2[/COLOR] is located in [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR]. [COLOR=3]Infant Metroid 4[/COLOR] is located in [COLOR=2]Sector 2 (TRO) - Nettori Arena[/COLOR].",
+                "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "RestrictedLabs": "[COLOR=3]Infant Metroid 1[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Serris Arena[/COLOR]. [COLOR=3]Infant Metroid 3[/COLOR] is located in [COLOR=2]Sector 1 (SRX) - Ridley Arena[/COLOR]. [COLOR=3]Infant Metroid 5[/COLOR] is located in [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].",
+                "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "Sector4Entrance": "[COLOR=4]Samus can position herself with Zozoros to form a sandwich.[/COLOR]",
+                "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
+                "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
             "ShipText": {
-                "InitialText": "Gather 4/5 Infant Metroids hiding around the B.S.L. to lure out the [COLOR=3]SA-X[/COLOR] and prepare for battle.",
+                "InitialText": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 5 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L.. Find and capture 5 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
                 "ConfirmText": "Any Objections, Lady?"
             }
         }
@@ -2716,12 +2737,12 @@
         },
         {
             "LineType": "White1",
-            "Text": "Sector 1 (SRX)",
+            "Text": "Sector 2 (TRO)",
             "BlankLines": 0
         },
         {
             "LineType": "White1",
-            "Text": "Antechamber",
+            "Text": "Ripper Tower",
             "BlankLines": 1
         },
         {
@@ -2731,12 +2752,12 @@
         },
         {
             "LineType": "White1",
-            "Text": "Sector 2 (TRO)",
+            "Text": "Sector 6 (NOC)",
             "BlankLines": 0
         },
         {
             "LineType": "White1",
-            "Text": "Zazabi Speedway",
+            "Text": "Zozoro Wine Cellar",
             "BlankLines": 1
         },
         {
@@ -2746,12 +2767,12 @@
         },
         {
             "LineType": "White1",
-            "Text": "Sector 3 (PYR)",
+            "Text": "Sector 6 (NOC)",
             "BlankLines": 0
         },
         {
             "LineType": "White1",
-            "Text": "Fiery Storage",
+            "Text": "X-B.O.X. Garage",
             "BlankLines": 1
         },
         {
@@ -2766,7 +2787,7 @@
         },
         {
             "LineType": "White1",
-            "Text": "Crumble City",
+            "Text": "Ripper Tower",
             "BlankLines": 1
         },
         {
@@ -2781,7 +2802,7 @@
         },
         {
             "LineType": "White1",
-            "Text": "Overgrown Cache",
+            "Text": "Zazabi Arena",
             "BlankLines": 1
         },
         {
@@ -2796,7 +2817,7 @@
         },
         {
             "LineType": "White1",
-            "Text": "Genesis Speedway",
+            "Text": "Cubby Hole",
             "BlankLines": 1
         },
         {
@@ -2811,7 +2832,7 @@
         },
         {
             "LineType": "White1",
-            "Text": "Magic Box",
+            "Text": "Ripper Road",
             "BlankLines": 1
         },
         {
@@ -2821,12 +2842,12 @@
         },
         {
             "LineType": "White1",
-            "Text": "Sector 4 (AQA)",
+            "Text": "Sector 3 (PYR)",
             "BlankLines": 0
         },
         {
             "LineType": "White1",
-            "Text": "C-Cache",
+            "Text": "Namihe's Lair",
             "BlankLines": 1
         },
         {
@@ -2836,12 +2857,12 @@
         },
         {
             "LineType": "White1",
-            "Text": "Sector 6 (NOC)",
+            "Text": "Main Deck",
             "BlankLines": 0
         },
         {
             "LineType": "White1",
-            "Text": "Spaceboost Alley",
+            "Text": "Nexus Storage",
             "BlankLines": 1
         },
         {
@@ -2866,12 +2887,12 @@
         },
         {
             "LineType": "White1",
-            "Text": "Sector 3 (PYR)",
+            "Text": "Sector 5 (ARC)",
             "BlankLines": 0
         },
         {
             "LineType": "White1",
-            "Text": "Garbage Chute",
+            "Text": "Gerubus Gully",
             "BlankLines": 1
         },
         {
@@ -2886,57 +2907,12 @@
         },
         {
             "LineType": "White1",
-            "Text": "Cubby Hole",
+            "Text": "Operations Ventilation",
             "BlankLines": 1
         },
         {
             "LineType": "Red",
             "Text": "Hi-Jump",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "White1",
-            "Text": "Sector 2 (TRO)",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "Data Courtyard",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "Red",
-            "Text": "Space Jump",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "White1",
-            "Text": "Main Deck",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "Attic",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "Red",
-            "Text": "Speed Booster",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "White1",
-            "Text": "Sector 2 (TRO)",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "Ripper Tower",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "Red",
-            "Text": "Screw Attack",
             "BlankLines": 1
         },
         {
@@ -2951,7 +2927,37 @@
         },
         {
             "LineType": "Red",
-            "Text": "Varia Suit",
+            "Text": "Space Jump",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "White1",
+            "Text": "Sector 2 (TRO)",
+            "BlankLines": 0
+        },
+        {
+            "LineType": "White1",
+            "Text": "Dessgeega Dorm",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "Red",
+            "Text": "Speed Booster",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "White1",
+            "Text": "Sector 4 (AQA)",
+            "BlankLines": 0
+        },
+        {
+            "LineType": "White1",
+            "Text": "Reservoir Vault",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "Red",
+            "Text": "Screw Attack",
             "BlankLines": 1
         },
         {
@@ -2966,6 +2972,21 @@
         },
         {
             "LineType": "Red",
+            "Text": "Varia Suit",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "White1",
+            "Text": "Sector 3 (PYR)",
+            "BlankLines": 0
+        },
+        {
+            "LineType": "White1",
+            "Text": "Security Access",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "Red",
             "Text": "Gravity Suit",
             "BlankLines": 1
         },
@@ -2976,7 +2997,7 @@
         },
         {
             "LineType": "White1",
-            "Text": "Level 2 Security Room",
+            "Text": "Geron's Treasure",
             "BlankLines": 1
         },
         {
@@ -2986,62 +3007,17 @@
         },
         {
             "LineType": "White1",
-            "Text": "Sector 1 (SRX)",
+            "Text": "Main Deck",
             "BlankLines": 0
         },
         {
             "LineType": "White1",
-            "Text": "Stabilizer Storage",
+            "Text": "Station Entrance",
             "BlankLines": 1
         },
         {
             "LineType": "Red",
             "Text": "Level 2 Keycard",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "White1",
-            "Text": "Sector 4 (AQA)",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "Reservoir East",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "Red",
-            "Text": "Level 3 Keycard",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "White1",
-            "Text": "Sector 1 (SRX)",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "Hornoad Hole",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "Red",
-            "Text": "Level 4 Keycard",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "White1",
-            "Text": "Sector 5 (ARC)",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "Flooded Airlock to Sector 4 (AQA)",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "Red",
-            "Text": "Infant Metroid 1",
             "BlankLines": 1
         },
         {
@@ -3056,22 +3032,7 @@
         },
         {
             "LineType": "Red",
-            "Text": "Infant Metroid 2",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "White1",
-            "Text": "Main Deck",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "Arachnus Arena",
-            "BlankLines": 1
-        },
-        {
-            "LineType": "Red",
-            "Text": "Infant Metroid 3",
+            "Text": "Level 3 Keycard",
             "BlankLines": 1
         },
         {
@@ -3081,7 +3042,67 @@
         },
         {
             "LineType": "White1",
-            "Text": "Main Boiler Control Room",
+            "Text": "Data Room",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "Red",
+            "Text": "Level 4 Keycard",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "White1",
+            "Text": "Sector 1 (SRX)",
+            "BlankLines": 0
+        },
+        {
+            "LineType": "White1",
+            "Text": "Wall Jump Tutorial",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "Red",
+            "Text": "Infant Metroid 1",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "White1",
+            "Text": "Sector 4 (AQA)",
+            "BlankLines": 0
+        },
+        {
+            "LineType": "White1",
+            "Text": "Serris Arena",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "Red",
+            "Text": "Infant Metroid 2",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "White1",
+            "Text": "Sector 5 (ARC)",
+            "BlankLines": 0
+        },
+        {
+            "LineType": "White1",
+            "Text": "Level 3 Security Room",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "Red",
+            "Text": "Infant Metroid 3",
+            "BlankLines": 1
+        },
+        {
+            "LineType": "White1",
+            "Text": "Sector 1 (SRX)",
+            "BlankLines": 0
+        },
+        {
+            "LineType": "White1",
+            "Text": "Ridley Arena",
             "BlankLines": 1
         },
         {
@@ -3091,12 +3112,12 @@
         },
         {
             "LineType": "White1",
-            "Text": "Sector 6 (NOC)",
+            "Text": "Sector 2 (TRO)",
             "BlankLines": 0
         },
         {
             "LineType": "White1",
-            "Text": "Varia Core-X Arena",
+            "Text": "Nettori Arena",
             "BlankLines": 1
         },
         {
@@ -3106,12 +3127,12 @@
         },
         {
             "LineType": "White1",
-            "Text": "Sector 2 (TRO)",
+            "Text": "Sector 4 (AQA)",
             "BlankLines": 0
         },
         {
             "LineType": "White1",
-            "Text": "Zazabi Arena",
+            "Text": "Cheddar Bay",
             "BlankLines": 1
         }
     ],
@@ -4968,7 +4989,7 @@
     "DisableMusic": false,
     "DisableSoundEffects": false,
     "_randovania_meta": {
-        "layout_was_user_modified": true,
+        "layout_was_user_modified": false,
         "in_race_setting": false
     }
 }

--- a/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
@@ -29,6 +29,7 @@
             {
                 "Source": "MainDeckData",
                 "Item": "MorphBall",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
@@ -44,11 +45,17 @@
             },
             {
                 "Source": "Arachnus",
-                "Item": "InfantMetroid"
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 56
+                }
             },
             {
                 "Source": "Serris",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -65,6 +72,7 @@
             {
                 "Source": "AqaData",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -81,6 +89,7 @@
             {
                 "Source": "Ridley",
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -97,6 +106,7 @@
             {
                 "Source": "TroData",
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -113,6 +123,7 @@
             {
                 "Source": "Yakuza",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -128,15 +139,26 @@
             },
             {
                 "Source": "Zazabi",
-                "Item": "InfantMetroid"
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 56
+                }
             },
             {
                 "Source": "MegaX",
-                "Item": "InfantMetroid"
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 56
+                }
             },
             {
                 "Source": "Nightmare",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -152,11 +174,17 @@
             },
             {
                 "Source": "WideCoreX",
-                "Item": "InfantMetroid"
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 56
+                }
             },
             {
                 "Source": "WaveCoreX",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -173,6 +201,7 @@
             {
                 "Source": "PyrData",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -189,6 +218,7 @@
             {
                 "Source": "ArcData1",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -204,11 +234,17 @@
             },
             {
                 "Source": "ChargeCoreX",
-                "Item": "InfantMetroid"
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 56
+                }
             },
             {
                 "Source": "Nettori",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -225,6 +261,7 @@
             {
                 "Source": "Level1",
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -241,6 +278,7 @@
             {
                 "Source": "Level2",
                 "Item": "GravitySuit",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Gravity Suit effect acquired.\nMove freely in liquids.",
@@ -257,6 +295,7 @@
             {
                 "Source": "Level3",
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -273,6 +312,7 @@
             {
                 "Source": "Level4",
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -289,6 +329,7 @@
             {
                 "Source": "Animals",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -305,6 +346,7 @@
             {
                 "Source": "Boiler",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -321,6 +363,7 @@
             {
                 "Source": "AuxiliaryPower",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -342,6 +385,7 @@
                 "BlockX": 13,
                 "BlockY": 14,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -362,6 +406,7 @@
                 "BlockX": 9,
                 "BlockY": 20,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -382,6 +427,7 @@
                 "BlockX": 14,
                 "BlockY": 65,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -402,6 +448,7 @@
                 "BlockX": 53,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -422,6 +469,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -442,6 +490,7 @@
                 "BlockX": 4,
                 "BlockY": 3,
                 "Item": "Missiles",
+                "Jingle": "Major",
                 "ItemSprite": "Missiles",
                 "ItemMessages": {
                     "Languages": {
@@ -462,6 +511,7 @@
                 "BlockX": 54,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -482,6 +532,7 @@
                 "BlockX": 5,
                 "BlockY": 29,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -502,6 +553,7 @@
                 "BlockX": 12,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -522,6 +574,7 @@
                 "BlockX": 29,
                 "BlockY": 29,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -542,6 +595,7 @@
                 "BlockX": 13,
                 "BlockY": 9,
                 "Item": "PowerBombs",
+                "Jingle": "Major",
                 "ItemSprite": "PowerBombs",
                 "ItemMessages": {
                     "Languages": {
@@ -562,6 +616,7 @@
                 "BlockX": 6,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -582,6 +637,7 @@
                 "BlockX": 14,
                 "BlockY": 10,
                 "Item": "SpaceJump",
+                "Jingle": "Major",
                 "ItemSprite": "SpaceJump",
                 "ItemMessages": {
                     "Languages": {
@@ -602,6 +658,7 @@
                 "BlockX": 27,
                 "BlockY": 10,
                 "Item": "Level3",
+                "Jingle": "Major",
                 "ItemSprite": "Level3",
                 "ItemMessages": {
                     "Languages": {
@@ -622,6 +679,7 @@
                 "BlockX": 8,
                 "BlockY": 6,
                 "Item": "ScrewAttack",
+                "Jingle": "Major",
                 "ItemSprite": "ScrewAttack",
                 "ItemMessages": {
                     "Languages": {
@@ -642,6 +700,7 @@
                 "BlockX": 44,
                 "BlockY": 19,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -662,6 +721,7 @@
                 "BlockX": 15,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -682,6 +742,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "ChargeBeam",
+                "Jingle": "Major",
                 "ItemSprite": "ChargeBeam",
                 "ItemMessages": {
                     "Languages": {
@@ -702,6 +763,7 @@
                 "BlockX": 12,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -722,6 +784,7 @@
                 "BlockX": 13,
                 "BlockY": 11,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -742,6 +805,7 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "Level1",
+                "Jingle": "Major",
                 "ItemSprite": "Level1",
                 "ItemMessages": {
                     "Languages": {
@@ -762,6 +826,7 @@
                 "BlockX": 10,
                 "BlockY": 2,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -782,6 +847,7 @@
                 "BlockX": 6,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -802,6 +868,7 @@
                 "BlockX": 13,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -822,6 +889,7 @@
                 "BlockX": 29,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -842,6 +910,7 @@
                 "BlockX": 13,
                 "BlockY": 4,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -862,6 +931,7 @@
                 "BlockX": 19,
                 "BlockY": 35,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -882,6 +952,7 @@
                 "BlockX": 44,
                 "BlockY": 7,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -902,6 +973,7 @@
                 "BlockX": 29,
                 "BlockY": 4,
                 "Item": "IceBeam",
+                "Jingle": "Major",
                 "ItemSprite": "IceBeam",
                 "ItemMessages": {
                     "Languages": {
@@ -922,6 +994,7 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -942,6 +1015,7 @@
                 "BlockX": 28,
                 "BlockY": 7,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -962,6 +1036,7 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "HiJump",
+                "Jingle": "Major",
                 "ItemSprite": "HiJump",
                 "ItemMessages": {
                     "Languages": {
@@ -982,6 +1057,7 @@
                 "BlockX": 21,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1002,6 +1078,7 @@
                 "BlockX": 5,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1022,6 +1099,7 @@
                 "BlockX": 29,
                 "BlockY": 16,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1042,6 +1120,7 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "SpeedBooster",
+                "Jingle": "Major",
                 "ItemSprite": "SpeedBooster",
                 "ItemMessages": {
                     "Languages": {
@@ -1062,6 +1141,7 @@
                 "BlockX": 3,
                 "BlockY": 24,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1082,6 +1162,7 @@
                 "BlockX": 4,
                 "BlockY": 5,
                 "Item": "WaveBeam",
+                "Jingle": "Major",
                 "ItemSprite": "WaveBeam",
                 "ItemMessages": {
                     "Languages": {
@@ -1102,6 +1183,7 @@
                 "BlockX": 9,
                 "BlockY": 14,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1122,6 +1204,7 @@
                 "BlockX": 7,
                 "BlockY": 4,
                 "Item": "WideBeam",
+                "Jingle": "Major",
                 "ItemSprite": "WideBeam",
                 "ItemMessages": {
                     "Languages": {
@@ -1142,6 +1225,7 @@
                 "BlockX": 10,
                 "BlockY": 26,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1162,6 +1246,7 @@
                 "BlockX": 44,
                 "BlockY": 13,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1182,6 +1267,7 @@
                 "BlockX": 5,
                 "BlockY": 17,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1202,6 +1288,7 @@
                 "BlockX": 9,
                 "BlockY": 9,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1222,6 +1309,7 @@
                 "BlockX": 22,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1242,6 +1330,7 @@
                 "BlockX": 42,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1262,6 +1351,7 @@
                 "BlockX": 12,
                 "BlockY": 25,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1282,6 +1372,7 @@
                 "BlockX": 43,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1302,6 +1393,7 @@
                 "BlockX": 19,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1322,6 +1414,7 @@
                 "BlockX": 12,
                 "BlockY": 7,
                 "Item": "PlasmaBeam",
+                "Jingle": "Major",
                 "ItemSprite": "PlasmaBeam",
                 "ItemMessages": {
                     "Languages": {
@@ -1342,6 +1435,7 @@
                 "BlockX": 36,
                 "BlockY": 27,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1362,6 +1456,7 @@
                 "BlockX": 4,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1382,6 +1477,7 @@
                 "BlockX": 15,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1402,6 +1498,7 @@
                 "BlockX": 10,
                 "BlockY": 15,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1422,6 +1519,7 @@
                 "BlockX": 4,
                 "BlockY": 27,
                 "Item": "Bombs",
+                "Jingle": "Major",
                 "ItemSprite": "Bombs",
                 "ItemMessages": {
                     "Languages": {
@@ -1442,6 +1540,7 @@
                 "BlockX": 15,
                 "BlockY": 86,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1462,6 +1561,7 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1482,6 +1582,7 @@
                 "BlockX": 22,
                 "BlockY": 29,
                 "Item": "Level2",
+                "Jingle": "Major",
                 "ItemSprite": "Level2",
                 "ItemMessages": {
                     "Languages": {
@@ -1502,6 +1603,7 @@
                 "BlockX": 12,
                 "BlockY": 29,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1522,6 +1624,7 @@
                 "BlockX": 24,
                 "BlockY": 9,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1542,6 +1645,7 @@
                 "BlockX": 38,
                 "BlockY": 15,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1562,6 +1666,7 @@
                 "BlockX": 44,
                 "BlockY": 5,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1582,6 +1687,7 @@
                 "BlockX": 23,
                 "BlockY": 20,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1602,6 +1708,7 @@
                 "BlockX": 57,
                 "BlockY": 19,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1622,6 +1729,7 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1642,6 +1750,7 @@
                 "BlockX": 9,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1662,6 +1771,7 @@
                 "BlockX": 10,
                 "BlockY": 13,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1682,6 +1792,7 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1702,6 +1813,7 @@
                 "BlockX": 42,
                 "BlockY": 5,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1722,6 +1834,7 @@
                 "BlockX": 22,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1742,6 +1855,7 @@
                 "BlockX": 15,
                 "BlockY": 4,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1762,6 +1876,7 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "IceMissiles",
+                "Jingle": "Major",
                 "ItemSprite": "IceMissiles",
                 "ItemMessages": {
                     "Languages": {
@@ -1782,6 +1897,7 @@
                 "BlockX": 5,
                 "BlockY": 5,
                 "Item": "VariaSuit",
+                "Jingle": "Major",
                 "ItemSprite": "VariaSuit",
                 "ItemMessages": {
                     "Languages": {
@@ -1802,6 +1918,7 @@
                 "BlockX": 20,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1822,6 +1939,7 @@
                 "BlockX": 3,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1842,6 +1960,7 @@
                 "BlockX": 13,
                 "BlockY": 3,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1862,6 +1981,7 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1882,6 +2002,7 @@
                 "BlockX": 3,
                 "BlockY": 48,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1902,6 +2023,7 @@
                 "BlockX": 14,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1922,6 +2044,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1942,6 +2065,7 @@
                 "BlockX": 23,
                 "BlockY": 7,
                 "Item": "SuperMissiles",
+                "Jingle": "Major",
                 "ItemSprite": "SuperMissiles",
                 "ItemMessages": {
                     "Languages": {
@@ -1962,6 +2086,7 @@
                 "BlockX": 14,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1982,6 +2107,7 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2002,6 +2128,7 @@
                 "BlockX": 8,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2022,6 +2149,7 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2042,6 +2170,7 @@
                 "BlockX": 13,
                 "BlockY": 8,
                 "Item": "Level4",
+                "Jingle": "Major",
                 "ItemSprite": "Level4",
                 "ItemMessages": {
                     "Languages": {
@@ -2062,6 +2191,7 @@
                 "BlockX": 11,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2082,6 +2212,7 @@
                 "BlockX": 41,
                 "BlockY": 18,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2102,6 +2233,7 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2122,6 +2254,7 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2142,6 +2275,7 @@
                 "BlockX": 29,
                 "BlockY": 20,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2162,6 +2296,7 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2182,6 +2317,7 @@
                 "BlockX": 5,
                 "BlockY": 6,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2202,6 +2338,7 @@
                 "BlockX": 19,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2222,6 +2359,7 @@
                 "BlockX": 9,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2242,6 +2380,7 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2262,6 +2401,7 @@
                 "BlockX": 45,
                 "BlockY": 6,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2282,6 +2422,7 @@
                 "BlockX": 33,
                 "BlockY": 10,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2302,6 +2443,7 @@
                 "BlockX": 10,
                 "BlockY": 24,
                 "Item": "DiffusionMissiles",
+                "Jingle": "Major",
                 "ItemSprite": "DiffusionMissiles",
                 "ItemMessages": {
                     "Languages": {
@@ -2322,6 +2464,7 @@
                 "BlockX": 25,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2342,6 +2485,7 @@
                 "BlockX": 9,
                 "BlockY": 8,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -2362,6 +2506,7 @@
                 "BlockX": 6,
                 "BlockY": 9,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -2382,6 +2527,7 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {

--- a/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
@@ -29,6 +29,7 @@
             {
                 "Source": "MainDeckData",
                 "Item": "MorphBall",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
@@ -44,15 +45,26 @@
             },
             {
                 "Source": "Arachnus",
-                "Item": "InfantMetroid"
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 56
+                }
             },
             {
                 "Source": "Serris",
-                "Item": "InfantMetroid"
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 56
+                }
             },
             {
                 "Source": "AqaData",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -68,11 +80,17 @@
             },
             {
                 "Source": "Ridley",
-                "Item": "InfantMetroid"
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 56
+                }
             },
             {
                 "Source": "TroData",
                 "Item": "PowerBombs",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -88,11 +106,17 @@
             },
             {
                 "Source": "Yakuza",
-                "Item": "InfantMetroid"
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 56
+                }
             },
             {
                 "Source": "Zazabi",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -109,6 +133,7 @@
             {
                 "Source": "MegaX",
                 "Item": "PlasmaBeam",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
@@ -125,6 +150,7 @@
             {
                 "Source": "Nightmare",
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -141,6 +167,7 @@
             {
                 "Source": "WideCoreX",
                 "Item": "IceMissiles",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Ice effect added to Missiles.\nUse it to freeze enemies.",
@@ -157,6 +184,7 @@
             {
                 "Source": "WaveCoreX",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -173,6 +201,7 @@
             {
                 "Source": "PyrData",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -189,6 +218,7 @@
             {
                 "Source": "ArcData1",
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -204,11 +234,17 @@
             },
             {
                 "Source": "ChargeCoreX",
-                "Item": "InfantMetroid"
+                "Item": "InfantMetroid",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 56
+                }
             },
             {
                 "Source": "Nettori",
                 "Item": "DiffusionMissiles",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
@@ -225,6 +261,7 @@
             {
                 "Source": "Level1",
                 "Item": "SpaceJump",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Space Jump ability acquired.\nSomersault continually in air.",
@@ -241,6 +278,7 @@
             {
                 "Source": "Level2",
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -257,6 +295,7 @@
             {
                 "Source": "Level3",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -273,6 +312,7 @@
             {
                 "Source": "Level4",
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -289,6 +329,7 @@
             {
                 "Source": "Animals",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -305,6 +346,7 @@
             {
                 "Source": "Boiler",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -321,6 +363,7 @@
             {
                 "Source": "AuxiliaryPower",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -342,6 +385,7 @@
                 "BlockX": 13,
                 "BlockY": 14,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -362,6 +406,7 @@
                 "BlockX": 9,
                 "BlockY": 20,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -382,6 +427,7 @@
                 "BlockX": 14,
                 "BlockY": 65,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -402,6 +448,7 @@
                 "BlockX": 53,
                 "BlockY": 10,
                 "Item": "HiJump",
+                "Jingle": "Major",
                 "ItemSprite": "HiJump",
                 "ItemMessages": {
                     "Languages": {
@@ -422,6 +469,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -442,6 +490,7 @@
                 "BlockX": 4,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -462,6 +511,7 @@
                 "BlockX": 54,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -482,6 +532,7 @@
                 "BlockX": 5,
                 "BlockY": 29,
                 "Item": "Level2",
+                "Jingle": "Major",
                 "ItemSprite": "Level2",
                 "ItemMessages": {
                     "Languages": {
@@ -502,6 +553,7 @@
                 "BlockX": 12,
                 "BlockY": 10,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -522,6 +574,7 @@
                 "BlockX": 29,
                 "BlockY": 29,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -542,6 +595,7 @@
                 "BlockX": 13,
                 "BlockY": 9,
                 "Item": "Level1",
+                "Jingle": "Major",
                 "ItemSprite": "Level1",
                 "ItemMessages": {
                     "Languages": {
@@ -562,6 +616,7 @@
                 "BlockX": 6,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -582,6 +637,7 @@
                 "BlockX": 14,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -602,6 +658,7 @@
                 "BlockX": 27,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -622,6 +679,7 @@
                 "BlockX": 8,
                 "BlockY": 6,
                 "Item": "Bombs",
+                "Jingle": "Major",
                 "ItemSprite": "Bombs",
                 "ItemMessages": {
                     "Languages": {
@@ -642,6 +700,7 @@
                 "BlockX": 44,
                 "BlockY": 19,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -662,6 +721,7 @@
                 "BlockX": 15,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -682,6 +742,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -702,6 +763,7 @@
                 "BlockX": 12,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -722,6 +784,7 @@
                 "BlockX": 13,
                 "BlockY": 11,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -742,6 +805,7 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -762,6 +826,7 @@
                 "BlockX": 10,
                 "BlockY": 2,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -782,6 +847,7 @@
                 "BlockX": 6,
                 "BlockY": 8,
                 "Item": "WaveBeam",
+                "Jingle": "Major",
                 "ItemSprite": "WaveBeam",
                 "ItemMessages": {
                     "Languages": {
@@ -802,6 +868,7 @@
                 "BlockX": 13,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -822,6 +889,7 @@
                 "BlockX": 29,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -842,6 +910,7 @@
                 "BlockX": 13,
                 "BlockY": 4,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -862,6 +931,7 @@
                 "BlockX": 19,
                 "BlockY": 35,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -882,6 +952,7 @@
                 "BlockX": 44,
                 "BlockY": 7,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -902,6 +973,7 @@
                 "BlockX": 29,
                 "BlockY": 4,
                 "Item": "WideBeam",
+                "Jingle": "Major",
                 "ItemSprite": "WideBeam",
                 "ItemMessages": {
                     "Languages": {
@@ -922,6 +994,7 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -942,6 +1015,7 @@
                 "BlockX": 28,
                 "BlockY": 7,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -962,6 +1036,7 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "ChargeBeam",
+                "Jingle": "Major",
                 "ItemSprite": "ChargeBeam",
                 "ItemMessages": {
                     "Languages": {
@@ -982,6 +1057,7 @@
                 "BlockX": 21,
                 "BlockY": 8,
                 "Item": "Missiles",
+                "Jingle": "Major",
                 "ItemSprite": "Missiles",
                 "ItemMessages": {
                     "Languages": {
@@ -1002,6 +1078,7 @@
                 "BlockX": 5,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1022,6 +1099,7 @@
                 "BlockX": 29,
                 "BlockY": 16,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1042,6 +1120,7 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1062,6 +1141,7 @@
                 "BlockX": 3,
                 "BlockY": 24,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1082,6 +1162,7 @@
                 "BlockX": 4,
                 "BlockY": 5,
                 "Item": "Level4",
+                "Jingle": "Major",
                 "ItemSprite": "Level4",
                 "ItemMessages": {
                     "Languages": {
@@ -1102,6 +1183,7 @@
                 "BlockX": 9,
                 "BlockY": 14,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1122,6 +1204,7 @@
                 "BlockX": 7,
                 "BlockY": 4,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1142,6 +1225,7 @@
                 "BlockX": 10,
                 "BlockY": 26,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1162,6 +1246,7 @@
                 "BlockX": 44,
                 "BlockY": 13,
                 "Item": "Level3",
+                "Jingle": "Major",
                 "ItemSprite": "Level3",
                 "ItemMessages": {
                     "Languages": {
@@ -1182,6 +1267,7 @@
                 "BlockX": 5,
                 "BlockY": 17,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1202,6 +1288,7 @@
                 "BlockX": 9,
                 "BlockY": 9,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1222,6 +1309,7 @@
                 "BlockX": 22,
                 "BlockY": 13,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1242,6 +1330,7 @@
                 "BlockX": 42,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1262,6 +1351,7 @@
                 "BlockX": 12,
                 "BlockY": 25,
                 "Item": "ScrewAttack",
+                "Jingle": "Major",
                 "ItemSprite": "ScrewAttack",
                 "ItemMessages": {
                     "Languages": {
@@ -1282,6 +1372,7 @@
                 "BlockX": 43,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1302,6 +1393,7 @@
                 "BlockX": 19,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1322,6 +1414,7 @@
                 "BlockX": 12,
                 "BlockY": 7,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1342,6 +1435,7 @@
                 "BlockX": 36,
                 "BlockY": 27,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1362,6 +1456,7 @@
                 "BlockX": 4,
                 "BlockY": 13,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1382,6 +1477,7 @@
                 "BlockX": 15,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1402,6 +1498,7 @@
                 "BlockX": 10,
                 "BlockY": 15,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1422,6 +1519,7 @@
                 "BlockX": 4,
                 "BlockY": 27,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1442,6 +1540,7 @@
                 "BlockX": 15,
                 "BlockY": 86,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1462,6 +1561,7 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1482,6 +1582,7 @@
                 "BlockX": 22,
                 "BlockY": 29,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1502,6 +1603,7 @@
                 "BlockX": 12,
                 "BlockY": 29,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1522,6 +1624,7 @@
                 "BlockX": 24,
                 "BlockY": 9,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1542,6 +1645,7 @@
                 "BlockX": 38,
                 "BlockY": 15,
                 "Item": "IceBeam",
+                "Jingle": "Major",
                 "ItemSprite": "IceBeam",
                 "ItemMessages": {
                     "Languages": {
@@ -1562,6 +1666,7 @@
                 "BlockX": 44,
                 "BlockY": 5,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1582,6 +1687,7 @@
                 "BlockX": 23,
                 "BlockY": 20,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1602,6 +1708,7 @@
                 "BlockX": 57,
                 "BlockY": 19,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1622,6 +1729,7 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1642,6 +1750,7 @@
                 "BlockX": 9,
                 "BlockY": 6,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1662,6 +1771,7 @@
                 "BlockX": 10,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1682,6 +1792,7 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1702,6 +1813,7 @@
                 "BlockX": 42,
                 "BlockY": 5,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1722,6 +1834,7 @@
                 "BlockX": 22,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1742,6 +1855,7 @@
                 "BlockX": 15,
                 "BlockY": 4,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1762,6 +1876,7 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "VariaSuit",
+                "Jingle": "Major",
                 "ItemSprite": "VariaSuit",
                 "ItemMessages": {
                     "Languages": {
@@ -1782,6 +1897,7 @@
                 "BlockX": 5,
                 "BlockY": 5,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1802,6 +1918,7 @@
                 "BlockX": 20,
                 "BlockY": 8,
                 "Item": "SuperMissiles",
+                "Jingle": "Major",
                 "ItemSprite": "SuperMissiles",
                 "ItemMessages": {
                     "Languages": {
@@ -1822,6 +1939,7 @@
                 "BlockX": 3,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1842,6 +1960,7 @@
                 "BlockX": 13,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1862,6 +1981,7 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1882,6 +2002,7 @@
                 "BlockX": 3,
                 "BlockY": 48,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1902,6 +2023,7 @@
                 "BlockX": 14,
                 "BlockY": 6,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1922,6 +2044,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1942,6 +2065,7 @@
                 "BlockX": 23,
                 "BlockY": 7,
                 "Item": "GravitySuit",
+                "Jingle": "Major",
                 "ItemSprite": "GravitySuit",
                 "ItemMessages": {
                     "Languages": {
@@ -1962,6 +2086,7 @@
                 "BlockX": 14,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1982,6 +2107,7 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2002,6 +2128,7 @@
                 "BlockX": 8,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2022,6 +2149,7 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2042,6 +2170,7 @@
                 "BlockX": 13,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2062,6 +2191,7 @@
                 "BlockX": 11,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2082,6 +2212,7 @@
                 "BlockX": 41,
                 "BlockY": 18,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2102,6 +2233,7 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2122,6 +2254,7 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2142,6 +2275,7 @@
                 "BlockX": 29,
                 "BlockY": 20,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2162,6 +2296,7 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2182,6 +2317,7 @@
                 "BlockX": 5,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2202,6 +2338,7 @@
                 "BlockX": 19,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2222,6 +2359,7 @@
                 "BlockX": 9,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2242,6 +2380,7 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "SpeedBooster",
+                "Jingle": "Major",
                 "ItemSprite": "SpeedBooster",
                 "ItemMessages": {
                     "Languages": {
@@ -2262,6 +2401,7 @@
                 "BlockX": 45,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2282,6 +2422,7 @@
                 "BlockX": 33,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2302,6 +2443,7 @@
                 "BlockX": 10,
                 "BlockY": 24,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2322,6 +2464,7 @@
                 "BlockX": 25,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2342,6 +2485,7 @@
                 "BlockX": 9,
                 "BlockY": 8,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -2362,6 +2506,7 @@
                 "BlockX": 6,
                 "BlockY": 9,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -2382,6 +2527,7 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {

--- a/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
@@ -385,8 +385,8 @@
                 "BlockX": 13,
                 "BlockY": 14,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -406,8 +406,8 @@
                 "BlockX": 9,
                 "BlockY": 20,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -427,8 +427,8 @@
                 "BlockX": 14,
                 "BlockY": 65,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -448,8 +448,8 @@
                 "BlockX": 53,
                 "BlockY": 10,
                 "Item": "HiJump",
-                "Jingle": "Major",
                 "ItemSprite": "HiJump",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Hi-Jump and Jumpball\nabilities acquired.",
@@ -469,8 +469,8 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -490,8 +490,8 @@
                 "BlockX": 4,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -511,8 +511,8 @@
                 "BlockX": 54,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -532,8 +532,8 @@
                 "BlockX": 5,
                 "BlockY": 29,
                 "Item": "Level2",
-                "Jingle": "Major",
                 "ItemSprite": "Level2",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Security Level 2 unlocked.\nGreen hatches now active.",
@@ -553,8 +553,8 @@
                 "BlockX": 12,
                 "BlockY": 10,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -574,8 +574,8 @@
                 "BlockX": 29,
                 "BlockY": 29,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -595,8 +595,8 @@
                 "BlockX": 13,
                 "BlockY": 9,
                 "Item": "Level1",
-                "Jingle": "Major",
                 "ItemSprite": "Level1",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Security Level 1 unlocked.\nBlue hatches now active.",
@@ -616,8 +616,8 @@
                 "BlockX": 6,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -637,8 +637,8 @@
                 "BlockX": 14,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -658,8 +658,8 @@
                 "BlockX": 27,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -679,8 +679,8 @@
                 "BlockX": 8,
                 "BlockY": 6,
                 "Item": "Bombs",
-                "Jingle": "Major",
                 "ItemSprite": "Bombs",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
@@ -700,8 +700,8 @@
                 "BlockX": 44,
                 "BlockY": 19,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -721,8 +721,8 @@
                 "BlockX": 15,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -742,8 +742,8 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -763,8 +763,8 @@
                 "BlockX": 12,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -784,8 +784,8 @@
                 "BlockX": 13,
                 "BlockY": 11,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -805,8 +805,8 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -826,8 +826,8 @@
                 "BlockX": 10,
                 "BlockY": 2,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -847,8 +847,8 @@
                 "BlockX": 6,
                 "BlockY": 8,
                 "Item": "WaveBeam",
-                "Jingle": "Major",
                 "ItemSprite": "WaveBeam",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Wave Beam ability acquired.\nBeam now penetrates walls.",
@@ -868,8 +868,8 @@
                 "BlockX": 13,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -889,8 +889,8 @@
                 "BlockX": 29,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -910,8 +910,8 @@
                 "BlockX": 13,
                 "BlockY": 4,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -931,8 +931,8 @@
                 "BlockX": 19,
                 "BlockY": 35,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -952,8 +952,8 @@
                 "BlockX": 44,
                 "BlockY": 7,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -973,8 +973,8 @@
                 "BlockX": 29,
                 "BlockY": 4,
                 "Item": "WideBeam",
-                "Jingle": "Major",
                 "ItemSprite": "WideBeam",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Wide Beam ability acquired.\nBeam widens dramatically.",
@@ -994,8 +994,8 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1015,8 +1015,8 @@
                 "BlockX": 28,
                 "BlockY": 7,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1036,8 +1036,8 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "ChargeBeam",
-                "Jingle": "Major",
                 "ItemSprite": "ChargeBeam",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
@@ -1057,8 +1057,8 @@
                 "BlockX": 21,
                 "BlockY": 8,
                 "Item": "Missiles",
-                "Jingle": "Major",
                 "ItemSprite": "Missiles",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -1078,8 +1078,8 @@
                 "BlockX": 5,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1099,8 +1099,8 @@
                 "BlockX": 29,
                 "BlockY": 16,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1120,8 +1120,8 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1141,8 +1141,8 @@
                 "BlockX": 3,
                 "BlockY": 24,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1162,8 +1162,8 @@
                 "BlockX": 4,
                 "BlockY": 5,
                 "Item": "Level4",
-                "Jingle": "Major",
                 "ItemSprite": "Level4",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Security Level 4 unlocked.\nRed hatches now active.",
@@ -1183,8 +1183,8 @@
                 "BlockX": 9,
                 "BlockY": 14,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1204,8 +1204,8 @@
                 "BlockX": 7,
                 "BlockY": 4,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1225,8 +1225,8 @@
                 "BlockX": 10,
                 "BlockY": 26,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1246,8 +1246,8 @@
                 "BlockX": 44,
                 "BlockY": 13,
                 "Item": "Level3",
-                "Jingle": "Major",
                 "ItemSprite": "Level3",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Security Level 3 unlocked.\nYellow hatches now active.",
@@ -1267,8 +1267,8 @@
                 "BlockX": 5,
                 "BlockY": 17,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1288,8 +1288,8 @@
                 "BlockX": 9,
                 "BlockY": 9,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1309,8 +1309,8 @@
                 "BlockX": 22,
                 "BlockY": 13,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1330,8 +1330,8 @@
                 "BlockX": 42,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1351,8 +1351,8 @@
                 "BlockX": 12,
                 "BlockY": 25,
                 "Item": "ScrewAttack",
-                "Jingle": "Major",
                 "ItemSprite": "ScrewAttack",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Screw Attack ability regained.\nSomersault into enemies.",
@@ -1372,8 +1372,8 @@
                 "BlockX": 43,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1393,8 +1393,8 @@
                 "BlockX": 19,
                 "BlockY": 13,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1414,8 +1414,8 @@
                 "BlockX": 12,
                 "BlockY": 7,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1435,8 +1435,8 @@
                 "BlockX": 36,
                 "BlockY": 27,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1456,8 +1456,8 @@
                 "BlockX": 4,
                 "BlockY": 13,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1477,8 +1477,8 @@
                 "BlockX": 15,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1498,8 +1498,8 @@
                 "BlockX": 10,
                 "BlockY": 15,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1519,8 +1519,8 @@
                 "BlockX": 4,
                 "BlockY": 27,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1540,8 +1540,8 @@
                 "BlockX": 15,
                 "BlockY": 86,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1561,8 +1561,8 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1582,8 +1582,8 @@
                 "BlockX": 22,
                 "BlockY": 29,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1603,8 +1603,8 @@
                 "BlockX": 12,
                 "BlockY": 29,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1624,8 +1624,8 @@
                 "BlockX": 24,
                 "BlockY": 9,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1645,8 +1645,8 @@
                 "BlockX": 38,
                 "BlockY": 15,
                 "Item": "IceBeam",
-                "Jingle": "Major",
                 "ItemSprite": "IceBeam",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Ice effect added to beam.\nUse beam to freeze enemies.",
@@ -1666,8 +1666,8 @@
                 "BlockX": 44,
                 "BlockY": 5,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1687,8 +1687,8 @@
                 "BlockX": 23,
                 "BlockY": 20,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1708,8 +1708,8 @@
                 "BlockX": 57,
                 "BlockY": 19,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1729,8 +1729,8 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1750,8 +1750,8 @@
                 "BlockX": 9,
                 "BlockY": 6,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1771,8 +1771,8 @@
                 "BlockX": 10,
                 "BlockY": 13,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1792,8 +1792,8 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1813,8 +1813,8 @@
                 "BlockX": 42,
                 "BlockY": 5,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1834,8 +1834,8 @@
                 "BlockX": 22,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1855,8 +1855,8 @@
                 "BlockX": 15,
                 "BlockY": 4,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1876,8 +1876,8 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "VariaSuit",
-                "Jingle": "Major",
                 "ItemSprite": "VariaSuit",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
@@ -1897,8 +1897,8 @@
                 "BlockX": 5,
                 "BlockY": 5,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1918,8 +1918,8 @@
                 "BlockX": 20,
                 "BlockY": 8,
                 "Item": "SuperMissiles",
-                "Jingle": "Major",
                 "ItemSprite": "SuperMissiles",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -1939,8 +1939,8 @@
                 "BlockX": 3,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1960,8 +1960,8 @@
                 "BlockX": 13,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1981,8 +1981,8 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2002,8 +2002,8 @@
                 "BlockX": 3,
                 "BlockY": 48,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2023,8 +2023,8 @@
                 "BlockX": 14,
                 "BlockY": 6,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2044,8 +2044,8 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2065,8 +2065,8 @@
                 "BlockX": 23,
                 "BlockY": 7,
                 "Item": "GravitySuit",
-                "Jingle": "Major",
                 "ItemSprite": "GravitySuit",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Gravity Suit effect acquired.\nMove freely in liquids.",
@@ -2086,8 +2086,8 @@
                 "BlockX": 14,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2107,8 +2107,8 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2128,8 +2128,8 @@
                 "BlockX": 8,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2149,8 +2149,8 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2170,8 +2170,8 @@
                 "BlockX": 13,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2191,8 +2191,8 @@
                 "BlockX": 11,
                 "BlockY": 3,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2212,8 +2212,8 @@
                 "BlockX": 41,
                 "BlockY": 18,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2233,8 +2233,8 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2254,8 +2254,8 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2275,8 +2275,8 @@
                 "BlockX": 29,
                 "BlockY": 20,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2296,8 +2296,8 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2317,8 +2317,8 @@
                 "BlockX": 5,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2338,8 +2338,8 @@
                 "BlockX": 19,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2359,8 +2359,8 @@
                 "BlockX": 9,
                 "BlockY": 13,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2380,8 +2380,8 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "SpeedBooster",
-                "Jingle": "Major",
                 "ItemSprite": "SpeedBooster",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Speed Booster power regained.\nRun until speed boost begins.",
@@ -2401,8 +2401,8 @@
                 "BlockX": 45,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2422,8 +2422,8 @@
                 "BlockX": 33,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2443,8 +2443,8 @@
                 "BlockX": 10,
                 "BlockY": 24,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2464,8 +2464,8 @@
                 "BlockX": 25,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2485,8 +2485,8 @@
                 "BlockX": 9,
                 "BlockY": 8,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -2506,8 +2506,8 @@
                 "BlockX": 6,
                 "BlockY": 9,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -2527,8 +2527,8 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -4958,6 +4958,7 @@
             "Name": "Cavern Save Access"
         }
     ],
+    "AccessibilityPatches": true,
     "AntiSoftlockRoomEdits": true,
     "PowerBombsWithoutBombs": true,
     "SkipDoorTransitions": false,

--- a/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
@@ -430,8 +430,8 @@
                 "BlockX": 13,
                 "BlockY": 14,
                 "Item": "Level1",
-                "Jingle": "Major",
                 "ItemSprite": "Level1",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Security Level 1 unlocked.\nBlue hatches now active.",
@@ -451,8 +451,8 @@
                 "BlockX": 9,
                 "BlockY": 20,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -472,8 +472,8 @@
                 "BlockX": 14,
                 "BlockY": 65,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -493,8 +493,8 @@
                 "BlockX": 53,
                 "BlockY": 10,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -514,8 +514,8 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MorphBall",
-                "Jingle": "Major",
                 "ItemSprite": "MorphBall",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
@@ -535,8 +535,8 @@
                 "BlockX": 4,
                 "BlockY": 3,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -556,8 +556,8 @@
                 "BlockX": 54,
                 "BlockY": 8,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -577,8 +577,8 @@
                 "BlockX": 5,
                 "BlockY": 29,
                 "Item": "HiJump",
-                "Jingle": "Major",
                 "ItemSprite": "HiJump",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Hi-Jump and Jumpball\nabilities acquired.",
@@ -598,8 +598,8 @@
                 "BlockX": 12,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -619,8 +619,8 @@
                 "BlockX": 29,
                 "BlockY": 29,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -640,8 +640,8 @@
                 "BlockX": 13,
                 "BlockY": 9,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -661,8 +661,8 @@
                 "BlockX": 6,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -682,8 +682,8 @@
                 "BlockX": 14,
                 "BlockY": 10,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -703,8 +703,8 @@
                 "BlockX": 27,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -724,8 +724,8 @@
                 "BlockX": 8,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -745,8 +745,8 @@
                 "BlockX": 44,
                 "BlockY": 19,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -766,8 +766,8 @@
                 "BlockX": 15,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -787,8 +787,8 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "SuperMissiles",
-                "Jingle": "Major",
                 "ItemSprite": "SuperMissiles",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -808,8 +808,8 @@
                 "BlockX": 12,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -829,8 +829,8 @@
                 "BlockX": 13,
                 "BlockY": 11,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -850,8 +850,8 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -871,8 +871,8 @@
                 "BlockX": 10,
                 "BlockY": 2,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -892,8 +892,8 @@
                 "BlockX": 6,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -913,8 +913,8 @@
                 "BlockX": 13,
                 "BlockY": 7,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -934,8 +934,8 @@
                 "BlockX": 29,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -955,8 +955,8 @@
                 "BlockX": 13,
                 "BlockY": 4,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -976,8 +976,8 @@
                 "BlockX": 19,
                 "BlockY": 35,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -997,8 +997,8 @@
                 "BlockX": 44,
                 "BlockY": 7,
                 "Item": "DiffusionMissiles",
-                "Jingle": "Major",
                 "ItemSprite": "DiffusionMissiles",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
@@ -1018,8 +1018,8 @@
                 "BlockX": 29,
                 "BlockY": 4,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1039,8 +1039,8 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -1060,8 +1060,8 @@
                 "BlockX": 28,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1081,8 +1081,8 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1102,8 +1102,8 @@
                 "BlockX": 21,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1123,8 +1123,8 @@
                 "BlockX": 5,
                 "BlockY": 8,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1144,8 +1144,8 @@
                 "BlockX": 29,
                 "BlockY": 16,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1165,8 +1165,8 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "Level3",
-                "Jingle": "Major",
                 "ItemSprite": "Level3",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Security Level 3 unlocked.\nYellow hatches now active.",
@@ -1186,8 +1186,8 @@
                 "BlockX": 3,
                 "BlockY": 24,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1207,8 +1207,8 @@
                 "BlockX": 4,
                 "BlockY": 5,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1228,8 +1228,8 @@
                 "BlockX": 9,
                 "BlockY": 14,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1249,8 +1249,8 @@
                 "BlockX": 7,
                 "BlockY": 4,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1270,8 +1270,8 @@
                 "BlockX": 10,
                 "BlockY": 26,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1291,8 +1291,8 @@
                 "BlockX": 44,
                 "BlockY": 13,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1312,8 +1312,8 @@
                 "BlockX": 5,
                 "BlockY": 17,
                 "Item": "GravitySuit",
-                "Jingle": "Major",
                 "ItemSprite": "GravitySuit",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Gravity Suit effect acquired.\nMove freely in liquids.",
@@ -1333,8 +1333,8 @@
                 "BlockX": 9,
                 "BlockY": 9,
                 "Item": "SpaceJump",
-                "Jingle": "Major",
                 "ItemSprite": "SpaceJump",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Space Jump ability acquired.\nSomersault continually in air.",
@@ -1354,8 +1354,8 @@
                 "BlockX": 22,
                 "BlockY": 13,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1375,8 +1375,8 @@
                 "BlockX": 42,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1396,8 +1396,8 @@
                 "BlockX": 12,
                 "BlockY": 25,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1417,8 +1417,8 @@
                 "BlockX": 43,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1438,8 +1438,8 @@
                 "BlockX": 19,
                 "BlockY": 13,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1459,8 +1459,8 @@
                 "BlockX": 12,
                 "BlockY": 7,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1480,8 +1480,8 @@
                 "BlockX": 36,
                 "BlockY": 27,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1501,8 +1501,8 @@
                 "BlockX": 4,
                 "BlockY": 13,
                 "Item": "Level2",
-                "Jingle": "Major",
                 "ItemSprite": "Level2",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Security Level 2 unlocked.\nGreen hatches now active.",
@@ -1522,8 +1522,8 @@
                 "BlockX": 15,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1543,8 +1543,8 @@
                 "BlockX": 10,
                 "BlockY": 15,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1564,8 +1564,8 @@
                 "BlockX": 4,
                 "BlockY": 27,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1585,8 +1585,8 @@
                 "BlockX": 15,
                 "BlockY": 86,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1606,8 +1606,8 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1627,8 +1627,8 @@
                 "BlockX": 22,
                 "BlockY": 29,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1648,8 +1648,8 @@
                 "BlockX": 12,
                 "BlockY": 29,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1669,8 +1669,8 @@
                 "BlockX": 24,
                 "BlockY": 9,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1690,8 +1690,8 @@
                 "BlockX": 38,
                 "BlockY": 15,
                 "Item": "Bombs",
-                "Jingle": "Major",
                 "ItemSprite": "Bombs",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
@@ -1711,8 +1711,8 @@
                 "BlockX": 44,
                 "BlockY": 5,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1732,8 +1732,8 @@
                 "BlockX": 23,
                 "BlockY": 20,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1753,8 +1753,8 @@
                 "BlockX": 57,
                 "BlockY": 19,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1774,8 +1774,8 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1795,8 +1795,8 @@
                 "BlockX": 9,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1816,8 +1816,8 @@
                 "BlockX": 10,
                 "BlockY": 13,
                 "Item": "WideBeam",
-                "Jingle": "Major",
                 "ItemSprite": "WideBeam",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Wide Beam ability acquired.\nBeam widens dramatically.",
@@ -1837,8 +1837,8 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1858,8 +1858,8 @@
                 "BlockX": 42,
                 "BlockY": 5,
                 "Item": "Level4",
-                "Jingle": "Major",
                 "ItemSprite": "Level4",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Security Level 4 unlocked.\nRed hatches now active.",
@@ -1879,8 +1879,8 @@
                 "BlockX": 22,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1900,8 +1900,8 @@
                 "BlockX": 15,
                 "BlockY": 4,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1921,8 +1921,8 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1942,8 +1942,8 @@
                 "BlockX": 5,
                 "BlockY": 5,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1963,8 +1963,8 @@
                 "BlockX": 20,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1984,8 +1984,8 @@
                 "BlockX": 3,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2005,8 +2005,8 @@
                 "BlockX": 13,
                 "BlockY": 3,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2026,8 +2026,8 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2047,8 +2047,8 @@
                 "BlockX": 3,
                 "BlockY": 48,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2068,8 +2068,8 @@
                 "BlockX": 14,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2089,8 +2089,8 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2110,8 +2110,8 @@
                 "BlockX": 23,
                 "BlockY": 7,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2131,8 +2131,8 @@
                 "BlockX": 14,
                 "BlockY": 3,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2152,8 +2152,8 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2173,8 +2173,8 @@
                 "BlockX": 8,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2194,8 +2194,8 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2215,8 +2215,8 @@
                 "BlockX": 13,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2236,8 +2236,8 @@
                 "BlockX": 11,
                 "BlockY": 3,
                 "Item": "PlasmaBeam",
-                "Jingle": "Major",
                 "ItemSprite": "PlasmaBeam",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
@@ -2257,8 +2257,8 @@
                 "BlockX": 41,
                 "BlockY": 18,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2278,8 +2278,8 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "IceMissiles",
-                "Jingle": "Major",
                 "ItemSprite": "IceMissiles",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Ice effect added to Missiles.\nUse it to freeze enemies.",
@@ -2299,8 +2299,8 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2320,8 +2320,8 @@
                 "BlockX": 29,
                 "BlockY": 20,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2341,8 +2341,8 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2362,8 +2362,8 @@
                 "BlockX": 5,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2383,8 +2383,8 @@
                 "BlockX": 19,
                 "BlockY": 8,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2404,8 +2404,8 @@
                 "BlockX": 9,
                 "BlockY": 13,
                 "Item": "VariaSuit",
-                "Jingle": "Major",
                 "ItemSprite": "VariaSuit",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
@@ -2425,8 +2425,8 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "SpeedBooster",
-                "Jingle": "Major",
                 "ItemSprite": "SpeedBooster",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Speed Booster power regained.\nRun until speed boost begins.",
@@ -2446,8 +2446,8 @@
                 "BlockX": 45,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2467,8 +2467,8 @@
                 "BlockX": 33,
                 "BlockY": 10,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -2488,8 +2488,8 @@
                 "BlockX": 10,
                 "BlockY": 24,
                 "Item": "PowerBombTank",
-                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2509,8 +2509,8 @@
                 "BlockX": 25,
                 "BlockY": 8,
                 "Item": "EnergyTank",
-                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2530,8 +2530,8 @@
                 "BlockX": 9,
                 "BlockY": 8,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -2551,8 +2551,8 @@
                 "BlockX": 6,
                 "BlockY": 9,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -2572,8 +2572,8 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "None",
-                "Jingle": "Minor",
                 "ItemSprite": "Empty",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -5469,6 +5469,7 @@
             "Name": "Cavern Save Access"
         }
     ],
+    "AccessibilityPatches": true,
     "AntiSoftlockRoomEdits": true,
     "PowerBombsWithoutBombs": true,
     "SkipDoorTransitions": true,

--- a/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
@@ -34,6 +34,7 @@
             {
                 "Source": "MainDeckData",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -50,6 +51,7 @@
             {
                 "Source": "Arachnus",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -66,6 +68,7 @@
             {
                 "Source": "Serris",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -82,6 +85,7 @@
             {
                 "Source": "AqaData",
                 "Item": "ScrewAttack",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Screw Attack ability regained.\nSomersault into enemies.",
@@ -98,6 +102,7 @@
             {
                 "Source": "Ridley",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -114,6 +119,7 @@
             {
                 "Source": "TroData",
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -130,6 +136,7 @@
             {
                 "Source": "Yakuza",
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -146,6 +153,7 @@
             {
                 "Source": "Zazabi",
                 "Item": "IceBeam",
+                "Jingle": "Major",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Ice effect added to beam.\nUse beam to freeze enemies.",
@@ -162,6 +170,7 @@
             {
                 "Source": "MegaX",
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -178,6 +187,7 @@
             {
                 "Source": "Nightmare",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -194,6 +204,7 @@
             {
                 "Source": "WideCoreX",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -210,6 +221,7 @@
             {
                 "Source": "WaveCoreX",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -226,6 +238,7 @@
             {
                 "Source": "PyrData",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -242,6 +255,7 @@
             {
                 "Source": "ArcData1",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -258,6 +272,7 @@
             {
                 "Source": "ChargeCoreX",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -274,6 +289,7 @@
             {
                 "Source": "Nettori",
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -290,6 +306,7 @@
             {
                 "Source": "Level1",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -306,6 +323,7 @@
             {
                 "Source": "Level2",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -322,6 +340,7 @@
             {
                 "Source": "Level3",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -338,6 +357,7 @@
             {
                 "Source": "Level4",
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -354,6 +374,7 @@
             {
                 "Source": "Animals",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -370,6 +391,7 @@
             {
                 "Source": "Boiler",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -386,6 +408,7 @@
             {
                 "Source": "AuxiliaryPower",
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemMessages": {
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
@@ -407,6 +430,7 @@
                 "BlockX": 13,
                 "BlockY": 14,
                 "Item": "Level1",
+                "Jingle": "Major",
                 "ItemSprite": "Level1",
                 "ItemMessages": {
                     "Languages": {
@@ -427,6 +451,7 @@
                 "BlockX": 9,
                 "BlockY": 20,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -447,6 +472,7 @@
                 "BlockX": 14,
                 "BlockY": 65,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -467,6 +493,7 @@
                 "BlockX": 53,
                 "BlockY": 10,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -487,6 +514,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MorphBall",
+                "Jingle": "Major",
                 "ItemSprite": "MorphBall",
                 "ItemMessages": {
                     "Languages": {
@@ -507,6 +535,7 @@
                 "BlockX": 4,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -527,6 +556,7 @@
                 "BlockX": 54,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -547,6 +577,7 @@
                 "BlockX": 5,
                 "BlockY": 29,
                 "Item": "HiJump",
+                "Jingle": "Major",
                 "ItemSprite": "HiJump",
                 "ItemMessages": {
                     "Languages": {
@@ -567,6 +598,7 @@
                 "BlockX": 12,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -587,6 +619,7 @@
                 "BlockX": 29,
                 "BlockY": 29,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -607,6 +640,7 @@
                 "BlockX": 13,
                 "BlockY": 9,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -627,6 +661,7 @@
                 "BlockX": 6,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -647,6 +682,7 @@
                 "BlockX": 14,
                 "BlockY": 10,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -667,6 +703,7 @@
                 "BlockX": 27,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -687,6 +724,7 @@
                 "BlockX": 8,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -707,6 +745,7 @@
                 "BlockX": 44,
                 "BlockY": 19,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -727,6 +766,7 @@
                 "BlockX": 15,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -747,6 +787,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "SuperMissiles",
+                "Jingle": "Major",
                 "ItemSprite": "SuperMissiles",
                 "ItemMessages": {
                     "Languages": {
@@ -767,6 +808,7 @@
                 "BlockX": 12,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -787,6 +829,7 @@
                 "BlockX": 13,
                 "BlockY": 11,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -807,6 +850,7 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -827,6 +871,7 @@
                 "BlockX": 10,
                 "BlockY": 2,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -847,6 +892,7 @@
                 "BlockX": 6,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -867,6 +913,7 @@
                 "BlockX": 13,
                 "BlockY": 7,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -887,6 +934,7 @@
                 "BlockX": 29,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -907,6 +955,7 @@
                 "BlockX": 13,
                 "BlockY": 4,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -927,6 +976,7 @@
                 "BlockX": 19,
                 "BlockY": 35,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -947,6 +997,7 @@
                 "BlockX": 44,
                 "BlockY": 7,
                 "Item": "DiffusionMissiles",
+                "Jingle": "Major",
                 "ItemSprite": "DiffusionMissiles",
                 "ItemMessages": {
                     "Languages": {
@@ -967,6 +1018,7 @@
                 "BlockX": 29,
                 "BlockY": 4,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -987,6 +1039,7 @@
                 "BlockX": 4,
                 "BlockY": 8,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -1007,6 +1060,7 @@
                 "BlockX": 28,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1027,6 +1081,7 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1047,6 +1102,7 @@
                 "BlockX": 21,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1067,6 +1123,7 @@
                 "BlockX": 5,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1087,6 +1144,7 @@
                 "BlockX": 29,
                 "BlockY": 16,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1107,6 +1165,7 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "Level3",
+                "Jingle": "Major",
                 "ItemSprite": "Level3",
                 "ItemMessages": {
                     "Languages": {
@@ -1127,6 +1186,7 @@
                 "BlockX": 3,
                 "BlockY": 24,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1147,6 +1207,7 @@
                 "BlockX": 4,
                 "BlockY": 5,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1167,6 +1228,7 @@
                 "BlockX": 9,
                 "BlockY": 14,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1187,6 +1249,7 @@
                 "BlockX": 7,
                 "BlockY": 4,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1207,6 +1270,7 @@
                 "BlockX": 10,
                 "BlockY": 26,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1227,6 +1291,7 @@
                 "BlockX": 44,
                 "BlockY": 13,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1247,6 +1312,7 @@
                 "BlockX": 5,
                 "BlockY": 17,
                 "Item": "GravitySuit",
+                "Jingle": "Major",
                 "ItemSprite": "GravitySuit",
                 "ItemMessages": {
                     "Languages": {
@@ -1267,6 +1333,7 @@
                 "BlockX": 9,
                 "BlockY": 9,
                 "Item": "SpaceJump",
+                "Jingle": "Major",
                 "ItemSprite": "SpaceJump",
                 "ItemMessages": {
                     "Languages": {
@@ -1287,6 +1354,7 @@
                 "BlockX": 22,
                 "BlockY": 13,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1307,6 +1375,7 @@
                 "BlockX": 42,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1327,6 +1396,7 @@
                 "BlockX": 12,
                 "BlockY": 25,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1347,6 +1417,7 @@
                 "BlockX": 43,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1367,6 +1438,7 @@
                 "BlockX": 19,
                 "BlockY": 13,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1387,6 +1459,7 @@
                 "BlockX": 12,
                 "BlockY": 7,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1407,6 +1480,7 @@
                 "BlockX": 36,
                 "BlockY": 27,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1427,6 +1501,7 @@
                 "BlockX": 4,
                 "BlockY": 13,
                 "Item": "Level2",
+                "Jingle": "Major",
                 "ItemSprite": "Level2",
                 "ItemMessages": {
                     "Languages": {
@@ -1447,6 +1522,7 @@
                 "BlockX": 15,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1467,6 +1543,7 @@
                 "BlockX": 10,
                 "BlockY": 15,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1487,6 +1564,7 @@
                 "BlockX": 4,
                 "BlockY": 27,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1507,6 +1585,7 @@
                 "BlockX": 15,
                 "BlockY": 86,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1527,6 +1606,7 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1547,6 +1627,7 @@
                 "BlockX": 22,
                 "BlockY": 29,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1567,6 +1648,7 @@
                 "BlockX": 12,
                 "BlockY": 29,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1587,6 +1669,7 @@
                 "BlockX": 24,
                 "BlockY": 9,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1607,6 +1690,7 @@
                 "BlockX": 38,
                 "BlockY": 15,
                 "Item": "Bombs",
+                "Jingle": "Major",
                 "ItemSprite": "Bombs",
                 "ItemMessages": {
                     "Languages": {
@@ -1627,6 +1711,7 @@
                 "BlockX": 44,
                 "BlockY": 5,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1647,6 +1732,7 @@
                 "BlockX": 23,
                 "BlockY": 20,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1667,6 +1753,7 @@
                 "BlockX": 57,
                 "BlockY": 19,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1687,6 +1774,7 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1707,6 +1795,7 @@
                 "BlockX": 9,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1727,6 +1816,7 @@
                 "BlockX": 10,
                 "BlockY": 13,
                 "Item": "WideBeam",
+                "Jingle": "Major",
                 "ItemSprite": "WideBeam",
                 "ItemMessages": {
                     "Languages": {
@@ -1747,6 +1837,7 @@
                 "BlockX": 3,
                 "BlockY": 7,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1767,6 +1858,7 @@
                 "BlockX": 42,
                 "BlockY": 5,
                 "Item": "Level4",
+                "Jingle": "Major",
                 "ItemSprite": "Level4",
                 "ItemMessages": {
                     "Languages": {
@@ -1787,6 +1879,7 @@
                 "BlockX": 22,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1807,6 +1900,7 @@
                 "BlockX": 15,
                 "BlockY": 4,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1827,6 +1921,7 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1847,6 +1942,7 @@
                 "BlockX": 5,
                 "BlockY": 5,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1867,6 +1963,7 @@
                 "BlockX": 20,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1887,6 +1984,7 @@
                 "BlockX": 3,
                 "BlockY": 10,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1907,6 +2005,7 @@
                 "BlockX": 13,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1927,6 +2026,7 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1947,6 +2047,7 @@
                 "BlockX": 3,
                 "BlockY": 48,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1967,6 +2068,7 @@
                 "BlockX": 14,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -1987,6 +2089,7 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2007,6 +2110,7 @@
                 "BlockX": 23,
                 "BlockY": 7,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2027,6 +2131,7 @@
                 "BlockX": 14,
                 "BlockY": 3,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2047,6 +2152,7 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2067,6 +2173,7 @@
                 "BlockX": 8,
                 "BlockY": 8,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2087,6 +2194,7 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2107,6 +2215,7 @@
                 "BlockX": 13,
                 "BlockY": 8,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2127,6 +2236,7 @@
                 "BlockX": 11,
                 "BlockY": 3,
                 "Item": "PlasmaBeam",
+                "Jingle": "Major",
                 "ItemSprite": "PlasmaBeam",
                 "ItemMessages": {
                     "Languages": {
@@ -2147,6 +2257,7 @@
                 "BlockX": 41,
                 "BlockY": 18,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2167,6 +2278,7 @@
                 "BlockX": 3,
                 "BlockY": 3,
                 "Item": "IceMissiles",
+                "Jingle": "Major",
                 "ItemSprite": "IceMissiles",
                 "ItemMessages": {
                     "Languages": {
@@ -2187,6 +2299,7 @@
                 "BlockX": 15,
                 "BlockY": 3,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2207,6 +2320,7 @@
                 "BlockX": 29,
                 "BlockY": 20,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2227,6 +2341,7 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2247,6 +2362,7 @@
                 "BlockX": 5,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2267,6 +2383,7 @@
                 "BlockX": 19,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2287,6 +2404,7 @@
                 "BlockX": 9,
                 "BlockY": 13,
                 "Item": "VariaSuit",
+                "Jingle": "Major",
                 "ItemSprite": "VariaSuit",
                 "ItemMessages": {
                     "Languages": {
@@ -2307,6 +2425,7 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "SpeedBooster",
+                "Jingle": "Major",
                 "ItemSprite": "SpeedBooster",
                 "ItemMessages": {
                     "Languages": {
@@ -2327,6 +2446,7 @@
                 "BlockX": 45,
                 "BlockY": 6,
                 "Item": "MissileTank",
+                "Jingle": "Minor",
                 "ItemSprite": "MissileTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2347,6 +2467,7 @@
                 "BlockX": 33,
                 "BlockY": 10,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -2367,6 +2488,7 @@
                 "BlockX": 10,
                 "BlockY": 24,
                 "Item": "PowerBombTank",
+                "Jingle": "Minor",
                 "ItemSprite": "PowerBombTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2387,6 +2509,7 @@
                 "BlockX": 25,
                 "BlockY": 8,
                 "Item": "EnergyTank",
+                "Jingle": "Minor",
                 "ItemSprite": "EnergyTank",
                 "ItemMessages": {
                     "Languages": {
@@ -2407,6 +2530,7 @@
                 "BlockX": 9,
                 "BlockY": 8,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -2427,6 +2551,7 @@
                 "BlockX": 6,
                 "BlockY": 9,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {
@@ -2447,6 +2572,7 @@
                 "BlockX": 29,
                 "BlockY": 9,
                 "Item": "None",
+                "Jingle": "Minor",
                 "ItemSprite": "Empty",
                 "ItemMessages": {
                     "Languages": {

--- a/test/test_files/patcher_data/fusion/shiny_pickups_dict_from_starter_preset.json
+++ b/test/test_files/patcher_data/fusion/shiny_pickups_dict_from_starter_preset.json
@@ -3,6 +3,7 @@
         {
             "Source": "MainDeckData",
             "Item": "MorphBall",
+            "Jingle": "Major",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
@@ -18,15 +19,26 @@
         },
         {
             "Source": "Arachnus",
-            "Item": "InfantMetroid"
+            "Item": "InfantMetroid",
+            "Jingle": "Major",
+            "ItemMessages": {
+                "Kind": "MessageID",
+                "MessageID": 56
+            }
         },
         {
             "Source": "Serris",
-            "Item": "InfantMetroid"
+            "Item": "InfantMetroid",
+            "Jingle": "Major",
+            "ItemMessages": {
+                "Kind": "MessageID",
+                "MessageID": 56
+            }
         },
         {
             "Source": "AqaData",
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -42,11 +54,17 @@
         },
         {
             "Source": "Ridley",
-            "Item": "InfantMetroid"
+            "Item": "InfantMetroid",
+            "Jingle": "Major",
+            "ItemMessages": {
+                "Kind": "MessageID",
+                "MessageID": 56
+            }
         },
         {
             "Source": "TroData",
             "Item": "PowerBombs",
+            "Jingle": "Major",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -62,11 +80,17 @@
         },
         {
             "Source": "Yakuza",
-            "Item": "InfantMetroid"
+            "Item": "InfantMetroid",
+            "Jingle": "Major",
+            "ItemMessages": {
+                "Kind": "MessageID",
+                "MessageID": 56
+            }
         },
         {
             "Source": "Zazabi",
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -83,6 +107,7 @@
         {
             "Source": "MegaX",
             "Item": "PlasmaBeam",
+            "Jingle": "Major",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
@@ -99,6 +124,7 @@
         {
             "Source": "Nightmare",
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -115,6 +141,7 @@
         {
             "Source": "WideCoreX",
             "Item": "IceMissiles",
+            "Jingle": "Major",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Ice effect added to Missiles.\nUse it to freeze enemies.",
@@ -131,6 +158,7 @@
         {
             "Source": "WaveCoreX",
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -147,6 +175,7 @@
         {
             "Source": "PyrData",
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -163,6 +192,7 @@
         {
             "Source": "ArcData1",
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -178,11 +208,17 @@
         },
         {
             "Source": "ChargeCoreX",
-            "Item": "InfantMetroid"
+            "Item": "InfantMetroid",
+            "Jingle": "Major",
+            "ItemMessages": {
+                "Kind": "MessageID",
+                "MessageID": 56
+            }
         },
         {
             "Source": "Nettori",
             "Item": "DiffusionMissiles",
+            "Jingle": "Major",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
@@ -199,6 +235,7 @@
         {
             "Source": "Level1",
             "Item": "SpaceJump",
+            "Jingle": "Major",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Space Jump ability acquired.\nSomersault continually in air.",
@@ -215,6 +252,7 @@
         {
             "Source": "Level2",
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -231,6 +269,7 @@
         {
             "Source": "Level3",
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -247,6 +286,7 @@
         {
             "Source": "Level4",
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -263,6 +303,7 @@
         {
             "Source": "Animals",
             "Item": "None",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Nothing acquired.",
@@ -279,6 +320,7 @@
         {
             "Source": "Boiler",
             "Item": "None",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Nothing acquired.",
@@ -295,6 +337,7 @@
         {
             "Source": "AuxiliaryPower",
             "Item": "None",
+            "Jingle": "Minor",
             "ItemMessages": {
                 "Languages": {
                     "JapaneseKanji": "Nothing acquired.",
@@ -316,6 +359,7 @@
             "BlockX": 13,
             "BlockY": 14,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -336,6 +380,7 @@
             "BlockX": 9,
             "BlockY": 20,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -356,6 +401,7 @@
             "BlockX": 14,
             "BlockY": 65,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -376,6 +422,7 @@
             "BlockX": 53,
             "BlockY": 10,
             "Item": "HiJump",
+            "Jingle": "Major",
             "ItemSprite": "HiJump",
             "ItemMessages": {
                 "Languages": {
@@ -396,6 +443,7 @@
             "BlockX": 4,
             "BlockY": 6,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -416,6 +464,7 @@
             "BlockX": 4,
             "BlockY": 3,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -436,6 +485,7 @@
             "BlockX": 54,
             "BlockY": 8,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -456,6 +506,7 @@
             "BlockX": 5,
             "BlockY": 29,
             "Item": "Level2",
+            "Jingle": "Major",
             "ItemSprite": "Level2",
             "ItemMessages": {
                 "Languages": {
@@ -476,6 +527,7 @@
             "BlockX": 12,
             "BlockY": 10,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -496,6 +548,7 @@
             "BlockX": 29,
             "BlockY": 29,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -516,6 +569,7 @@
             "BlockX": 13,
             "BlockY": 9,
             "Item": "Level1",
+            "Jingle": "Major",
             "ItemSprite": "Level1",
             "ItemMessages": {
                 "Languages": {
@@ -536,6 +590,7 @@
             "BlockX": 6,
             "BlockY": 10,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -556,6 +611,7 @@
             "BlockX": 14,
             "BlockY": 10,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -576,6 +632,7 @@
             "BlockX": 27,
             "BlockY": 10,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -596,6 +653,7 @@
             "BlockX": 8,
             "BlockY": 6,
             "Item": "Bombs",
+            "Jingle": "Major",
             "ItemSprite": "Bombs",
             "ItemMessages": {
                 "Languages": {
@@ -616,6 +674,7 @@
             "BlockX": 44,
             "BlockY": 19,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -636,6 +695,7 @@
             "BlockX": 15,
             "BlockY": 8,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -656,6 +716,7 @@
             "BlockX": 4,
             "BlockY": 6,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -676,6 +737,7 @@
             "BlockX": 12,
             "BlockY": 8,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -696,6 +758,7 @@
             "BlockX": 13,
             "BlockY": 11,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -716,6 +779,7 @@
             "BlockX": 4,
             "BlockY": 8,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -736,6 +800,7 @@
             "BlockX": 10,
             "BlockY": 2,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -756,6 +821,7 @@
             "BlockX": 6,
             "BlockY": 8,
             "Item": "WaveBeam",
+            "Jingle": "Major",
             "ItemSprite": "WaveBeam",
             "ItemMessages": {
                 "Languages": {
@@ -776,6 +842,7 @@
             "BlockX": 13,
             "BlockY": 7,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -796,6 +863,7 @@
             "BlockX": 29,
             "BlockY": 8,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -816,6 +884,7 @@
             "BlockX": 13,
             "BlockY": 4,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -836,6 +905,7 @@
             "BlockX": 19,
             "BlockY": 35,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -856,6 +926,7 @@
             "BlockX": 44,
             "BlockY": 7,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -876,6 +947,7 @@
             "BlockX": 29,
             "BlockY": 4,
             "Item": "WideBeam",
+            "Jingle": "Major",
             "ItemSprite": "WideBeam",
             "ItemMessages": {
                 "Languages": {
@@ -896,6 +968,7 @@
             "BlockX": 4,
             "BlockY": 8,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -916,6 +989,7 @@
             "BlockX": 28,
             "BlockY": 7,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -936,6 +1010,7 @@
             "BlockX": 40,
             "BlockY": 7,
             "Item": "ChargeBeam",
+            "Jingle": "Major",
             "ItemSprite": "ChargeBeam",
             "ItemMessages": {
                 "Languages": {
@@ -956,6 +1031,7 @@
             "BlockX": 21,
             "BlockY": 8,
             "Item": "Missiles",
+            "Jingle": "Major",
             "ItemSprite": "Missiles",
             "ItemMessages": {
                 "Languages": {
@@ -976,6 +1052,7 @@
             "BlockX": 5,
             "BlockY": 8,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -996,6 +1073,7 @@
             "BlockX": 29,
             "BlockY": 16,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -1016,6 +1094,7 @@
             "BlockX": 3,
             "BlockY": 7,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1036,6 +1115,7 @@
             "BlockX": 3,
             "BlockY": 24,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1056,6 +1136,7 @@
             "BlockX": 4,
             "BlockY": 5,
             "Item": "Level4",
+            "Jingle": "Major",
             "ItemSprite": "Level4",
             "ItemMessages": {
                 "Languages": {
@@ -1076,6 +1157,7 @@
             "BlockX": 9,
             "BlockY": 14,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1096,6 +1178,7 @@
             "BlockX": 7,
             "BlockY": 4,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1116,6 +1199,7 @@
             "BlockX": 10,
             "BlockY": 26,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -1136,6 +1220,7 @@
             "BlockX": 44,
             "BlockY": 13,
             "Item": "Level3",
+            "Jingle": "Major",
             "ItemSprite": "Level3",
             "ItemMessages": {
                 "Languages": {
@@ -1156,6 +1241,7 @@
             "BlockX": 5,
             "BlockY": 17,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyMissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1176,6 +1262,7 @@
             "BlockX": 9,
             "BlockY": 9,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1196,6 +1283,7 @@
             "BlockX": 22,
             "BlockY": 13,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -1216,6 +1304,7 @@
             "BlockX": 42,
             "BlockY": 8,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1236,6 +1325,7 @@
             "BlockX": 12,
             "BlockY": 25,
             "Item": "ScrewAttack",
+            "Jingle": "Major",
             "ItemSprite": "ScrewAttack",
             "ItemMessages": {
                 "Languages": {
@@ -1256,6 +1346,7 @@
             "BlockX": 43,
             "BlockY": 10,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1276,6 +1367,7 @@
             "BlockX": 19,
             "BlockY": 13,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1296,6 +1388,7 @@
             "BlockX": 12,
             "BlockY": 7,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -1316,6 +1409,7 @@
             "BlockX": 36,
             "BlockY": 27,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -1336,6 +1430,7 @@
             "BlockX": 4,
             "BlockY": 13,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -1356,6 +1451,7 @@
             "BlockX": 15,
             "BlockY": 10,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1376,6 +1472,7 @@
             "BlockX": 10,
             "BlockY": 15,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1396,6 +1493,7 @@
             "BlockX": 4,
             "BlockY": 27,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -1416,6 +1514,7 @@
             "BlockX": 15,
             "BlockY": 86,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1436,6 +1535,7 @@
             "BlockX": 15,
             "BlockY": 3,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1456,6 +1556,7 @@
             "BlockX": 22,
             "BlockY": 29,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1476,6 +1577,7 @@
             "BlockX": 12,
             "BlockY": 29,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1496,6 +1598,7 @@
             "BlockX": 24,
             "BlockY": 9,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1516,6 +1619,7 @@
             "BlockX": 38,
             "BlockY": 15,
             "Item": "IceBeam",
+            "Jingle": "Major",
             "ItemSprite": "IceBeam",
             "ItemMessages": {
                 "Languages": {
@@ -1536,6 +1640,7 @@
             "BlockX": 44,
             "BlockY": 5,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1556,6 +1661,7 @@
             "BlockX": 23,
             "BlockY": 20,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1576,6 +1682,7 @@
             "BlockX": 57,
             "BlockY": 19,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1596,6 +1703,7 @@
             "BlockX": 40,
             "BlockY": 7,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -1616,6 +1724,7 @@
             "BlockX": 9,
             "BlockY": 6,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1636,6 +1745,7 @@
             "BlockX": 10,
             "BlockY": 13,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1656,6 +1766,7 @@
             "BlockX": 3,
             "BlockY": 7,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1676,6 +1787,7 @@
             "BlockX": 42,
             "BlockY": 5,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1696,6 +1808,7 @@
             "BlockX": 22,
             "BlockY": 10,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1716,6 +1829,7 @@
             "BlockX": 15,
             "BlockY": 4,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1736,6 +1850,7 @@
             "BlockX": 4,
             "BlockY": 10,
             "Item": "VariaSuit",
+            "Jingle": "Major",
             "ItemSprite": "VariaSuit",
             "ItemMessages": {
                 "Languages": {
@@ -1756,6 +1871,7 @@
             "BlockX": 5,
             "BlockY": 5,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1776,6 +1892,7 @@
             "BlockX": 20,
             "BlockY": 8,
             "Item": "SuperMissiles",
+            "Jingle": "Major",
             "ItemSprite": "SuperMissiles",
             "ItemMessages": {
                 "Languages": {
@@ -1796,6 +1913,7 @@
             "BlockX": 3,
             "BlockY": 10,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1816,6 +1934,7 @@
             "BlockX": 13,
             "BlockY": 3,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1836,6 +1955,7 @@
             "BlockX": 3,
             "BlockY": 3,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1856,6 +1976,7 @@
             "BlockX": 3,
             "BlockY": 48,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -1876,6 +1997,7 @@
             "BlockX": 14,
             "BlockY": 6,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1896,6 +2018,7 @@
             "BlockX": 4,
             "BlockY": 6,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1916,6 +2039,7 @@
             "BlockX": 23,
             "BlockY": 7,
             "Item": "GravitySuit",
+            "Jingle": "Major",
             "ItemSprite": "GravitySuit",
             "ItemMessages": {
                 "Languages": {
@@ -1936,6 +2060,7 @@
             "BlockX": 14,
             "BlockY": 3,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1956,6 +2081,7 @@
             "BlockX": 14,
             "BlockY": 8,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -1976,6 +2102,7 @@
             "BlockX": 8,
             "BlockY": 8,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -1996,6 +2123,7 @@
             "BlockX": 4,
             "BlockY": 10,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -2016,6 +2144,7 @@
             "BlockX": 13,
             "BlockY": 8,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -2036,6 +2165,7 @@
             "BlockX": 11,
             "BlockY": 3,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -2056,6 +2186,7 @@
             "BlockX": 41,
             "BlockY": 18,
             "Item": "EnergyTank",
+            "Jingle": "Minor",
             "ItemSprite": "EnergyTank",
             "ItemMessages": {
                 "Languages": {
@@ -2076,6 +2207,7 @@
             "BlockX": 3,
             "BlockY": 3,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -2096,6 +2228,7 @@
             "BlockX": 15,
             "BlockY": 3,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -2116,6 +2249,7 @@
             "BlockX": 29,
             "BlockY": 20,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -2136,6 +2270,7 @@
             "BlockX": 29,
             "BlockY": 9,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -2156,6 +2291,7 @@
             "BlockX": 5,
             "BlockY": 6,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -2176,6 +2312,7 @@
             "BlockX": 19,
             "BlockY": 8,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -2196,6 +2333,7 @@
             "BlockX": 9,
             "BlockY": 13,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -2216,6 +2354,7 @@
             "BlockX": 14,
             "BlockY": 8,
             "Item": "SpeedBooster",
+            "Jingle": "Major",
             "ItemSprite": "SpeedBooster",
             "ItemMessages": {
                 "Languages": {
@@ -2236,6 +2375,7 @@
             "BlockX": 45,
             "BlockY": 6,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -2256,6 +2396,7 @@
             "BlockX": 33,
             "BlockY": 10,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -2276,6 +2417,7 @@
             "BlockX": 10,
             "BlockY": 24,
             "Item": "PowerBombTank",
+            "Jingle": "Minor",
             "ItemSprite": "ShinyPowerBombTank",
             "ItemMessages": {
                 "Languages": {
@@ -2296,6 +2438,7 @@
             "BlockX": 25,
             "BlockY": 8,
             "Item": "MissileTank",
+            "Jingle": "Minor",
             "ItemSprite": "MissileTank",
             "ItemMessages": {
                 "Languages": {
@@ -2316,6 +2459,7 @@
             "BlockX": 9,
             "BlockY": 8,
             "Item": "None",
+            "Jingle": "Minor",
             "ItemSprite": "Empty",
             "ItemMessages": {
                 "Languages": {
@@ -2336,6 +2480,7 @@
             "BlockX": 6,
             "BlockY": 9,
             "Item": "None",
+            "Jingle": "Minor",
             "ItemSprite": "Empty",
             "ItemMessages": {
                 "Languages": {
@@ -2356,6 +2501,7 @@
             "BlockX": 29,
             "BlockY": 9,
             "Item": "None",
+            "Jingle": "Minor",
             "ItemSprite": "Empty",
             "ItemMessages": {
                 "Languages": {

--- a/uv.lock
+++ b/uv.lock
@@ -1006,15 +1006,15 @@ wheels = [
 
 [[package]]
 name = "mars-patcher"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozendict" },
     { name = "jsonschema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/14/131b45c2c7fee624eab3e07468427d4007c246d9373b3a47887fb6ce3eda/mars_patcher-0.5.0.tar.gz", hash = "sha256:c80635aa8ae820d79b7135b11882fca14119948be25189430435a58efce9ef46", size = 193767, upload-time = "2025-06-20T12:10:35.843Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/40/34a5422aff96eb54bf247d0a96ac7da3ea42fcbaa272e73f3fadd1cd5cd3/mars_patcher-0.6.0.tar.gz", hash = "sha256:fac88a9ed2f088624c12c77d3fad2b62597459e235578d1d8c4df0c4a0167410", size = 285546, upload-time = "2025-07-12T00:40:26.637Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/a4/a0fd8f5f13e4ccb1000970b1a6d3409097e6d9998c103d94a9bb87532cd4/mars_patcher-0.5.0-py3-none-any.whl", hash = "sha256:d05f6cecb15890102ffe80357fd63d6c11b7bf0f1ea9ea0a267493bc5f362643", size = 187050, upload-time = "2025-06-20T12:10:34.309Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/baada2b85a06fc569cf4fe1d055d9150f1c6df4c75f6eef666b797dfffd3/mars_patcher-0.6.0-py3-none-any.whl", hash = "sha256:69a474e215f864793741514a076d7ffb90f169fc366576bfdcb80777c0fdbf84", size = 278099, upload-time = "2025-07-12T00:40:25.093Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates the mars-patcher package to add base accessibility patches, item jingles, and MessageIDs for infant metroids.

Message IDs are referenced as decimal in RDV, but Hex in asm. [Their values can be found here](https://github.com/MetroidAdvRandomizerSystem/mars-fusion-asm/blob/main/inc/enums.inc#L130)

~~Will depend on a patcher release which hasn't been published yet.~~
