### PR TITLE
Echoes: Make Amorbis safer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [10.0.0] - 2025-08-0?
+## [10.1.0] - 2025-09-0?
+
+### Metroid Prime 2 Echoes
+
+#### Logic Database
+
+##### Dark Agon Wastes
+
+- Changed: Minor adjustment aimed at making Amorbis safer for the generator, no changes to requirements in practice.
+
+## [10.0.0] - 2025-08-01
 
 - **Major** - Added: Metroid Fusion has been added with full single player support. Includes random starting locations, some toggleable patches, and more.
 - Added: 10 more joke hints.

--- a/randovania/games/prime2/logic_database/Dark Agon Wastes.json
+++ b/randovania/games/prime2/logic_database/Dark Agon Wastes.json
@@ -8301,6 +8301,15 @@
                                 ]
                             }
                         },
+                        "Event - Amorbis": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "Event86",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
                         "Amorbis Trigger": {
                             "type": "and",
                             "data": {

--- a/randovania/games/prime2/logic_database/Dark Agon Wastes.txt
+++ b/randovania/games/prime2/logic_database/Dark Agon Wastes.txt
@@ -900,6 +900,8 @@ Hint Features - Boss, Temple
   > Event - Dark Agon Temple Key Gate
       # https://www.youtube.com/watch?v=yd91qBUxCeA
       Dark Agon Key 1 and Dark Agon Key 2 and Dark Agon Key 3 and Morph Ball Bomb and Morph Ball and Space Jump Boots and Bomb Space Jump (Expert) and Single Room Out of Bounds (Expert) and Slope Jump (Expert) and Standable Terrain (Expert) and Dark World Damage ≥ 175
+  > Event - Amorbis
+      After Amorbis
   > Amorbis Trigger
       All of the following:
           Knowledge (Intermediate)


### PR DESCRIPTION
Add connection back to Amorbis event node.

Similar to the other PR, for Aerie. Generation data added to https://docs.google.com/spreadsheets/d/1gKB6yVDSLPciEL69vMNx-oaxV8ynv7nHVzkHJclmc9A/edit?usp=sharing (same document).