### PR TITLE
Add action to abandon a world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.1.0] - 2025-09-0?
 
+- Added: Action to abandon a world in a multiworld session.
+
 ### Metroid Dread
 
 #### Logic Database

--- a/randovania/gui/lib/multiplayer_session_api.py
+++ b/randovania/gui/lib/multiplayer_session_api.py
@@ -240,6 +240,11 @@ class MultiplayerSessionApi(QtCore.QObject):
         await self._session_admin_player(owner, admin_actions.SessionAdminUserAction.UNCLAIM, str(world_uid))
 
     @handle_network_errors
+    async def abandon_world(self, world_uid: uuid.UUID, owner: int) -> None:
+        self.logger.info("Abandon World %s from %d", world_uid, owner)
+        await self._session_admin_player(owner, admin_actions.SessionAdminUserAction.ABANDON, str(world_uid))
+
+    @handle_network_errors
     async def rename_world(self, world_uid: uuid.UUID, new_name: str) -> None:
         self.logger.info("Renaming world %s to %s", world_uid, new_name)
         await self._session_admin_global(

--- a/randovania/gui/widgets/multiplayer_session_users_widget.py
+++ b/randovania/gui/widgets/multiplayer_session_users_widget.py
@@ -192,7 +192,7 @@ class MultiplayerSessionUsersWidget(QtWidgets.QTreeWidget):
         await self._session_api.unclaim_world(world_uid, owner)
 
     @asyncSlot()
-    async def _world_abandon(self, world_uid: uuid.UUID, owner: int):
+    async def _world_abandon(self, world_uid: uuid.UUID, owner: int) -> None:
         user_response = await async_dialog.message_box(
             None,
             QtWidgets.QMessageBox.Icon.Warning,

--- a/randovania/server/multiplayer/session_admin.py
+++ b/randovania/server/multiplayer/session_admin.py
@@ -572,7 +572,7 @@ def _set_allow_coop(sa: ServerApp, session: MultiplayerSession, new_state: bool)
         session.save()
 
 
-def _abandon_world(sa: ServerApp, session: MultiplayerSession, world_uid: uuid.UUID):
+def _abandon_world(sa: ServerApp, session: MultiplayerSession, world_uid: uuid.UUID) -> None:
     world = World.get_by_uuid(world_uid)
 
     logger().info(f"{session_common.describe_session(session, world)} abandoned!")

--- a/test/gui/lib/test_multiplayer_session_api.py
+++ b/test/gui/lib/test_multiplayer_session_api.py
@@ -263,6 +263,26 @@ async def test_unclaim_world(session_api, caplog):
     ]
 
 
+async def test_abandon_world(session_api, caplog):
+    uid = uuid.UUID("487fd145-d590-4984-b761-056974ce7d6d")
+
+    # Run
+    await session_api.abandon_world(uid, 20)
+
+    # Assert
+    session_api.network_client.server_call.assert_called_once_with(
+        "multiplayer_admin_player",
+        [1234, 20, admin_actions.SessionAdminUserAction.ABANDON.value, "487fd145-d590-4984-b761-056974ce7d6d"],
+    )
+    assert caplog.record_tuples == [
+        (
+            "MultiplayerSessionApi",
+            logging.INFO,
+            "[Session 1234] Abandon World 487fd145-d590-4984-b761-056974ce7d6d from 20",
+        )
+    ]
+
+
 async def test_rename_world(session_api, caplog):
     uid = uuid.UUID("487fd145-d590-4984-b761-056974ce7d6d")
 


### PR DESCRIPTION
Simple solution to abandon a world by collecting all locations.
Should be replaced in the future whenever we have a logical release of items.

Should there be some sort of state indicating that it was abandonend? That way it would already be in preperation for a logical release and we could mark it somehow in the ui as abandoned.

<img width="551" height="154" alt="image" src="https://github.com/user-attachments/assets/8d22fd7d-e3be-4155-97da-0a06e8ba57bc" />
<img width="602" height="394" alt="image" src="https://github.com/user-attachments/assets/4dd058b5-2868-47b6-836d-242e6f26db20" />
