### PR TITLE
Generator: Get rid of duplicate actions

### DIFF
--- a/randovania/generator/filler/pickup_list.py
+++ b/randovania/generator/filler/pickup_list.py
@@ -174,16 +174,16 @@ def get_pickups_that_solves_unreachable(
 
     all_lists = _requirement_lists_without_satisfied_resources(state, possible_sets, uncollected_resources)
 
-    result = []
+    # Hacky way to get rid of duplicates. Can't use a set as a set's order is not deterministic.
+    result = {}
     for requirement_list in sorted(all_lists, key=lambda it: it.as_stable_sort_tuple):
         pickups = pickups_to_solve_list(pickups_left, requirement_list, state)
         if pickups is not None and pickups:
-            # FIXME: avoid duplicates in result
-            result.append(tuple(pickups))
+            result[tuple(pickups)] = ""
 
     if debug.debug_level() > 2:
         print(">> All pickup combinations alternatives:")
-        for items in sorted(result):
+        for items in sorted(result.keys()):
             print("* {}".format(", ".join(p.name for p in items)))
 
-    return tuple(result)
+    return tuple(result.keys())


### PR DESCRIPTION
Did benchmarks for only 2 games cause i was lazy:
```
python -m randovania development benchmark compare before after
                    Difference | Fixes | Failures |     Mean |    Stdev |   Median
                 Metroid Dread |     0 |        0 |   -2.628 |    3.367 |   -2.506
                 
                 
python -m randovania development benchmark compare b a         
                    Difference | Fixes | Failures |     Mean |    Stdev |   Median
                Metroid Fusion |     1 |        3 |    0.171 |    1.667 |    0.195
```

Reason for fusion being different is because it hit a case of having duplicate actions. And since those got removed probably increased the chances of placing only keycards and locking itself out.