### PR TITLE
Bump am2r_yams to 2.8.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -104,14 +104,14 @@ wheels = [
 
 [[package]]
 name = "am2r-yams"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pythonnet" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/3e/8bdab0eb7898a03d99b42a15c859319e6f832294b590e286dd1f89f354a6/am2r_yams-2.8.3.tar.gz", hash = "sha256:611649966c8c7cc87f7e1ab26e7ebfe42094fbd82b55cc55cd865e4edc1f4651", size = 2148206, upload-time = "2025-10-07T18:28:07.294Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/d8/04764b054298048ad9ffbf06dc40b81e594df8909ceaf4dd14e200098531/am2r_yams-2.8.4.tar.gz", hash = "sha256:31a1e8a5d096ddfc760c8ee595b6d17c1464dda009893ae8426626eb10001c60", size = 2146488, upload-time = "2025-10-20T19:54:39.974Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/c0/40ddd3ee4494c1b0a524bb6b778a832cd2fc56df93421b2de7232e8d62bf/am2r_yams-2.8.3-py3-none-any.whl", hash = "sha256:ed1872441a65adbc4ad034a8b8f51cf4f003d65b9b3c2e377d6841f4005a3716", size = 2141677, upload-time = "2025-10-07T18:28:04.378Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/e3/7a8acde6687d450299bd985715f689f7948657068a4da8f44017ee1a36dd/am2r_yams-2.8.4-py3-none-any.whl", hash = "sha256:84974262af6a3000bd591561af0f42720b19c7d352eabaa9d2655553d201ea08", size = 2139564, upload-time = "2025-10-20T19:54:37.96Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes a crash on export that 2.8.3 introduced