### PR TITLE
Status Bar: Increase message length before wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Command line arguments for gathering statistics about a collection of generated games. These commands are intended for advanced uses only.
 - Changed: Gave the window for viewing a Multiworld Session some slight visual readjustment
 - Changed: Slightly increased the font size used in the status bar.
+- Changed: Increased how long text in the status bar can be before it wraps.
 - Changed: Gave the "Stop" button in the status bar an icon.
 
 

--- a/randovania/gui/game_details/game_details_window.py
+++ b/randovania/gui/game_details/game_details_window.py
@@ -67,7 +67,7 @@ class GameDetailsWindow(CloseEventWidget, Ui_GameDetailsWindow, BackgroundTaskMi
         self.progress_bar.setVisible(False)
         self.stop_background_process_button.setVisible(False)
 
-        self.status_bar.addWidget(self.progress_label)
+        self.status_bar.addWidget(self.progress_label, 2)
         self.status_bar.addPermanentWidget(self.progress_bar)
         self.status_bar.addPermanentWidget(self.stop_background_process_button)
 

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -143,7 +143,7 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
         self.progress_bar.setVisible(False)
         self.stop_background_process_button.setVisible(False)
 
-        self.status_bar.addWidget(self.progress_label)
+        self.status_bar.addWidget(self.progress_label, 2)
         self.status_bar.addPermanentWidget(self.progress_bar)
         self.status_bar.addPermanentWidget(self.stop_background_process_button)
 

--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -236,7 +236,7 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         self.progress_bar.setVisible(False)
         self.background_process_button.setVisible(False)
 
-        self.status_bar.addWidget(self.progress_label)
+        self.status_bar.addWidget(self.progress_label, 2)
         self.status_bar.addPermanentWidget(self.progress_bar)
         self.status_bar.addPermanentWidget(self.background_process_button)
 


### PR DESCRIPTION
Randomly stumbled upon this. Parameter indicates stretching.
Long text now:
<img width="820" height="741" alt="grafik" src="https://github.com/user-attachments/assets/22cacbdf-6c73-450f-a3d6-c628cac13274" />
