### PR TITLE
Fusion: Fix hide-with-random on nothings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: The title screen will now display the Randovania and patcher version.
 - Added: 5 joke hints.
+- Fixed: Incorrect exporting behaviour, if the option to hide text of pickups was enabled.
 - Removed: The "Anti-Softlock" option and instead made the following permanent changes:
   - Sector 2 Ripper Tower: The Crumble Block is moved one tile up to make it easier to Screw Attack the Bomb Block.
   - Sector 2 Crumble City: On the far left of the tunnel, the Shot Block has been changed into a Crumble Block.

--- a/randovania/games/fusion/exporter/patch_data_factory.py
+++ b/randovania/games/fusion/exporter/patch_data_factory.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
 class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeticPatches]):
     _placeholder_metroid_message = "placeholder metroid text"
+    _metroid_message_id = 56
     _lang_list = ["JapaneseKanji", "JapaneseHiragana", "English", "German", "French", "Italian", "Spanish"]
     _easter_egg_bob = 64
     _easter_egg_shiny = 1024
@@ -51,14 +52,12 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
             node = self.game.region_list.node_from_pickup_index(pickup.index)
             is_major = False
             jingle = "Minor"
-            message_id = None
             if "source" in node.extra:
                 is_major = True
             if not pickup.is_for_remote_player and pickup.conditional_resources[0].resources:
                 conditional_extras = pickup.conditional_resources[0].resources[-1][0].extra
                 resource = conditional_extras["item"]
                 jingle = conditional_extras.get("Jingle", "Minor")
-                message_id = conditional_extras.get("MessageID", None)
             else:
                 resource = "None"
 
@@ -67,12 +66,10 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
 
             item_message = {}
             # Handles special case for infant metroids which use ASM to automatically determine message via a MessageID
-            if text != self._placeholder_metroid_message:
-                item_message = {"Languages": dict.fromkeys(self._lang_list, text), "Kind": "CustomMessage"}
+            if text == self._placeholder_metroid_message:
+                item_message = {"Kind": "MessageID", "MessageID": self._metroid_message_id}
             else:
-                if message_id is None:
-                    raise ValueError("Suppossed to use a message id but none given?")
-                item_message = {"Kind": "MessageID", "MessageID": message_id}
+                item_message = {"Kind": "CustomMessage", "Languages": dict.fromkeys(self._lang_list, text)}
 
             # Shiny easter eggs
             if (

--- a/test/test_files/log_files/fusion/all_hidden_with_random.rdvgame
+++ b/test/test_files/log_files/fusion/all_hidden_with_random.rdvgame
@@ -318,7 +318,7 @@
                     "Namihe's Lair/Pickup (Power Bomb Tank)": "Ice Missile Data",
                     "Processing Access/Pickup (Hidden Missile Tank)": "Power Bomb Tank",
                     "Security Access/Pickup (Hidden Missile Tank)": "Varia Suit",
-                    "Sova Processing/Pickup (Energy Tank)": "Power Bomb Tank",
+                    "Sova Processing/Pickup (Energy Tank)": "Nothing",
                     "Sova Processing/Pickup (Missile Tank)": "Energy Tank"
                 },
                 "Sector 4 (AQA)": {

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
@@ -31,6 +31,7 @@
                 "Item": "MorphBall",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -39,8 +40,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -48,6 +48,7 @@
                 "Item": "Level4",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -56,8 +57,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -65,6 +65,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -73,8 +74,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -82,6 +82,7 @@
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -90,8 +91,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -99,6 +99,7 @@
                 "Item": "InfantMetroid",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -107,8 +108,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -116,6 +116,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -124,8 +125,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -133,6 +133,7 @@
                 "Item": "InfantMetroid",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -141,8 +142,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -150,6 +150,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -158,8 +159,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -167,6 +167,7 @@
                 "Item": "InfantMetroid",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -175,8 +176,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -184,6 +184,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -192,8 +193,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -201,6 +201,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -209,8 +210,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -218,6 +218,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -226,8 +227,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -235,6 +235,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -243,8 +244,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -252,6 +252,7 @@
                 "Item": "ScrewAttack",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -260,8 +261,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -269,6 +269,7 @@
                 "Item": "InfantMetroid",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -277,8 +278,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -286,6 +286,7 @@
                 "Item": "InfantMetroid",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -294,8 +295,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -303,6 +303,7 @@
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -311,8 +312,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -320,6 +320,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -328,8 +329,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -337,6 +337,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -345,8 +346,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -354,6 +354,7 @@
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -362,8 +363,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -371,6 +371,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -379,8 +380,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -388,6 +388,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -396,8 +397,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -405,6 +405,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -413,8 +414,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             }
         ],
@@ -428,6 +428,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -436,8 +437,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -449,6 +449,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -457,8 +458,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -470,6 +470,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -478,8 +479,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -491,6 +491,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -499,8 +500,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -512,6 +512,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -520,8 +521,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -533,6 +533,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -541,8 +542,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -554,6 +554,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -562,8 +563,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -575,6 +575,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -583,8 +584,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -596,6 +596,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -604,8 +605,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -617,6 +617,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -625,8 +626,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -638,6 +638,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -646,8 +647,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -659,6 +659,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -667,8 +668,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -680,6 +680,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -688,8 +689,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -701,6 +701,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -709,8 +710,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -722,6 +722,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -730,8 +731,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -743,6 +743,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -751,8 +752,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -764,6 +764,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -772,8 +773,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -785,6 +785,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -793,8 +794,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -806,6 +806,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -814,8 +815,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -827,6 +827,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -835,8 +836,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -848,6 +848,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -856,8 +857,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -869,6 +869,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -877,8 +878,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -890,6 +890,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -898,8 +899,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -911,6 +911,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -919,8 +920,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -932,6 +932,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -940,8 +941,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -953,6 +953,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -961,8 +962,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -974,6 +974,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -982,8 +983,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -995,6 +995,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1003,8 +1004,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1016,6 +1016,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1024,8 +1025,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1037,6 +1037,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1045,8 +1046,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1058,6 +1058,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1066,8 +1067,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1079,6 +1079,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1087,8 +1088,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1100,6 +1100,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1108,8 +1109,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1121,6 +1121,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1129,8 +1130,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1142,6 +1142,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1150,8 +1151,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1163,6 +1163,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1171,8 +1172,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1184,6 +1184,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1192,8 +1193,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1205,6 +1205,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1213,8 +1214,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1226,6 +1226,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1234,8 +1235,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1247,6 +1247,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1255,8 +1256,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1268,6 +1268,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1276,8 +1277,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1289,6 +1289,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1297,8 +1298,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1310,6 +1310,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1318,8 +1319,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1331,6 +1331,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1339,8 +1340,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1352,6 +1352,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1360,8 +1361,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1373,6 +1373,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1381,8 +1382,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1394,6 +1394,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1402,8 +1403,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1415,6 +1415,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1423,8 +1424,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1436,6 +1436,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1444,8 +1445,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1457,6 +1457,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1465,8 +1466,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1478,6 +1478,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1486,8 +1487,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1499,6 +1499,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1507,8 +1508,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1520,6 +1520,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1528,8 +1529,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1541,6 +1541,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1549,8 +1550,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1562,6 +1562,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1570,8 +1571,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1583,6 +1583,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1591,8 +1592,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1604,6 +1604,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1612,8 +1613,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1625,6 +1625,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1633,8 +1634,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1646,6 +1646,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1654,8 +1655,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1667,6 +1667,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1675,8 +1676,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1688,6 +1688,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1696,8 +1697,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1709,6 +1709,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1717,8 +1718,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1730,6 +1730,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1738,8 +1739,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1751,6 +1751,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1759,8 +1760,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1772,6 +1772,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1780,8 +1781,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1793,6 +1793,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1801,8 +1802,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1814,6 +1814,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1822,8 +1823,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1835,6 +1835,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1843,8 +1844,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1856,6 +1856,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1864,8 +1865,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1877,6 +1877,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1885,8 +1886,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1898,6 +1898,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1906,8 +1907,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1919,6 +1919,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1927,8 +1928,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1940,6 +1940,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1948,8 +1949,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1961,6 +1961,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1969,8 +1970,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1982,6 +1982,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -1990,8 +1991,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2003,6 +2003,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2011,8 +2012,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2024,6 +2024,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2032,8 +2033,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2045,6 +2045,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2053,8 +2054,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2066,6 +2066,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2074,8 +2075,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2087,6 +2087,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2095,8 +2096,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2108,6 +2108,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2116,8 +2117,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2129,6 +2129,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2137,8 +2138,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2150,6 +2150,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2158,8 +2159,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2171,6 +2171,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2179,8 +2180,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2192,6 +2192,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2200,8 +2201,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2213,6 +2213,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2221,8 +2222,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2234,6 +2234,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2242,8 +2243,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2255,6 +2255,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2263,8 +2264,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2276,6 +2276,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2284,8 +2285,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2297,6 +2297,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2305,8 +2306,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2318,6 +2318,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2326,8 +2327,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2339,6 +2339,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2347,8 +2348,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2360,6 +2360,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2368,8 +2369,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2381,6 +2381,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2389,8 +2390,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2402,6 +2402,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2410,8 +2411,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2423,6 +2423,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2431,8 +2432,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2444,6 +2444,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2452,8 +2453,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2465,6 +2465,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2473,8 +2474,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2486,6 +2486,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2494,8 +2495,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2507,6 +2507,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2515,8 +2516,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2528,6 +2528,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2536,8 +2537,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2549,6 +2549,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2557,8 +2558,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2570,6 +2570,7 @@
                 "ItemSprite": "Anonymous",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Unknown Item acquired.",
                         "JapaneseHiragana": "Unknown Item acquired.",
@@ -2578,8 +2579,7 @@
                         "French": "Unknown Item acquired.",
                         "Italian": "Unknown Item acquired.",
                         "Spanish": "Unknown Item acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             }
         ]

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
@@ -31,6 +31,7 @@
                 "Item": "MorphBall",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -39,8 +40,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -48,6 +48,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -56,8 +57,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -65,23 +65,7 @@
                 "Item": "InfantMetroid",
                 "Jingle": "Major",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Source": "AqaData",
-                "Item": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "JapaneseHiragana": "Security Level 1 unlocked.\nBlue hatches now active.",
@@ -90,8 +74,24 @@
                         "French": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "Italian": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "Spanish": "Security Level 1 unlocked.\nBlue hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Source": "AqaData",
+                "Item": "PowerBombTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -99,6 +99,7 @@
                 "Item": "InfantMetroid",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -107,8 +108,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -116,6 +116,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -124,8 +125,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -133,6 +133,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -141,8 +142,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -150,23 +150,7 @@
                 "Item": "IceBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Source": "MegaX",
-                "Item": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -175,8 +159,24 @@
                         "French": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Italian": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Spanish": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Source": "MegaX",
+                "Item": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -184,16 +184,16 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
                 }
             },
             {
@@ -201,6 +201,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -209,8 +210,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -218,16 +218,16 @@
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "JapaneseHiragana": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "English": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "German": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "French": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "Italian": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "Spanish": "Wide Beam ability acquired.\nBeam widens dramatically."
+                    }
                 }
             },
             {
@@ -235,16 +235,8 @@
                 "Item": "Level3",
                 "Jingle": "Major",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    "Kind": "MessageID",
+                    "MessageID": 56
                 }
             },
             {
@@ -252,16 +244,8 @@
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    "Kind": "MessageID",
+                    "MessageID": 56
                 }
             },
             {
@@ -269,6 +253,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -277,8 +262,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -286,16 +270,16 @@
                 "Item": "InfantMetroid",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -303,6 +287,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -311,8 +296,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -320,6 +304,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -328,8 +313,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -337,23 +321,7 @@
                 "Item": "InfantMetroid",
                 "Jingle": "Major",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Source": "Level4",
-                "Item": "EnergyTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -362,8 +330,24 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Source": "Level4",
+                "Item": "EnergyTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -371,8 +355,16 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
-                    "Kind": "MessageID",
-                    "MessageID": 51
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -380,6 +372,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -388,8 +381,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -397,16 +389,16 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "JapaneseHiragana": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "English": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "German": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "French": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "Italian": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "Spanish": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right]."
+                    }
                 }
             }
         ],
@@ -417,19 +409,19 @@
                 "BlockX": 13,
                 "BlockY": 14,
                 "Item": "Level1",
-                "ItemSprite": "MorphBall",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "JapaneseHiragana": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "English": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "German": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "French": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "Italian": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
-                        "Spanish": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -441,6 +433,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -449,8 +442,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -459,19 +451,19 @@
                 "BlockX": 14,
                 "BlockY": 65,
                 "Item": "PowerBombs",
-                "ItemSprite": "PowerBombTank",
+                "ItemSprite": "SpeedBooster",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "JapaneseHiragana": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "English": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "German": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "French": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "Italian": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "Spanish": "Speed Booster power regained.\nRun until speed boost begins."
+                    }
                 }
             },
             {
@@ -483,6 +475,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -491,8 +484,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -501,30 +493,10 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 0,
-                "Room": 47,
-                "BlockX": 4,
-                "BlockY": 3,
-                "Item": "PowerBombTank",
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -533,8 +505,28 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Area": 0,
+                "Room": 47,
+                "BlockX": 4,
+                "BlockY": 3,
+                "Item": "PowerBombTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -543,19 +535,19 @@
                 "BlockX": 54,
                 "BlockY": 8,
                 "Item": "EnergyTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -564,19 +556,19 @@
                 "BlockX": 5,
                 "BlockY": 29,
                 "Item": "PowerBombTank",
-                "ItemSprite": "SuperMissiles",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "JapaneseHiragana": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "English": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "German": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "French": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "Italian": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "Spanish": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -585,30 +577,10 @@
                 "BlockX": 12,
                 "BlockY": 10,
                 "Item": "DiffusionMissiles",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "VariaSuit",
                 "Jingle": "Major",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 0,
-                "Room": 69,
-                "BlockX": 29,
-                "BlockY": 29,
-                "Item": "MissileTank",
-                "ItemSprite": "VariaSuit",
-                "Jingle": "Minor",
-                "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "JapaneseHiragana": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
@@ -617,8 +589,28 @@
                         "French": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "Italian": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "Spanish": "Varia Suit effect acquired.\nSurvive extreme temperatures."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Area": 0,
+                "Room": 69,
+                "BlockX": 29,
+                "BlockY": 29,
+                "Item": "MissileTank",
+                "ItemSprite": "MorphBall",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "JapaneseHiragana": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "English": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "German": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "French": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "Italian": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
+                        "Spanish": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph."
+                    }
                 }
             },
             {
@@ -627,19 +619,19 @@
                 "BlockX": 13,
                 "BlockY": 9,
                 "Item": "Missiles",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "ChargeBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "JapaneseHiragana": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "English": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "German": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "French": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "Italian": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "Spanish": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge."
+                    }
                 }
             },
             {
@@ -651,6 +643,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -659,8 +652,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -669,19 +661,19 @@
                 "BlockX": 14,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -690,19 +682,19 @@
                 "BlockX": 27,
                 "BlockY": 10,
                 "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
+                "ItemSprite": "Level3",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "JapaneseHiragana": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "English": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "German": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "French": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "Italian": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "Spanish": "Security Level 3 unlocked.\nYellow hatches now active."
+                    }
                 }
             },
             {
@@ -711,30 +703,10 @@
                 "BlockX": 8,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "ItemSprite": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 1,
-                "Room": 17,
-                "BlockX": 44,
-                "BlockY": 19,
-                "Item": "EnergyTank",
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -743,19 +715,19 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
                 "Area": 1,
-                "Room": 30,
-                "BlockX": 15,
-                "BlockY": 8,
-                "Item": "MissileTank",
+                "Room": 17,
+                "BlockX": 44,
+                "BlockY": 19,
+                "Item": "EnergyTank",
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -764,8 +736,28 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Area": 1,
+                "Room": 30,
+                "BlockX": 15,
+                "BlockY": 8,
+                "Item": "MissileTank",
+                "ItemSprite": "ScrewAttack",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "JapaneseHiragana": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "English": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "German": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "French": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "Italian": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "Spanish": "Screw Attack ability regained.\nSomersault into enemies."
+                    }
                 }
             },
             {
@@ -774,19 +766,19 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "PowerBombTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "SuperMissiles",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "JapaneseHiragana": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "English": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "German": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "French": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "Italian": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "Spanish": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
+                    }
                 }
             },
             {
@@ -795,19 +787,19 @@
                 "BlockX": 12,
                 "BlockY": 8,
                 "Item": "Level2",
-                "ItemSprite": "WaveBeam",
+                "ItemSprite": "EnergyTank",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "JapaneseHiragana": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "English": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "German": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "French": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "Italian": "Wave Beam ability acquired.\nBeam now penetrates walls.",
-                        "Spanish": "Wave Beam ability acquired.\nBeam now penetrates walls."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
                 }
             },
             {
@@ -819,6 +811,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -827,8 +820,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -840,6 +832,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -848,8 +841,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -858,19 +850,19 @@
                 "BlockX": 10,
                 "BlockY": 2,
                 "Item": "MissileTank",
-                "ItemSprite": "PowerBombTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -879,19 +871,19 @@
                 "BlockX": 6,
                 "BlockY": 8,
                 "Item": "Level4",
-                "ItemSprite": "EnergyTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -903,6 +895,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -911,8 +904,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -921,19 +913,19 @@
                 "BlockX": 29,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "ItemSprite": "PowerBombTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -942,19 +934,19 @@
                 "BlockX": 13,
                 "BlockY": 4,
                 "Item": "MissileTank",
-                "ItemSprite": "PowerBombTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -963,19 +955,19 @@
                 "BlockX": 19,
                 "BlockY": 35,
                 "Item": "EnergyTank",
-                "ItemSprite": "Level4",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "JapaneseHiragana": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "English": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "German": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "French": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "Italian": "Security Level 4 unlocked.\nRed hatches now active.",
-                        "Spanish": "Security Level 4 unlocked.\nRed hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -987,6 +979,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -995,8 +988,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1005,114 +997,10 @@
                 "BlockX": 29,
                 "BlockY": 4,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 25,
-                "BlockX": 4,
-                "BlockY": 8,
-                "Item": "EnergyTank",
-                "ItemSprite": "Level3",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "JapaneseHiragana": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "English": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "German": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "French": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "Italian": "Security Level 3 unlocked.\nYellow hatches now active.",
-                        "Spanish": "Security Level 3 unlocked.\nYellow hatches now active."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 27,
-                "BlockX": 28,
-                "BlockY": 7,
-                "Item": "SpaceJump",
-                "ItemSprite": "SpeedBooster",
-                "Jingle": "Major",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Speed Booster power regained.\nRun until speed boost begins.",
-                        "JapaneseHiragana": "Speed Booster power regained.\nRun until speed boost begins.",
-                        "English": "Speed Booster power regained.\nRun until speed boost begins.",
-                        "German": "Speed Booster power regained.\nRun until speed boost begins.",
-                        "French": "Speed Booster power regained.\nRun until speed boost begins.",
-                        "Italian": "Speed Booster power regained.\nRun until speed boost begins.",
-                        "Spanish": "Speed Booster power regained.\nRun until speed boost begins."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 31,
-                "BlockX": 40,
-                "BlockY": 7,
-                "Item": "PowerBombTank",
-                "ItemSprite": "EnergyTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 33,
-                "BlockX": 21,
-                "BlockY": 8,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 2,
-                "Room": 42,
-                "BlockX": 5,
-                "BlockY": 8,
-                "Item": "PowerBombTank",
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1121,19 +1009,19 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
                 "Area": 2,
-                "Room": 47,
-                "BlockX": 29,
-                "BlockY": 16,
-                "Item": "MissileTank",
+                "Room": 25,
+                "BlockX": 4,
+                "BlockY": 8,
+                "Item": "EnergyTank",
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1142,8 +1030,112 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Area": 2,
+                "Room": 27,
+                "BlockX": 28,
+                "BlockY": 7,
+                "Item": "SpaceJump",
+                "ItemSprite": "Level4",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "JapaneseHiragana": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "English": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "German": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "French": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "Italian": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "Spanish": "Security Level 4 unlocked.\nRed hatches now active."
+                    }
+                }
+            },
+            {
+                "Area": 2,
+                "Room": 31,
+                "BlockX": 40,
+                "BlockY": 7,
+                "Item": "PowerBombTank",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "Area": 2,
+                "Room": 33,
+                "BlockX": 21,
+                "BlockY": 8,
+                "Item": "MissileTank",
+                "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
+                }
+            },
+            {
+                "Area": 2,
+                "Room": 42,
+                "BlockX": 5,
+                "BlockY": 8,
+                "Item": "PowerBombTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "Area": 2,
+                "Room": 47,
+                "BlockX": 29,
+                "BlockY": 16,
+                "Item": "MissileTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -1155,6 +1147,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1163,8 +1156,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1173,19 +1165,19 @@
                 "BlockX": 3,
                 "BlockY": 24,
                 "Item": "ChargeBeam",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "EnergyTank",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
                 }
             },
             {
@@ -1194,19 +1186,19 @@
                 "BlockX": 4,
                 "BlockY": 5,
                 "Item": "EnergyTank",
-                "ItemSprite": "PowerBombTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -1218,6 +1210,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1226,8 +1219,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1239,6 +1231,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1247,8 +1240,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1257,19 +1249,19 @@
                 "BlockX": 10,
                 "BlockY": 26,
                 "Item": "MissileTank",
-                "ItemSprite": "PowerBombTank",
+                "ItemSprite": "WaveBeam",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "JapaneseHiragana": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "English": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "German": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "French": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "Italian": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "Spanish": "Wave Beam ability acquired.\nBeam now penetrates walls."
+                    }
                 }
             },
             {
@@ -1278,19 +1270,19 @@
                 "BlockX": 44,
                 "BlockY": 13,
                 "Item": "VariaSuit",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "Bombs",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "JapaneseHiragana": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "English": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "German": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "French": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "Italian": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "Spanish": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right]."
+                    }
                 }
             },
             {
@@ -1299,19 +1291,19 @@
                 "BlockX": 5,
                 "BlockY": 17,
                 "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
+                "ItemSprite": "PlasmaBeam",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "JapaneseHiragana": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "English": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "German": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "French": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "Italian": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "Spanish": "Plasma Beam ability acquired.\nBeam now pierces enemies."
+                    }
                 }
             },
             {
@@ -1320,19 +1312,19 @@
                 "BlockX": 9,
                 "BlockY": 9,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
                 }
             },
             {
@@ -1341,19 +1333,19 @@
                 "BlockX": 22,
                 "BlockY": 13,
                 "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -1365,6 +1357,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1373,8 +1366,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1383,30 +1375,10 @@
                 "BlockX": 12,
                 "BlockY": 25,
                 "Item": "MissileTank",
-                "ItemSprite": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 3,
-                "Room": 19,
-                "BlockX": 43,
-                "BlockY": 10,
-                "Item": "PowerBombTank",
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1415,8 +1387,20 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Area": 3,
+                "Room": 19,
+                "BlockX": 43,
+                "BlockY": 10,
+                "Item": "None",
+                "ItemSprite": "InfantMetroid",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "MessageID",
+                    "MessageID": 56
                 }
             },
             {
@@ -1425,64 +1409,10 @@
                 "BlockX": 19,
                 "BlockY": 13,
                 "Item": "EnergyTank",
-                "ItemSprite": "ChargeBeam",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "JapaneseHiragana": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "English": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "German": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "French": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "Italian": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
-                        "Spanish": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 3,
-                "Room": 28,
-                "BlockX": 12,
-                "BlockY": 7,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 3,
-                "Room": 28,
-                "BlockX": 36,
-                "BlockY": 27,
-                "Item": "MissileTank",
-                "ItemSprite": "InfantMetroid",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Kind": "MessageID",
-                    "MessageID": 51
-                }
-            },
-            {
-                "Area": 3,
-                "Room": 30,
-                "BlockX": 4,
-                "BlockY": 13,
-                "Item": "IceMissiles",
                 "ItemSprite": "PowerBombTank",
-                "Jingle": "Major",
+                "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1491,8 +1421,70 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Area": 3,
+                "Room": 28,
+                "BlockX": 12,
+                "BlockY": 7,
+                "Item": "MissileTank",
+                "ItemSprite": "Missiles",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "JapaneseHiragana": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "English": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "German": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "French": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "Italian": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "Spanish": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
+                    }
+                }
+            },
+            {
+                "Area": 3,
+                "Room": 28,
+                "BlockX": 36,
+                "BlockY": 27,
+                "Item": "MissileTank",
+                "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
+                }
+            },
+            {
+                "Area": 3,
+                "Room": 30,
+                "BlockX": 4,
+                "BlockY": 13,
+                "Item": "IceMissiles",
+                "ItemSprite": "EnergyTank",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
                 }
             },
             {
@@ -1504,6 +1496,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1512,8 +1505,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1522,19 +1514,19 @@
                 "BlockX": 10,
                 "BlockY": 15,
                 "Item": "PowerBombTank",
-                "ItemSprite": "Missiles",
+                "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "JapaneseHiragana": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "English": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "German": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "French": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "Italian": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
-                        "Spanish": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
                 }
             },
             {
@@ -1543,93 +1535,10 @@
                 "BlockX": 4,
                 "BlockY": 27,
                 "Item": "MissileTank",
-                "ItemSprite": "EnergyTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 3,
-                "Room": 35,
-                "BlockX": 15,
-                "BlockY": 86,
-                "Item": "PowerBombTank",
-                "ItemSprite": "GravitySuit",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "JapaneseHiragana": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "English": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "German": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "French": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "Italian": "Gravity Suit effect acquired.\nMove freely in liquids.",
-                        "Spanish": "Gravity Suit effect acquired.\nMove freely in liquids."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 3,
-                "Room": 37,
-                "BlockX": 15,
-                "BlockY": 3,
-                "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 4,
-                "Room": 6,
-                "BlockX": 22,
-                "BlockY": 29,
-                "Item": "PowerBombTank",
-                "ItemSprite": "EnergyTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 4,
-                "Room": 10,
-                "BlockX": 12,
-                "BlockY": 29,
-                "Item": "MissileTank",
                 "ItemSprite": "Level2",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "JapaneseHiragana": "Security Level 2 unlocked.\nGreen hatches now active.",
@@ -1638,19 +1547,19 @@
                         "French": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "Italian": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "Spanish": "Security Level 2 unlocked.\nGreen hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
-                "Area": 4,
-                "Room": 13,
-                "BlockX": 24,
-                "BlockY": 9,
-                "Item": "SpeedBooster",
+                "Area": 3,
+                "Room": 35,
+                "BlockX": 15,
+                "BlockY": 86,
+                "Item": "PowerBombTank",
                 "ItemSprite": "MissileTank",
-                "Jingle": "Major",
+                "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1659,8 +1568,91 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Area": 3,
+                "Room": 37,
+                "BlockX": 15,
+                "BlockY": 3,
+                "Item": "MissileTank",
+                "ItemSprite": "GravitySuit",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "JapaneseHiragana": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "English": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "German": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "French": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "Italian": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "Spanish": "Gravity Suit effect acquired.\nMove freely in liquids."
+                    }
+                }
+            },
+            {
+                "Area": 4,
+                "Room": 6,
+                "BlockX": 22,
+                "BlockY": 29,
+                "Item": "PowerBombTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "Area": 4,
+                "Room": 10,
+                "BlockX": 12,
+                "BlockY": 29,
+                "Item": "MissileTank",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "Area": 4,
+                "Room": 13,
+                "BlockX": 24,
+                "BlockY": 9,
+                "Item": "SpeedBooster",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -1672,6 +1664,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1680,8 +1673,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1690,11 +1682,19 @@
                 "BlockX": 44,
                 "BlockY": 5,
                 "Item": "MissileTank",
-                "ItemSprite": "InfantMetroid",
+                "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
-                    "Kind": "MessageID",
-                    "MessageID": 51
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
                 }
             },
             {
@@ -1706,6 +1706,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1714,8 +1715,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1724,19 +1724,19 @@
                 "BlockX": 57,
                 "BlockY": 19,
                 "Item": "MissileTank",
-                "ItemSprite": "Bombs",
+                "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "JapaneseHiragana": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "English": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "German": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "French": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "Italian": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
-                        "Spanish": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
                 }
             },
             {
@@ -1745,30 +1745,10 @@
                 "BlockX": 40,
                 "BlockY": 7,
                 "Item": "InfantMetroid",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Major",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 4,
-                "Room": 28,
-                "BlockX": 9,
-                "BlockY": 6,
-                "Item": "PowerBombTank",
-                "ItemSprite": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1777,19 +1757,19 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
                 "Area": 4,
-                "Room": 33,
-                "BlockX": 10,
-                "BlockY": 13,
-                "Item": "EnergyTank",
+                "Room": 28,
+                "BlockX": 9,
+                "BlockY": 6,
+                "Item": "PowerBombTank",
                 "ItemSprite": "HiJump",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Hi-Jump and Jumpball\nabilities acquired.",
                         "JapaneseHiragana": "Hi-Jump and Jumpball\nabilities acquired.",
@@ -1798,19 +1778,19 @@
                         "French": "Hi-Jump and Jumpball\nabilities acquired.",
                         "Italian": "Hi-Jump and Jumpball\nabilities acquired.",
                         "Spanish": "Hi-Jump and Jumpball\nabilities acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
                 "Area": 4,
-                "Room": 36,
-                "BlockX": 3,
-                "BlockY": 7,
+                "Room": 33,
+                "BlockX": 10,
+                "BlockY": 13,
                 "Item": "EnergyTank",
                 "ItemSprite": "SpaceJump",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Space Jump ability acquired.\nSomersault continually in air.",
                         "JapaneseHiragana": "Space Jump ability acquired.\nSomersault continually in air.",
@@ -1819,8 +1799,28 @@
                         "French": "Space Jump ability acquired.\nSomersault continually in air.",
                         "Italian": "Space Jump ability acquired.\nSomersault continually in air.",
                         "Spanish": "Space Jump ability acquired.\nSomersault continually in air."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Area": 4,
+                "Room": 36,
+                "BlockX": 3,
+                "BlockY": 7,
+                "Item": "EnergyTank",
+                "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
                 }
             },
             {
@@ -1829,11 +1829,19 @@
                 "BlockX": 42,
                 "BlockY": 5,
                 "Item": "PowerBombTank",
-                "ItemSprite": "InfantMetroid",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
-                    "Kind": "MessageID",
-                    "MessageID": 52
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -1845,6 +1853,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1853,8 +1862,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1866,6 +1874,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1874,8 +1883,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1884,19 +1892,19 @@
                 "BlockX": 4,
                 "BlockY": 10,
                 "Item": "EnergyTank",
-                "ItemSprite": "PowerBombTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -1908,6 +1916,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1916,8 +1925,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1929,6 +1937,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1937,8 +1946,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1947,19 +1955,19 @@
                 "BlockX": 3,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -1968,19 +1976,11 @@
                 "BlockX": 13,
                 "BlockY": 3,
                 "Item": "PowerBombTank",
-                "ItemSprite": "PlasmaBeam",
+                "ItemSprite": "InfantMetroid",
                 "Jingle": "Minor",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "JapaneseHiragana": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "English": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "German": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "French": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "Italian": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
-                        "Spanish": "Plasma Beam ability acquired.\nBeam now pierces enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    "Kind": "MessageID",
+                    "MessageID": 56
                 }
             },
             {
@@ -1992,6 +1992,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2000,8 +2001,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2013,6 +2013,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2021,8 +2022,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2034,6 +2034,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2042,8 +2043,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2052,19 +2052,19 @@
                 "BlockX": 4,
                 "BlockY": 6,
                 "Item": "SuperMissiles",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -2073,19 +2073,19 @@
                 "BlockX": 23,
                 "BlockY": 7,
                 "Item": "MissileTank",
-                "ItemSprite": "PowerBombTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -2094,19 +2094,19 @@
                 "BlockX": 14,
                 "BlockY": 3,
                 "Item": "Bombs",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "EnergyTank",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
                 }
             },
             {
@@ -2115,135 +2115,10 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "ItemSprite": "EnergyTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 5,
-                "Room": 36,
-                "BlockX": 8,
-                "BlockY": 8,
-                "Item": "PowerBombTank",
-                "ItemSprite": "ScrewAttack",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "JapaneseHiragana": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "English": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "German": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "French": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "Italian": "Screw Attack ability regained.\nSomersault into enemies.",
-                        "Spanish": "Screw Attack ability regained.\nSomersault into enemies."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 5,
-                "Room": 47,
-                "BlockX": 4,
-                "BlockY": 10,
-                "Item": "PowerBombTank",
-                "ItemSprite": "IceBeam",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "JapaneseHiragana": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "English": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "German": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "French": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "Italian": "Ice effect added to beam.\nUse beam to freeze enemies.",
-                        "Spanish": "Ice effect added to beam.\nUse beam to freeze enemies."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 5,
-                "Room": 50,
-                "BlockX": 13,
-                "BlockY": 8,
-                "Item": "PowerBombTank",
-                "ItemSprite": "IceMissiles",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "JapaneseHiragana": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "English": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "German": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "French": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "Italian": "Ice effect added to Missiles.\nUse it to freeze enemies.",
-                        "Spanish": "Ice effect added to Missiles.\nUse it to freeze enemies."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 5,
-                "Room": 51,
-                "BlockX": 11,
-                "BlockY": 3,
-                "Item": "MissileTank",
-                "ItemSprite": "PowerBombTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 6,
-                "Room": 0,
-                "BlockX": 41,
-                "BlockY": 18,
-                "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
-                "Jingle": "Minor",
-                "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
-                }
-            },
-            {
-                "Area": 6,
-                "Room": 15,
-                "BlockX": 3,
-                "BlockY": 3,
-                "Item": "WideBeam",
                 "ItemSprite": "MissileTank",
-                "Jingle": "Major",
+                "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2252,40 +2127,82 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
-                "Area": 6,
-                "Room": 18,
-                "BlockX": 15,
-                "BlockY": 3,
-                "Item": "MissileTank",
-                "ItemSprite": "PowerBombTank",
+                "Area": 5,
+                "Room": 36,
+                "BlockX": 8,
+                "BlockY": 8,
+                "Item": "PowerBombTank",
+                "ItemSprite": "IceBeam",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
-                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "JapaneseHiragana": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "English": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "German": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "French": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "Italian": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "Spanish": "Ice effect added to beam.\nUse beam to freeze enemies."
+                    }
                 }
             },
             {
-                "Area": 6,
-                "Room": 18,
-                "BlockX": 29,
-                "BlockY": 20,
-                "Item": "PlasmaBeam",
-                "ItemSprite": "EnergyTank",
-                "Jingle": "Major",
+                "Area": 5,
+                "Room": 47,
+                "BlockX": 4,
+                "BlockY": 10,
+                "Item": "PowerBombTank",
+                "ItemSprite": "IceMissiles",
+                "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "JapaneseHiragana": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "English": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "German": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "French": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "Italian": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "Spanish": "Ice effect added to Missiles.\nUse it to freeze enemies."
+                    }
+                }
+            },
+            {
+                "Area": 5,
+                "Room": 50,
+                "BlockX": 13,
+                "BlockY": 8,
+                "Item": "PowerBombTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "Area": 5,
+                "Room": 51,
+                "BlockX": 11,
+                "BlockY": 3,
+                "Item": "MissileTank",
+                "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2294,8 +2211,91 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
+                }
+            },
+            {
+                "Area": 6,
+                "Room": 0,
+                "BlockX": 41,
+                "BlockY": 18,
+                "Item": "EnergyTank",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "Area": 6,
+                "Room": 15,
+                "BlockX": 3,
+                "BlockY": 3,
+                "Item": "WideBeam",
+                "ItemSprite": "PowerBombTank",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "Area": 6,
+                "Room": 18,
+                "BlockX": 15,
+                "BlockY": 3,
+                "Item": "MissileTank",
+                "ItemSprite": "EnergyTank",
+                "Jingle": "Minor",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
+                }
+            },
+            {
+                "Area": 6,
+                "Room": 18,
+                "BlockX": 29,
+                "BlockY": 20,
+                "Item": "PlasmaBeam",
+                "ItemSprite": "MissileTank",
+                "Jingle": "Major",
+                "ItemMessages": {
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -2307,6 +2307,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2315,8 +2316,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2325,19 +2325,19 @@
                 "BlockX": 5,
                 "BlockY": 6,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -2346,19 +2346,19 @@
                 "BlockX": 19,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "ItemSprite": "WideBeam",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "JapaneseHiragana": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "English": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "German": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "French": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "Italian": "Wide Beam ability acquired.\nBeam widens dramatically.",
-                        "Spanish": "Wide Beam ability acquired.\nBeam widens dramatically."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -2370,6 +2370,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2378,8 +2379,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2388,19 +2388,11 @@
                 "BlockX": 14,
                 "BlockY": 8,
                 "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
+                "ItemSprite": "InfantMetroid",
                 "Jingle": "Minor",
                 "ItemMessages": {
-                    "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    "Kind": "MessageID",
+                    "MessageID": 56
                 }
             },
             {
@@ -2409,11 +2401,19 @@
                 "BlockX": 45,
                 "BlockY": 6,
                 "Item": "PowerBombTank",
-                "ItemSprite": "InfantMetroid",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
-                    "Kind": "MessageID",
-                    "MessageID": 52
+                    "Kind": "CustomMessage",
+                    "Languages": {
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -2422,19 +2422,19 @@
                 "BlockX": 33,
                 "BlockY": 10,
                 "Item": "MissileTank",
-                "ItemSprite": "EnergyTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -2443,19 +2443,19 @@
                 "BlockX": 10,
                 "BlockY": 24,
                 "Item": "EnergyTank",
-                "ItemSprite": "EnergyTank",
+                "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
-                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
                 }
             },
             {
@@ -2467,6 +2467,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2475,8 +2476,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2485,19 +2485,19 @@
                 "BlockX": 9,
                 "BlockY": 8,
                 "Item": "MissileTank",
-                "ItemSprite": "DiffusionMissiles",
+                "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "JapaneseHiragana": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "English": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "German": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "French": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "Italian": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
-                        "Spanish": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "English": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "German": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
                 }
             },
             {
@@ -2506,19 +2506,19 @@
                 "BlockX": 6,
                 "BlockY": 9,
                 "Item": "MissileTank",
-                "ItemSprite": "MissileTank",
+                "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
-                        "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "English": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "German": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "French": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
-                        "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                        "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "English": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "German": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "French": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
+                        "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
+                    }
                 }
             },
             {
@@ -2530,6 +2530,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2538,8 +2539,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             }
         ]
@@ -2593,7 +2593,7 @@
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector4Entrance": "[COLOR=4]WARNING: Excessive exposure to Puyos is known to cause fevers.[/COLOR]",
+                "Sector4Entrance": "[COLOR=4]1, 2, 3, 4! Of randomization I want more![/COLOR]",
                 "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
@@ -2612,7 +2612,7 @@
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector4Entrance": "[COLOR=4]WARNING: Excessive exposure to Puyos is known to cause fevers.[/COLOR]",
+                "Sector4Entrance": "[COLOR=4]1, 2, 3, 4! Of randomization I want more![/COLOR]",
                 "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
@@ -2631,7 +2631,7 @@
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector4Entrance": "[COLOR=4]WARNING: Excessive exposure to Puyos is known to cause fevers.[/COLOR]",
+                "Sector4Entrance": "[COLOR=4]1, 2, 3, 4! Of randomization I want more![/COLOR]",
                 "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
@@ -2650,7 +2650,7 @@
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector4Entrance": "[COLOR=4]WARNING: Excessive exposure to Puyos is known to cause fevers.[/COLOR]",
+                "Sector4Entrance": "[COLOR=4]1, 2, 3, 4! Of randomization I want more![/COLOR]",
                 "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
@@ -2669,7 +2669,7 @@
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector4Entrance": "[COLOR=4]WARNING: Excessive exposure to Puyos is known to cause fevers.[/COLOR]",
+                "Sector4Entrance": "[COLOR=4]1, 2, 3, 4! Of randomization I want more![/COLOR]",
                 "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
@@ -2688,7 +2688,7 @@
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector4Entrance": "[COLOR=4]WARNING: Excessive exposure to Puyos is known to cause fevers.[/COLOR]",
+                "Sector4Entrance": "[COLOR=4]1, 2, 3, 4! Of randomization I want more![/COLOR]",
                 "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
@@ -2707,7 +2707,7 @@
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "Sector2Entrance": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "Sector3Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "Sector4Entrance": "[COLOR=4]WARNING: Excessive exposure to Puyos is known to cause fevers.[/COLOR]",
+                "Sector4Entrance": "[COLOR=4]1, 2, 3, 4! Of randomization I want more![/COLOR]",
                 "Sector5Entrance": "A [COLOR=3]suit[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "Sector6Entrance": "The [COLOR=3]Level 2 Keycard[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR]."
             },
@@ -4994,7 +4994,7 @@
     "DisableMusic": false,
     "DisableSoundEffects": false,
     "_randovania_meta": {
-        "layout_was_user_modified": false,
+        "layout_was_user_modified": true,
         "in_race_setting": false
     }
 }

--- a/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
@@ -31,6 +31,7 @@
                 "Item": "MorphBall",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
                         "JapaneseHiragana": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
@@ -39,8 +40,7 @@
                         "French": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
                         "Italian": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
                         "Spanish": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -57,6 +57,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -65,8 +66,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -74,6 +74,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -82,8 +83,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -91,6 +91,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -99,8 +100,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -108,6 +108,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -116,8 +117,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -125,6 +125,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -133,8 +134,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -160,6 +160,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -168,8 +169,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -186,6 +186,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -194,8 +195,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -203,6 +203,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -211,8 +212,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -220,6 +220,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -228,8 +229,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -246,6 +246,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -254,8 +255,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -263,6 +263,7 @@
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -271,8 +272,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -280,6 +280,7 @@
                 "Item": "GravitySuit",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Gravity Suit effect acquired.\nMove freely in liquids.",
                         "JapaneseHiragana": "Gravity Suit effect acquired.\nMove freely in liquids.",
@@ -288,8 +289,7 @@
                         "French": "Gravity Suit effect acquired.\nMove freely in liquids.",
                         "Italian": "Gravity Suit effect acquired.\nMove freely in liquids.",
                         "Spanish": "Gravity Suit effect acquired.\nMove freely in liquids."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -297,6 +297,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -305,8 +306,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -314,6 +314,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -322,8 +323,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -331,6 +331,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -339,8 +340,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -348,6 +348,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -356,8 +357,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -365,6 +365,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -373,8 +374,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             }
         ],
@@ -388,6 +388,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -396,8 +397,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -409,6 +409,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -417,8 +418,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -430,6 +430,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -438,8 +439,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -451,6 +451,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -459,8 +460,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -472,6 +472,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -480,8 +481,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -493,6 +493,7 @@
                 "ItemSprite": "Missiles",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -501,8 +502,7 @@
                         "French": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Italian": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Spanish": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -514,6 +514,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -522,8 +523,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -535,6 +535,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -543,8 +544,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -556,6 +556,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -564,8 +565,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -577,6 +577,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -585,8 +586,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -598,6 +598,7 @@
                 "ItemSprite": "PowerBombs",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -606,8 +607,7 @@
                         "French": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Italian": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Spanish": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -619,6 +619,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -627,8 +628,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -640,6 +640,7 @@
                 "ItemSprite": "SpaceJump",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Space Jump ability acquired.\nSomersault continually in air.",
                         "JapaneseHiragana": "Space Jump ability acquired.\nSomersault continually in air.",
@@ -648,8 +649,7 @@
                         "French": "Space Jump ability acquired.\nSomersault continually in air.",
                         "Italian": "Space Jump ability acquired.\nSomersault continually in air.",
                         "Spanish": "Space Jump ability acquired.\nSomersault continually in air."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -661,6 +661,7 @@
                 "ItemSprite": "Level3",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 3 unlocked.\nYellow hatches now active.",
                         "JapaneseHiragana": "Security Level 3 unlocked.\nYellow hatches now active.",
@@ -669,8 +670,7 @@
                         "French": "Security Level 3 unlocked.\nYellow hatches now active.",
                         "Italian": "Security Level 3 unlocked.\nYellow hatches now active.",
                         "Spanish": "Security Level 3 unlocked.\nYellow hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -682,6 +682,7 @@
                 "ItemSprite": "ScrewAttack",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Screw Attack ability regained.\nSomersault into enemies.",
                         "JapaneseHiragana": "Screw Attack ability regained.\nSomersault into enemies.",
@@ -690,8 +691,7 @@
                         "French": "Screw Attack ability regained.\nSomersault into enemies.",
                         "Italian": "Screw Attack ability regained.\nSomersault into enemies.",
                         "Spanish": "Screw Attack ability regained.\nSomersault into enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -703,6 +703,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -711,8 +712,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -724,6 +724,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -732,8 +733,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -745,6 +745,7 @@
                 "ItemSprite": "ChargeBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
                         "JapaneseHiragana": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
@@ -753,8 +754,7 @@
                         "French": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
                         "Italian": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
                         "Spanish": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -766,6 +766,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -774,8 +775,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -787,6 +787,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -795,8 +796,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -808,6 +808,7 @@
                 "ItemSprite": "Level1",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "JapaneseHiragana": "Security Level 1 unlocked.\nBlue hatches now active.",
@@ -816,8 +817,7 @@
                         "French": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "Italian": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "Spanish": "Security Level 1 unlocked.\nBlue hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -829,6 +829,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -837,8 +838,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -850,6 +850,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -858,8 +859,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -871,6 +871,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -879,8 +880,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -892,6 +892,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -900,8 +901,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -913,6 +913,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -921,8 +922,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -934,6 +934,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -942,8 +943,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -955,6 +955,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -963,8 +964,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -976,6 +976,7 @@
                 "ItemSprite": "IceBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Ice effect added to beam.\nUse beam to freeze enemies.",
                         "JapaneseHiragana": "Ice effect added to beam.\nUse beam to freeze enemies.",
@@ -984,8 +985,7 @@
                         "French": "Ice effect added to beam.\nUse beam to freeze enemies.",
                         "Italian": "Ice effect added to beam.\nUse beam to freeze enemies.",
                         "Spanish": "Ice effect added to beam.\nUse beam to freeze enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -997,6 +997,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1005,8 +1006,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1018,6 +1018,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1026,8 +1027,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1039,6 +1039,7 @@
                 "ItemSprite": "HiJump",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Hi-Jump and Jumpball\nabilities acquired.",
                         "JapaneseHiragana": "Hi-Jump and Jumpball\nabilities acquired.",
@@ -1047,8 +1048,7 @@
                         "French": "Hi-Jump and Jumpball\nabilities acquired.",
                         "Italian": "Hi-Jump and Jumpball\nabilities acquired.",
                         "Spanish": "Hi-Jump and Jumpball\nabilities acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1060,6 +1060,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1068,8 +1069,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1081,6 +1081,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1089,8 +1090,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1102,6 +1102,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1110,8 +1111,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1123,6 +1123,7 @@
                 "ItemSprite": "SpeedBooster",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Speed Booster power regained.\nRun until speed boost begins.",
                         "JapaneseHiragana": "Speed Booster power regained.\nRun until speed boost begins.",
@@ -1131,8 +1132,7 @@
                         "French": "Speed Booster power regained.\nRun until speed boost begins.",
                         "Italian": "Speed Booster power regained.\nRun until speed boost begins.",
                         "Spanish": "Speed Booster power regained.\nRun until speed boost begins."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1144,6 +1144,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1152,8 +1153,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1165,6 +1165,7 @@
                 "ItemSprite": "WaveBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Wave Beam ability acquired.\nBeam now penetrates walls.",
                         "JapaneseHiragana": "Wave Beam ability acquired.\nBeam now penetrates walls.",
@@ -1173,8 +1174,7 @@
                         "French": "Wave Beam ability acquired.\nBeam now penetrates walls.",
                         "Italian": "Wave Beam ability acquired.\nBeam now penetrates walls.",
                         "Spanish": "Wave Beam ability acquired.\nBeam now penetrates walls."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1186,6 +1186,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1194,8 +1195,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1207,6 +1207,7 @@
                 "ItemSprite": "WideBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Wide Beam ability acquired.\nBeam widens dramatically.",
                         "JapaneseHiragana": "Wide Beam ability acquired.\nBeam widens dramatically.",
@@ -1215,8 +1216,7 @@
                         "French": "Wide Beam ability acquired.\nBeam widens dramatically.",
                         "Italian": "Wide Beam ability acquired.\nBeam widens dramatically.",
                         "Spanish": "Wide Beam ability acquired.\nBeam widens dramatically."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1228,6 +1228,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1236,8 +1237,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1249,6 +1249,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1257,8 +1258,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1270,6 +1270,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1278,8 +1279,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1291,6 +1291,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1299,8 +1300,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1312,6 +1312,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1320,8 +1321,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1333,6 +1333,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1341,8 +1342,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1354,6 +1354,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1362,8 +1363,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1375,6 +1375,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1383,8 +1384,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1396,6 +1396,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1404,8 +1405,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1417,6 +1417,7 @@
                 "ItemSprite": "PlasmaBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
                         "JapaneseHiragana": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
@@ -1425,8 +1426,7 @@
                         "French": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
                         "Italian": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
                         "Spanish": "Plasma Beam ability acquired.\nBeam now pierces enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1438,6 +1438,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1446,8 +1447,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1459,6 +1459,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1467,8 +1468,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1480,6 +1480,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1488,8 +1489,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1501,6 +1501,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1509,8 +1510,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1522,6 +1522,7 @@
                 "ItemSprite": "Bombs",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
@@ -1530,8 +1531,7 @@
                         "French": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
                         "Italian": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
                         "Spanish": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1543,6 +1543,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1551,8 +1552,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1564,6 +1564,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1572,8 +1573,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1585,6 +1585,7 @@
                 "ItemSprite": "Level2",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "JapaneseHiragana": "Security Level 2 unlocked.\nGreen hatches now active.",
@@ -1593,8 +1594,7 @@
                         "French": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "Italian": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "Spanish": "Security Level 2 unlocked.\nGreen hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1606,6 +1606,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1614,8 +1615,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1627,6 +1627,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1635,8 +1636,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1648,6 +1648,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1656,8 +1657,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1669,6 +1669,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1677,8 +1678,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1690,6 +1690,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1698,8 +1699,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1711,6 +1711,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1719,8 +1720,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1732,6 +1732,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1740,8 +1741,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1753,6 +1753,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1761,8 +1762,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1774,6 +1774,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1782,8 +1783,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1795,6 +1795,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1803,8 +1804,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1816,6 +1816,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1824,8 +1825,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1837,6 +1837,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1845,8 +1846,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1858,6 +1858,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1866,8 +1867,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1879,6 +1879,7 @@
                 "ItemSprite": "IceMissiles",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Ice effect added to Missiles.\nUse it to freeze enemies.",
                         "JapaneseHiragana": "Ice effect added to Missiles.\nUse it to freeze enemies.",
@@ -1887,8 +1888,7 @@
                         "French": "Ice effect added to Missiles.\nUse it to freeze enemies.",
                         "Italian": "Ice effect added to Missiles.\nUse it to freeze enemies.",
                         "Spanish": "Ice effect added to Missiles.\nUse it to freeze enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1900,6 +1900,7 @@
                 "ItemSprite": "VariaSuit",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "JapaneseHiragana": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
@@ -1908,8 +1909,7 @@
                         "French": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "Italian": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "Spanish": "Varia Suit effect acquired.\nSurvive extreme temperatures."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1921,6 +1921,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1929,8 +1930,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1942,6 +1942,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1950,8 +1951,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1963,6 +1963,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1971,8 +1972,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1984,6 +1984,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1992,8 +1993,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2005,6 +2005,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2013,8 +2014,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2026,6 +2026,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2034,8 +2035,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2047,6 +2047,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2055,8 +2056,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2068,6 +2068,7 @@
                 "ItemSprite": "SuperMissiles",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -2076,8 +2077,7 @@
                         "French": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Italian": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Spanish": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2089,6 +2089,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2097,8 +2098,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2110,6 +2110,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2118,8 +2119,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2131,6 +2131,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2139,8 +2140,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2152,6 +2152,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2160,8 +2161,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2173,6 +2173,7 @@
                 "ItemSprite": "Level4",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 4 unlocked.\nRed hatches now active.",
                         "JapaneseHiragana": "Security Level 4 unlocked.\nRed hatches now active.",
@@ -2181,8 +2182,7 @@
                         "French": "Security Level 4 unlocked.\nRed hatches now active.",
                         "Italian": "Security Level 4 unlocked.\nRed hatches now active.",
                         "Spanish": "Security Level 4 unlocked.\nRed hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2194,6 +2194,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2202,8 +2203,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2215,6 +2215,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2223,8 +2224,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2236,6 +2236,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2244,8 +2245,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2257,6 +2257,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2265,8 +2266,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2278,6 +2278,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2286,8 +2287,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2299,6 +2299,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2307,8 +2308,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2320,6 +2320,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2328,8 +2329,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2341,6 +2341,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2349,8 +2350,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2362,6 +2362,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2370,8 +2371,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2383,6 +2383,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2391,8 +2392,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2404,6 +2404,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2412,8 +2413,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2425,6 +2425,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2433,8 +2434,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2446,6 +2446,7 @@
                 "ItemSprite": "DiffusionMissiles",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
@@ -2454,8 +2455,7 @@
                         "French": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
                         "Italian": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
                         "Spanish": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2467,6 +2467,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2475,8 +2476,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2488,6 +2488,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -2496,8 +2497,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2509,6 +2509,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -2517,8 +2518,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2530,6 +2530,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -2538,8 +2539,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             }
         ]

--- a/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
@@ -31,6 +31,7 @@
                 "Item": "MorphBall",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
                         "JapaneseHiragana": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
@@ -39,8 +40,7 @@
                         "French": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
                         "Italian": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
                         "Spanish": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -66,6 +66,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -74,8 +75,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -92,6 +92,7 @@
                 "Item": "PowerBombs",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -100,8 +101,7 @@
                         "French": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Italian": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Spanish": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -118,6 +118,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -126,8 +127,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -135,6 +135,7 @@
                 "Item": "PlasmaBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
                         "JapaneseHiragana": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
@@ -143,8 +144,7 @@
                         "French": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
                         "Italian": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
                         "Spanish": "Plasma Beam ability acquired.\nBeam now pierces enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -152,6 +152,7 @@
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -160,8 +161,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -169,6 +169,7 @@
                 "Item": "IceMissiles",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Ice effect added to Missiles.\nUse it to freeze enemies.",
                         "JapaneseHiragana": "Ice effect added to Missiles.\nUse it to freeze enemies.",
@@ -177,8 +178,7 @@
                         "French": "Ice effect added to Missiles.\nUse it to freeze enemies.",
                         "Italian": "Ice effect added to Missiles.\nUse it to freeze enemies.",
                         "Spanish": "Ice effect added to Missiles.\nUse it to freeze enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -186,6 +186,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -194,8 +195,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -203,6 +203,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -211,8 +212,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -220,6 +220,7 @@
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -228,8 +229,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -246,6 +246,7 @@
                 "Item": "DiffusionMissiles",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
@@ -254,8 +255,7 @@
                         "French": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
                         "Italian": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
                         "Spanish": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -263,6 +263,7 @@
                 "Item": "SpaceJump",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Space Jump ability acquired.\nSomersault continually in air.",
                         "JapaneseHiragana": "Space Jump ability acquired.\nSomersault continually in air.",
@@ -271,8 +272,7 @@
                         "French": "Space Jump ability acquired.\nSomersault continually in air.",
                         "Italian": "Space Jump ability acquired.\nSomersault continually in air.",
                         "Spanish": "Space Jump ability acquired.\nSomersault continually in air."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -280,6 +280,7 @@
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -288,8 +289,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -297,6 +297,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -305,8 +306,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -314,6 +314,7 @@
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -322,8 +323,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -331,6 +331,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -339,8 +340,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -348,6 +348,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -356,8 +357,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -365,6 +365,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -373,8 +374,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             }
         ],
@@ -388,6 +388,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -396,8 +397,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -409,6 +409,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -417,8 +418,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -430,6 +430,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -438,8 +439,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -451,6 +451,7 @@
                 "ItemSprite": "HiJump",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Hi-Jump and Jumpball\nabilities acquired.",
                         "JapaneseHiragana": "Hi-Jump and Jumpball\nabilities acquired.",
@@ -459,8 +460,7 @@
                         "French": "Hi-Jump and Jumpball\nabilities acquired.",
                         "Italian": "Hi-Jump and Jumpball\nabilities acquired.",
                         "Spanish": "Hi-Jump and Jumpball\nabilities acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -472,6 +472,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -480,8 +481,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -493,6 +493,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -501,8 +502,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -514,6 +514,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -522,8 +523,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -535,6 +535,7 @@
                 "ItemSprite": "Level2",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "JapaneseHiragana": "Security Level 2 unlocked.\nGreen hatches now active.",
@@ -543,8 +544,7 @@
                         "French": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "Italian": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "Spanish": "Security Level 2 unlocked.\nGreen hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -556,6 +556,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -564,8 +565,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -577,6 +577,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -585,8 +586,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -598,6 +598,7 @@
                 "ItemSprite": "Level1",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "JapaneseHiragana": "Security Level 1 unlocked.\nBlue hatches now active.",
@@ -606,8 +607,7 @@
                         "French": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "Italian": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "Spanish": "Security Level 1 unlocked.\nBlue hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -619,6 +619,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -627,8 +628,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -640,6 +640,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -648,8 +649,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -661,6 +661,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -669,8 +670,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -682,6 +682,7 @@
                 "ItemSprite": "Bombs",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
@@ -690,8 +691,7 @@
                         "French": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
                         "Italian": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
                         "Spanish": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -703,6 +703,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -711,8 +712,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -724,6 +724,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -732,8 +733,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -745,6 +745,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -753,8 +754,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -766,6 +766,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -774,8 +775,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -787,6 +787,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -795,8 +796,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -808,6 +808,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -816,8 +817,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -829,6 +829,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -837,8 +838,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -850,6 +850,7 @@
                 "ItemSprite": "WaveBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Wave Beam ability acquired.\nBeam now penetrates walls.",
                         "JapaneseHiragana": "Wave Beam ability acquired.\nBeam now penetrates walls.",
@@ -858,8 +859,7 @@
                         "French": "Wave Beam ability acquired.\nBeam now penetrates walls.",
                         "Italian": "Wave Beam ability acquired.\nBeam now penetrates walls.",
                         "Spanish": "Wave Beam ability acquired.\nBeam now penetrates walls."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -871,6 +871,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -879,8 +880,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -892,6 +892,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -900,8 +901,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -913,6 +913,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -921,8 +922,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -934,6 +934,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -942,8 +943,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -955,6 +955,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -963,8 +964,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -976,6 +976,7 @@
                 "ItemSprite": "WideBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Wide Beam ability acquired.\nBeam widens dramatically.",
                         "JapaneseHiragana": "Wide Beam ability acquired.\nBeam widens dramatically.",
@@ -984,8 +985,7 @@
                         "French": "Wide Beam ability acquired.\nBeam widens dramatically.",
                         "Italian": "Wide Beam ability acquired.\nBeam widens dramatically.",
                         "Spanish": "Wide Beam ability acquired.\nBeam widens dramatically."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -997,6 +997,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1005,8 +1006,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1018,6 +1018,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1026,8 +1027,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1039,6 +1039,7 @@
                 "ItemSprite": "ChargeBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
                         "JapaneseHiragana": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
@@ -1047,8 +1048,7 @@
                         "French": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
                         "Italian": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
                         "Spanish": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1060,6 +1060,7 @@
                 "ItemSprite": "Missiles",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -1068,8 +1069,7 @@
                         "French": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Italian": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Spanish": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1081,6 +1081,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1089,8 +1090,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1102,6 +1102,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1110,8 +1111,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1123,6 +1123,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1131,8 +1132,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1144,6 +1144,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1152,8 +1153,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1165,6 +1165,7 @@
                 "ItemSprite": "Level4",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 4 unlocked.\nRed hatches now active.",
                         "JapaneseHiragana": "Security Level 4 unlocked.\nRed hatches now active.",
@@ -1173,8 +1174,7 @@
                         "French": "Security Level 4 unlocked.\nRed hatches now active.",
                         "Italian": "Security Level 4 unlocked.\nRed hatches now active.",
                         "Spanish": "Security Level 4 unlocked.\nRed hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1186,6 +1186,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1194,8 +1195,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1207,6 +1207,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1215,8 +1216,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1228,6 +1228,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1236,8 +1237,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1249,6 +1249,7 @@
                 "ItemSprite": "Level3",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 3 unlocked.\nYellow hatches now active.",
                         "JapaneseHiragana": "Security Level 3 unlocked.\nYellow hatches now active.",
@@ -1257,8 +1258,7 @@
                         "French": "Security Level 3 unlocked.\nYellow hatches now active.",
                         "Italian": "Security Level 3 unlocked.\nYellow hatches now active.",
                         "Spanish": "Security Level 3 unlocked.\nYellow hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1270,6 +1270,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1278,8 +1279,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1291,6 +1291,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1299,8 +1300,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1312,6 +1312,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1320,8 +1321,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1333,6 +1333,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1341,8 +1342,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1354,6 +1354,7 @@
                 "ItemSprite": "ScrewAttack",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Screw Attack ability regained.\nSomersault into enemies.",
                         "JapaneseHiragana": "Screw Attack ability regained.\nSomersault into enemies.",
@@ -1362,8 +1363,7 @@
                         "French": "Screw Attack ability regained.\nSomersault into enemies.",
                         "Italian": "Screw Attack ability regained.\nSomersault into enemies.",
                         "Spanish": "Screw Attack ability regained.\nSomersault into enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1375,6 +1375,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1383,8 +1384,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1396,6 +1396,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1404,8 +1405,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1417,6 +1417,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1425,8 +1426,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1438,6 +1438,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1446,8 +1447,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1459,6 +1459,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1467,8 +1468,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1480,6 +1480,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1488,8 +1489,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1501,6 +1501,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1509,8 +1510,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1522,6 +1522,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1530,8 +1531,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1543,6 +1543,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1551,8 +1552,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1564,6 +1564,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1572,8 +1573,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1585,6 +1585,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1593,8 +1594,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1606,6 +1606,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1614,8 +1615,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1627,6 +1627,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1635,8 +1636,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1648,6 +1648,7 @@
                 "ItemSprite": "IceBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Ice effect added to beam.\nUse beam to freeze enemies.",
                         "JapaneseHiragana": "Ice effect added to beam.\nUse beam to freeze enemies.",
@@ -1656,8 +1657,7 @@
                         "French": "Ice effect added to beam.\nUse beam to freeze enemies.",
                         "Italian": "Ice effect added to beam.\nUse beam to freeze enemies.",
                         "Spanish": "Ice effect added to beam.\nUse beam to freeze enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1669,6 +1669,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1677,8 +1678,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1690,6 +1690,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1698,8 +1699,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1711,6 +1711,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1719,8 +1720,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1732,6 +1732,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1740,8 +1741,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1753,6 +1753,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1761,8 +1762,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1774,6 +1774,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1782,8 +1783,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1795,6 +1795,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1803,8 +1804,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1816,6 +1816,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1824,8 +1825,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1837,6 +1837,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1845,8 +1846,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1858,6 +1858,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1866,8 +1867,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1879,6 +1879,7 @@
                 "ItemSprite": "VariaSuit",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "JapaneseHiragana": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
@@ -1887,8 +1888,7 @@
                         "French": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "Italian": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "Spanish": "Varia Suit effect acquired.\nSurvive extreme temperatures."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1900,6 +1900,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1908,8 +1909,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1921,6 +1921,7 @@
                 "ItemSprite": "SuperMissiles",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -1929,8 +1930,7 @@
                         "French": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Italian": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Spanish": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1942,6 +1942,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1950,8 +1951,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1963,6 +1963,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1971,8 +1972,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1984,6 +1984,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1992,8 +1993,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2005,6 +2005,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2013,8 +2014,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2026,6 +2026,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2034,8 +2035,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2047,6 +2047,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2055,8 +2056,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2068,6 +2068,7 @@
                 "ItemSprite": "GravitySuit",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Gravity Suit effect acquired.\nMove freely in liquids.",
                         "JapaneseHiragana": "Gravity Suit effect acquired.\nMove freely in liquids.",
@@ -2076,8 +2077,7 @@
                         "French": "Gravity Suit effect acquired.\nMove freely in liquids.",
                         "Italian": "Gravity Suit effect acquired.\nMove freely in liquids.",
                         "Spanish": "Gravity Suit effect acquired.\nMove freely in liquids."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2089,6 +2089,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2097,8 +2098,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2110,6 +2110,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2118,8 +2119,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2131,6 +2131,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2139,8 +2140,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2152,6 +2152,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2160,8 +2161,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2173,6 +2173,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2181,8 +2182,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2194,6 +2194,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2202,8 +2203,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2215,6 +2215,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2223,8 +2224,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2236,6 +2236,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2244,8 +2245,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2257,6 +2257,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2265,8 +2266,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2278,6 +2278,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2286,8 +2287,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2299,6 +2299,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2307,8 +2308,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2320,6 +2320,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2328,8 +2329,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2341,6 +2341,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2349,8 +2350,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2362,6 +2362,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2370,8 +2371,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2383,6 +2383,7 @@
                 "ItemSprite": "SpeedBooster",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Speed Booster power regained.\nRun until speed boost begins.",
                         "JapaneseHiragana": "Speed Booster power regained.\nRun until speed boost begins.",
@@ -2391,8 +2392,7 @@
                         "French": "Speed Booster power regained.\nRun until speed boost begins.",
                         "Italian": "Speed Booster power regained.\nRun until speed boost begins.",
                         "Spanish": "Speed Booster power regained.\nRun until speed boost begins."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2404,6 +2404,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2412,8 +2413,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2425,6 +2425,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2433,8 +2434,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2446,6 +2446,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2454,8 +2455,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2467,6 +2467,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2475,8 +2476,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2488,6 +2488,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -2496,8 +2497,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2509,6 +2509,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -2517,8 +2518,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2530,6 +2530,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -2538,8 +2539,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             }
         ]

--- a/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
@@ -36,6 +36,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -44,8 +45,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -53,6 +53,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -61,8 +62,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -70,6 +70,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -78,8 +79,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -87,6 +87,7 @@
                 "Item": "ScrewAttack",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Screw Attack ability regained.\nSomersault into enemies.",
                         "JapaneseHiragana": "Screw Attack ability regained.\nSomersault into enemies.",
@@ -95,8 +96,7 @@
                         "French": "Screw Attack ability regained.\nSomersault into enemies.",
                         "Italian": "Screw Attack ability regained.\nSomersault into enemies.",
                         "Spanish": "Screw Attack ability regained.\nSomersault into enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -104,6 +104,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -112,8 +113,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -121,6 +121,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -129,8 +130,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -138,6 +138,7 @@
                 "Item": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -146,8 +147,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -155,6 +155,7 @@
                 "Item": "IceBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Ice effect added to beam.\nUse beam to freeze enemies.",
                         "JapaneseHiragana": "Ice effect added to beam.\nUse beam to freeze enemies.",
@@ -163,8 +164,7 @@
                         "French": "Ice effect added to beam.\nUse beam to freeze enemies.",
                         "Italian": "Ice effect added to beam.\nUse beam to freeze enemies.",
                         "Spanish": "Ice effect added to beam.\nUse beam to freeze enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -172,6 +172,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -180,8 +181,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -189,6 +189,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -197,8 +198,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -206,6 +206,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -214,8 +215,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -223,6 +223,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -231,8 +232,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -240,6 +240,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -248,8 +249,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -257,6 +257,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -265,8 +266,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -274,6 +274,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -282,8 +283,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -291,6 +291,7 @@
                 "Item": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -299,8 +300,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -308,6 +308,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -316,8 +317,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -325,6 +325,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -333,8 +334,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -342,6 +342,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -350,8 +351,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -359,6 +359,7 @@
                 "Item": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -367,8 +368,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -376,6 +376,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -384,8 +385,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -393,6 +393,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -401,8 +402,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -410,6 +410,7 @@
                 "Item": "None",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -418,8 +419,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             }
         ],
@@ -433,6 +433,7 @@
                 "ItemSprite": "Level1",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "JapaneseHiragana": "Security Level 1 unlocked.\nBlue hatches now active.",
@@ -441,8 +442,7 @@
                         "French": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "Italian": "Security Level 1 unlocked.\nBlue hatches now active.",
                         "Spanish": "Security Level 1 unlocked.\nBlue hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -454,6 +454,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -462,8 +463,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -475,6 +475,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -483,8 +484,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -496,6 +496,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -504,8 +505,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -517,6 +517,7 @@
                 "ItemSprite": "MorphBall",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
                         "JapaneseHiragana": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
@@ -525,8 +526,7 @@
                         "French": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
                         "Italian": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph.",
                         "Spanish": "Morph Ball ability acquired.\nPress [Down_button_left][Down_button_right] twice to morph."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -538,6 +538,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -546,8 +547,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -559,6 +559,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -567,8 +568,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -580,6 +580,7 @@
                 "ItemSprite": "HiJump",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Hi-Jump and Jumpball\nabilities acquired.",
                         "JapaneseHiragana": "Hi-Jump and Jumpball\nabilities acquired.",
@@ -588,8 +589,7 @@
                         "French": "Hi-Jump and Jumpball\nabilities acquired.",
                         "Italian": "Hi-Jump and Jumpball\nabilities acquired.",
                         "Spanish": "Hi-Jump and Jumpball\nabilities acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -601,6 +601,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -609,8 +610,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -622,6 +622,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -630,8 +631,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -643,6 +643,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -651,8 +652,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -664,6 +664,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -672,8 +673,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -685,6 +685,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -693,8 +694,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -706,6 +706,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -714,8 +715,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -727,6 +727,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -735,8 +736,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -748,6 +748,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -756,8 +757,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -769,6 +769,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -777,8 +778,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -790,6 +790,7 @@
                 "ItemSprite": "SuperMissiles",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
@@ -798,8 +799,7 @@
                         "French": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Italian": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
                         "Spanish": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -811,6 +811,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -819,8 +820,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -832,6 +832,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -840,8 +841,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -853,6 +853,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -861,8 +862,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -874,6 +874,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -882,8 +883,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -895,6 +895,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -903,8 +904,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -916,6 +916,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -924,8 +925,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -937,6 +937,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -945,8 +946,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -958,6 +958,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -966,8 +967,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -979,6 +979,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -987,8 +988,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1000,6 +1000,7 @@
                 "ItemSprite": "DiffusionMissiles",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
@@ -1008,8 +1009,7 @@
                         "French": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
                         "Italian": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
                         "Spanish": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1021,6 +1021,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1029,8 +1030,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1042,6 +1042,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -1050,8 +1051,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1063,6 +1063,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1071,8 +1072,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1084,6 +1084,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1092,8 +1093,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1105,6 +1105,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1113,8 +1114,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1126,6 +1126,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1134,8 +1135,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1147,6 +1147,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1155,8 +1156,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1168,6 +1168,7 @@
                 "ItemSprite": "Level3",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 3 unlocked.\nYellow hatches now active.",
                         "JapaneseHiragana": "Security Level 3 unlocked.\nYellow hatches now active.",
@@ -1176,8 +1177,7 @@
                         "French": "Security Level 3 unlocked.\nYellow hatches now active.",
                         "Italian": "Security Level 3 unlocked.\nYellow hatches now active.",
                         "Spanish": "Security Level 3 unlocked.\nYellow hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1189,6 +1189,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1197,8 +1198,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1210,6 +1210,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1218,8 +1219,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1231,6 +1231,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1239,8 +1240,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1252,6 +1252,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1260,8 +1261,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1273,6 +1273,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1281,8 +1282,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1294,6 +1294,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1302,8 +1303,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1315,6 +1315,7 @@
                 "ItemSprite": "GravitySuit",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Gravity Suit effect acquired.\nMove freely in liquids.",
                         "JapaneseHiragana": "Gravity Suit effect acquired.\nMove freely in liquids.",
@@ -1323,8 +1324,7 @@
                         "French": "Gravity Suit effect acquired.\nMove freely in liquids.",
                         "Italian": "Gravity Suit effect acquired.\nMove freely in liquids.",
                         "Spanish": "Gravity Suit effect acquired.\nMove freely in liquids."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1336,6 +1336,7 @@
                 "ItemSprite": "SpaceJump",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Space Jump ability acquired.\nSomersault continually in air.",
                         "JapaneseHiragana": "Space Jump ability acquired.\nSomersault continually in air.",
@@ -1344,8 +1345,7 @@
                         "French": "Space Jump ability acquired.\nSomersault continually in air.",
                         "Italian": "Space Jump ability acquired.\nSomersault continually in air.",
                         "Spanish": "Space Jump ability acquired.\nSomersault continually in air."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1357,6 +1357,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1365,8 +1366,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1378,6 +1378,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1386,8 +1387,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1399,6 +1399,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1407,8 +1408,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1420,6 +1420,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1428,8 +1429,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1441,6 +1441,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1449,8 +1450,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1462,6 +1462,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1470,8 +1471,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1483,6 +1483,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1491,8 +1492,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1504,6 +1504,7 @@
                 "ItemSprite": "Level2",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "JapaneseHiragana": "Security Level 2 unlocked.\nGreen hatches now active.",
@@ -1512,8 +1513,7 @@
                         "French": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "Italian": "Security Level 2 unlocked.\nGreen hatches now active.",
                         "Spanish": "Security Level 2 unlocked.\nGreen hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1525,6 +1525,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1533,8 +1534,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1546,6 +1546,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1554,8 +1555,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1567,6 +1567,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1575,8 +1576,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1588,6 +1588,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1596,8 +1597,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1609,6 +1609,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1617,8 +1618,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1630,6 +1630,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1638,8 +1639,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1651,6 +1651,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1659,8 +1660,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1672,6 +1672,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1680,8 +1681,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1693,6 +1693,7 @@
                 "ItemSprite": "Bombs",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
                         "JapaneseHiragana": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
@@ -1701,8 +1702,7 @@
                         "French": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
                         "Italian": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
                         "Spanish": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right]."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1714,6 +1714,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -1722,8 +1723,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1735,6 +1735,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1743,8 +1744,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1756,6 +1756,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1764,8 +1765,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1777,6 +1777,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1785,8 +1786,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1798,6 +1798,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1806,8 +1807,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1819,6 +1819,7 @@
                 "ItemSprite": "WideBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Wide Beam ability acquired.\nBeam widens dramatically.",
                         "JapaneseHiragana": "Wide Beam ability acquired.\nBeam widens dramatically.",
@@ -1827,8 +1828,7 @@
                         "French": "Wide Beam ability acquired.\nBeam widens dramatically.",
                         "Italian": "Wide Beam ability acquired.\nBeam widens dramatically.",
                         "Spanish": "Wide Beam ability acquired.\nBeam widens dramatically."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1840,6 +1840,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1848,8 +1849,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1861,6 +1861,7 @@
                 "ItemSprite": "Level4",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Security Level 4 unlocked.\nRed hatches now active.",
                         "JapaneseHiragana": "Security Level 4 unlocked.\nRed hatches now active.",
@@ -1869,8 +1870,7 @@
                         "French": "Security Level 4 unlocked.\nRed hatches now active.",
                         "Italian": "Security Level 4 unlocked.\nRed hatches now active.",
                         "Spanish": "Security Level 4 unlocked.\nRed hatches now active."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1882,6 +1882,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1890,8 +1891,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1903,6 +1903,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1911,8 +1912,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1924,6 +1924,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -1932,8 +1933,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1945,6 +1945,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1953,8 +1954,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1966,6 +1966,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1974,8 +1975,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -1987,6 +1987,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -1995,8 +1996,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2008,6 +2008,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2016,8 +2017,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2029,6 +2029,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2037,8 +2038,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2050,6 +2050,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2058,8 +2059,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2071,6 +2071,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2079,8 +2080,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2092,6 +2092,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2100,8 +2101,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2113,6 +2113,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2121,8 +2122,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2134,6 +2134,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2142,8 +2143,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2155,6 +2155,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2163,8 +2164,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2176,6 +2176,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2184,8 +2185,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2197,6 +2197,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2205,8 +2206,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2218,6 +2218,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2226,8 +2227,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2239,6 +2239,7 @@
                 "ItemSprite": "PlasmaBeam",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
                         "JapaneseHiragana": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
@@ -2247,8 +2248,7 @@
                         "French": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
                         "Italian": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
                         "Spanish": "Plasma Beam ability acquired.\nBeam now pierces enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2260,6 +2260,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2268,8 +2269,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2281,6 +2281,7 @@
                 "ItemSprite": "IceMissiles",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Ice effect added to Missiles.\nUse it to freeze enemies.",
                         "JapaneseHiragana": "Ice effect added to Missiles.\nUse it to freeze enemies.",
@@ -2289,8 +2290,7 @@
                         "French": "Ice effect added to Missiles.\nUse it to freeze enemies.",
                         "Italian": "Ice effect added to Missiles.\nUse it to freeze enemies.",
                         "Spanish": "Ice effect added to Missiles.\nUse it to freeze enemies."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2302,6 +2302,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2310,8 +2311,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2323,6 +2323,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2331,8 +2332,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2344,6 +2344,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2352,8 +2353,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2365,6 +2365,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2373,8 +2374,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2386,6 +2386,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2394,8 +2395,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2407,6 +2407,7 @@
                 "ItemSprite": "VariaSuit",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "JapaneseHiragana": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
@@ -2415,8 +2416,7 @@
                         "French": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "Italian": "Varia Suit effect acquired.\nSurvive extreme temperatures.",
                         "Spanish": "Varia Suit effect acquired.\nSurvive extreme temperatures."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2428,6 +2428,7 @@
                 "ItemSprite": "SpeedBooster",
                 "Jingle": "Major",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Speed Booster power regained.\nRun until speed boost begins.",
                         "JapaneseHiragana": "Speed Booster power regained.\nRun until speed boost begins.",
@@ -2436,8 +2437,7 @@
                         "French": "Speed Booster power regained.\nRun until speed boost begins.",
                         "Italian": "Speed Booster power regained.\nRun until speed boost begins.",
                         "Spanish": "Speed Booster power regained.\nRun until speed boost begins."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2449,6 +2449,7 @@
                 "ItemSprite": "MissileTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Missile Tank acquired.\nCapacity increased by 5.",
                         "JapaneseHiragana": "Missile Tank acquired.\nCapacity increased by 5.",
@@ -2457,8 +2458,7 @@
                         "French": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Italian": "Missile Tank acquired.\nCapacity increased by 5.",
                         "Spanish": "Missile Tank acquired.\nCapacity increased by 5."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2470,6 +2470,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -2478,8 +2479,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2491,6 +2491,7 @@
                 "ItemSprite": "PowerBombTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "JapaneseHiragana": "Power Bomb Tank acquired.\nCapacity increased by 2.",
@@ -2499,8 +2500,7 @@
                         "French": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Italian": "Power Bomb Tank acquired.\nCapacity increased by 2.",
                         "Spanish": "Power Bomb Tank acquired.\nCapacity increased by 2."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2512,6 +2512,7 @@
                 "ItemSprite": "EnergyTank",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Energy Tank acquired.\nCapacity increased by 100.",
                         "JapaneseHiragana": "Energy Tank acquired.\nCapacity increased by 100.",
@@ -2520,8 +2521,7 @@
                         "French": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Italian": "Energy Tank acquired.\nCapacity increased by 100.",
                         "Spanish": "Energy Tank acquired.\nCapacity increased by 100."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2533,6 +2533,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -2541,8 +2542,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2554,6 +2554,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -2562,8 +2563,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             },
             {
@@ -2575,6 +2575,7 @@
                 "ItemSprite": "Empty",
                 "Jingle": "Minor",
                 "ItemMessages": {
+                    "Kind": "CustomMessage",
                     "Languages": {
                         "JapaneseKanji": "Nothing acquired.",
                         "JapaneseHiragana": "Nothing acquired.",
@@ -2583,8 +2584,7 @@
                         "French": "Nothing acquired.",
                         "Italian": "Nothing acquired.",
                         "Spanish": "Nothing acquired."
-                    },
-                    "Kind": "CustomMessage"
+                    }
                 }
             }
         ]


### PR DESCRIPTION
Changed one rdvgame in order to hit the test case of "nothing was replaced with metroid data"