### PR TITLE
Create centralized storage of Presets for server

### DIFF
--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -729,7 +729,7 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
             GeneratorParameters(
                 seed_number=random.randint(0, 2**31),
                 spoiler=spoiler,
-                presets=[VersionedPreset.from_str(world.preset_raw).get_preset() for world in self._session.worlds],
+                presets=[world.preset.get_preset() for world in self._session.worlds],
             )
         )
         return await self.generate_game_with_permalink(permalink, retries=retries)

--- a/randovania/lib/migration_lib.py
+++ b/randovania/lib/migration_lib.py
@@ -24,10 +24,14 @@ Migrations = typing.Sequence[Migration | None]
 GameMigrations = typing.Sequence[GameMigration | None]
 
 
+def get_schema_version(data: dict) -> int:
+    return typing.cast("int", data.get("schema_version", 1))
+
+
 def apply_migrations(
     data: dict, migrations: Migrations, *, copy_before_migrating: bool = False, version_name: str = "version"
 ) -> dict:
-    schema_version = typing.cast("int", data.get("schema_version", 1))
+    schema_version = get_schema_version(data)
     version = get_version(migrations)
 
     while schema_version < version:

--- a/randovania/network_common/multiplayer_session.py
+++ b/randovania/network_common/multiplayer_session.py
@@ -63,12 +63,12 @@ class MultiplayerUser(RandovaniaUser):
 class MultiplayerWorld(JsonDataclass):
     id: uuid.UUID
     name: str
-    preset_raw: str
+    preset_raw: bytes
     has_been_beaten: bool
 
     @cached_property
     def preset(self) -> VersionedPreset:
-        return VersionedPreset.from_str(self.preset_raw)
+        return VersionedPreset.from_bytes(self.preset_raw)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/randovania/server/multiplayer/world_api.py
+++ b/randovania/server/multiplayer/world_api.py
@@ -168,7 +168,7 @@ async def collect_locations(
     session = source_world.session
 
     sa.logger.info(f"{session_common.describe_session(session, source_world)} found items {pickup_locations}")
-    description = session.layout_description
+    description = session.get_layout_description()
     assert description is not None
 
     receiver_worlds = set()
@@ -367,8 +367,8 @@ async def world_sync(sa: ServerApp, sid: str, request: ServerSyncRequest) -> Ser
 async def emit_world_pickups_update(sa: ServerApp, world: World) -> None:
     session = world.session
 
-    assert session.layout_description is not None
-    description = session.layout_description
+    description = session.get_layout_description()
+    assert description is not None
 
     assert world.order is not None
     resource_database = _get_resource_database(description, world.order)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from randovania.game_description.game_description import GameDescription
     from randovania.game_description.pickup.pickup_database import PickupDatabase
     from randovania.game_description.resources.resource_database import ResourceDatabase
+    from randovania.layout.versioned_preset import VersionedPreset
 
 
 class TestFilesDir:
@@ -78,8 +79,13 @@ def blank_available_in_multi(request: pytest.FixtureRequest) -> bool:
 
 
 @pytest.fixture(scope="session")
-def default_preset() -> Preset:
-    return PresetManager(None).default_preset.get_preset()
+def default_versioned_preset() -> VersionedPreset:
+    return PresetManager(None).default_preset
+
+
+@pytest.fixture(scope="session")
+def default_preset(default_versioned_preset) -> Preset:
+    return default_versioned_preset.get_preset()
 
 
 @pytest.fixture(scope="session")

--- a/test/gui/dialog/test_preset_history_dialog.py
+++ b/test/gui/dialog/test_preset_history_dialog.py
@@ -96,7 +96,7 @@ def test_get_old_preset_bad_json():
 
 def test_get_old_preset_bad_formatting():
     assert preset_history_dialog._get_old_preset('{"name": "theName"}') == (
-        "Preset theName at this version can't be used as it contains the following error:\n'schema_version'"
+        "Preset theName at this version can't be used as it contains the following error:\n'layout_configuration'"
     )
 
 

--- a/test/gui/test_multiplayer_session_window.py
+++ b/test/gui/test_multiplayer_session_window.py
@@ -78,23 +78,19 @@ def sample_session(preset_manager: PresetManager) -> MultiplayerSessionEntry:
             MultiplayerWorld(
                 name="W1",
                 id=u1,
-                preset_raw=json.dumps(
-                    preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_json
-                ),
+                preset_raw=preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_bytes(),
                 has_been_beaten=False,
             ),
             MultiplayerWorld(
                 name="W2",
                 id=u2,
-                preset_raw=json.dumps(preset_manager.default_preset.as_json),
+                preset_raw=preset_manager.default_preset.as_bytes(),
                 has_been_beaten=False,
             ),
             MultiplayerWorld(
                 name="W3",
                 id=u3,
-                preset_raw=json.dumps(
-                    preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_json
-                ),
+                preset_raw=preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_bytes(),
                 has_been_beaten=False,
             ),
         ],
@@ -206,9 +202,7 @@ async def test_on_session_meta_update(
             MultiplayerWorld(
                 name="W1",
                 id=u1,
-                preset_raw=json.dumps(
-                    preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_json
-                ),
+                preset_raw=preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_bytes(),
                 has_been_beaten=False,
             ),
         ],
@@ -531,13 +525,13 @@ async def test_generate_game(
         MultiplayerWorld(
             id=uuid.uuid4(),
             name="W1",
-            preset_raw=json.dumps(preset_manager.default_preset.as_json),
+            preset_raw=preset_manager.default_preset.as_bytes(),
             has_been_beaten=False,
         ),
         MultiplayerWorld(
             id=uuid.uuid4(),
             name="W2",
-            preset_raw=json.dumps(preset_manager.default_preset.as_json),
+            preset_raw=preset_manager.default_preset.as_bytes(),
             has_been_beaten=False,
         ),
     ]
@@ -980,7 +974,7 @@ async def test_game_export_listener(
         new_callable=AsyncMock,
         return_value=QtWidgets.QDialog.DialogCode.Accepted,
     )
-    mock_preset_from = mocker.patch("randovania.layout.versioned_preset.VersionedPreset.from_str")
+    mock_preset_from = mocker.patch("randovania.layout.versioned_preset.VersionedPreset.from_bytes")
 
     game = mock_preset_from.return_value.game
     window._session = MagicMock()
@@ -988,7 +982,7 @@ async def test_game_export_listener(
     world = MultiplayerWorld(
         id=uuid.uuid4(),
         name="W1",
-        preset_raw=json.dumps(preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_json),
+        preset_raw=preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_bytes(),
         has_been_beaten=False,
     )
     window._session.get_world.return_value = world

--- a/test/gui/widgets/test_multiplayer_session_users_widget.py
+++ b/test/gui/widgets/test_multiplayer_session_users_widget.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 import uuid
 from unittest.mock import MagicMock
 
@@ -28,23 +27,19 @@ def test_widgets_in_normal_session(skip_qtbot, preset_manager):
             MultiplayerWorld(
                 name="W1",
                 id=u1,
-                preset_raw=json.dumps(
-                    preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_json
-                ),
+                preset_raw=preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_bytes(),
                 has_been_beaten=True,
             ),
             MultiplayerWorld(
                 name="W2",
                 id=u2,
-                preset_raw=json.dumps(preset_manager.default_preset.as_json),
+                preset_raw=preset_manager.default_preset.as_bytes(),
                 has_been_beaten=False,
             ),
             MultiplayerWorld(
                 name="W3",
                 id=u3,
-                preset_raw=json.dumps(
-                    preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_json
-                ),
+                preset_raw=preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_bytes(),
                 has_been_beaten=False,
             ),
         ],
@@ -147,23 +142,19 @@ def test_widgets_in_coop_session(skip_qtbot, preset_manager):
             MultiplayerWorld(
                 name="W1",
                 id=u1,
-                preset_raw=json.dumps(
-                    preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_json
-                ),
+                preset_raw=preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_bytes(),
                 has_been_beaten=True,
             ),
             MultiplayerWorld(
                 name="W2",
                 id=u2,
-                preset_raw=json.dumps(preset_manager.default_preset.as_json),
+                preset_raw=preset_manager.default_preset.as_bytes(),
                 has_been_beaten=False,
             ),
             MultiplayerWorld(
                 name="W3",
                 id=u3,
-                preset_raw=json.dumps(
-                    preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_json
-                ),
+                preset_raw=preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).as_bytes(),
                 has_been_beaten=False,
             ),
         ],

--- a/test/server/multiplayer/conftest.py
+++ b/test/server/multiplayer/conftest.py
@@ -45,19 +45,19 @@ def solo_two_world_session_setup_fixture(test_files_dir) -> Callable[[], databas
             creator=user1,
             creation_date=datetime.datetime(2020, 5, 2, 10, 20, tzinfo=datetime.UTC),
         )
-        session.layout_description = description
+        session.set_layout_description(description)
         session.save()
         w1 = database.World.create_for(
             session=session,
             name="World 1",
-            preset=preset_0,
+            preset_bytes=preset_0.as_bytes(),
             order=0,
             uid=uuid.UUID("1179c986-758a-4170-9b07-fe4541d78db0"),
         )
         w2 = database.World.create_for(
             session=session,
             name="World 2",
-            preset=preset_1,
+            preset_bytes=preset_1.as_bytes(),
             order=1,
             uid=uuid.UUID("6b5ac1a1-d250-4f05-a5fb-ae37e8a92165"),
         )
@@ -82,18 +82,26 @@ def solo_two_world_session(clean_database, solo_two_world_session_setup) -> data
 
 
 @pytest.fixture
-def two_player_session(clean_database):
+def two_player_session(clean_database, default_versioned_preset):
     user1 = database.User.create(id=1234, name="The Name")
     user2 = database.User.create(id=1235, name="Other Name")
 
     session = database.MultiplayerSession.create(
         id=1, name="Debug", state=MultiplayerSessionVisibility.VISIBLE, creator=user1
     )
-    w1 = database.World.create(
-        session=session, name="World 1", preset="{}", order=0, uuid=uuid.UUID("1179c986-758a-4170-9b07-fe4541d78db0")
+    w1 = database.World.create_for(
+        session=session,
+        name="World 1",
+        preset_bytes=default_versioned_preset.as_bytes(),
+        order=0,
+        uid=uuid.UUID("1179c986-758a-4170-9b07-fe4541d78db0"),
     )
-    w2 = database.World.create(
-        session=session, name="World 2", preset="{}", order=1, uuid=uuid.UUID("6b5ac1a1-d250-4f05-a5fb-ae37e8a92165")
+    w2 = database.World.create_for(
+        session=session,
+        name="World 2",
+        preset_bytes=default_versioned_preset.as_bytes(),
+        order=1,
+        uid=uuid.UUID("6b5ac1a1-d250-4f05-a5fb-ae37e8a92165"),
     )
 
     database.MultiplayerMembership.create(user=user1, session=session, admin=True)
@@ -135,7 +143,7 @@ def one_world_two_player_coop_session(clean_database):
 
 
 @pytest.fixture
-def session_update(clean_database, mocker):
+def session_update(clean_database, default_versioned_preset, mocker):
     mock_layout = MagicMock(spec=LayoutDescription)
     mock_layout.shareable_word_hash = "Words of O-Lir"
     mock_layout.shareable_hash = "ABCDEFG"
@@ -154,7 +162,7 @@ def session_update(clean_database, mocker):
     target = mock_layout.all_patches.__getitem__.return_value.pickup_assignment.__getitem__.return_value
     target.pickup.name = "The Pickup"
 
-    mocker.patch("randovania.server.database.MultiplayerSession._get_layout_description", return_value=mock_layout)
+    mocker.patch("randovania.server.database.MultiplayerSession.get_layout_description", return_value=mock_layout)
 
     user1 = database.User.create(id=1234, name="The Name")
     user2 = database.User.create(id=1235, name="Other")
@@ -170,11 +178,19 @@ def session_update(clean_database, mocker):
     database.MultiplayerMembership.create(
         user=user2, session=session, row=1, admin=False, ready=True, connection_state="Game"
     )
-    w1 = database.World.create(
-        session=session, name="World1", uuid=uuid.UUID("67d75d0e-da8d-4a90-b29e-cae83bcf9519"), preset="{}", order=0
+    w1 = database.World.create_for(
+        session=session,
+        name="World1",
+        preset_bytes=default_versioned_preset.as_bytes(),
+        order=0,
+        uid=uuid.UUID("67d75d0e-da8d-4a90-b29e-cae83bcf9519"),
     )
-    w2 = database.World.create(
-        session=session, name="World2", uuid=uuid.UUID("d0f7ed70-66b0-413c-bc13-f9f7fb018726"), preset="{}", order=1
+    w2 = database.World.create_for(
+        session=session,
+        name="World2",
+        preset_bytes=default_versioned_preset.as_bytes(),
+        order=1,
+        uid=uuid.UUID("d0f7ed70-66b0-413c-bc13-f9f7fb018726"),
     )
 
     database.WorldAction.create(provider=w1, location=0, session=session, receiver=w2, time=time)

--- a/test/server/multiplayer/test_session_admin.py
+++ b/test/server/multiplayer/test_session_admin.py
@@ -109,13 +109,13 @@ async def test_admin_player_kick_member(two_player_session, mock_sa, mocker, moc
                 {
                     "id": "1179c986-758a-4170-9b07-fe4541d78db0",
                     "name": "World 1",
-                    "preset_raw": "{}",
+                    "preset_raw": ANY,
                     "has_been_beaten": False,
                 },
                 {
                     "id": "6b5ac1a1-d250-4f05-a5fb-ae37e8a92165",
                     "name": "World 2",
-                    "preset_raw": "{}",
+                    "preset_raw": ANY,
                     "has_been_beaten": False,
                 },
             ],
@@ -223,9 +223,7 @@ async def test_admin_session_patcher_file(mock_sa, mock_audit, mocker, two_playe
     mock_sa.get_current_user.return_value = database.User.get_by_id(1235)
     w2 = database.World.get_by_id(2)
 
-    mock_layout_description: PropertyMock = mocker.patch(
-        "randovania.server.database.MultiplayerSession.layout_description", new_callable=PropertyMock
-    )
+    mock_layout_description = mocker.patch("randovania.server.database.MultiplayerSession.get_layout_description")
     game = mock_layout_description.return_value.get_preset.return_value.game
     game.data.layout.cosmetic_patches = EchoesCosmeticPatches
 
@@ -596,8 +594,8 @@ async def test_admin_session_change_layout_description(
     session = database.MultiplayerSession.create(
         id=1, name="Debug", state=MultiplayerSessionVisibility.VISIBLE, creator=user1, generation_in_progress=user1
     )
-    database.World.create_for(session=session, name="W1", preset=preset, order=0)
-    database.World.create_for(session=session, name="W2", preset=preset, order=1)
+    database.World.create_for(session=session, name="W1", preset_bytes=preset.as_bytes(), order=0)
+    database.World.create_for(session=session, name="W2", preset_bytes=preset.as_bytes(), order=1)
     database.MultiplayerMembership.create(user=user1, session=session, row=None, admin=True)
 
     new_preset = preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME_ECHOES).get_preset()
@@ -747,8 +745,8 @@ async def test_admin_session_download_layout_description(
 async def test_admin_session_download_layout_description_no_spoiler(
     clean_database, mock_emit_session_update, mock_sa, mocker
 ):
-    mock_layout_description: PropertyMock = mocker.patch(
-        "randovania.server.database.MultiplayerSession.layout_description", new_callable=PropertyMock
+    mock_layout_description = mocker.patch(
+        "randovania.server.database.MultiplayerSession.get_layout_description",
     )
     user1 = database.User.create(id=1234, name="The Name")
     session = database.MultiplayerSession.create(

--- a/test/server/multiplayer/test_session_api.py
+++ b/test/server/multiplayer/test_session_api.py
@@ -139,7 +139,12 @@ async def test_create_session(clean_database, preset_manager, default_game_list,
 
 
 async def test_join_session(
-    mock_emit_session_update, mock_sa, clean_database, default_game_list, mocker: MockerFixture
+    mock_emit_session_update,
+    mock_sa,
+    clean_database,
+    default_game_list,
+    default_versioned_preset,
+    mocker: MockerFixture,
 ):
     # Setup
     user1 = database.User.create(id=1234, name="The Name")
@@ -150,8 +155,11 @@ async def test_join_session(
     mock_join_multiplayer_session = mocker.patch("randovania.server.multiplayer.session_common.join_room")
 
     session = database.MultiplayerSession.create(name="The Session", password=None, creator=user1)
-    database.World.create(
-        session=session, name="World 1", preset="{}", uuid=uuid.UUID("bc82b6cf-df76-4c3d-9ea0-0695c2f7e719")
+    database.World.create_for(
+        session=session,
+        name="World 1",
+        preset_bytes=default_versioned_preset.as_bytes(),
+        uid=uuid.UUID("bc82b6cf-df76-4c3d-9ea0-0695c2f7e719"),
     )
     database.MultiplayerMembership.create(
         user=user2, session=session, row=0, admin=True, connection_state="Online, Badass"
@@ -174,7 +182,7 @@ async def test_join_session(
             {
                 "id": "bc82b6cf-df76-4c3d-9ea0-0695c2f7e719",
                 "name": "World 1",
-                "preset_raw": "{}",
+                "preset_raw": default_versioned_preset.as_bytes(),
                 "has_been_beaten": False,
             }
         ],

--- a/test/server/multiplayer/test_session_common.py
+++ b/test/server/multiplayer/test_session_common.py
@@ -15,7 +15,7 @@ from randovania.server import database
 from randovania.server.multiplayer import session_common
 
 
-async def test_emit_session_meta_update(session_update, mock_sa, default_game_list):
+async def test_emit_session_meta_update(session_update, mock_sa, default_versioned_preset, default_game_list):
     mock_emit = mock_sa.sio.emit
 
     session_json = {
@@ -42,13 +42,13 @@ async def test_emit_session_meta_update(session_update, mock_sa, default_game_li
             {
                 "id": "67d75d0e-da8d-4a90-b29e-cae83bcf9519",
                 "name": "World1",
-                "preset_raw": "{}",
+                "preset_raw": default_versioned_preset.as_bytes(),
                 "has_been_beaten": False,
             },
             {
                 "id": "d0f7ed70-66b0-413c-bc13-f9f7fb018726",
                 "name": "World2",
-                "preset_raw": "{}",
+                "preset_raw": default_versioned_preset.as_bytes(),
                 "has_been_beaten": False,
             },
         ],

--- a/test/server/multiplayer/test_world_api.py
+++ b/test/server/multiplayer/test_world_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, call
+from unittest.mock import AsyncMock, MagicMock, call
 
 import peewee
 import pytest
@@ -71,8 +71,8 @@ async def test_emit_world_pickups_update_one_action(
     # Setup
     mock_emit = mock_sa.sio.emit
 
-    mock_session_description: PropertyMock = mocker.patch(
-        "randovania.server.database.MultiplayerSession.layout_description", new_callable=PropertyMock
+    mock_session_description = mocker.patch(
+        "randovania.server.database.MultiplayerSession.get_layout_description",
     )
     mock_get_resource_database: MagicMock = mocker.patch(
         "randovania.server.multiplayer.world_api._get_resource_database", autospec=True
@@ -157,9 +157,7 @@ async def test_game_session_collect_pickup_for_self(
 
     mock_sa.sio.emit = AsyncMock()
 
-    mock_session_description: PropertyMock = mocker.patch(
-        "randovania.server.database.MultiplayerSession.layout_description", new_callable=PropertyMock
-    )
+    mock_session_description = mocker.patch("randovania.server.database.MultiplayerSession.get_layout_description")
     mock_get_resource_database: MagicMock = mocker.patch(
         "randovania.server.multiplayer.world_api._get_resource_database", autospec=True
     )
@@ -216,9 +214,7 @@ async def test_collect_locations_other(
     mock_add_pickup_to_inventory = mocker.patch(
         "randovania.server.multiplayer.world_api._add_pickup_to_inventory", autospec=True, return_value=b"bar"
     )
-    mock_session_description: PropertyMock = mocker.patch(
-        "randovania.server.database.MultiplayerSession.layout_description", new_callable=PropertyMock
-    )
+    mock_session_description = mocker.patch("randovania.server.database.MultiplayerSession.get_layout_description")
     mock_emit_session_update = mocker.patch(
         "randovania.server.multiplayer.session_common.emit_session_actions_update", autospec=True
     )

--- a/test/server/test_database.py
+++ b/test/server/test_database.py
@@ -39,24 +39,32 @@ def test_multiplayer_session_create_session_entry(clean_database, has_descriptio
     worlds = []
     actions = []
     if has_description:
+        preset0 = VersionedPreset.with_preset(description.get_preset(0))
+        preset1 = VersionedPreset.with_preset(description.get_preset(1))
+
         dt = datetime.datetime(2023, 6, 10, 23, 27, 25, 357120, tzinfo=datetime.UTC)
-        w1 = database.World.create_for(
-            session=s, name="Prime 1", order=0, preset=VersionedPreset.with_preset(description.get_preset(0))
-        )
+        w1 = database.World.create_for(session=s, name="Prime 1", order=0, preset_bytes=preset0.as_bytes())
         w2 = database.World.create_for(
-            session=s, name="Prime 2", order=1, preset=VersionedPreset.with_preset(description.get_preset(1))
+            session=s,
+            name="Prime 2",
+            order=1,
+            preset_bytes=preset1.as_bytes(),
         )
         database.WorldAction.create(provider=w1, location=34, session=s, receiver=w2, time=dt)
 
-        s.layout_description = description
+        s.set_layout_description(description)
         s.save()
         game_details = GameDetails(
             seed_hash="XXXXXXXX",
             spoiler=True,
             word_hash="Some Words",
         )
-        worlds.append(MultiplayerWorld(id=w1.uuid, name="Prime 1", preset_raw=w1.preset, has_been_beaten=False))
-        worlds.append(MultiplayerWorld(id=w2.uuid, name="Prime 2", preset_raw=w2.preset, has_been_beaten=False))
+        worlds.append(
+            MultiplayerWorld(id=w1.uuid, name="Prime 1", preset_raw=preset0.as_bytes(), has_been_beaten=False)
+        )
+        worlds.append(
+            MultiplayerWorld(id=w2.uuid, name="Prime 2", preset_raw=preset1.as_bytes(), has_been_beaten=False)
+        )
         actions.append(
             MultiplayerSessionAction(
                 provider=w1.uuid, receiver=w2.uuid, pickup="Power Bomb Expansion", location=34, time=dt

--- a/test/server/test_migration.py
+++ b/test/server/test_migration.py
@@ -34,6 +34,8 @@ def test_migrations(empty_database):
         ' "migration" VARCHAR(255) NOT NULL)',
         'CREATE UNIQUE INDEX "performed_database_migrations_migration"'
         ' ON "performed_database_migrations" ("migration")',
+        'CREATE TABLE IF NOT EXISTS "preset_data" ("sha256" BLOB NOT NULL PRIMARY KEY, "content" BLOB NOT NULL,'
+        '"schema_version" INTEGER NOT NULL, "game" VARCHAR(255) NOT NULL)',
         'CREATE TABLE "user_access_token" ("user_id" INTEGER NOT NULL, "name" VARCHAR(255) NOT NULL,'
         ' "creation_date" DATETIME NOT NULL, "last_used" DATETIME NOT NULL, PRIMARY KEY ("user_id", "name"),'
         ' FOREIGN KEY ("user_id") REFERENCES "user" ("id"))',


### PR DESCRIPTION
This table stores all presets identified by their sha256 hash, ensuring that duplicated presets do not use more storage than needed. We also store presets compressed.

There's some basic tooling for the server storing the preset received as is, without updating to latest version. One step further to supporting old clients in latest server.

A follow-up from this is an API for getting a Preset from a given hash, and then adding that hash to the `ServerWorldResponse` for `ServerWorldSync`, combined with the client storing a database of hash -> preset locally too. Working towards changing the received pickups list being a list of pickup names. Which not only removes the garbage code of encoding PickupEntry, but also is another necessary step for supporting old clients in latest server.