### PR TITLE
Make included presets a list of filenames, instead of a dict with hardcoded key

### DIFF
--- a/randovania/cli/commands/new_game.py
+++ b/randovania/cli/commands/new_game.py
@@ -318,7 +318,7 @@ def load_presets(template: RandovaniaGame) -> dict[str, VersionedPreset]:
         v.get_preset()
         return v
 
-    return {preset_config["path"]: get(preset_config["path"]) for preset_config in template.data.presets}
+    return {preset_path: get(preset_path) for preset_path in template.data.presets}
 
 
 def copy_presets(old_presets: dict[str, VersionedPreset], gd: GameDescription, pickup_db: PickupDatabase) -> None:

--- a/randovania/cli/commands/refresh_presets.py
+++ b/randovania/cli/commands/refresh_presets.py
@@ -18,7 +18,7 @@ def refresh_presets_command_logic(args: ArgumentParser) -> None:
         base_path = game.data_path.joinpath("presets")
 
         for preset_relative_path in game.data.presets:
-            preset_path = base_path.joinpath(preset_relative_path["path"])
+            preset_path = base_path.joinpath(preset_relative_path)
             preset = VersionedPreset[BaseConfiguration].from_file_sync(preset_path)
             preset.ensure_converted()
             preset.save_to_file(preset_path)

--- a/randovania/game/data.py
+++ b/randovania/game/data.py
@@ -32,10 +32,11 @@ class GameData:
     development_state: DevelopmentState
     """Controls how mature the game is considered to be. Various part of the UI display different games depending on
     the development state.
-    Games start in DEVELOPMENT, change to EXPERIMENTAL when somewhat usable and move to STABLE when given approval."""
+    Games start in SOURCE_ONLY, change to STAGING when somewhat usable and move to STABLE when given approval."""
 
-    presets: Iterable[dict[str, str]]
-    """List of at least one dict mapping the key "path" to a path to the given preset."""
+    presets: Iterable[str]
+    """List of preset filenames that should be included by default for this game.
+    The file must exist in the "presets" subdirectory of the game."""
 
     faq: Iterable[tuple[str, str]]
     """List of question to markdown-formatted response of FAQ entries."""

--- a/randovania/games/am2r/game_data.py
+++ b/randovania/games/am2r/game_data.py
@@ -91,7 +91,7 @@ game_data: randovania.game.data.GameData = randovania.game.data.GameData(
     long_name="Another Metroid 2 Remake",
     development_state=randovania.game.development_state.DevelopmentState.STABLE,
     presets=[
-        {"path": "starter_preset.rdvpreset"},
+        "starter_preset.rdvpreset",
     ],
     faq=[
         (

--- a/randovania/games/blank/game_data.py
+++ b/randovania/games/blank/game_data.py
@@ -83,9 +83,7 @@ game_data: randovania.game.data.GameData = randovania.game.data.GameData(
     short_name="Blank",
     long_name="Blank Development Game",
     development_state=randovania.game.development_state.DevelopmentState.STAGING,
-    presets=[
-        {"path": "starter_preset.rdvpreset"},
-    ],
+    presets=["starter_preset.rdvpreset"],
     faq=[],
     web_info=randovania.game.web_info.GameWebInfo(
         what_can_randomize=(

--- a/randovania/games/cave_story/game_data.py
+++ b/randovania/games/cave_story/game_data.py
@@ -90,9 +90,9 @@ game_data: randovania.game.data.GameData = randovania.game.data.GameData(
     long_name="Cave Story",
     development_state=randovania.game.development_state.DevelopmentState.STABLE,
     presets=[
-        {"path": "starter_preset.rdvpreset"},
-        {"path": "multiworld-starter-preset.rdvpreset"},
-        {"path": "classic.rdvpreset"},
+        "starter_preset.rdvpreset",
+        "multiworld-starter-preset.rdvpreset",
+        "classic.rdvpreset",
     ],
     faq=[],
     web_info=randovania.game.web_info.GameWebInfo(

--- a/randovania/games/dread/game_data.py
+++ b/randovania/games/dread/game_data.py
@@ -86,8 +86,8 @@ game_data: randovania.game.data.GameData = randovania.game.data.GameData(
     long_name="Metroid Dread",
     development_state=randovania.game.development_state.DevelopmentState.STABLE,
     presets=[
-        {"path": "starter_preset.rdvpreset"},
-        {"path": "april_fools_2023.rdvpreset"},
+        "starter_preset.rdvpreset",
+        "april_fools_2023.rdvpreset",
     ],
     faq=[
         (

--- a/randovania/games/factorio/game_data.py
+++ b/randovania/games/factorio/game_data.py
@@ -79,7 +79,7 @@ game_data: randovania.game.data.GameData = randovania.game.data.GameData(
     long_name="Factorio",
     development_state=randovania.game.development_state.DevelopmentState.STABLE,
     presets=[
-        {"path": "starter_preset.rdvpreset"},
+        "starter_preset.rdvpreset",
     ],
     faq=[
         ("What versions of the game is supported?", "Only Factorio 2.0 is supported."),

--- a/randovania/games/fusion/game_data.py
+++ b/randovania/games/fusion/game_data.py
@@ -92,8 +92,8 @@ game_data: randovania.game.data.GameData = randovania.game.data.GameData(
     long_name="Metroid Fusion",
     development_state=randovania.game.development_state.DevelopmentState.STABLE,
     presets=[
-        {"path": "open_sector_hub.rdvpreset"},
-        {"path": "vanilla_start.rdvpreset"},
+        "open_sector_hub.rdvpreset",
+        "vanilla_start.rdvpreset",
     ],
     faq=[
         (

--- a/randovania/games/planets_zebeth/game_data.py
+++ b/randovania/games/planets_zebeth/game_data.py
@@ -78,8 +78,8 @@ game_data: randovania.game.data.GameData = randovania.game.data.GameData(
     long_name="Metroid Planets (Zebeth)",
     development_state=randovania.game.development_state.DevelopmentState.SOURCE_ONLY,
     presets=[
-        {"path": "starter_preset.rdvpreset"},
-        {"path": "starter_preset_shuffle_keys.rdvpreset"},
+        "starter_preset.rdvpreset",
+        "starter_preset_shuffle_keys.rdvpreset",
     ],
     faq=[
         (

--- a/randovania/games/prime1/game_data.py
+++ b/randovania/games/prime1/game_data.py
@@ -110,9 +110,9 @@ game_data: randovania.game.data.GameData = randovania.game.data.GameData(
     long_name="Metroid Prime",
     development_state=randovania.game.development_state.DevelopmentState.STABLE,
     presets=[
-        {"path": "starter_preset.rdvpreset"},
-        {"path": "moderate_challenge.rdvpreset"},
-        {"path": "april_fools_2022.rdvpreset"},
+        "starter_preset.rdvpreset",
+        "moderate_challenge.rdvpreset",
+        "april_fools_2022.rdvpreset",
     ],
     faq=[
         (

--- a/randovania/games/prime2/game_data.py
+++ b/randovania/games/prime2/game_data.py
@@ -101,8 +101,8 @@ game_data: randovania.game.data.GameData = randovania.game.data.GameData(
     long_name="Metroid Prime 2: Echoes",
     development_state=randovania.game.development_state.DevelopmentState.STABLE,
     presets=[
-        {"path": "starter_preset.rdvpreset"},
-        {"path": "darkszero_deluxe.rdvpreset"},
+        "starter_preset.rdvpreset",
+        "darkszero_deluxe.rdvpreset",
     ],
     faq=[
         (

--- a/randovania/games/prime_hunters/game_data.py
+++ b/randovania/games/prime_hunters/game_data.py
@@ -83,7 +83,7 @@ game_data: randovania.game.data.GameData = randovania.game.data.GameData(
     long_name="Metroid Prime Hunters",
     development_state=randovania.game.development_state.DevelopmentState.SOURCE_ONLY,
     presets=[
-        {"path": "starter_preset.rdvpreset"},
+        "starter_preset.rdvpreset",
     ],
     faq=[],
     web_info=randovania.game.web_info.GameWebInfo(

--- a/randovania/games/samus_returns/game_data.py
+++ b/randovania/games/samus_returns/game_data.py
@@ -104,8 +104,8 @@ game_data: randovania.game.data.GameData = randovania.game.data.GameData(
     long_name="Metroid: Samus Returns",
     development_state=randovania.game.development_state.DevelopmentState.STABLE,
     presets=[
-        {"path": "starter_preset.rdvpreset"},
-        {"path": "multiworld-starter-preset.rdvpreset"},
+        "starter_preset.rdvpreset",
+        "multiworld-starter-preset.rdvpreset",
     ],
     faq=[
         (

--- a/randovania/interface_common/preset_manager.py
+++ b/randovania/interface_common/preset_manager.py
@@ -25,7 +25,7 @@ def read_preset_list() -> list[Path]:
     preset_list = []
     for game in enum_lib.iterate_enum(RandovaniaGame):
         base_path = game.data_path.joinpath("presets")
-        preset_list.extend([base_path.joinpath(preset["path"]) for preset in game.data.presets])
+        preset_list.extend([base_path.joinpath(preset_relative_path) for preset_relative_path in game.data.presets])
 
     return preset_list
 

--- a/test/games/test_game.py
+++ b/test/games/test_game.py
@@ -63,7 +63,7 @@ def test_exporter(game_enum):
 def test_presets():
     from randovania.interface_common.preset_manager import PresetManager
 
-    games_preset_count = defaultdict(int)
+    games_preset_count: dict[RandovaniaGame, int] = defaultdict(int)
 
     # Ensure that we can parse all the games' presets
     manager = PresetManager(None)

--- a/test/games/test_game.py
+++ b/test/games/test_game.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from unittest.mock import MagicMock
+
+from randovania.game.game_enum import RandovaniaGame
+from randovania.lib import enum_lib
 
 
 def test_gui(skip_qtbot, game_enum):
@@ -54,3 +58,18 @@ def test_exporter(game_enum):
     from randovania.exporter.game_exporter import GameExporter
 
     assert isinstance(game_enum.exporter, GameExporter)
+
+
+def test_presets():
+    from randovania.interface_common.preset_manager import PresetManager
+
+    games_preset_count = defaultdict(int)
+
+    # Ensure that we can parse all the games' presets
+    manager = PresetManager(None)
+    for uuid, preset in manager.included_presets.items():
+        games_preset_count[preset.game] += 1
+
+    # Assert that every game has at least one preset
+    for game in enum_lib.iterate_enum(RandovaniaGame):
+        assert games_preset_count[game] >= 0


### PR DESCRIPTION
Having a hardcoded key in a dictionary kinda defeats the purpose of using the dictionary in the first place.
I feel like there may have been plans in the past to use something other than paths (including preset directly?) which was never used.