### PR TITLE
WIP: Item collection notifications discord webhook

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,7 @@
     "qtForPython.uic.liveExecution.enabled": false,
     "mypy-type-checker.args": [
         "--config-file=${workspaceFolder}/pyproject.toml"
-    ]
+    ],
+    "python.venvPath": "./.venv",
+    "python.analysis.typeCheckingMode": "off"
 }

--- a/randovania/games/am2r/gui/generated/am2r_cosmetic_patches_dialog_ui.py
+++ b/randovania/games/am2r/gui/generated/am2r_cosmetic_patches_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'am2r_cosmetic_patches_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/am2r/gui/generated/am2r_game_export_dialog_ui.py
+++ b/randovania/games/am2r/gui/generated/am2r_game_export_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'am2r_game_export_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/am2r/gui/generated/games_tab_am2r_widget_ui.py
+++ b/randovania/games/am2r/gui/generated/games_tab_am2r_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'games_tab_am2r_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/am2r/gui/generated/preset_am2r_chaos_ui.py
+++ b/randovania/games/am2r/gui/generated/preset_am2r_chaos_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_am2r_chaos.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/am2r/gui/generated/preset_am2r_gameplay_ui.py
+++ b/randovania/games/am2r/gui/generated/preset_am2r_gameplay_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_am2r_gameplay.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/am2r/gui/generated/preset_am2r_goal_ui.py
+++ b/randovania/games/am2r/gui/generated/preset_am2r_goal_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_am2r_goal.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/am2r/gui/generated/preset_am2r_hints_ui.py
+++ b/randovania/games/am2r/gui/generated/preset_am2r_hints_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_am2r_hints.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/am2r/gui/generated/preset_am2r_room_design_ui.py
+++ b/randovania/games/am2r/gui/generated/preset_am2r_room_design_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_am2r_room_design.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/am2r/gui/generated/preset_teleporters_am2r_ui.py
+++ b/randovania/games/am2r/gui/generated/preset_teleporters_am2r_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_teleporters_am2r.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/blank/gui/generated/blank_cosmetic_patches_dialog_ui.py
+++ b/randovania/games/blank/gui/generated/blank_cosmetic_patches_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'blank_cosmetic_patches_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/blank/gui/generated/games_tab_blank_widget_ui.py
+++ b/randovania/games/blank/gui/generated/games_tab_blank_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'games_tab_blank_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/cave_story/gui/generated/cs_cosmetic_patches_dialog_ui.py
+++ b/randovania/games/cave_story/gui/generated/cs_cosmetic_patches_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'cs_cosmetic_patches_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/cave_story/gui/generated/cs_game_export_dialog_ui.py
+++ b/randovania/games/cave_story/gui/generated/cs_game_export_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'cs_game_export_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/cave_story/gui/generated/games_tab_cavestory_widget_ui.py
+++ b/randovania/games/cave_story/gui/generated/games_tab_cavestory_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'games_tab_cavestory_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/cave_story/gui/generated/preset_cs_hp_ui.py
+++ b/randovania/games/cave_story/gui/generated/preset_cs_hp_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_cs_hp.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/cave_story/gui/generated/preset_cs_objective_ui.py
+++ b/randovania/games/cave_story/gui/generated/preset_cs_objective_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_cs_objective.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/dread/gui/generated/dread_cosmetic_patches_dialog_ui.py
+++ b/randovania/games/dread/gui/generated/dread_cosmetic_patches_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'dread_cosmetic_patches_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/dread/gui/generated/dread_game_export_dialog_ui.py
+++ b/randovania/games/dread/gui/generated/dread_game_export_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'dread_game_export_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/dread/gui/generated/games_tab_dread_widget_ui.py
+++ b/randovania/games/dread/gui/generated/games_tab_dread_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'games_tab_dread_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/dread/gui/generated/preset_dread_chaos_ui.py
+++ b/randovania/games/dread/gui/generated/preset_dread_chaos_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_dread_chaos.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/dread/gui/generated/preset_dread_energy_ui.py
+++ b/randovania/games/dread/gui/generated/preset_dread_energy_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_dread_energy.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/dread/gui/generated/preset_dread_goal_ui.py
+++ b/randovania/games/dread/gui/generated/preset_dread_goal_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_dread_goal.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/dread/gui/generated/preset_dread_lights_ui.py
+++ b/randovania/games/dread/gui/generated/preset_dread_lights_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_dread_lights.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/dread/gui/generated/preset_dread_patches_ui.py
+++ b/randovania/games/dread/gui/generated/preset_dread_patches_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_dread_patches.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/dread/gui/generated/preset_teleporters_dread_ui.py
+++ b/randovania/games/dread/gui/generated/preset_teleporters_dread_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_teleporters_dread.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/factorio/gui/generated/factorio_game_export_dialog_ui.py
+++ b/randovania/games/factorio/gui/generated/factorio_game_export_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'factorio_game_export_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/factorio/gui/generated/games_tab_factorio_widget_ui.py
+++ b/randovania/games/factorio/gui/generated/games_tab_factorio_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'games_tab_factorio_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/factorio/gui/generated/preset_factorio_patches_ui.py
+++ b/randovania/games/factorio/gui/generated/preset_factorio_patches_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_factorio_patches.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/fusion/gui/generated/fusion_cosmetic_patches_dialog_ui.py
+++ b/randovania/games/fusion/gui/generated/fusion_cosmetic_patches_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'fusion_cosmetic_patches_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/fusion/gui/generated/fusion_game_export_dialog_ui.py
+++ b/randovania/games/fusion/gui/generated/fusion_game_export_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'fusion_game_export_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/fusion/gui/generated/games_tab_fusion_widget_ui.py
+++ b/randovania/games/fusion/gui/generated/games_tab_fusion_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'games_tab_fusion_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/fusion/gui/generated/preset_fusion_goal_ui.py
+++ b/randovania/games/fusion/gui/generated/preset_fusion_goal_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_fusion_goal.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/fusion/gui/generated/preset_fusion_hints_ui.py
+++ b/randovania/games/fusion/gui/generated/preset_fusion_hints_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_fusion_hints.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/fusion/gui/generated/preset_fusion_patches_ui.py
+++ b/randovania/games/fusion/gui/generated/preset_fusion_patches_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_fusion_patches.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/planets_zebeth/gui/generated/games_tab_planets_zebeth_widget_ui.py
+++ b/randovania/games/planets_zebeth/gui/generated/games_tab_planets_zebeth_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'games_tab_planets_zebeth_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/planets_zebeth/gui/generated/planets_zebeth_cosmetic_patches_dialog_ui.py
+++ b/randovania/games/planets_zebeth/gui/generated/planets_zebeth_cosmetic_patches_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'planets_zebeth_cosmetic_patches_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/planets_zebeth/gui/generated/planets_zebeth_game_export_dialog_ui.py
+++ b/randovania/games/planets_zebeth/gui/generated/planets_zebeth_game_export_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'planets_zebeth_game_export_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/planets_zebeth/gui/generated/preset_planets_zebeth_goal_ui.py
+++ b/randovania/games/planets_zebeth/gui/generated/preset_planets_zebeth_goal_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_planets_zebeth_goal.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime1/gui/generated/games_tab_prime_widget_ui.py
+++ b/randovania/games/prime1/gui/generated/games_tab_prime_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'games_tab_prime_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime1/gui/generated/preset_prime_chaos_ui.py
+++ b/randovania/games/prime1/gui/generated/preset_prime_chaos_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_prime_chaos.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime1/gui/generated/preset_prime_enemy_stat_randomizer_ui.py
+++ b/randovania/games/prime1/gui/generated/preset_prime_enemy_stat_randomizer_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_prime_enemy_stat_randomizer.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime1/gui/generated/preset_prime_goal_ui.py
+++ b/randovania/games/prime1/gui/generated/preset_prime_goal_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_prime_goal.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime1/gui/generated/preset_prime_qol_ui.py
+++ b/randovania/games/prime1/gui/generated/preset_prime_qol_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_prime_qol.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime1/gui/generated/preset_teleporters_prime1_ui.py
+++ b/randovania/games/prime1/gui/generated/preset_teleporters_prime1_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_teleporters_prime1.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime1/gui/generated/prime_cosmetic_patches_dialog_ui.py
+++ b/randovania/games/prime1/gui/generated/prime_cosmetic_patches_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'prime_cosmetic_patches_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime1/gui/generated/prime_game_export_dialog_ui.py
+++ b/randovania/games/prime1/gui/generated/prime_game_export_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'prime_game_export_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime2/gui/generated/echoes_cosmetic_patches_dialog_ui.py
+++ b/randovania/games/prime2/gui/generated/echoes_cosmetic_patches_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'echoes_cosmetic_patches_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime2/gui/generated/echoes_game_export_dialog_ui.py
+++ b/randovania/games/prime2/gui/generated/echoes_game_export_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'echoes_game_export_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime2/gui/generated/games_tab_echoes_widget_ui.py
+++ b/randovania/games/prime2/gui/generated/games_tab_echoes_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'games_tab_echoes_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime2/gui/generated/preset_echoes_beam_configuration_ui.py
+++ b/randovania/games/prime2/gui/generated/preset_echoes_beam_configuration_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_echoes_beam_configuration.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime2/gui/generated/preset_echoes_goal_ui.py
+++ b/randovania/games/prime2/gui/generated/preset_echoes_goal_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_echoes_goal.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime2/gui/generated/preset_echoes_hints_ui.py
+++ b/randovania/games/prime2/gui/generated/preset_echoes_hints_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_echoes_hints.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime2/gui/generated/preset_echoes_patches_ui.py
+++ b/randovania/games/prime2/gui/generated/preset_echoes_patches_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_echoes_patches.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime2/gui/generated/preset_echoes_translators_ui.py
+++ b/randovania/games/prime2/gui/generated/preset_echoes_translators_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_echoes_translators.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime2/gui/generated/preset_teleporters_prime2_ui.py
+++ b/randovania/games/prime2/gui/generated/preset_teleporters_prime2_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_teleporters_prime2.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime_hunters/gui/generated/games_tab_prime_hunters_widget_ui.py
+++ b/randovania/games/prime_hunters/gui/generated/games_tab_prime_hunters_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'games_tab_prime_hunters_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime_hunters/gui/generated/preset_prime_hunters_force_fields_ui.py
+++ b/randovania/games/prime_hunters/gui/generated/preset_prime_hunters_force_fields_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_prime_hunters_force_fields.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime_hunters/gui/generated/preset_prime_hunters_goal_ui.py
+++ b/randovania/games/prime_hunters/gui/generated/preset_prime_hunters_goal_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_prime_hunters_goal.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime_hunters/gui/generated/preset_teleporters_prime_hunters_ui.py
+++ b/randovania/games/prime_hunters/gui/generated/preset_teleporters_prime_hunters_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_teleporters_prime_hunters.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/prime_hunters/gui/generated/prime_hunters_cosmetic_patches_dialog_ui.py
+++ b/randovania/games/prime_hunters/gui/generated/prime_hunters_cosmetic_patches_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'prime_hunters_cosmetic_patches_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/samus_returns/gui/generated/games_tab_samusreturns_widget_ui.py
+++ b/randovania/games/samus_returns/gui/generated/games_tab_samusreturns_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'games_tab_samusreturns_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/samus_returns/gui/generated/msr_cosmetic_patches_dialog_ui.py
+++ b/randovania/games/samus_returns/gui/generated/msr_cosmetic_patches_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'msr_cosmetic_patches_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/samus_returns/gui/generated/msr_game_export_dialog_ui.py
+++ b/randovania/games/samus_returns/gui/generated/msr_game_export_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'msr_game_export_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/samus_returns/gui/generated/preset_msr_aeion_and_energy_ui.py
+++ b/randovania/games/samus_returns/gui/generated/preset_msr_aeion_and_energy_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_msr_aeion_and_energy.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/samus_returns/gui/generated/preset_msr_goal_ui.py
+++ b/randovania/games/samus_returns/gui/generated/preset_msr_goal_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_msr_goal.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/samus_returns/gui/generated/preset_msr_hints_ui.py
+++ b/randovania/games/samus_returns/gui/generated/preset_msr_hints_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_msr_hints.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/samus_returns/gui/generated/preset_msr_patches_ui.py
+++ b/randovania/games/samus_returns/gui/generated/preset_msr_patches_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_msr_patches.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/samus_returns/gui/generated/preset_msr_reserves_ui.py
+++ b/randovania/games/samus_returns/gui/generated/preset_msr_reserves_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_msr_reserves.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/games/samus_returns/gui/generated/preset_teleporters_msr_ui.py
+++ b/randovania/games/samus_returns/gui/generated/preset_teleporters_msr_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_teleporters_msr.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/area_details_popup_ui.py
+++ b/randovania/gui/generated/area_details_popup_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'area_details_popup.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/async_race_admin_dialog_ui.py
+++ b/randovania/gui/generated/async_race_admin_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'async_race_admin_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/async_race_creation_dialog_ui.py
+++ b/randovania/gui/generated/async_race_creation_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'async_race_creation_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/async_race_proof_popup_ui.py
+++ b/randovania/gui/generated/async_race_proof_popup_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'async_race_proof_popup.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/async_race_room_window_ui.py
+++ b/randovania/gui/generated/async_race_room_window_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'async_race_room_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/async_race_settings_ui.py
+++ b/randovania/gui/generated/async_race_settings_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'async_race_settings.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/auto_tracker_window_ui.py
+++ b/randovania/gui/generated/auto_tracker_window_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'auto_tracker_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/background_process_dialog_ui.py
+++ b/randovania/gui/generated/background_process_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'background_process_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/connections_editor_ui.py
+++ b/randovania/gui/generated/connections_editor_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'connections_editor.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/customize_preset_dialog_ui.py
+++ b/randovania/gui/generated/customize_preset_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'customize_preset_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/data_editor_ui.py
+++ b/randovania/gui/generated/data_editor_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'data_editor.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/debug_connector_window_ui.py
+++ b/randovania/gui/generated/debug_connector_window_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'debug_connector_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/game_connection_window_ui.py
+++ b/randovania/gui/generated/game_connection_window_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'game_connection_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/game_details_window_ui.py
+++ b/randovania/gui/generated/game_details_window_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'game_details_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/game_validator_widget_ui.py
+++ b/randovania/gui/generated/game_validator_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'game_validator_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/generate_game_widget_ui.py
+++ b/randovania/gui/generated/generate_game_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'generate_game_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/hint_feature_database_editor_ui.py
+++ b/randovania/gui/generated/hint_feature_database_editor_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'hint_feature_database_editor.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/hint_feature_tab_ui.py
+++ b/randovania/gui/generated/hint_feature_tab_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'hint_feature_tab.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/login_prompt_dialog_ui.py
+++ b/randovania/gui/generated/login_prompt_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'login_prompt_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/main_window_ui.py
+++ b/randovania/gui/generated/main_window_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'main_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/multiplayer_session_browser_dialog_ui.py
+++ b/randovania/gui/generated/multiplayer_session_browser_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'multiplayer_session_browser_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/multiplayer_session_ui.py
+++ b/randovania/gui/generated/multiplayer_session_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'multiplayer_session.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/multiplayer_session_ui.py
+++ b/randovania/gui/generated/multiplayer_session_ui.py
@@ -142,6 +142,37 @@ class Ui_MultiplayerSessionWindow(object):
 
         self.session_admin_layout.addWidget(self.allow_coop_check, 3, 0, 1, 1)
 
+        self.horizontalLayout = QHBoxLayout()
+        self.horizontalLayout.setSpacing(6)
+        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.notification_webhook_textbox = QLineEdit(self.session_admin_group)
+        self.notification_webhook_textbox.setObjectName(u"notification_webhook_textbox")
+        sizePolicy1.setHeightForWidth(self.notification_webhook_textbox.sizePolicy().hasHeightForWidth())
+        self.notification_webhook_textbox.setSizePolicy(sizePolicy1)
+        self.notification_webhook_textbox.setMaximumSize(QSize(450, 24))
+
+        self.horizontalLayout.addWidget(self.notification_webhook_textbox)
+
+        self.notification_webhook_set_button = QPushButton(self.session_admin_group)
+        self.notification_webhook_set_button.setObjectName(u"notification_webhook_set_button")
+        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Fixed)
+        sizePolicy2.setHorizontalStretch(0)
+        sizePolicy2.setVerticalStretch(0)
+        sizePolicy2.setHeightForWidth(self.notification_webhook_set_button.sizePolicy().hasHeightForWidth())
+        self.notification_webhook_set_button.setSizePolicy(sizePolicy2)
+
+        self.horizontalLayout.addWidget(self.notification_webhook_set_button)
+
+        self.notification_webhook_clear_button = QPushButton(self.session_admin_group)
+        self.notification_webhook_clear_button.setObjectName(u"notification_webhook_clear_button")
+        sizePolicy2.setHeightForWidth(self.notification_webhook_clear_button.sizePolicy().hasHeightForWidth())
+        self.notification_webhook_clear_button.setSizePolicy(sizePolicy2)
+
+        self.horizontalLayout.addWidget(self.notification_webhook_clear_button)
+
+
+        self.session_admin_layout.addLayout(self.horizontalLayout, 2, 1, 1, 1)
+
 
         self.session_tab_layout.addWidget(self.session_admin_group, 0, 0, 1, 2)
 
@@ -230,11 +261,11 @@ class Ui_MultiplayerSessionWindow(object):
 
         self.progress_label = QLabel(self.central_widget)
         self.progress_label.setObjectName(u"progress_label")
-        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
-        sizePolicy2.setHorizontalStretch(0)
-        sizePolicy2.setVerticalStretch(0)
-        sizePolicy2.setHeightForWidth(self.progress_label.sizePolicy().hasHeightForWidth())
-        self.progress_label.setSizePolicy(sizePolicy2)
+        sizePolicy3 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        sizePolicy3.setHorizontalStretch(0)
+        sizePolicy3.setVerticalStretch(0)
+        sizePolicy3.setHeightForWidth(self.progress_label.sizePolicy().hasHeightForWidth())
+        self.progress_label.setSizePolicy(sizePolicy3)
         self.progress_label.setTextFormat(Qt.TextFormat.MarkdownText)
         self.progress_label.setAlignment(Qt.AlignmentFlag.AlignLeading|Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
         self.progress_label.setWordWrap(True)
@@ -264,12 +295,12 @@ class Ui_MultiplayerSessionWindow(object):
         MultiplayerSessionWindow.setCentralWidget(self.central_widget)
         self.menu_bar = QMenuBar(MultiplayerSessionWindow)
         self.menu_bar.setObjectName(u"menu_bar")
-        self.menu_bar.setGeometry(QRect(0, 0, 773, 23))
+        self.menu_bar.setGeometry(QRect(0, 0, 773, 21))
         MultiplayerSessionWindow.setMenuBar(self.menu_bar)
 
         self.retranslateUi(MultiplayerSessionWindow)
 
-        self.tab_widget.setCurrentIndex(0)
+        self.tab_widget.setCurrentIndex(1)
 
 
         QMetaObject.connectSlotsByName(MultiplayerSessionWindow)
@@ -296,6 +327,13 @@ class Ui_MultiplayerSessionWindow(object):
         self.view_game_details_button.setText(QCoreApplication.translate("MultiplayerSessionWindow", u"View Spoiler", None))
         self.everyone_can_claim_check.setText(QCoreApplication.translate("MultiplayerSessionWindow", u"Everyone can claim worlds", None))
         self.allow_coop_check.setText(QCoreApplication.translate("MultiplayerSessionWindow", u"Enable Co-Op", None))
+#if QT_CONFIG(tooltip)
+        self.notification_webhook_textbox.setToolTip(QCoreApplication.translate("MultiplayerSessionWindow", u"<html><head/><body><p>Discord webhook URL</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.notification_webhook_textbox.setText("")
+        self.notification_webhook_textbox.setPlaceholderText(QCoreApplication.translate("MultiplayerSessionWindow", u"Discord webhook URL", None))
+        self.notification_webhook_set_button.setText(QCoreApplication.translate("MultiplayerSessionWindow", u"Set", None))
+        self.notification_webhook_clear_button.setText(QCoreApplication.translate("MultiplayerSessionWindow", u"Clear", None))
         self.connectivity_group.setTitle(QCoreApplication.translate("MultiplayerSessionWindow", u"Connectivity", None))
         self.server_connection_button.setText(QCoreApplication.translate("MultiplayerSessionWindow", u"Connect to Server", None))
         self.edit_game_connections_button.setText(QCoreApplication.translate("MultiplayerSessionWindow", u"Edit Game Connections", None))

--- a/randovania/gui/generated/node_details_popup_ui.py
+++ b/randovania/gui/generated/node_details_popup_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'node_details_popup.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/permalink_dialog_ui.py
+++ b/randovania/gui/generated/permalink_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'permalink_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/pickup_details_tab_ui.py
+++ b/randovania/gui/generated/pickup_details_tab_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'pickup_details_tab.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/preset_customize_description_ui.py
+++ b/randovania/gui/generated/preset_customize_description_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_customize_description.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/preset_dock_rando_ui.py
+++ b/randovania/gui/generated/preset_dock_rando_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_dock_rando.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/preset_generation_ui.py
+++ b/randovania/gui/generated/preset_generation_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_generation.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/preset_hints_ui.py
+++ b/randovania/gui/generated/preset_hints_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_hints.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/preset_history_dialog_ui.py
+++ b/randovania/gui/generated/preset_history_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_history_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/preset_item_pool_ui.py
+++ b/randovania/gui/generated/preset_item_pool_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_item_pool.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/preset_location_pool_ui.py
+++ b/randovania/gui/generated/preset_location_pool_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_location_pool.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/preset_patcher_energy_ui.py
+++ b/randovania/gui/generated/preset_patcher_energy_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_patcher_energy.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/preset_starting_area_ui.py
+++ b/randovania/gui/generated/preset_starting_area_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_starting_area.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/preset_trick_level_ui.py
+++ b/randovania/gui/generated/preset_trick_level_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'preset_trick_level.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/racetime_browser_dialog_ui.py
+++ b/randovania/gui/generated/racetime_browser_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'racetime_browser_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/randovania_help_widget_ui.py
+++ b/randovania/gui/generated/randovania_help_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'randovania_help_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/reporting_optout_widget_ui.py
+++ b/randovania/gui/generated/reporting_optout_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'reporting_optout_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/resource_database_editor_ui.py
+++ b/randovania/gui/generated/resource_database_editor_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'resource_database_editor.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/scroll_label_dialog_ui.py
+++ b/randovania/gui/generated/scroll_label_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'scroll_label_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/select_preset_dialog_ui.py
+++ b/randovania/gui/generated/select_preset_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'select_preset_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/select_preset_widget_ui.py
+++ b/randovania/gui/generated/select_preset_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'select_preset_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/standard_pickup_widget_ui.py
+++ b/randovania/gui/generated/standard_pickup_widget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'standard_pickup_widget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/text_prompt_dialog_ui.py
+++ b/randovania/gui/generated/text_prompt_dialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'text_prompt_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/tracker_window_ui.py
+++ b/randovania/gui/generated/tracker_window_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'tracker_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/trick_details_popup_ui.py
+++ b/randovania/gui/generated/trick_details_popup_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'trick_details_popup.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/trick_usage_popup_ui.py
+++ b/randovania/gui/generated/trick_usage_popup_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'trick_usage_popup.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/widget_location_pool_row_ui.py
+++ b/randovania/gui/generated/widget_location_pool_row_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'widget_location_pool_row.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/generated/widget_pickup_style_ui.py
+++ b/randovania/gui/generated/widget_pickup_style_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'widget_pickup_style.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/randovania/gui/lib/multiplayer_session_api.py
+++ b/randovania/gui/lib/multiplayer_session_api.py
@@ -320,6 +320,11 @@ class MultiplayerSessionApi(QtCore.QObject):
         )
 
     @handle_network_errors
+    async def set_notification_webhook(self, url: str | None) -> None:
+        self.logger.info("Setting notification webhook to %s", url)
+        await self._session_admin_global(admin_actions.SessionAdminGlobalAction.SET_NOTIFICATION_WEBHOOK, url)
+
+    @handle_network_errors
     async def switch_readiness(self, user_id: int) -> None:
         self.logger.info("Switching ready-ness of %d", user_id)
         await self._session_admin_player(

--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -260,6 +260,8 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         self.view_game_details_button.clicked.connect(self.view_game_details)
         self.everyone_can_claim_check.clicked.connect(self._on_everyone_can_claim_check)
         self.allow_coop_check.clicked.connect(self._on_allow_coop_check)
+        self.notification_webhook_clear_button.clicked.connect(self.notification_webhook_clear_button_clicked)
+        self.notification_webhook_set_button.clicked.connect(self.notification_webhook_set_button_clicked)
 
         # Background Tasks
         self.background_tasks_button_lock_signal.connect(self.enable_buttons_with_background_tasks)
@@ -374,6 +376,9 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         self.allow_coop_check.setEnabled(self.users_widget.is_admin() and not_genned_yet)
         self.allow_coop_check.setText(
             "Enable Co-Op" + ("" if not_genned_yet else " (can only be changed before generation)")
+        )
+        self.notification_webhook_textbox.setText(
+            "" if session.notification_webhook is None else session.notification_webhook
         )
 
     @asyncSlot(MultiplayerSessionActions)
@@ -1009,6 +1014,20 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         common_qt_lib.set_clipboard(permalink_str)
         common_qt_lib.set_default_window_icon(dialog)
         await async_dialog.execute_dialog(dialog)
+
+    @asyncSlot()
+    @handle_network_errors
+    async def notification_webhook_set_button_clicked(self):
+        webhook_url: str = self.notification_webhook_textbox.text()
+        if webhook_url == "":
+            webhook_url = None
+        await self.game_session_api.set_notification_webhook(webhook_url)
+
+    @asyncSlot()
+    @handle_network_errors
+    async def notification_webhook_clear_button_clicked(self):
+        self.notification_webhook_textbox.clear()
+        await self.game_session_api.set_notification_webhook(None)
 
     @asyncSlot()
     @handle_network_errors

--- a/randovania/gui/ui_files/multiplayer_session.ui
+++ b/randovania/gui/ui_files/multiplayer_session.ui
@@ -27,7 +27,7 @@
     <item>
      <widget class="QTabWidget" name="tab_widget">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="tab_worlds">
        <attribute name="title">
@@ -156,6 +156,61 @@
               <string>Enable Co-Op</string>
              </property>
             </widget>
+           </item>
+           <item row="2" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QLineEdit" name="notification_webhook_textbox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>450</width>
+                 <height>24</height>
+                </size>
+               </property>
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Discord webhook URL&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="placeholderText">
+                <string>Discord webhook URL</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="notification_webhook_set_button">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Set</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="notification_webhook_clear_button">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Clear</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </widget>
@@ -352,7 +407,7 @@
      <x>0</x>
      <y>0</y>
      <width>773</width>
-     <height>23</height>
+     <height>21</height>
     </rect>
    </property>
   </widget>

--- a/randovania/network_common/admin_actions.py
+++ b/randovania/network_common/admin_actions.py
@@ -22,6 +22,7 @@ class SessionAdminGlobalAction(Enum):
     REQUEST_PERMALINK = "request_permalink"
     SET_ALLOW_COOP = "set_allow_coop"
     SET_ALLOW_EVERYONE_CLAIM = "set_allow_everyone_claim"
+    SET_NOTIFICATION_WEBHOOK = "set_notification_webhook"
 
 
 class SessionAdminUserAction(Enum):

--- a/randovania/network_common/multiplayer_session.py
+++ b/randovania/network_common/multiplayer_session.py
@@ -108,6 +108,7 @@ class MultiplayerSessionEntry(JsonDataclass):
     allowed_games: list[RandovaniaGame]
     allow_coop: bool
     allow_everyone_claim_world: bool
+    notification_webhook: str | None
 
     @property
     def users(self) -> dict[int, MultiplayerUser]:

--- a/randovania/server/database.py
+++ b/randovania/server/database.py
@@ -166,6 +166,7 @@ class MultiplayerSession(BaseModel):
     creation_date: str = peewee.DateTimeField(default=lib.datetime_now)
     generation_in_progress: User | None = peewee.ForeignKeyField(User, null=True)
     dev_features: str | None = peewee.CharField(null=True)
+    notification_webhook: str | None = peewee.CharField(null=True)
 
     allow_coop: bool = peewee.BooleanField(default=False)
     allow_everyone_claim_world: bool = peewee.BooleanField(default=False)
@@ -353,6 +354,7 @@ class MultiplayerSession(BaseModel):
             allowed_games=self.allowed_games,
             allow_coop=self.allow_coop,
             allow_everyone_claim_world=self.allow_everyone_claim_world,
+            notification_webhook=self.notification_webhook,
         )
 
     def get_audit_log(self) -> MultiplayerSessionAuditLog:

--- a/randovania/server/multiplayer/world_api.py
+++ b/randovania/server/multiplayer/world_api.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import construct
 import flask_socketio
 import peewee
+import requests
 import sentry_sdk
 from frozendict import frozendict
 
@@ -155,6 +156,25 @@ def _collect_location(
             emit_inventory_update(sa, target_world, assoc.user_id, new_inventory)
 
     log("It's a %s for %s.", pickup_target.pickup.name, target_world.name)
+
+    if session.notification_webhook is not None:
+        associations: Iterable[WorldUserAssociation] = WorldUserAssociation.select().where(
+            WorldUserAssociation.world == target_world,
+        )
+        mentions = " ".join(
+            [
+                (f"@{str(assoc.user.discord_id)}>" if assoc.user.discord_id is not None else assoc.user.name)
+                for assoc in associations
+            ]
+        )
+        message = (
+            f"{mentions}{', your ' if mentions != '' else ''}{pickup_target.pickup.name} "
+            "was collected in {session.name} - {target_world.name}!"
+        )
+        data = {"content": message}
+
+        requests.post(session.notification_webhook, json=data)
+
     return target_world
 
 


### PR DESCRIPTION
This is a working Proof-of-Concept that allows a session admin to add a Discord webhook URL to a multiworld session. Whenever a cross-world item is collected, a message is sent in the Discord channel that the webhook points at. If the receiving world has a user associated they will be pinged.

Remaining todos:
- [ ] Write a changelog entry
- [ ] Write tests
- [ ] Possibly improve the UI
- [ ] Reword the notification text to be less awkward
- [ ] Database migration