### PR TITLE
Ruff update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.13
+    rev: v0.12.2
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,6 @@ git_describe_command = [
 
 [tool.ruff]
 line-length = 120
-target-version = "py312"
 
 [tool.ruff.lint]
 select = [
@@ -231,7 +230,6 @@ extend-ignore = [
     "PLW0603",  # we use some globals here and there
     "PLW2901",  # TODO: should actually fix these
     "PLC0415",  # we explicitly use the import within a function to postpone the loading of a module
-    "PLW1641",  # allow implementation __eq__ without __hash__
     
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,7 @@ git_describe_command = [
 
 [tool.ruff]
 line-length = 120
-target-version = "py311"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = [
@@ -230,6 +230,9 @@ extend-ignore = [
     "ISC001",  # may cause conflicts with formatter
     "PLW0603",  # we use some globals here and there
     "PLW2901",  # TODO: should actually fix these
+    "PLC0415",  # we explicitly use the import within a function to postpone the loading of a module
+    "PLW1641",  # allow implementation __eq__ without __hash__
+    
 ]
 
 [tool.ruff.lint.isort]

--- a/randovania/bitpacking/bitpacking.py
+++ b/randovania/bitpacking/bitpacking.py
@@ -456,7 +456,7 @@ def pack_sorted_array_elements(
         yield from normal_results
 
 
-def decode_sorted_array_elements(decoder: BitPackDecoder, array: list[T]) -> list[T]:
+def decode_sorted_array_elements[T](decoder: BitPackDecoder, array: list[T]) -> list[T]:
     result = []
 
     if not array:
@@ -561,7 +561,7 @@ def encode_tuple(value: Sequence[T], encoder: Callable[[T], Iterator[tuple[int, 
         yield from encoder(it)
 
 
-def decode_tuple(decoder: BitPackDecoder, item_decoder: Callable[[BitPackDecoder], T]) -> tuple[T, ...]:
+def decode_tuple[T](decoder: BitPackDecoder, item_decoder: Callable[[BitPackDecoder], T]) -> tuple[T, ...]:
     size = decode_big_int(decoder)
     return tuple(item_decoder(decoder) for _ in range(size))
 
@@ -599,7 +599,7 @@ def pack_value(value: BitPackValue, metadata: dict | None = None) -> bytes:
 BoundTypeValue = typing.TypeVar("BoundTypeValue", bound=BitPackValue)
 
 
-def round_trip(value: BoundTypeValue, metadata: dict | None = None) -> BoundTypeValue:
+def round_trip[BoundTypeValue: BitPackValue](value: BoundTypeValue, metadata: dict | None = None) -> BoundTypeValue:
     """
     Encodes the given value and then recreates it using the encoded value
     :param value:

--- a/randovania/bitpacking/construct_pack.py
+++ b/randovania/bitpacking/construct_pack.py
@@ -57,7 +57,7 @@ class DictAdapter(construct.Adapter):
         return list(obj.items())
 
 
-class ConstructTypedStruct(construct.Adapter, typing.Generic[T]):
+class ConstructTypedStruct[T](construct.Adapter):
     def __init__(self, cls: type[T], field_types: dict[str, type]):
         self.cls = cls
         self.field_types = field_types
@@ -253,6 +253,6 @@ def encode(obj: T, type_: type[T] | None = None) -> bytes:
     return compiled_construct_for_type(t).build(obj)
 
 
-def decode(data: bytes, type_: type[T]) -> T:
+def decode[T](data: bytes, type_: type[T]) -> T:
     t: type = type_
     return construct_for_type(t).parse(data)

--- a/randovania/cli/commands/new_game.py
+++ b/randovania/cli/commands/new_game.py
@@ -32,7 +32,7 @@ from randovania.game_description.resources.location_category import LocationCate
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.game_description.resources.resource_database import ResourceDatabase, default_base_damage_reduction
 from randovania.layout.base.ammo_pickup_configuration import AmmoPickupConfiguration
-from randovania.layout.base.base_configuration import StartingLocationList
+from randovania.layout.base.base_configuration import BaseConfiguration, StartingLocationList
 from randovania.layout.base.dock_rando_configuration import DockRandoConfiguration, DockRandoMode, DockTypeState
 from randovania.layout.base.standard_pickup_configuration import StandardPickupConfiguration
 from randovania.layout.base.standard_pickup_state import StandardPickupState
@@ -314,7 +314,7 @@ def create_pickup_database(game_enum: RandovaniaGame) -> PickupDatabase:
 
 def load_presets(template: RandovaniaGame) -> dict[str, VersionedPreset]:
     def get(path: str) -> VersionedPreset:
-        v = VersionedPreset.from_file_sync(_GAMES_PATH.joinpath(template.value, "presets", path))
+        v = VersionedPreset[BaseConfiguration].from_file_sync(_GAMES_PATH.joinpath(template.value, "presets", path))
         v.get_preset()
         return v
 

--- a/randovania/cli/commands/refresh_presets.py
+++ b/randovania/cli/commands/refresh_presets.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from randovania.game.game_enum import RandovaniaGame
+from randovania.layout.base.base_configuration import BaseConfiguration
 from randovania.layout.versioned_preset import VersionedPreset
 from randovania.lib import enum_lib
 
@@ -18,7 +19,7 @@ def refresh_presets_command_logic(args: ArgumentParser) -> None:
 
         for preset_relative_path in game.data.presets:
             preset_path = base_path.joinpath(preset_relative_path["path"])
-            preset = VersionedPreset.from_file_sync(preset_path)
+            preset = VersionedPreset[BaseConfiguration].from_file_sync(preset_path)
             preset.ensure_converted()
             preset.save_to_file(preset_path)
 

--- a/randovania/exporter/hints/hint_namer.py
+++ b/randovania/exporter/hints/hint_namer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Generic, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, NamedTuple, TypeVar
 
 from randovania.game_description import default_database
 from randovania.game_description.hint import SpecificHintPrecision
@@ -28,7 +28,7 @@ class PickupLocation(NamedTuple):
 ColorT = TypeVar("ColorT")
 
 
-class HintNamer(Generic[ColorT]):
+class HintNamer[ColorT]:
     location_formatters: dict[HintLocationPrecision | HintFeature, LocationFormatter]
 
     def __init__(self, all_patches: dict[int, GamePatches], players_config: PlayersConfiguration):

--- a/randovania/game_description/hint.py
+++ b/randovania/game_description/hint.py
@@ -267,7 +267,7 @@ class RedTempleHint(BaseHint):
         return HintType.RED_TEMPLE_KEY_SET
 
 
-Hint: typing.TypeAlias = LocationHint | JokeHint | RedTempleHint
+type Hint = LocationHint | JokeHint | RedTempleHint
 
 
 class HintType(Enum):

--- a/randovania/game_description/resources/resource_collection.py
+++ b/randovania/game_description/resources/resource_collection.py
@@ -53,6 +53,9 @@ class ResourceCollection:
     def _comparison_tuple(self) -> tuple[ResourceGainTuple, bool]:
         return tuple(self.as_resource_gain()), self.add_self_as_requirement_to_resources
 
+    def __hash__(self) -> int:
+        return hash(self._comparison_tuple)
+
     def __eq__(self, other: object) -> bool:
         return isinstance(other, ResourceCollection) and (self._comparison_tuple == other._comparison_tuple)
 

--- a/randovania/game_description/resources/search.py
+++ b/randovania/game_description/resources/search.py
@@ -16,7 +16,9 @@ class MissingResource(ValueError):
 T = TypeVar("T", bound=ResourceInfo)
 
 
-def find_resource_info_with_id(info_list: typing.Sequence[T], short_name: str, resource_type: ResourceType) -> T:
+def find_resource_info_with_id[ResourceInfoT: ResourceInfo](
+    info_list: typing.Sequence[ResourceInfoT], short_name: str, resource_type: ResourceType
+) -> ResourceInfoT:
     for info in info_list:
         if info.short_name == short_name:
             return info
@@ -25,7 +27,9 @@ def find_resource_info_with_id(info_list: typing.Sequence[T], short_name: str, r
     )
 
 
-def find_resource_info_with_long_name(info_list: typing.Sequence[T], long_name: str) -> T:
+def find_resource_info_with_long_name[ResourceInfoT: ResourceInfo](
+    info_list: typing.Sequence[ResourceInfoT], long_name: str
+) -> ResourceInfoT:
     for info in info_list:
         if info.long_name == long_name:
             return info

--- a/randovania/generator/filler/weighted_locations.py
+++ b/randovania/generator/filler/weighted_locations.py
@@ -22,6 +22,9 @@ class WeightedLocations:
     def __init__(self, items: dict[tuple[PlayerState, PickupIndex], float]):
         self._items = items
 
+    def __hash__(self) -> int:
+        return hash(self._items)
+
     def __eq__(self, other: object) -> bool:
         return isinstance(other, WeightedLocations) and self._items == other._items
 

--- a/randovania/generator/reach_lib.py
+++ b/randovania/generator/reach_lib.py
@@ -32,7 +32,9 @@ def filter_pickup_nodes(nodes: Iterator[Node]) -> Iterator[PickupNode]:
             yield node
 
 
-def _filter_collectable(resource_nodes: Iterator[ResourceNodeT], reach: GeneratorReach) -> Iterator[ResourceNodeT]:
+def _filter_collectable[ResourceNodeT: ResourceNode](
+    resource_nodes: Iterator[ResourceNodeT], reach: GeneratorReach
+) -> Iterator[ResourceNodeT]:
     context = reach.node_context()
     for resource_node in resource_nodes:
         if resource_node.should_collect(context) and resource_node.requirement_to_collect().satisfied(
@@ -41,13 +43,13 @@ def _filter_collectable(resource_nodes: Iterator[ResourceNodeT], reach: Generato
             yield resource_node
 
 
-def _filter_reachable(nodes: Iterator[NodeT], reach: GeneratorReach) -> Iterator[NodeT]:
+def _filter_reachable[NodeT: Node](nodes: Iterator[NodeT], reach: GeneratorReach) -> Iterator[NodeT]:
     for node in nodes:
         if reach.is_reachable_node(node):
             yield node
 
 
-def _filter_out_dangerous_actions(
+def _filter_out_dangerous_actions[ResourceNodeT: ResourceNode](
     resource_nodes: Iterator[ResourceNodeT],
     game: GameDescription,
     context: NodeContext,

--- a/randovania/gui/lib/editable_table_model.py
+++ b/randovania/gui/lib/editable_table_model.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import typing
+from typing import override
 
 from PySide6 import QtCore
 from PySide6.QtCore import QDateTime, Qt
-from typing_extensions import override
 
 if typing.TYPE_CHECKING:
     from types import EllipsisType

--- a/randovania/gui/lib/multiplayer_session_api.py
+++ b/randovania/gui/lib/multiplayer_session_api.py
@@ -26,7 +26,7 @@ RetType = typing.TypeVar("RetType")
 OriginalFunc = typing.Callable[Param, RetType]
 
 
-def handle_network_errors(
+def handle_network_errors[**Param, RetType](
     fn: typing.Callable[typing.Concatenate[MultiplayerSessionApi, Param], RetType],
 ) -> typing.Callable[Param, RetType]:
     @functools.wraps(fn)

--- a/randovania/gui/preset_settings/preset_tab.py
+++ b/randovania/gui/preset_settings/preset_tab.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import dataclasses
 import typing
-from typing import Generic
 
 from PySide6 import QtWidgets
 
-from randovania.layout.base.base_configuration import ConfigurationT_co
+from randovania.layout.base.base_configuration import BaseConfiguration
 
 if typing.TYPE_CHECKING:
     from randovania.game_description.game_description import GameDescription
@@ -15,12 +14,12 @@ if typing.TYPE_CHECKING:
     from randovania.layout.preset import Preset
 
 
-class PresetTab(QtWidgets.QMainWindow, Generic[ConfigurationT_co]):
+class PresetTab[BaseConfigurationT: BaseConfiguration](QtWidgets.QMainWindow):
     RANDOMIZER_LOGIC_HEADER = "Randomizer Logic"
     GAME_MODIFICATIONS_HEADER = "Game Modifications"
 
     def __init__(
-        self, editor: PresetEditor[ConfigurationT_co], game_description: GameDescription, window_manager: WindowManager
+        self, editor: PresetEditor[BaseConfigurationT], game_description: GameDescription, window_manager: WindowManager
     ):
         super().__init__()
         self._editor = editor
@@ -62,7 +61,7 @@ class PresetTab(QtWidgets.QMainWindow, Generic[ConfigurationT_co]):
         """If this tab starts a new header, returns the name of the header. If it doesn't, returns None."""
         raise NotImplementedError
 
-    def on_preset_changed(self, preset: Preset[ConfigurationT_co]) -> None:
+    def on_preset_changed(self, preset: Preset[BaseConfigurationT]) -> None:
         raise NotImplementedError
 
     # Persistence helpers

--- a/randovania/interface_common/options.py
+++ b/randovania/interface_common/options.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-def identity(v: T) -> T:
+def identity[T](v: T) -> T:
     return v
 
 

--- a/randovania/layout/generator_parameters.py
+++ b/randovania/layout/generator_parameters.py
@@ -11,6 +11,7 @@ from randovania.bitpacking.bitpacking import BitPackDecoder, BitPackValue
 from randovania.game.game_enum import RandovaniaGame
 from randovania.games import default_data
 from randovania.interface_common.preset_manager import PresetManager
+from randovania.layout.base.base_configuration import BaseConfiguration
 from randovania.layout.preset import Preset
 
 if TYPE_CHECKING:
@@ -98,7 +99,9 @@ class GeneratorParameters(BitPackValue):
             development = bitpacking.decode_bool(decoder)
 
         manager = PresetManager(None)
-        presets = [Preset.bit_pack_unpack(decoder, {"manager": manager, "game": game}) for game in games]
+        presets = [
+            Preset[BaseConfiguration].bit_pack_unpack(decoder, {"manager": manager, "game": game}) for game in games
+        ]
 
         if not development:
             for game in _get_unique_games(presets):

--- a/randovania/layout/preset.py
+++ b/randovania/layout/preset.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import dataclasses
 import typing
 import uuid as uuid_module
-from typing import TYPE_CHECKING, Generic, Self
+from typing import TYPE_CHECKING, Self
 
 from randovania.bitpacking.bitpacking import BitPackDecoder, BitPackValue
 from randovania.game.game_enum import RandovaniaGame
-from randovania.layout.base.base_configuration import ConfigurationT_co
+from randovania.layout.base.base_configuration import BaseConfiguration
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
 
 
 @dataclasses.dataclass(frozen=True)
-class Preset(BitPackValue, Generic[ConfigurationT_co]):
+class Preset[BaseConfigurationT: BaseConfiguration](BitPackValue):
     name: str
     uuid: uuid_module.UUID
     description: str
     game: RandovaniaGame
-    configuration: ConfigurationT_co
+    configuration: BaseConfigurationT
 
     @property
     def as_json(self) -> dict:
@@ -41,7 +41,7 @@ class Preset(BitPackValue, Generic[ConfigurationT_co]):
             uuid=uuid_module.UUID(value["uuid"]),
             description=value["description"],
             game=game,
-            configuration=typing.cast("type[ConfigurationT_co]", game.data.layout.configuration).from_json(
+            configuration=typing.cast("type[BaseConfigurationT]", game.data.layout.configuration).from_json(
                 value["configuration"]
             ),
         )
@@ -66,7 +66,7 @@ class Preset(BitPackValue, Generic[ConfigurationT_co]):
         manager: PresetManager = metadata["manager"]
         game: RandovaniaGame = metadata["game"]
 
-        reference = typing.cast("Preset[ConfigurationT_co]", manager.reference_preset_for_game(game).get_preset())
+        reference = typing.cast("Preset[BaseConfigurationT]", manager.reference_preset_for_game(game).get_preset())
 
         return cls(
             name=f"{game.long_name} Custom",

--- a/randovania/layout/versioned_preset.py
+++ b/randovania/layout/versioned_preset.py
@@ -89,6 +89,9 @@ class VersionedPreset[BaseConfigurationT: BaseConfiguration]:
             assert self.data is not None
             return UUID(self.data["uuid"])
 
+    def __hash__(self) -> int:
+        return hash(self.get_preset())
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, VersionedPreset):
             return self.get_preset() == other.get_preset()

--- a/randovania/layout/versioned_preset.py
+++ b/randovania/layout/versioned_preset.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import TYPE_CHECKING, Generic, Self
+from typing import TYPE_CHECKING, Self
 from uuid import UUID
 
 import aiofiles
@@ -11,7 +11,7 @@ import slugify
 
 from randovania.game.game_enum import RandovaniaGame
 from randovania.layout import preset_migration
-from randovania.layout.base.base_configuration import ConfigurationT_co
+from randovania.layout.base.base_configuration import BaseConfiguration
 from randovania.layout.preset import Preset
 from randovania.lib import json_lib
 from randovania.lib.construct_lib import CompressedJsonValue, NullTerminatedCompressedJsonValue
@@ -45,11 +45,11 @@ class InvalidPreset(Exception):
         self.original_exception = original_exception
 
 
-class VersionedPreset(Generic[ConfigurationT_co]):
+class VersionedPreset[BaseConfigurationT: BaseConfiguration]:
     is_included_preset: bool = False
     data: dict | None
     exception: InvalidPreset | None = None
-    _preset: Preset[ConfigurationT_co] | None = None
+    _preset: Preset[BaseConfigurationT] | None = None
 
     def __init__(self, data: dict | None) -> None:
         self.data = data
@@ -116,7 +116,7 @@ class VersionedPreset(Generic[ConfigurationT_co]):
                 self.exception = InvalidPreset(e)
                 raise self.exception from e
 
-    def get_preset(self) -> Preset[ConfigurationT_co]:
+    def get_preset(self) -> Preset[BaseConfigurationT]:
         self.ensure_converted()
         if self.exception:
             raise self.exception
@@ -143,7 +143,7 @@ class VersionedPreset(Generic[ConfigurationT_co]):
         return cls(json_lib.read_dict(path))
 
     @classmethod
-    def with_preset(cls, preset: Preset[ConfigurationT_co]) -> Self:
+    def with_preset(cls, preset: Preset[BaseConfigurationT]) -> Self:
         result = cls(None)
         result._preset = preset
         return result

--- a/randovania/lib/container_lib.py
+++ b/randovania/lib/container_lib.py
@@ -4,13 +4,15 @@ import operator
 import typing
 
 if typing.TYPE_CHECKING:
-    from _typeshed import SupportsRichComparisonT
+    from _typeshed import SupportsRichComparison
 
 X = typing.TypeVar("X")
 Y = typing.TypeVar("Y")
 
 
-def iterate_key_sorted[Y](obj: dict[SupportsRichComparisonT, Y]) -> list[tuple[SupportsRichComparisonT, Y]]:
+def iterate_key_sorted[SupportsRichComparisonT: SupportsRichComparison, Y](
+    obj: dict[SupportsRichComparisonT, Y],
+) -> list[tuple[SupportsRichComparisonT, Y]]:
     return sorted(obj.items(), key=operator.itemgetter(0))
 
 

--- a/randovania/lib/container_lib.py
+++ b/randovania/lib/container_lib.py
@@ -10,7 +10,7 @@ X = typing.TypeVar("X")
 Y = typing.TypeVar("Y")
 
 
-def iterate_key_sorted(obj: dict[SupportsRichComparisonT, Y]) -> list[tuple[SupportsRichComparisonT, Y]]:
+def iterate_key_sorted[Y](obj: dict[SupportsRichComparisonT, Y]) -> list[tuple[SupportsRichComparisonT, Y]]:
     return sorted(obj.items(), key=operator.itemgetter(0))
 
 
@@ -21,7 +21,7 @@ def ensure_in_set(element: X, the_set: set[X], present: bool) -> None:
         the_set.remove(element)
 
 
-def zip2(a: typing.Iterable[X], b: typing.Iterable[Y], *, strict: bool = True) -> typing.Iterable[tuple[X, Y]]:
+def zip2[X, Y](a: typing.Iterable[X], b: typing.Iterable[Y], *, strict: bool = True) -> typing.Iterable[tuple[X, Y]]:
     """zip, but for 2 elements and always strict.
     Mainly because PyCharm doesn't do types correctly for zip :("""
     return zip(a, b, strict=strict)

--- a/randovania/lib/enum_lib.py
+++ b/randovania/lib/enum_lib.py
@@ -9,12 +9,12 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound=Enum)
 
 
-def iterate_enum(enum_class: type[T]) -> Iterator[T]:
+def iterate_enum[T: Enum](enum_class: type[T]) -> Iterator[T]:
     assert issubclass(enum_class, Enum)
     yield from enum_class
 
 
-def enum_definition_order(enum_instance: T) -> int:
+def enum_definition_order[T: Enum](enum_instance: T) -> int:
     """
     Returns the index at which the given enum instance was defined.
     Useful for sorting functions.

--- a/randovania/lib/json_lib.py
+++ b/randovania/lib/json_lib.py
@@ -9,16 +9,16 @@ import aiofiles
 if TYPE_CHECKING:
     from collections.abc import Hashable
     from pathlib import Path
-    from typing import Any, TypeAlias
+    from typing import Any
 
-_JsonPrimitive: TypeAlias = str | int | float | bool | None
+type _JsonPrimitive = str | int | float | bool | None
 
-JsonObject_RO: TypeAlias = Mapping[str, "JsonType_RO"]
-JsonType_RO: TypeAlias = JsonObject_RO | Sequence["JsonType_RO"] | _JsonPrimitive
+type JsonObject_RO = Mapping[str, "JsonType_RO"]
+type JsonType_RO = JsonObject_RO | Sequence["JsonType_RO"] | _JsonPrimitive
 """Covariant type alias useful when accepting read-only input."""
 
-JsonObject: TypeAlias = dict[str, "JsonType"]
-JsonType: TypeAlias = JsonObject | list["JsonType"] | _JsonPrimitive
+type JsonObject = dict[str, "JsonType"]
+type JsonType = JsonObject | list["JsonType"] | _JsonPrimitive
 """Invariant and mutable type alias. Use `typing.cast()` or a type guard if more specificity is needed."""
 
 

--- a/randovania/lib/pyeasyga.py
+++ b/randovania/lib/pyeasyga.py
@@ -47,8 +47,8 @@ import typing
 from operator import attrgetter
 
 SeedData = typing.TypeVar("SeedData")
-Fitness: typing.TypeAlias = float
-Genes: typing.TypeAlias = list[int]
+type Fitness = float
+type Genes = list[int]
 
 
 class Chromosome:

--- a/randovania/lib/random_lib.py
+++ b/randovania/lib/random_lib.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-def shuffle(rng: Random, x: Iterator[T]) -> list[T]:
+def shuffle[T](rng: Random, x: Iterator[T]) -> list[T]:
     """
     Shuffles a copy of the given iterator.
     :param rng:
@@ -44,7 +44,7 @@ def iterate_with_weights(rng: Random, items: Iterable[T], item_weights: Mapping[
         yield item
 
 
-def select_element_with_weight(rng: Random, weighted_items: Mapping[T, float]) -> T:
+def select_element_with_weight[T](rng: Random, weighted_items: Mapping[T, float]) -> T:
     """
     Choose a random element, with each one having a custom weight.
     :param rng: The random object to use.
@@ -54,7 +54,7 @@ def select_element_with_weight(rng: Random, weighted_items: Mapping[T, float]) -
     return next(iterate_with_weights(rng=rng, items=list(weighted_items.keys()), item_weights=weighted_items))
 
 
-def select_element_with_weight_and_uniform_fallback(rng: Random, weighted_items: Mapping[T, float]) -> T:
+def select_element_with_weight_and_uniform_fallback[T](rng: Random, weighted_items: Mapping[T, float]) -> T:
     """
     Same as `select_element_with_weight`, but if all elements have weight 0 then one is selected uniformly.
     """

--- a/randovania/network_common/error.py
+++ b/randovania/network_common/error.py
@@ -43,6 +43,9 @@ class BaseNetworkError(Exception):
 
         raise RuntimeError("Unknown error")
 
+    def __hash__(self) -> int:
+        return hash(self.detail)
+
     def __eq__(self, other):
         return isinstance(other, type(self)) and self.detail == other.detail
 

--- a/randovania/resolver/exceptions.py
+++ b/randovania/resolver/exceptions.py
@@ -19,6 +19,9 @@ class GenerationFailure(Exception):
     def __reduce__(self):
         return GenerationFailure, (super().__str__(), self.generator_params, self.source)
 
+    def __hash__(self) -> int:
+        return hash(self.generator_params)
+
     def __eq__(self, other):
         if not isinstance(other, GenerationFailure):
             return False
@@ -36,6 +39,9 @@ class ImpossibleForSolver(GenerationFailure):
 
     def __reduce__(self):
         return ImpossibleForSolver, (super().__str__(), self.generator_params, self.layout)
+
+    def __hash__(self) -> int:
+        return self.layout.__hash__()
 
     def __eq__(self, other):
         if not isinstance(other, ImpossibleForSolver):

--- a/randovania/server/discord/preset_lookup.py
+++ b/randovania/server/discord/preset_lookup.py
@@ -240,7 +240,9 @@ class RequestPresetsView(discord.ui.View):
 T = typing.TypeVar("T")
 
 
-async def _try_get(message: discord.Message, attachment: discord.Attachment, decoder: Callable[[dict], T]) -> T | None:
+async def _try_get[T](
+    message: discord.Message, attachment: discord.Attachment, decoder: Callable[[dict], T]
+) -> T | None:
     try:
         data = await attachment.read()
         return decoder(json.loads(data.decode("utf-8")))

--- a/test/bitpacking/test_bitpacking.py
+++ b/test/bitpacking/test_bitpacking.py
@@ -243,6 +243,9 @@ class BitPackValueUsingReference(bitpacking.BitPackValue):
         value = decoder.decode_single(128) + reference.value
         return BitPackValueUsingReference(value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
     def __eq__(self, other):
         return self.value == other.value
 

--- a/test/bitpacking/test_construct.py
+++ b/test/bitpacking/test_construct.py
@@ -141,6 +141,9 @@ class NonJsonThing:
         self.a = a
         self.b = b
 
+    def __hash__(self) -> int:
+        return hash(self.a) + hash(self.b)
+
     def __eq__(self, other):
         return isinstance(other, NonJsonThing) and other.a == self.a and other.b == self.b
 

--- a/test/games/prime1/exporter/test_prime_dangerous_settings.py
+++ b/test/games/prime1/exporter/test_prime_dangerous_settings.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from randovania.layout.layout_description import LayoutDescription
 
 
-def test_dangerous_settings(test_files_dir, rdvgame_filename="prime1_crazy_seed.rdvgame"):
-    rdvgame = test_files_dir.joinpath("log_files", rdvgame_filename)
+def test_dangerous_settings(test_files_dir):
+    rdvgame = test_files_dir.joinpath("log_files", "prime1_crazy_seed.rdvgame")
     layout_description = LayoutDescription.from_file(rdvgame)
     preset = layout_description.get_preset(0)
 

--- a/test/layout/test_echoes_configuration.py
+++ b/test/layout/test_echoes_configuration.py
@@ -44,7 +44,7 @@ def empty_bit_pack_encode(*args):
 
 
 @contextlib.contextmanager
-def make_dummy(cls: type[T]) -> T:
+def make_dummy[T](cls: type[T]) -> T:
     m = MagicMock(spec=cls)
     m.bit_pack_encode = empty_bit_pack_encode
     m.as_json = m


### PR DESCRIPTION
Ignore PLC0415 [import-outside-top-level ](https://docs.astral.sh/ruff/rules/import-outside-top-level/#import-outside-top-level-plc0415) 
Ignore PLW1641  (should maybe fixed instead?) [eq-without-hash ](https://docs.astral.sh/ruff/rules/eq-without-hash/)
Fix PT028 [pytest-parameter-with-default-argument](https://docs.astral.sh/ruff/rules/pytest-parameter-with-default-argument/)  
Fix `SyntaxError: Cannot use type parameter lists on Python 3.11 (syntax was added in Python 3.12)` by targeting 3.12 with Ruff
Implement UP047  [non-pep695-generic-function](https://docs.astral.sh/ruff/rules/non-pep695-generic-function/) 
Fix UP040 [non-pep695-type-alias](https://docs.astral.sh/ruff/rules/non-pep695-type-alias/)
Fix UP046 [non-pep695-generic-class](https://docs.astral.sh/ruff/rules/non-pep695-generic-class/)
Fix UP035 (Import from `typing` instead: `override`) [deprecated-import](https://docs.astral.sh/ruff/rules/deprecated-import/)

Supersedes #8368