### PR TITLE
Prime 1: Improve Elevator Rando containing credits as a target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Adjusted fit of main menu text to accommodate larger seed hashes
 - Changed: Adjusted fit of DLR Blast Shields over doors
 - Changed: Research Core cutscene camera angle will now be consistent regardless of the height of the placed pickup
+- Changed: Improved chance of successfully generating a game when shuffling everything on One-Way Anywhere elevator randomization.
+- Changed: Disallowed shuffling the Essence Dead cutscene elevator on One-Way with Cycles and with Replacement, unless Skip Final Bosses is enabled, as otherwise that would leave no path to the Credits.
 
 #### Logic Database
 

--- a/randovania/games/prime1/generator/base_patches_factory.py
+++ b/randovania/games/prime1/generator/base_patches_factory.py
@@ -10,6 +10,7 @@ from randovania.generator.teleporter_distributor import (
     get_dock_connections_assignment_for_teleporter,
     get_teleporter_connections,
 )
+from randovania.layout.lib.teleporters import TeleporterShuffleMode
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -56,6 +57,17 @@ class PrimeBasePatchesFactory(BasePatchesFactory[PrimeConfiguration]):
         yield from super().dock_connections_assignment(configuration, game, rng)
 
         teleporter_connection = get_teleporter_connections(configuration.teleporters, game, rng)
+
+        if configuration.teleporters.mode == TeleporterShuffleMode.ONE_WAY_ANYTHING:
+            credits_node = configuration.teleporters.get_credits_node()
+            if (
+                credits_node in configuration.teleporters.valid_targets
+                and credits_node not in teleporter_connection.values()
+            ):
+                # If nothing goes to credits, randomly assign one
+                random_key = rng.choice(list(teleporter_connection.keys()))
+                teleporter_connection[random_key] = credits_node
+
         dock_assignment = get_dock_connections_assignment_for_teleporter(
             configuration.teleporters, game, teleporter_connection
         )

--- a/test/games/common/prime_family/test_trilogy_teleporters.py
+++ b/test/games/common/prime_family/test_trilogy_teleporters.py
@@ -1,0 +1,94 @@
+import dataclasses
+
+import pytest
+
+from randovania.game.game_enum import RandovaniaGame
+from randovania.layout.lib.teleporters import TeleporterShuffleMode
+from randovania.lib import enum_lib
+
+
+@pytest.mark.parametrize(
+    "shuffle_mode",
+    list(enum_lib.iterate_enum(TeleporterShuffleMode)),
+)
+@pytest.mark.parametrize(
+    "final_bosses",
+    [True, False],
+)
+def test_prime_static_assignments(preset_manager, shuffle_mode, final_bosses):
+    # Setup
+    base = preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME).get_preset()
+
+    base = dataclasses.replace(
+        base,
+        configuration=dataclasses.replace(
+            base.configuration,
+            teleporters=dataclasses.replace(
+                base.configuration.teleporters, skip_final_bosses=final_bosses, mode=shuffle_mode
+            ),
+        ),
+    )
+
+    # Run
+    static_assignments = base.configuration.teleporters.static_teleporters
+
+    # Assert
+
+    try:
+        source, target = next(iter(static_assignments.items()))
+    except StopIteration:
+        source, target = None, None
+
+    if final_bosses:
+        assert len(static_assignments) == 1
+        assert source.area == "Artifact Temple"
+        assert target.area == "Credits"
+    elif not final_bosses and shuffle_mode in [
+        TeleporterShuffleMode.ONE_WAY_TELEPORTER,
+        TeleporterShuffleMode.ONE_WAY_TELEPORTER_REPLACEMENT,
+    ]:
+        assert len(static_assignments) == 1
+        assert source.area == "Metroid Prime Lair"
+        assert target.area == "Credits"
+    else:
+        assert len(static_assignments) == 0
+
+
+@pytest.mark.parametrize(
+    "shuffle_mode",
+    list(enum_lib.iterate_enum(TeleporterShuffleMode)),
+)
+@pytest.mark.parametrize(
+    "final_bosses",
+    [True, False],
+)
+def test_echoes_static_assignments(preset_manager, shuffle_mode, final_bosses):
+    # Setup
+    base = preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).get_preset()
+
+    base = dataclasses.replace(
+        base,
+        configuration=dataclasses.replace(
+            base.configuration,
+            teleporters=dataclasses.replace(
+                base.configuration.teleporters, skip_final_bosses=final_bosses, mode=shuffle_mode
+            ),
+        ),
+    )
+
+    # Run
+    static_assignments = base.configuration.teleporters.static_teleporters
+
+    # Assert
+
+    try:
+        source, target = next(iter(static_assignments.items()))
+    except StopIteration:
+        source, target = None, None
+
+    if final_bosses:
+        assert len(static_assignments) == 1
+        assert source.area == "Sky Temple Gateway"
+        assert target.area == "Credits"
+    else:
+        assert len(static_assignments) == 0


### PR DESCRIPTION
The TLDR; is: let's try to ensure that we always have the possibility of having the credits as a viable target.