### PR TITLE
Fusion Change Softlock UI Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid Fusion
 
 - Added: 5 joke hints.
+- Changed: Anti-Softlock option under the Game Modifications -> Gameplay tab in the preset settings was changed to "Room Edits" and now includes an explanation and list of changes the option provides.
 
 #### Logic Database
 

--- a/randovania/games/fusion/gui/generated/preset_fusion_patches_ui.py
+++ b/randovania/games/fusion/gui/generated/preset_fusion_patches_ui.py
@@ -37,7 +37,7 @@ class Ui_PresetFusionPatches(object):
         self.scroll_area.setWidgetResizable(True)
         self.scroll_contents = QWidget()
         self.scroll_contents.setObjectName(u"scroll_contents")
-        self.scroll_contents.setGeometry(QRect(0, 0, 709, 703))
+        self.scroll_contents.setGeometry(QRect(0, 0, 709, 667))
         sizePolicy = QSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -193,9 +193,7 @@ class Ui_PresetFusionPatches(object):
 "<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><br />Sector 4:</p>\n"
 "<ul style=\"margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;\">\n"
 "<li style=\" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">Security Bypass: A bomb block at the bottom of the room was changed to a non-reforming shot block, preventing you from entering a morph "
-                        "tunnel without bombs to get back out.</li></ul>\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><br /></p>\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><br /></p></body></html>", None))
+                        "tunnel without bombs to get back out.</li></ul></body></html>", None))
         self.gameplay_group.setTitle(QCoreApplication.translate("PresetFusionPatches", u"Other", None))
         self.instant_transitions_check.setText(QCoreApplication.translate("PresetFusionPatches", u"Enable Instant Hatch Transitions", None))
         self.instant_transitions_label.setText(QCoreApplication.translate("PresetFusionPatches", u"<html><head/><body><p>Enabling this will skip the transition animation for hatches.</p></body></html>", None))

--- a/randovania/games/fusion/gui/generated/preset_fusion_patches_ui.py
+++ b/randovania/games/fusion/gui/generated/preset_fusion_patches_ui.py
@@ -37,7 +37,7 @@ class Ui_PresetFusionPatches(object):
         self.scroll_area.setWidgetResizable(True)
         self.scroll_contents = QWidget()
         self.scroll_contents.setObjectName(u"scroll_contents")
-        self.scroll_contents.setGeometry(QRect(0, 0, 709, 422))
+        self.scroll_contents.setGeometry(QRect(0, 0, 709, 703))
         sizePolicy = QSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -75,7 +75,7 @@ class Ui_PresetFusionPatches(object):
         self.etank_layout.setContentsMargins(-1, 0, -1, -1)
         self.etank_capacity_label = QLabel(self.energy_group)
         self.etank_capacity_label.setObjectName(u"etank_capacity_label")
-        self.etank_capacity_label.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
+        self.etank_capacity_label.setAlignment(Qt.AlignmentFlag.AlignLeading|Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
 
         self.etank_layout.addWidget(self.etank_capacity_label)
 
@@ -176,8 +176,26 @@ class Ui_PresetFusionPatches(object):
 "While logic will respect this value, only the original value (100) has been tested.", None))
         self.etank_capacity_label.setText(QCoreApplication.translate("PresetFusionPatches", u"Energy per tank:", None))
         self.room_group.setTitle(QCoreApplication.translate("PresetFusionPatches", u"Room Design", None))
-        self.anti_softlock_check.setText(QCoreApplication.translate("PresetFusionPatches", u"Enable Anti-Softlock Room Edits", None))
-        self.anti_softlock_label.setText(QCoreApplication.translate("PresetFusionPatches", u"Enabling this will modify certain rooms to prevent potential softlocks for the player.", None))
+        self.anti_softlock_check.setText(QCoreApplication.translate("PresetFusionPatches", u"Enable Room Edits", None))
+        self.anti_softlock_label.setText(QCoreApplication.translate("PresetFusionPatches", u"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
+"<html><head><meta name=\"qrichtext\" content=\"1\" /><meta charset=\"utf-8\" /><style type=\"text/css\">\n"
+"p, li { white-space: pre-wrap; }\n"
+"hr { height: 1px; border-width: 0; }\n"
+"li.unchecked::marker { content: \"\\2610\"; }\n"
+"li.checked::marker { content: \"\\2612\"; }\n"
+"</style></head><body style=\" font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;\">\n"
+"<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">Enabling this will modify the following rooms to allow the player to leave more easily and give more diverse seed generation.<br /><br />Sector 2:</p>\n"
+"<ul style=\"margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;\">\n"
+"<li style=\" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">Ripper Towe"
+                        "r: The crumble block in the drop-down tunnel is raised one block.</li>\n"
+"<li style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">Cultivation Station: The bomb block above the item changed to a shot block.</li>\n"
+"<li style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">Crumble City: The leftmost shot block in the morph tunnel was changed to a crumble block.</li></ul>\n"
+"<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><br />Sector 4:</p>\n"
+"<ul style=\"margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;\">\n"
+"<li style=\" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">Security Bypass: A bomb block at the bottom of the room was changed to a non-reforming shot block, preventing you from entering a morph "
+                        "tunnel without bombs to get back out.</li></ul>\n"
+"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><br /></p>\n"
+"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><br /></p></body></html>", None))
         self.gameplay_group.setTitle(QCoreApplication.translate("PresetFusionPatches", u"Other", None))
         self.instant_transitions_check.setText(QCoreApplication.translate("PresetFusionPatches", u"Enable Instant Hatch Transitions", None))
         self.instant_transitions_label.setText(QCoreApplication.translate("PresetFusionPatches", u"<html><head/><body><p>Enabling this will skip the transition animation for hatches.</p></body></html>", None))

--- a/randovania/games/fusion/gui/ui_files/preset_fusion_patches.ui
+++ b/randovania/games/fusion/gui/ui_files/preset_fusion_patches.ui
@@ -44,7 +44,7 @@
          <x>0</x>
          <y>0</y>
          <width>709</width>
-         <height>703</height>
+         <height>667</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -177,9 +177,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
 &lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Crumble City: The leftmost shot block in the morph tunnel was changed to a crumble block.&lt;/li&gt;&lt;/ul&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;Sector 4:&lt;/p&gt;
 &lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;
-&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Security Bypass: A bomb block at the bottom of the room was changed to a non-reforming shot block, preventing you from entering a morph tunnel without bombs to get back out.&lt;/li&gt;&lt;/ul&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Security Bypass: A bomb block at the bottom of the room was changed to a non-reforming shot block, preventing you from entering a morph tunnel without bombs to get back out.&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>

--- a/randovania/games/fusion/gui/ui_files/preset_fusion_patches.ui
+++ b/randovania/games/fusion/gui/ui_files/preset_fusion_patches.ui
@@ -44,7 +44,7 @@
          <x>0</x>
          <y>0</y>
          <width>709</width>
-         <height>422</height>
+         <height>703</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -69,10 +69,10 @@
         <item>
          <spacer name="top_spacer">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
+           <enum>QSizePolicy::Policy::Fixed</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -116,7 +116,7 @@ While logic will respect this value, only the original value (100) has been test
                 <string>Energy per tank:</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -150,7 +150,7 @@ While logic will respect this value, only the original value (100) has been test
            <item>
             <widget class="QCheckBox" name="anti_softlock_check">
              <property name="text">
-              <string>Enable Anti-Softlock Room Edits</string>
+              <string>Enable Room Edits</string>
              </property>
             </widget>
            </item>
@@ -163,7 +163,23 @@ While logic will respect this value, only the original value (100) has been test
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Enabling this will modify certain rooms to prevent potential softlocks for the player.</string>
+              <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Enabling this will modify the following rooms to allow the player to leave more easily and give more diverse seed generation.&lt;br /&gt;&lt;br /&gt;Sector 2:&lt;/p&gt;
+&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;
+&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ripper Tower: The crumble block in the drop-down tunnel is raised one block.&lt;/li&gt;
+&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Cultivation Station: The bomb block above the item changed to a shot block.&lt;/li&gt;
+&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Crumble City: The leftmost shot block in the morph tunnel was changed to a crumble block.&lt;/li&gt;&lt;/ul&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;Sector 4:&lt;/p&gt;
+&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;
+&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Security Bypass: A bomb block at the bottom of the room was changed to a non-reforming shot block, preventing you from entering a morph tunnel without bombs to get back out.&lt;/li&gt;&lt;/ul&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>
@@ -231,7 +247,7 @@ While logic will respect this value, only the original value (100) has been test
         <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>


### PR DESCRIPTION
This was brought up as an issue
- Anitsoftlock was misleading as it does not prevent all softlocks

Changed

- UI text from anti softlock to "Room Edits"
- Clarify what the option does
- List exactly what the room edits are

Wording change ideas from Reggie
List verified by Clue

<img width="950" height="741" alt="image" src="https://github.com/user-attachments/assets/85db57de-3f60-4b90-a57b-0e9250feae8d" />

