### PR TITLE
Dread: Fix oversight with ledge warping out of diffusion beam room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: A video for breaking the uppermost blob in Burenia Hub to Dairon with a pseudo-wave.
 
+##### Cataris
+
+- Fixed: An oversight where one would be expected to Ledge Warp out of the Diffusion Beam Room after collecting the Diffusion Beam, but in order to do so, one would need any bombs. And that bomb would be in that room.
+
 ##### Ghavoran
 
 - Changed: Flipper Room: The Morph Ball Launcher now connects to the door to Navigation Station and is trivial, instead ot connecting to the door to Elun Transport Access and requiring that the Flipper has been rotated.

--- a/randovania/games/dread/logic_database/Cataris.json
+++ b/randovania/games/dread/logic_database/Cataris.json
@@ -20440,21 +20440,17 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "LedgeWarp",
-                                            "amount": 2,
+                                            "type": "items",
+                                            "name": "Varia",
+                                            "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Lay Any Bomb"
-                                    },
-                                    {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Varia",
+                                            "type": "events",
+                                            "name": "CatarisLedgeWarpSetupOutsideDiffusionRoom",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -23355,6 +23351,27 @@
                                     }
                                 ]
                             }
+                        },
+                        "Event - Ledge Warp Setup": {
+                            "type": "and",
+                            "data": {
+                                "comment": "https://youtu.be/Y3wgVEtidi0",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "LedgeWarp",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Any Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -24091,6 +24108,31 @@
                                         }
                                     }
                                 ]
+                            }
+                        }
+                    }
+                },
+                "Event - Ledge Warp Setup": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -9607.69,
+                        "y": -4925.11,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "CatarisLedgeWarpSetupOutsideDiffusionRoom",
+                    "connections": {
+                        "Tunnel to Diffusion Beam Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }

--- a/randovania/games/dread/logic_database/Cataris.json
+++ b/randovania/games/dread/logic_database/Cataris.json
@@ -20454,6 +20454,15 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "LedgeWarp",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -23357,15 +23366,6 @@
                             "data": {
                                 "comment": "https://youtu.be/Y3wgVEtidi0",
                                 "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "LedgeWarp",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    },
                                     {
                                         "type": "template",
                                         "data": "Lay Any Bomb"

--- a/randovania/games/dread/logic_database/Cataris.txt
+++ b/randovania/games/dread/logic_database/Cataris.txt
@@ -3198,7 +3198,7 @@ Extra - asset_id: collision_camera_044
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
   > Tunnel to Teleport to Dairon
       # https://youtu.be/Y3wgVEtidi0
-      Varia Suit and After Cataris - Ledge Warp Setup Outside Diffusion Room
+      Varia Suit and After Cataris - Ledge Warp Setup Outside Diffusion Room and Ledge Warp (Intermediate)
 
 > Pickup (Power Bomb Tank); Heals? False
   * Layers: default
@@ -3684,7 +3684,7 @@ Extra - asset_id: collision_camera_051
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 120
   > Event - Ledge Warp Setup
       # https://youtu.be/Y3wgVEtidi0
-      Ledge Warp (Intermediate) and Lay Any Bomb
+      Lay Any Bomb
 
 > Tunnel to Kraid Eyedoor Room; Heals? False
   * Layers: default

--- a/randovania/games/dread/logic_database/Cataris.txt
+++ b/randovania/games/dread/logic_database/Cataris.txt
@@ -3198,7 +3198,7 @@ Extra - asset_id: collision_camera_044
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
   > Tunnel to Teleport to Dairon
       # https://youtu.be/Y3wgVEtidi0
-      Varia Suit and Ledge Warp (Intermediate) and Lay Any Bomb
+      Varia Suit and After Cataris - Ledge Warp Setup Outside Diffusion Room
 
 > Pickup (Power Bomb Tank); Heals? False
   * Layers: default
@@ -3682,6 +3682,9 @@ Extra - asset_id: collision_camera_051
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 120
+  > Event - Ledge Warp Setup
+      # https://youtu.be/Y3wgVEtidi0
+      Ledge Warp (Intermediate) and Lay Any Bomb
 
 > Tunnel to Kraid Eyedoor Room; Heals? False
   * Layers: default
@@ -3763,6 +3766,12 @@ Extra - asset_id: collision_camera_051
       Any of the following:
           Wave Beam
           Pseudo-Wave Beam (Beginner) and Shoot Diffusion Beam
+
+> Event - Ledge Warp Setup; Heals? False
+  * Layers: default
+  * Event Cataris - Ledge Warp Setup Outside Diffusion Room
+  > Tunnel to Diffusion Beam Room
+      Trivial
 
 ----------------
 Green EMMI Introduction Access

--- a/randovania/games/dread/logic_database/header.json
+++ b/randovania/games/dread/logic_database/header.json
@@ -840,6 +840,10 @@
                 "long_name": "Cataris - Lower Power Bomb Tank Ceiling",
                 "extra": {}
             },
+            "CatarisLedgeWarpSetupOutsideDiffusionRoom": {
+                "long_name": "Cataris - Ledge Warp Setup Outside Diffusion Room",
+                "extra": {}
+            },
             "ElunSoldier": {
                 "long_name": "Elun - Chozo Soldier Fight",
                 "extra": {}


### PR DESCRIPTION
The logic is meant to break the missile door, then set up the ledge warp, then roll into the room by opening the door with a bomb. However, it's important that the bomb is not placed on the diffusion beam pickup.