### PR TITLE
Fix: Don't show hidden pickups in the Pickup Hint Features GUI tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.1.0] - 2025-09-0?
 
+- Fixed: Hidden Pickups are not shown anymore in the "Pickup Hint Features" tab of a game.
+
 ### Metroid Dread
 
 #### Logic Database

--- a/randovania/gui/widgets/hint_feature_tab.py
+++ b/randovania/gui/widgets/hint_feature_tab.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from PySide6.QtWidgets import QLabel, QSizePolicy, QSpacerItem, QVBoxLayout, QWidget
 
 from randovania.game_description.db.pickup_node import PickupNode
+from randovania.game_description.pickup.pickup_definition.standard_pickup import StandardPickupDefinition
 from randovania.gui.generated.hint_feature_tab_ui import Ui_HintFeatureTab
 from randovania.gui.lib.data_editor_links import (
     data_editor_href,
@@ -167,7 +168,18 @@ class PickupHintFeatureTab(HintFeatureTab):
                 continue
 
             def pickups_with_feature(group: dict[str, BasePickupDefinition]) -> Iterable[str]:
-                yield from (name for name, pickup in group.items() if feature in pickup.hint_features)
+                yield from (
+                    name
+                    for name, pickup in group.items()
+                    # Pickup has to have the feature and has to show in the GUI. Only StandardPickups have the GUI flag.
+                    if (
+                        feature in pickup.hint_features
+                        and (
+                            not isinstance(pickup, StandardPickupDefinition)
+                            or (isinstance(pickup, StandardPickupDefinition) and not pickup.hide_from_gui)
+                        )
+                    )
+                )
 
             pickup_names: list[str] = []
             pickup_names.extend(pickups_with_feature(pickup_db.generated_pickups))


### PR DESCRIPTION
I've considered moving the "hide_from_gui" flag to the base pickup.
But then I also would've needed to add all the proper functionality to hide expansions if they're supposed to be hidden.
And I didn't wanna go through that effort for something we don't use.