### PR TITLE
Fusion Fix Sanctum Missing Room Rame

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -9774,7 +9774,8 @@
             "extra": {
                 "map_name": "Sector 241",
                 "room_id": [
-                    41
+                    41,
+                    45
                 ],
                 "minimap_coordinates": [
                     {

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1488,7 +1488,7 @@ Extra - unlocked_save_recharge_station: True
 ----------------
 Sanctum
 Extra - map_name: Sector 241
-Extra - room_id: [41]
+Extra - room_id: [41, 45]
 Extra - minimap_coordinates: [{'x': 7, 'y': 12}, {'x': 8, 'y': 12}]
 > Door to Cathedral; Heals? False
   * Layers: default


### PR DESCRIPTION
From Bug Report
- Sanctum had a "Room name not provided"
- Was identified that Sanctum has 2 rooms and the transtion was occuring to the room id that was not getting passed
- Added in the other room ID to the DB

Tested
- Both Room IDs will now get passed to the patcher and both will display as Sanctum comming in from both entrances now

<img width="1192" height="823" alt="image" src="https://github.com/user-attachments/assets/0a19479c-6b8c-4ffa-a582-7f8d55a44895" />
