### PR TITLE
Fusion: Fix unable to export game in weird edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: 5 joke hints.
 - Added: Racetime integration with category https://racetime.gg/mfr-rdv
 - Fixed: Incorrect exporting behaviour, if the option to hide text of pickups was enabled.
+- Fixed: Unable to export a randomized game, in case the input file could not be read.
 - Removed: The "Anti-Softlock" option and instead made the following permanent changes:
   - Sector 2 Ripper Tower: The Crumble Block is moved one tile up to make it easier to Screw Attack the Bomb Block.
   - Sector 2 Crumble City: On the far left of the tunnel, the Shot Block has been changed into a Crumble Block.

--- a/randovania/games/fusion/gui/dialog/game_export_dialog.py
+++ b/randovania/games/fusion/gui/dialog/game_export_dialog.py
@@ -36,9 +36,14 @@ def is_fusion_validator(path: Path | None) -> bool:
     if is_file_validator(path):
         return True
     assert path is not None
-    with path.open("rb") as file:
-        data = file.read()
-        md5_returned = hashlib.md5(data).hexdigest()
+    try:
+        with path.open("rb") as file:
+            data = file.read()
+            md5_returned = hashlib.md5(data).hexdigest()
+    except Exception:
+        # If any error during opening happens, suppress that and pretend its invalid,
+        # as otherwise it would cause the dialog to be inaccessible.
+        return True
     if md5_expected == md5_returned:
         return False
     else:


### PR DESCRIPTION
I have no clue how this can even happen considering we use is_file_validator right before. Couldn't find anything on the docs either, other than invalid path or no perms to open, neither of which I think are the case here
But apparently it does happen, so band-aid it is.