### PR TITLE
Benchmark: Run twice, no multithreading

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,17 +7,15 @@ on:
       - main
 
 jobs:
-  benchmark:
+  walltime:
     runs-on: 'ubuntu-latest'
-    name: Benchmark
+    name: Walltime Benchmark
 
     timeout-minutes: 30
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -37,6 +35,6 @@ jobs:
       - name: run pytest (benchmark)
         uses: CodSpeedHQ/action@v4
         with:
-          run: uv run pytest -n auto --codspeed --codspeed-max-rounds=1 --skip-gui-tests
+          run: uv run pytest --codspeed --codspeed-max-rounds=2 --skip-gui-tests
           mode: walltime
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
Two runs helps a bit with outliers, and not running in parallel also helps with that.