### PR TITLE
Optimize World Creation on layout import

### DIFF
--- a/randovania/gui/lib/multiplayer_session_api.py
+++ b/randovania/gui/lib/multiplayer_session_api.py
@@ -128,14 +128,14 @@ class MultiplayerSessionApi(QtCore.QObject):
         self.logger = SessionIdLoggerAdapter(_base_logger, self)
 
     async def _session_admin_global(
-        self, action: admin_actions.SessionAdminGlobalAction, *args: JsonType | bytes
+        self, action: admin_actions.SessionAdminGlobalAction, *args: JsonType | bytes, emit_event: bool = True
     ) -> JsonType | None:
         assert self.widget_root is not None
         try:
             self.widget_root.setEnabled(False)
             return await self.network_client.server_call(
                 "multiplayer_admin_session",
-                [self.current_session_id, action.value, *args],
+                [self.current_session_id, action.value, emit_event, *args],
             )
         finally:
             self.widget_root.setEnabled(True)
@@ -267,12 +267,13 @@ class MultiplayerSessionApi(QtCore.QObject):
         )
 
     @handle_network_errors
-    async def create_unclaimed_world(self, name: str, preset: VersionedPreset) -> None:
+    async def create_unclaimed_world(self, name: str, preset: VersionedPreset, emit_event: bool) -> None:
         self.logger.info("Creating unclaimed world named '%s' with %s", name, preset.name)
         await self._session_admin_global(
             admin_actions.SessionAdminGlobalAction.CREATE_WORLD,
             name,
             preset.as_bytes(),
+            emit_event=emit_event,
         )
 
     @handle_network_errors

--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -826,13 +826,14 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         all_names = {world.name for world in self._session.worlds}
         for i in range(len(self._session.worlds), parameters.world_count):
             name = f"World {i + 1}"
+            is_last_world = True if i == (parameters.world_count - 1) else False
             for suffix in itertools.count():
                 if name not in all_names:
                     break
                 name = f"World {i + 1} ({suffix + 1})"
 
             await self.game_session_api.create_unclaimed_world(
-                name, VersionedPreset.with_preset(parameters.get_preset(i))
+                name, VersionedPreset.with_preset(parameters.get_preset(i)), is_last_world
             )
 
         if parameters.world_count != len(self._session.worlds):

--- a/randovania/server/multiplayer/session_admin.py
+++ b/randovania/server/multiplayer/session_admin.py
@@ -395,7 +395,9 @@ async def _get_permalink(sa: ServerApp, sid: str, session: MultiplayerSession) -
     return session.layout_description.permalink.as_base64_str
 
 
-async def admin_session(sa: ServerApp, sid: str, session_id: int, action: str, *args: typing.Any) -> typing.Any:
+async def admin_session(
+    sa: ServerApp, sid: str, session_id: int, action: str, emit_event: bool, *args: typing.Any
+) -> typing.Any:
     monitoring.set_tag("action", action)
 
     action_ = SessionAdminGlobalAction(action)
@@ -450,7 +452,10 @@ async def admin_session(sa: ServerApp, sid: str, session_id: int, action: str, *
     elif action_ == SessionAdminGlobalAction.SET_ALLOW_EVERYONE_CLAIM:
         await _set_allow_everyone_claim(sa, sid, session, *args)
 
-    await session_common.emit_session_meta_update(sa, session)
+    if emit_event:
+        await session_common.emit_session_meta_update(sa, session)
+    else:
+        sa.logger.info("Asked to not emit a session event")
 
 
 async def _kick_user(


### PR DESCRIPTION
Need to fix tests still.
I mostly opened the PR to get feedback on whether this approach is even okay to begin with.
The thought behind it was for clients to not update themselves every time when we're mass sending actions, because one session update is costly client side.
I initially thought about having some kind of "do-not-update-session" event, that we send first to the clients. But that seemed annoying and kinda risky? E.g. what happens if you just somehow miss the event where you were told to start listening to events again.

So instead I just opted for an option during the server admin_session function to determine whether we emit or not. Making that part of `*args` doesn't really work, and afaik i can't provide it as a named argument easily