### PR TITLE
GUI: Clean up how Specific Pickup Hints are displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.3.0] - 2025-11-??
 
+- Changed: Centered the text at the top of the Hints preset settings.
 - Changed: Cleaned up how Specific Pickup Hints are shown in the preset settings.
+- Changed: Places that describe a preset with Specific Pickup Hints have slightly better grammar in some cases.
 
 ### Factorio
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.3.0] - 2025-11-??
 
+- Changed: Cleaned up how Specific Pickup Hints are shown in the preset settings.
+
 ### Metroid Prime
 
 #### Logic Database

--- a/randovania/games/am2r/game_data.py
+++ b/randovania/games/am2r/game_data.py
@@ -57,11 +57,11 @@ def _hints() -> randovania.game.hints.GameHints:
         hint_distributor=AM2RHintDistributor(),
         specific_pickup_hints={
             "artifacts": randovania.game.hints.SpecificHintDetails(
-                long_name="DNA",
+                long_name="DNA Hints",
                 description="This controls how precise the DNA hints for the Wisdom Septoggs are.",
             ),
             "ice_beam": randovania.game.hints.SpecificHintDetails(
-                long_name="Ice Beam",
+                long_name="Ice Beam Hint",
                 description="This controls how precise the hint for Ice Beam in Genetics Laboratory is.",
             ),
         },

--- a/randovania/games/fusion/game_data.py
+++ b/randovania/games/fusion/game_data.py
@@ -58,11 +58,11 @@ def _hints() -> randovania.game.hints.GameHints:
         hint_distributor=FusionHintDistributor(),
         specific_pickup_hints={
             "artifacts": randovania.game.hints.SpecificHintDetails(
-                long_name="Infant Metroids",
+                long_name="Infant Metroids Hint",
                 description="This controls how precise the Infant Metroids hint at Restricted Labs is.",
             ),
             "charge_beam": randovania.game.hints.SpecificHintDetails(
-                long_name="Charge Beam",
+                long_name="Charge Beam Hint",
                 description="This controls how precise the hint for Charge Beam in Auxiliary Navigation Room is.",
             ),
         },

--- a/randovania/games/prime1/game_data.py
+++ b/randovania/games/prime1/game_data.py
@@ -68,11 +68,11 @@ def _hints() -> randovania.game.hints.GameHints:
         hint_distributor=PrimeHintDistributor(),
         specific_pickup_hints={
             "artifacts": randovania.game.hints.SpecificHintDetails(
-                long_name="Chozo Artifacts",
+                long_name="Chozo Artifact Hints",
                 description="This controls how precise the hints for Chozo Artifacts in Artifact Temple are.",
             ),
             "phazon_suit": randovania.game.hints.SpecificHintDetails(
-                long_name="Phazon Suit",
+                long_name="Phazon Suit Hint",
                 description="This controls how precise the hint for Phazon Suit in Impact Crater is.",
                 disabled_details="No hint is added.",
                 hide_area_details=(

--- a/randovania/games/prime2/game_data.py
+++ b/randovania/games/prime2/game_data.py
@@ -69,7 +69,7 @@ def _hints() -> randovania.game.hints.GameHints:
         hint_distributor=EchoesHintDistributor(),
         specific_pickup_hints={
             "sky_temple_keys": randovania.game.hints.SpecificHintDetails(
-                long_name="Sky Temple Keys",
+                long_name="Sky Temple Key Hints",
                 description="This controls how precise the hints for Sky Temple Keys in Sky Temple Gateway are.",
             )
         },

--- a/randovania/games/samus_returns/game_data.py
+++ b/randovania/games/samus_returns/game_data.py
@@ -73,7 +73,7 @@ def _hints() -> randovania.game.hints.GameHints:
         hint_distributor=MSRHintDistributor(),
         specific_pickup_hints={
             "artifacts": randovania.game.hints.SpecificHintDetails(
-                long_name="Metroid DNA",
+                long_name="Metroid DNA Hints",
                 description="This controls how precise the Metroid DNA hints for the DNA Chozo Seals are.",
             ),
             "final_boss_item": randovania.game.hints.SpecificHintDetails(

--- a/randovania/games/samus_returns/game_data.py
+++ b/randovania/games/samus_returns/game_data.py
@@ -77,7 +77,7 @@ def _hints() -> randovania.game.hints.GameHints:
                 description="This controls how precise the Metroid DNA hints for the DNA Chozo Seals are.",
             ),
             "final_boss_item": randovania.game.hints.SpecificHintDetails(
-                long_name="Final Boss Item",
+                long_name="Final Boss Item Hint",
                 description=(
                     "After collecting all Metroid DNA, a message appears that says that "
                     "the final boss can be fought and where to find them. "

--- a/randovania/gui/generated/preset_hints_ui.py
+++ b/randovania/gui/generated/preset_hints_ui.py
@@ -38,7 +38,7 @@ class Ui_PresetHints(object):
         self.scroll_area.setWidgetResizable(True)
         self.scroll_area_contents = QWidget()
         self.scroll_area_contents.setObjectName(u"scroll_area_contents")
-        self.scroll_area_contents.setGeometry(QRect(0, 0, 567, 604))
+        self.scroll_area_contents.setGeometry(QRect(0, -104, 567, 670))
         sizePolicy = QSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -198,14 +198,15 @@ class Ui_PresetHints(object):
 
         self.scroll_area_layout.addWidget(self.specific_location_hints_box)
 
-        self.specific_pickup_hints_box = QGroupBox(self.scroll_area_contents)
-        self.specific_pickup_hints_box.setObjectName(u"specific_pickup_hints_box")
-        self.verticalLayout = QVBoxLayout(self.specific_pickup_hints_box)
+        self.specific_pickup_hints_widget = QWidget(self.scroll_area_contents)
+        self.specific_pickup_hints_widget.setObjectName(u"specific_pickup_hints_widget")
+        self.verticalLayout = QVBoxLayout(self.specific_pickup_hints_widget)
         self.verticalLayout.setSpacing(6)
         self.verticalLayout.setContentsMargins(11, 11, 11, 11)
         self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
 
-        self.scroll_area_layout.addWidget(self.specific_pickup_hints_box)
+        self.scroll_area_layout.addWidget(self.specific_pickup_hints_widget)
 
         self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
@@ -237,6 +238,5 @@ class Ui_PresetHints(object):
         self.specific_location_hints_box.setTitle(QCoreApplication.translate("PresetHints", u"Specific Location Hints", None))
         self.enable_specific_location_hints_check.setText(QCoreApplication.translate("PresetHints", u"Enable specific location hints", None))
         self.enable_specific_location_hints_description.setText(QCoreApplication.translate("PresetHints", u"Specific location hints are hints that are always in the same hint location, and always provide you with information about the pickup in the specific pickup location associated with that hint. If disabled, all specific location hints will be replaced with jokes.", None))
-        self.specific_pickup_hints_box.setTitle(QCoreApplication.translate("PresetHints", u"Specific Pickup Hints", None))
     # retranslateUi
 

--- a/randovania/gui/generated/preset_hints_ui.py
+++ b/randovania/gui/generated/preset_hints_ui.py
@@ -38,7 +38,7 @@ class Ui_PresetHints(object):
         self.scroll_area.setWidgetResizable(True)
         self.scroll_area_contents = QWidget()
         self.scroll_area_contents.setObjectName(u"scroll_area_contents")
-        self.scroll_area_contents.setGeometry(QRect(0, -104, 567, 670))
+        self.scroll_area_contents.setGeometry(QRect(0, 0, 567, 670))
         sizePolicy = QSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -51,6 +51,7 @@ class Ui_PresetHints(object):
         self.scroll_area_layout.setContentsMargins(6, 6, 6, 6)
         self.hint_system_description = QLabel(self.scroll_area_contents)
         self.hint_system_description.setObjectName(u"hint_system_description")
+        self.hint_system_description.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.hint_system_description.setWordWrap(True)
 
         self.scroll_area_layout.addWidget(self.hint_system_description)

--- a/randovania/gui/preset_settings/hints_tab.py
+++ b/randovania/gui/preset_settings/hints_tab.py
@@ -74,7 +74,7 @@ class PresetHints(PresetTab, Ui_PresetHints):
             for hint, details in game_description.game.hints.specific_pickup_hints.items():
                 self.create_specific_hint_group(hint, details)
         else:
-            self.specific_pickup_hints_box.setVisible(False)
+            self.specific_pickup_hints_widget.setVisible(False)
 
     @classmethod
     def tab_title(cls) -> str:
@@ -137,7 +137,7 @@ class PresetHints(PresetTab, Ui_PresetHints):
     def create_specific_hint_group(self, hint: str, details: SpecificHintDetails) -> None:
         """Create the widget for editing this specific pickup hint, and connect its signal."""
 
-        hint_group = QtWidgets.QGroupBox(self.specific_pickup_hints_box)
+        hint_group = QtWidgets.QGroupBox(self.specific_pickup_hints_widget)
         hint_group.setObjectName(f"hint_{hint}_group")
         hint_group.setTitle(details.long_name)
         vertical_layout = QtWidgets.QVBoxLayout(hint_group)

--- a/randovania/gui/ui_files/preset_hints.ui
+++ b/randovania/gui/ui_files/preset_hints.ui
@@ -42,9 +42,9 @@
        <property name="geometry">
         <rect>
          <x>0</x>
-         <y>0</y>
+         <y>-104</y>
          <width>567</width>
-         <height>604</height>
+         <height>670</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -105,7 +105,7 @@
            <item>
             <widget class="Line" name="resolver_hints_line">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
             </widget>
            </item>
@@ -129,7 +129,7 @@
            <item>
             <widget class="Line" name="minimum_available_locations_line">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
             </widget>
            </item>
@@ -164,7 +164,7 @@
               <item>
                <spacer name="minimum_available_locations_spacer">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -206,7 +206,7 @@
            <item>
             <widget class="Line" name="minimum_weight_line">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
             </widget>
            </item>
@@ -235,7 +235,7 @@
               <item>
                <spacer name="minimum_weight_spacer">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -307,17 +307,27 @@
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="specific_pickup_hints_box">
-          <property name="title">
-           <string>Specific Pickup Hints</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout"/>
+         <widget class="QWidget" name="specific_pickup_hints_widget" native="true">
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+          </layout>
          </widget>
         </item>
         <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>

--- a/randovania/gui/ui_files/preset_hints.ui
+++ b/randovania/gui/ui_files/preset_hints.ui
@@ -42,7 +42,7 @@
        <property name="geometry">
         <rect>
          <x>0</x>
-         <y>-104</y>
+         <y>0</y>
          <width>567</width>
          <height>670</height>
         </rect>
@@ -73,6 +73,9 @@
          <widget class="QLabel" name="hint_system_description">
           <property name="text">
            <string>For more information about Randovania's hint system, please refer to the various hint-related tabs on this game's page.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
           <property name="wordWrap">
            <bool>true</bool>

--- a/randovania/layout/preset_describer.py
+++ b/randovania/layout/preset_describer.py
@@ -125,7 +125,7 @@ class GamePresetDescriber:
 
         for hint, mode in configuration.hints.specific_pickup_hints.items():
             details = configuration.game.hints.specific_pickup_hints[hint]
-            strings.append(f"{details.long_name} Hint: {mode.long_name}")
+            strings.append(f"{details.long_name}: {mode.long_name}")
 
         return strings
 

--- a/test/games/am2r/layout/test_am2r_describer.py
+++ b/test/games/am2r/layout/test_am2r_describer.py
@@ -67,7 +67,7 @@ def test_am2r_format_params(artifacts: AM2RArtifactConfig, darkness_chance: int)
             if artifacts.required_artifacts
             else [dna_where]
         ),
-        "Hints": ["DNA Hint: Region and area", "Ice Beam Hint: Region only"],
+        "Hints": ["DNA Hints: Region and area", "Ice Beam Hint: Region only"],
         "Item Pool": [
             f"Size: {118 + artifacts.placed_artifacts} of 134",
             "Vanilla starting items",

--- a/test/games/prime1/layout/test_preset_describer.py
+++ b/test/games/prime1/layout/test_preset_describer.py
@@ -58,7 +58,7 @@ def test_prime_format_params(use_enemy_attribute_randomizer, pre_place_artifacts
         ],
         "Gameplay": ["Starts at Tallon Overworld - Landing Site"],
         "Hints": [
-            "Chozo Artifacts Hint: Region and area",
+            "Chozo Artifact Hints: Region and area",
             "Phazon Suit Hint: Region only",
         ],
         "Difficulty": [],

--- a/test/games/prime2/layout/test_echoes_preset_describer.py
+++ b/test/games/prime2/layout/test_echoes_preset_describer.py
@@ -75,7 +75,7 @@ def test_echoes_format_params(
         expected_hints.append("Random hints disabled")
     if not enable_specific_location_hints:
         expected_hints.append("Specific location hints disabled")
-    expected_hints.append(f"Sky Temple Keys Hint: {stk_hint_mode.long_name}")
+    expected_hints.append(f"Sky Temple Key Hints: {stk_hint_mode.long_name}")
 
     # Run
     result = RandovaniaGame.METROID_PRIME_ECHOES.data.layout.preset_describer.format_params(layout_configuration)
@@ -165,5 +165,5 @@ def test_echoes_format_params2(default_echoes_configuration):
             "Split beam ammo",
             "Sky Temple Keys at all bosses",
         ],
-        "Hints": ["Sky Temple Keys Hint: Region and area"],
+        "Hints": ["Sky Temple Key Hints: Region and area"],
     }

--- a/test/games/samus_returns/layout/test_msr_describer.py
+++ b/test/games/samus_returns/layout/test_msr_describer.py
@@ -75,7 +75,7 @@ def test_msr_format_params(artifacts) -> None:
             "Change Surface Cavern Cavity Crumble Blocks, Change Area 1 Transport to Surface and Area 2 Crumble Blocks",
         ],
         "Hints": [
-            "Metroid DNA Hint: Region and area",
+            "Metroid DNA Hints: Region and area",
             "Final Boss Item Hint: Region only",
         ],
         "Environmental Damage": [

--- a/test/gui/preset_settings/test_hints_tab.py
+++ b/test/gui/preset_settings/test_hints_tab.py
@@ -66,7 +66,7 @@ def test_on_preset_changed(enable_random_hints: bool, skip_qtbot, hints_tab_with
 
     assert hints_tab.random_hints_box.isVisibleTo(parent) == has_random_hints
     assert hints_tab.specific_location_hints_box.isVisibleTo(parent) == has_specific_location_hints
-    assert hints_tab.specific_pickup_hints_box.isVisibleTo(parent) == has_specific_pickup_hints
+    assert hints_tab.specific_pickup_hints_widget.isVisibleTo(parent) == has_specific_pickup_hints
 
 
 def test_persist_enable_random_hints(skip_qtbot, preset_manager):


### PR DESCRIPTION
Gets rid of the ugly nested groupbox
<img width="1136" height="994" alt="image" src="https://github.com/user-attachments/assets/6745102d-e902-44c4-a487-29204d0dbcba" />
