### PR TITLE
Dread: Add requirements to Arbitrary Enky blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### Artaria
 
+- Added: Extra requirements to break the blobs in Arbitrary Enky Room, to improve the quality of generated games.
 - Fixed: Screw Attack Room: Using a Shinespark to reach Start Point 2 from the door to Transport to Burenia was missing a requirement on having activated the Rotatable.
 
 ### Metroid Fusion

--- a/randovania/games/dread/logic_database/Artaria.json
+++ b/randovania/games/dread/logic_database/Artaria.json
@@ -23498,17 +23498,67 @@
                             }
                         },
                         "Event - ArbEnky Blob West": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "This piece of logic is here so help the generator not break the dangerous blob for no reason.",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "node",
+                                                                "data": {
+                                                                    "region": "Artaria",
+                                                                    "area": "Navigation Station North",
+                                                                    "node": "Save Station"
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Slide",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Beam"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Bomb"
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/dread/logic_database/Artaria.txt
+++ b/randovania/games/dread/logic_database/Artaria.txt
@@ -4312,7 +4312,12 @@ Extra - asset_id: collision_camera_070
           Morph Ball
           After Artaria - ArbEnky Blob West and Can Slide
   > Event - ArbEnky Blob West
-      Lay Small Bomb or Shoot Beam
+      All of the following:
+          Any of the following:
+              # This piece of logic is here so help the generator not break the dangerous blob for no reason.
+              Morph Ball
+              Slide and Artaria/Navigation Station North/Save Station
+          Lay Small Bomb or Shoot Beam
 
 ----------------
 EMMI First Chase End


### PR DESCRIPTION
Avoid having the generator breaking the blobs when they have no effect other than to have the weight of a dangerous event and cut off a path that can be used to escape from Invisible Corpius Room.