### PR TITLE
Fusion: on a Core-X parasite rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: 5 more joke hints.
 - Changed: Infant Metroid hints have been reformatted for easier readability.
+- Changed: "guarded by a boss" feature hint has been reworked to "on a Core-x Parasite" for more clarity
 - Fixed: Typo in a joke hint.
-
-### Metroid Fusion
 
 #### Logic Database
 
@@ -46,12 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Cathedral: Ludicrous JBJ to escape from bottom to top section reduced to Expert, accompanying ttv clip replaced by YouTube link having better input display.
 - Changed: Data Courtyard: Advanced JBJ to break left block from beneath reduced to Intermediate.
 - Added: Zazabi Arena: Ludicrous JBJ to escape, having no jump upgrades (besides bombs).
+- Removed: Zazabi speedway: Location removed from feature hint "guarded by a boss" due to Core-X parasite feature hint rework
 
 ##### Sector 3 (PYR)
 
 - Changed: Namihe's Lair: Expert JBJs, to both get the item and escape, reduced to Advanced.
 - Changed: Processing Access: Expert JBJ off sova to top door reduced to Advanced.
 - Changed: Glass Tube to Sector 5: Expert JBJ to break block reduced to Intermediate, via easier method.
+- Removed: Data Room : Location removed from feature hint "guarded by a boss" due to Core-X parasite feature hint rework
 
 ##### Sector 4 (AQA)
 
@@ -67,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Entrance Lobby: Expert JBJ to bomb floor from beneath reduced to Advanced.
 - Changed: Zozoro Wine Cellar: Expert JBJ to item reduced to Advanced.
 - Changed: Twin Caverns West: Expert JBJ to tunnel reduced to Advanced.
+- Removed: X-B.O.X. Garage: Location removed from feature hint "guarded by a boss" due to Core-X parasite feature hint rework
 
 ## [10.1.0] - 2025-09-02
 

--- a/randovania/games/fusion/exporter/patch_data_factory.py
+++ b/randovania/games/fusion/exporter/patch_data_factory.py
@@ -291,7 +291,7 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
             )
 
             if operations_hint:
-                operations_hint = f"{metroid_hint_base} bosses:[NEXT]{operations_hint.rstrip('\n')}"
+                operations_hint = f"{metroid_hint_base} Core-X parasites:[NEXT]{operations_hint.rstrip('\n')}"
             else:
                 operations_hint = no_metroids_hint
 

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -7667,7 +7667,7 @@
                     "location_category": "major",
                     "custom_index_group": null,
                     "hint_features": [
-                        "boss"
+                        "core_x_parasite"
                     ],
                     "connections": {
                         "Arena": {
@@ -13688,7 +13688,7 @@
         "Yakuza Arena": {
             "default_node": null,
             "hint_features": [
-                "boss"
+                "core_x_parasite"
             ],
             "extra": {
                 "map_name": "Main Deck86",

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -1223,7 +1223,7 @@ Hint Features - Multiple Pickups
 > Pickup (Morph Ball); Heals? False
   * Layers: default
   * Pickup 100; Category? Major
-  * Hint Features - Boss
+  * Hint Features - On a Core-x parasite
   * Extra - area: 0
   * Extra - room: 38
   * Extra - source: Arachnus
@@ -2302,7 +2302,7 @@ Yakuza Arena
 Extra - map_name: Main Deck86
 Extra - room_id: [86]
 Extra - minimap_coordinates: [{'x': 21, 'y': 19}, {'x': 21, 'y': 20}, {'x': 21, 'y': 21}]
-Hint Features - Boss
+Hint Features - On a Core-x parasite
 > Door to Silo Scaffolding; Heals? False
   * Layers: default
   * Open Hatch to Silo Scaffolding/Door to Yakuza Arena

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -7008,7 +7008,7 @@
         "Ridley Arena": {
             "default_node": null,
             "hint_features": [
-                "boss"
+                "core_x_parasite"
             ],
             "extra": {
                 "map_name": "Sector 127",
@@ -11142,7 +11142,7 @@
         "Charge Core Arena": {
             "default_node": null,
             "hint_features": [
-                "boss",
+                "core_x_parasite",
                 "multiple-pickups"
             ],
             "extra": {

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -1023,7 +1023,7 @@ Ridley Arena
 Extra - map_name: Sector 127
 Extra - room_id: [27]
 Extra - minimap_coordinates: [{'x': 1, 'y': 8}, {'x': 1, 'y': 9}]
-Hint Features - Boss
+Hint Features - On a Core-x parasite
 > Door to Ridley Arena Access; Heals? False
   * Layers: default
   * L0 Hatch to Ridley Arena Access/Door to Ridley Arena
@@ -1591,7 +1591,7 @@ Charge Core Arena
 Extra - map_name: Sector 140
 Extra - room_id: [40]
 Extra - minimap_coordinates: [{'x': 9, 'y': 4}, {'x': 9, 'y': 5}, {'x': 9, 'y': 6}, {'x': 10, 'y': 5}, {'x': 10, 'y': 6}]
-Hint Features - Boss, Multiple Pickups
+Hint Features - On a Core-x parasite, Multiple Pickups
 > Pickup (Energy Tank); Heals? False
   * Layers: default
   * Pickup 19; Category? Major

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -3916,7 +3916,7 @@
         "Zazabi Arena": {
             "default_node": null,
             "hint_features": [
-                "boss"
+                "core_x_parasite"
             ],
             "extra": {
                 "map_name": "Sector 218",
@@ -5119,7 +5119,7 @@
         "Nettori Arena": {
             "default_node": null,
             "hint_features": [
-                "boss"
+                "core_x_parasite"
             ],
             "extra": {
                 "map_name": "Sector 222",
@@ -11977,7 +11977,6 @@
         "Zazabi Speedway": {
             "default_node": null,
             "hint_features": [
-                "boss",
                 "multiple-pickups"
             ],
             "extra": {

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -654,7 +654,7 @@ Zazabi Arena
 Extra - map_name: Sector 218
 Extra - room_id: [18]
 Extra - minimap_coordinates: [{'x': 13, 'y': 12}, {'x': 13, 'y': 13}, {'x': 14, 'y': 12}, {'x': 14, 'y': 13}]
-Hint Features - Boss
+Hint Features - On a Core-x parasite
 > Door to Zazabi Arena Access; Heals? False
   * Layers: default
   * L0 Hatch to Zazabi Arena Access/Door to Zazabi Arena
@@ -838,7 +838,7 @@ Nettori Arena
 Extra - map_name: Sector 222
 Extra - room_id: [22, 51]
 Extra - minimap_coordinates: [{'x': 13, 'y': 5}, {'x': 13, 'y': 6}, {'x': 14, 'y': 5}, {'x': 14, 'y': 6}]
-Hint Features - Boss
+Hint Features - On a Core-x parasite
 > Door to Shooting Gallery; Heals? False
   * Layers: default
   * L0 Hatch to Shooting Gallery/Door to Nettori Arena
@@ -1856,7 +1856,7 @@ Zazabi Speedway
 Extra - map_name: Sector 255
 Extra - room_id: [55]
 Extra - minimap_coordinates: [{'x': 16, 'y': 12}, {'x': 16, 'y': 13}, {'x': 16, 'y': 14}, {'x': 17, 'y': 12}, {'x': 17, 'y': 13}, {'x': 17, 'y': 14}, {'x': 18, 'y': 12}, {'x': 18, 'y': 13}, {'x': 18, 'y': 14}]
-Hint Features - Boss, Multiple Pickups
+Hint Features - Multiple Pickups
 > Pickup (Power Bomb Tank); Heals? False
   * Layers: default
   * Pickup 40; Category? Minor

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -6669,7 +6669,6 @@
         "Data Room": {
             "default_node": null,
             "hint_features": [
-                "boss",
                 "data_room"
             ],
             "extra": {
@@ -7495,9 +7494,7 @@
         },
         "Main Boiler Control Room": {
             "default_node": null,
-            "hint_features": [
-                "boss"
-            ],
+            "hint_features": [],
             "extra": {
                 "map_name": "Sector 325",
                 "room_id": [
@@ -7768,7 +7765,9 @@
                     "pickup_index": 110,
                     "location_category": "major",
                     "custom_index_group": null,
-                    "hint_features": [],
+                    "hint_features": [
+                        "core_x_parasite"
+                    ],
                     "connections": {
                         "Door to Main Boiler": {
                             "type": "and",

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -937,7 +937,7 @@ Data Room
 Extra - map_name: Sector 321
 Extra - room_id: [21]
 Extra - minimap_coordinates: [{'x': 18, 'y': 3}]
-Hint Features - Boss, Data Room
+Hint Features - Data Room
 > Door to B.O.X. Arena; Heals? False
   * Layers: default
   * L2 Hatch to B.O.X. Arena/Door to Data Room
@@ -1057,7 +1057,6 @@ Main Boiler Control Room
 Extra - map_name: Sector 325
 Extra - room_id: [25]
 Extra - minimap_coordinates: [{'x': 3, 'y': 7}, {'x': 3, 'y': 8}, {'x': 4, 'y': 7}, {'x': 4, 'y': 8}]
-Hint Features - Boss
 > Door to Main Boiler; Heals? False
   * Layers: default
   * L0 Hatch to Main Boiler/Door to Main Boiler Control Room
@@ -1095,6 +1094,7 @@ Hint Features - Boss
 > Pickup (Wide Beam); Heals? False
   * Layers: default
   * Pickup 110; Category? Major
+  * Hint Features - On a Core-x parasite
   * Extra - area: 3
   * Extra - room: 25
   * Extra - source: WideCoreX

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -15681,8 +15681,8 @@
         "Serris Arena": {
             "default_node": null,
             "hint_features": [
-                "boss",
-                "climbable"
+                "climbable",
+                "core_x_parasite"
             ],
             "extra": {
                 "map_name": "Sector 442",

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -2161,7 +2161,7 @@ Serris Arena
 Extra - map_name: Sector 442
 Extra - room_id: [42]
 Extra - minimap_coordinates: [{'x': 10, 'y': 0}, {'x': 10, 'y': 1}, {'x': 11, 'y': 0}, {'x': 11, 'y': 1}]
-Hint Features - Boss, Climbable Surface
+Hint Features - Climbable Surface, On a Core-x parasite
 > Door to Serris Speedway; Heals? False
   * Layers: default
   * L0 Hatch to Serris Speedway/Door to Serris Arena

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -4968,8 +4968,8 @@
         "Nightmare Arena": {
             "default_node": null,
             "hint_features": [
-                "boss",
-                "climbable"
+                "climbable",
+                "core_x_parasite"
             ],
             "extra": {
                 "map_name": "Sector 520",

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -747,7 +747,7 @@ Nightmare Arena
 Extra - map_name: Sector 520
 Extra - room_id: [20]
 Extra - minimap_coordinates: [{'x': 22, 'y': 5}, {'x': 22, 'y': 6}, {'x': 23, 'y': 5}, {'x': 23, 'y': 6}]
-Hint Features - Boss, Climbable Surface
+Hint Features - Climbable Surface, On a Core-x parasite
 > Door to Nightmare Lower Access; Heals? False
   * Layers: default
   * L0 Hatch to Nightmare Lower Access/Door to Nightmare Arena

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -4301,7 +4301,7 @@
         "Varia Core-X Arena": {
             "default_node": null,
             "hint_features": [
-                "boss"
+                "core_x_parasite"
             ],
             "extra": {
                 "map_name": "Sector 613",
@@ -5475,8 +5475,8 @@
         "X-B.O.X. Arena": {
             "default_node": null,
             "hint_features": [
-                "boss",
-                "climbable"
+                "climbable",
+                "core_x_parasite"
             ],
             "extra": {
                 "map_name": "Sector 616",
@@ -6578,7 +6578,6 @@
         "X-B.O.X. Garage": {
             "default_node": null,
             "hint_features": [
-                "boss",
                 "multiple-pickups",
                 "shutter"
             ],

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -580,7 +580,7 @@ Varia Core-X Arena
 Extra - map_name: Sector 613
 Extra - room_id: [13]
 Extra - minimap_coordinates: [{'x': 10, 'y': 10}, {'x': 10, 'y': 11}, {'x': 10, 'y': 12}, {'x': 11, 'y': 10}, {'x': 11, 'y': 11}, {'x': 11, 'y': 12}]
-Hint Features - Boss
+Hint Features - On a Core-x parasite
 > Door to Data Room; Heals? False
   * Layers: default
   * L2 Hatch to Data Room/Door to Varia Core-X Arena
@@ -725,7 +725,7 @@ X-B.O.X. Arena
 Extra - map_name: Sector 616
 Extra - room_id: [16]
 Extra - minimap_coordinates: [{'x': 7, 'y': 5}, {'x': 7, 'y': 6}, {'x': 8, 'y': 5}, {'x': 8, 'y': 6}]
-Hint Features - Boss, Climbable Surface
+Hint Features - Climbable Surface, On a Core-x parasite
 > Door to X-B.O.X. Arena Access; Heals? False
   * Layers: default
   * L0 Hatch to X-B.O.X. Arena Access/Door to X-B.O.X. Arena
@@ -863,7 +863,7 @@ X-B.O.X. Garage
 Extra - map_name: Sector 618
 Extra - room_id: [18]
 Extra - minimap_coordinates: [{'x': 9, 'y': 5}, {'x': 9, 'y': 6}, {'x': 10, 'y': 6}]
-Hint Features - Boss, Multiple Pickups, 1-way Shutter
+Hint Features - Multiple Pickups, 1-way Shutter
 > Pickup (Hidden Power Bomb Tank); Heals? False
   * Layers: default
   * Pickup 90; Category? Minor

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -2897,11 +2897,11 @@
                 "in a Security Room"
             ]
         },
-        "boss": {
-            "long_name": "Boss",
+        "core_x_parasite": {
+            "long_name": "On a Core-x parasite",
             "hint_details": [
                 "",
-                "guarded by a boss"
+                "on a Core-x parasite"
             ]
         },
         "shutter": {

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
@@ -2606,7 +2606,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2625,7 +2625,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2644,7 +2644,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2663,7 +2663,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2682,7 +2682,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2701,7 +2701,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2720,7 +2720,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Charge Core-X[/COLOR].\n2. [COLOR=1]Neo-Ridley[/COLOR].\n3. [COLOR=1]Nettori[/COLOR].\n4. [COLOR=1]Varia Core-X[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 6 (NOC)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
@@ -2587,7 +2587,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "[COLOR=3]Metroids[/COLOR] detected at the following locations:[NEXT]1. [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].[NEXT]2. [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
@@ -2606,7 +2606,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "[COLOR=3]Metroids[/COLOR] detected at the following locations:[NEXT]1. [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].[NEXT]2. [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
@@ -2625,7 +2625,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "[COLOR=3]Metroids[/COLOR] detected at the following locations:[NEXT]1. [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].[NEXT]2. [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
@@ -2644,7 +2644,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "[COLOR=3]Metroids[/COLOR] detected at the following locations:[NEXT]1. [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].[NEXT]2. [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
@@ -2663,7 +2663,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "[COLOR=3]Metroids[/COLOR] detected at the following locations:[NEXT]1. [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].[NEXT]2. [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
@@ -2682,7 +2682,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "[COLOR=3]Metroids[/COLOR] detected at the following locations:[NEXT]1. [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].[NEXT]2. [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
@@ -2701,7 +2701,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Ice Missile Data[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Neo-Ridley[/COLOR].\n2. [COLOR=1]Nettori[/COLOR].\n3. [COLOR=1]Serris[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "[COLOR=3]Metroids[/COLOR] detected at the following locations:[NEXT]1. [COLOR=2]Sector 4 (AQA) - Cheddar Bay[/COLOR].[NEXT]2. [COLOR=2]Sector 5 (ARC) - Level 3 Security Room[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",

--- a/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
@@ -2566,7 +2566,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2585,7 +2585,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2604,7 +2604,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2623,7 +2623,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2642,7 +2642,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2661,7 +2661,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
@@ -2680,7 +2680,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Super Missile Data[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Infant Metroid 4[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Varia Core-X[/COLOR].\n4. [COLOR=1]Wide Core-X[/COLOR].\n5. [COLOR=1]Zazabi[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 1 (SRX)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Varia Suit[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",

--- a/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
@@ -2566,7 +2566,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Charge Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
@@ -2585,7 +2585,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Charge Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
@@ -2604,7 +2604,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Charge Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
@@ -2623,7 +2623,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Charge Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
@@ -2642,7 +2642,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Charge Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
@@ -2661,7 +2661,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Charge Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
@@ -2680,7 +2680,7 @@
             "NavigationTerminals": {
                 "MainDeckEast": "The [COLOR=3]Level 3 Keycard[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR].",
                 "MainDeckWest": "The [COLOR=3]Charge Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
-                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following bosses:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
+                "OperationsDeck": "[COLOR=3]Metroids[/COLOR] detected at the following Core-X parasites:[NEXT]1. [COLOR=1]Arachnus[/COLOR].\n2. [COLOR=1]Charge Core-X[/COLOR].\n3. [COLOR=1]Neo-Ridley[/COLOR].\n4. [COLOR=1]Serris[/COLOR].\n5. [COLOR=1]Yakuza[/COLOR].",
                 "AuxiliaryPower": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Sector 2 (TRO)[/COLOR].",
                 "RestrictedLabs": "This terminal was unable to scan for any [COLOR=3]Metroids[/COLOR].",
                 "Sector1Entrance": "The [COLOR=3]Wide Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",


### PR DESCRIPTION
Discussion was sparked when guarded by a boss item was hinted zazabi speedway

Reasons for change was discussed in on the discord dev channel

- Changed "guarded by a boss" feature hint to "on a Core-x parasite"
- Updated the locations and removed those that did no qualify
- Changed the text for the operations deck hint
- Updated test files
- Updated Change log

<img width="686" height="608" alt="image" src="https://github.com/user-attachments/assets/7410863c-b71f-429f-a2b5-e721c6e7438a" />

<img width="1148" height="223" alt="image" src="https://github.com/user-attachments/assets/cb7b24e7-fb55-4a35-9fdb-b46bac2854d8" />

<img width="1219" height="474" alt="image" src="https://github.com/user-attachments/assets/a4fbbe90-ee44-47d5-8012-838d0a291951" />

