### PR TITLE
Fusion: optimize blank line in credits

### DIFF
--- a/randovania/games/fusion/exporter/patch_data_factory.py
+++ b/randovania/games/fusion/exporter/patch_data_factory.py
@@ -421,7 +421,7 @@ class FusionPatchDataFactory(PatchDataFactory[FusionConfiguration, FusionCosmeti
                     credits_array.append({"LineType": "White1", "Text": line, "BlankLines": 0})
                 for line in area_lines:
                     credits_array.append({"LineType": "White1", "Text": line, "BlankLines": 0})
-                credits_array.append({"LineType": "White1", "Text": "", "BlankLines": 0})
+                credits_array[-1]["BlankLines"] = 1
 
         # Have last item give more space
         credits_array[-1]["BlankLines"] = 3

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
@@ -2778,12 +2778,7 @@
         {
             "LineType": "White1",
             "Text": "Spaceboost Alley",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2798,12 +2793,7 @@
         {
             "LineType": "White1",
             "Text": "Magic Box",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2818,12 +2808,7 @@
         {
             "LineType": "White1",
             "Text": "Deserted Runway",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2838,12 +2823,7 @@
         {
             "LineType": "White1",
             "Text": "Cheddar Bay",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2858,12 +2838,7 @@
         {
             "LineType": "White1",
             "Text": "Reservoir Vault",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2878,12 +2853,7 @@
         {
             "LineType": "White1",
             "Text": "Station Entrance",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2898,12 +2868,7 @@
         {
             "LineType": "White1",
             "Text": "Fiery Storage",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2918,12 +2883,7 @@
         {
             "LineType": "White1",
             "Text": "Alcove",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2938,12 +2898,7 @@
         {
             "LineType": "White1",
             "Text": "Broken Bridge",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2958,12 +2913,7 @@
         {
             "LineType": "White1",
             "Text": "Operations Deck Data Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2978,12 +2928,7 @@
         {
             "LineType": "White1",
             "Text": "Data Courtyard",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2998,12 +2943,7 @@
         {
             "LineType": "White1",
             "Text": "Cubby Hole",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3018,12 +2958,7 @@
         {
             "LineType": "White1",
             "Text": "Twin Caverns West",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3038,12 +2973,7 @@
         {
             "LineType": "White1",
             "Text": "Zazabi Arena Access",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3058,12 +2988,7 @@
         {
             "LineType": "White1",
             "Text": "Ripper Tower",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3078,12 +3003,7 @@
         {
             "LineType": "White1",
             "Text": "Data Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3103,12 +3023,7 @@
         {
             "LineType": "White1",
             "Text": "(AQA)",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3123,12 +3038,7 @@
         {
             "LineType": "White1",
             "Text": "Alcove",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3143,12 +3053,7 @@
         {
             "LineType": "White1",
             "Text": "Kago Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3163,12 +3068,7 @@
         {
             "LineType": "White1",
             "Text": "Attic",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3183,12 +3083,7 @@
         {
             "LineType": "White1",
             "Text": "Geron's Treasure",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3203,12 +3098,7 @@
         {
             "LineType": "White1",
             "Text": "Arachnus Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3223,12 +3113,7 @@
         {
             "LineType": "White1",
             "Text": "Varia Core-X Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3243,12 +3128,7 @@
         {
             "LineType": "White1",
             "Text": "Charge Core Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3263,12 +3143,7 @@
         {
             "LineType": "White1",
             "Text": "Yakuza Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3283,12 +3158,7 @@
         {
             "LineType": "White1",
             "Text": "Ridley Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3303,11 +3173,6 @@
         {
             "LineType": "White1",
             "Text": "Nettori Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
             "BlankLines": 3
         },
         {

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
@@ -2759,12 +2759,7 @@
         {
             "LineType": "White1",
             "Text": "Ripper Tower",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2779,12 +2774,7 @@
         {
             "LineType": "White1",
             "Text": "Zozoro Wine Cellar",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2799,12 +2789,7 @@
         {
             "LineType": "White1",
             "Text": "X-B.O.X. Garage",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2819,12 +2804,7 @@
         {
             "LineType": "White1",
             "Text": "Ripper Tower",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2839,12 +2819,7 @@
         {
             "LineType": "White1",
             "Text": "Zazabi Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2859,12 +2834,7 @@
         {
             "LineType": "White1",
             "Text": "Cubby Hole",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2879,12 +2849,7 @@
         {
             "LineType": "White1",
             "Text": "Ripper Road",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2899,12 +2864,7 @@
         {
             "LineType": "White1",
             "Text": "Namihe's Lair",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2919,12 +2879,7 @@
         {
             "LineType": "White1",
             "Text": "Nexus Storage",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2939,12 +2894,7 @@
         {
             "LineType": "White1",
             "Text": "Operations Deck Data Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2959,12 +2909,7 @@
         {
             "LineType": "White1",
             "Text": "Gerubus Gully",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2979,12 +2924,7 @@
         {
             "LineType": "White1",
             "Text": "Operations Ventilation",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2999,12 +2939,7 @@
         {
             "LineType": "White1",
             "Text": "Lava Lake",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3019,12 +2954,7 @@
         {
             "LineType": "White1",
             "Text": "Dessgeega Dorm",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3039,12 +2969,7 @@
         {
             "LineType": "White1",
             "Text": "Reservoir Vault",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3059,12 +2984,7 @@
         {
             "LineType": "White1",
             "Text": "Training Aerie",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3079,12 +2999,7 @@
         {
             "LineType": "White1",
             "Text": "Security Access",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3099,12 +3014,7 @@
         {
             "LineType": "White1",
             "Text": "Geron's Treasure",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3119,12 +3029,7 @@
         {
             "LineType": "White1",
             "Text": "Station Entrance",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3139,12 +3044,7 @@
         {
             "LineType": "White1",
             "Text": "Charge Core Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3159,12 +3059,7 @@
         {
             "LineType": "White1",
             "Text": "Data Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3179,12 +3074,7 @@
         {
             "LineType": "White1",
             "Text": "Wall Jump Tutorial",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3199,12 +3089,7 @@
         {
             "LineType": "White1",
             "Text": "Serris Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3219,12 +3104,7 @@
         {
             "LineType": "White1",
             "Text": "Level 3 Security Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3239,12 +3119,7 @@
         {
             "LineType": "White1",
             "Text": "Ridley Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3259,12 +3134,7 @@
         {
             "LineType": "White1",
             "Text": "Nettori Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3279,11 +3149,6 @@
         {
             "LineType": "White1",
             "Text": "Cheddar Bay",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
             "BlankLines": 3
         },
         {

--- a/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
@@ -2738,12 +2738,7 @@
         {
             "LineType": "White1",
             "Text": "Antechamber",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2758,12 +2753,7 @@
         {
             "LineType": "White1",
             "Text": "Zazabi Speedway",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2778,12 +2768,7 @@
         {
             "LineType": "White1",
             "Text": "Fiery Storage",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2798,12 +2783,7 @@
         {
             "LineType": "White1",
             "Text": "Crumble City",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2818,12 +2798,7 @@
         {
             "LineType": "White1",
             "Text": "Overgrown Cache",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2838,12 +2813,7 @@
         {
             "LineType": "White1",
             "Text": "Genesis Speedway",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2858,12 +2828,7 @@
         {
             "LineType": "White1",
             "Text": "Magic Box",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2878,12 +2843,7 @@
         {
             "LineType": "White1",
             "Text": "C-Cache",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2898,12 +2858,7 @@
         {
             "LineType": "White1",
             "Text": "Spaceboost Alley",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2918,12 +2873,7 @@
         {
             "LineType": "White1",
             "Text": "Operations Deck Data Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2938,12 +2888,7 @@
         {
             "LineType": "White1",
             "Text": "Garbage Chute",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2958,12 +2903,7 @@
         {
             "LineType": "White1",
             "Text": "Cubby Hole",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2978,12 +2918,7 @@
         {
             "LineType": "White1",
             "Text": "Data Courtyard",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2998,12 +2933,7 @@
         {
             "LineType": "White1",
             "Text": "Attic",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3018,12 +2948,7 @@
         {
             "LineType": "White1",
             "Text": "Ripper Tower",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3038,12 +2963,7 @@
         {
             "LineType": "White1",
             "Text": "Lava Lake",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3058,12 +2978,7 @@
         {
             "LineType": "White1",
             "Text": "Training Aerie",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3078,12 +2993,7 @@
         {
             "LineType": "White1",
             "Text": "Level 2 Security Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3098,12 +3008,7 @@
         {
             "LineType": "White1",
             "Text": "Stabilizer Storage",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3118,12 +3023,7 @@
         {
             "LineType": "White1",
             "Text": "Reservoir East",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3138,12 +3038,7 @@
         {
             "LineType": "White1",
             "Text": "Hornoad Hole",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3163,12 +3058,7 @@
         {
             "LineType": "White1",
             "Text": "(AQA)",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3183,12 +3073,7 @@
         {
             "LineType": "White1",
             "Text": "Charge Core Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3203,12 +3088,7 @@
         {
             "LineType": "White1",
             "Text": "Arachnus Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3223,12 +3103,7 @@
         {
             "LineType": "White1",
             "Text": "Main Boiler Control Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3243,12 +3118,7 @@
         {
             "LineType": "White1",
             "Text": "Varia Core-X Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3263,11 +3133,6 @@
         {
             "LineType": "White1",
             "Text": "Zazabi Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
             "BlankLines": 3
         },
         {

--- a/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
@@ -2738,12 +2738,7 @@
         {
             "LineType": "White1",
             "Text": "Data Courtyard",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2758,12 +2753,7 @@
         {
             "LineType": "White1",
             "Text": "Overgrown Cache",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2778,12 +2768,7 @@
         {
             "LineType": "White1",
             "Text": "Varia Core-X Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2798,12 +2783,7 @@
         {
             "LineType": "White1",
             "Text": "Wall Jump Tutorial",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2818,12 +2798,7 @@
         {
             "LineType": "White1",
             "Text": "Reservoir Vault",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2838,12 +2813,7 @@
         {
             "LineType": "White1",
             "Text": "Kago Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2858,12 +2828,7 @@
         {
             "LineType": "White1",
             "Text": "Training Aerie",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2878,12 +2843,7 @@
         {
             "LineType": "White1",
             "Text": "Main Boiler Control Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2898,12 +2858,7 @@
         {
             "LineType": "White1",
             "Text": "Nettori Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2918,12 +2873,7 @@
         {
             "LineType": "White1",
             "Text": "Operations Deck Data Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2938,12 +2888,7 @@
         {
             "LineType": "White1",
             "Text": "Lava Lake",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2958,12 +2903,7 @@
         {
             "LineType": "White1",
             "Text": "Data Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2978,12 +2918,7 @@
         {
             "LineType": "White1",
             "Text": "Arachnus Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -2998,12 +2933,7 @@
         {
             "LineType": "White1",
             "Text": "Level 1 Security Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3018,12 +2948,7 @@
         {
             "LineType": "White1",
             "Text": "Vault",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3038,12 +2963,7 @@
         {
             "LineType": "White1",
             "Text": "Lava Maze",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3058,12 +2978,7 @@
         {
             "LineType": "White1",
             "Text": "C-Cache",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3078,12 +2993,7 @@
         {
             "LineType": "White1",
             "Text": "Magic Box",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3098,12 +3008,7 @@
         {
             "LineType": "White1",
             "Text": "Cubby Hole",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3118,12 +3023,7 @@
         {
             "LineType": "White1",
             "Text": "Silo Scaffolding",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3138,12 +3038,7 @@
         {
             "LineType": "White1",
             "Text": "Security Access",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3158,12 +3053,7 @@
         {
             "LineType": "White1",
             "Text": "Crumble City",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3178,12 +3068,7 @@
         {
             "LineType": "White1",
             "Text": "Ridley Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3198,12 +3083,7 @@
         {
             "LineType": "White1",
             "Text": "Arachnus Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3218,12 +3098,7 @@
         {
             "LineType": "White1",
             "Text": "Serris Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3238,12 +3113,7 @@
         {
             "LineType": "White1",
             "Text": "Yakuza Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3258,11 +3128,6 @@
         {
             "LineType": "White1",
             "Text": "Charge Core Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
             "BlankLines": 3
         },
         {

--- a/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
@@ -3384,12 +3384,7 @@
         {
             "LineType": "White1",
             "Text": "Pump Control Unit",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3404,12 +3399,7 @@
         {
             "LineType": "White1",
             "Text": "Transmutation Trial",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3424,12 +3414,7 @@
         {
             "LineType": "White1",
             "Text": "Zazabi Arena",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3444,12 +3429,7 @@
         {
             "LineType": "White1",
             "Text": "Antechamber",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3464,12 +3444,7 @@
         {
             "LineType": "White1",
             "Text": "Zozoro Wine Cellar",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3484,12 +3459,7 @@
         {
             "LineType": "White1",
             "Text": "Zazabi Arena Access",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3504,12 +3474,7 @@
         {
             "LineType": "White1",
             "Text": "Operations Ventilation Storage",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3524,12 +3489,7 @@
         {
             "LineType": "White1",
             "Text": "Reservoir Vault",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3544,12 +3504,7 @@
         {
             "LineType": "White1",
             "Text": "Silo Scaffolding",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3564,12 +3519,7 @@
         {
             "LineType": "White1",
             "Text": "Alcove",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3584,12 +3534,7 @@
         {
             "LineType": "White1",
             "Text": "Vault",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3604,12 +3549,7 @@
         {
             "LineType": "White1",
             "Text": "Data Room",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3624,12 +3564,7 @@
         {
             "LineType": "White1",
             "Text": "Twin Caverns West",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3644,12 +3579,7 @@
         {
             "LineType": "White1",
             "Text": "Bob's Abode",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3664,12 +3594,7 @@
         {
             "LineType": "White1",
             "Text": "Station Entrance",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3684,12 +3609,7 @@
         {
             "LineType": "White1",
             "Text": "Namihe's Lair",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3704,12 +3624,7 @@
         {
             "LineType": "White1",
             "Text": "Ripper Tower",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
-            "BlankLines": 0
+            "BlankLines": 1
         },
         {
             "LineType": "Red",
@@ -3724,11 +3639,6 @@
         {
             "LineType": "White1",
             "Text": "Aquarium Kago Storage",
-            "BlankLines": 0
-        },
-        {
-            "LineType": "White1",
-            "Text": "",
             "BlankLines": 3
         },
         {


### PR DESCRIPTION
The fusion credits wants to write one blank line. Previously this was done by writing an empty string as a new line.
However it is much more memory efficient for the game, to just tell the previous element to include one more newlines.
This doesn't *fully* make the "Credits exceeded length" dissapear, but it postpones it to where 99% of people won't encounter it.
Before this change, I was able to trigger it by only including a few duplicates, after this change in order to trigger it, I have to shuffle ~95 majors (out of 127 locations). 

Fixes https://randovania.sentry.io/issues/6916113458/