### PR TITLE
Fusion: Exclude Nettori Backdoor from DLR

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -2506,7 +2506,7 @@
                         "node": "Door to Shooting Gallery"
                     },
                     "default_dock_weakness": "L0 Hatch",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -4894,7 +4894,7 @@
                         "node": "Door to Nettori Arena Access"
                     },
                     "default_dock_weakness": "L0 Hatch",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -411,7 +411,7 @@ Extra - room_id: [12]
 Extra - minimap_coordinates: [{'x': 15, 'y': 6}, {'x': 15, 'y': 7}]
 > Door to Nettori Arena Access; Heals? False
   * Layers: default
-  * L0 Hatch to Nettori Arena Access/Door to Shooting Gallery
+  * L0 Hatch to Nettori Arena Access/Door to Shooting Gallery; Excluded from Dock Lock Rando
   * Extra - door_idx: (25,)
   > Door to Nettori Arena
       Trivial
@@ -794,7 +794,7 @@ Extra - minimap_coordinates: [{'x': 11, 'y': 6}, {'x': 12, 'y': 5}, {'x': 12, 'y
 
 > Door to Shooting Gallery; Heals? False
   * Layers: default
-  * L0 Hatch to Shooting Gallery/Door to Nettori Arena Access
+  * L0 Hatch to Shooting Gallery/Door to Nettori Arena Access; Excluded from Dock Lock Rando
   * Extra - door_idx: (47, 75)
   > Door to Overgrown Spire
       Any of the following:


### PR DESCRIPTION
No changelog, as Fusion does not have DLR in stable/staging.

Haven't tested in-game, but the doors don't show up in the resulting json, so I'm assuming it works.

Fixes https://github.com/MetroidAdvRandomizerSystem/mars-fusion-asm/issues/146