### PR TITLE
Multiworld: Don't send items for Mercury Steam games on main menu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
+- Changed: In Multiworld, don't send items to the game while it's not in-game.
+
 #### Logic Database
 
 ##### Artaria
@@ -30,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: Flipper Room: The Morph Ball Launcher now connects to the door to Navigation Station and is trivial, instead ot connecting to the door to Elun Transport Access and requiring that the Flipper has been rotated.
 - Changed: Flipper Room: Spinning the Flipper with the ledge warp from below now connects from the door to Elun Transport Access instead of from the Tunnel to Spider Magnet Elevator. It is now also logical to perform the ledge warp from below when Transport Randomizer is disabled.
+
+### Metroid: Samus Returns
+
+- Changed: In Multiworld, don't send items to the game while it's not in-game.
 
 ### Metroid Fusion
 

--- a/randovania/game_connection/connector/mercury_remote_connector.py
+++ b/randovania/game_connection/connector/mercury_remote_connector.py
@@ -119,7 +119,8 @@ class MercuryConnector(RemoteConnector):
     async def new_received_pickups_received(self, new_received_pickups: str) -> None:
         new_recv_as_int = int(new_received_pickups)
         self.logger.debug("Received Pickups: %s", new_received_pickups)
-        self.in_cooldown = False
+        if self.current_region is not None:
+            self.in_cooldown = False
         self.received_pickups = new_recv_as_int
         await self.receive_remote_pickups()
 


### PR DESCRIPTION
Fixes #7960