### PR TITLE
Don't import caver on startup

### DIFF
--- a/randovania/games/cave_story/exporter/game_exporter.py
+++ b/randovania/games/cave_story/exporter/game_exporter.py
@@ -5,12 +5,10 @@ import dataclasses
 import typing
 from pathlib import Path
 
-from caver import patcher as caver_patcher
-from caver.patcher import CSPlatform
-
 from randovania import monitoring
 from randovania.exporter.game_exporter import GameExporter, GameExportParams
 from randovania.game.game_enum import RandovaniaGame
+from randovania.games.cave_story.exporter.options import CSPlatform
 from randovania.lib import json_lib, status_update_lib
 
 if typing.TYPE_CHECKING:
@@ -69,6 +67,10 @@ class CSGameExporter(GameExporter[CSGameExportParams]):
         new_patch["platform"] = export_params.platform.value
         monitoring.set_tag("cs_platform", new_patch["platform"])
         try:
-            caver_patcher.patch_files(new_patch, export_params.output_path, export_params.platform, progress_update)
+            from caver import patcher as caver_patcher
+
+            caver_patcher.patch_files(
+                new_patch, export_params.output_path, caver_patcher.CSPlatform(new_patch["platform"]), progress_update
+            )
         finally:
             json_lib.write_path(export_params.output_path.joinpath("data", "patcher_data.json"), patch_data)

--- a/randovania/games/cave_story/exporter/options.py
+++ b/randovania/games/cave_story/exporter/options.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
 import dataclasses
+import enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Self, override
 
 if TYPE_CHECKING:
     from randovania.lib.json_lib import JsonObject
 
-from caver.patcher import CSPlatform
-
 from randovania.game.game_enum import RandovaniaGame
 from randovania.interface_common.options import PerGameOptions, decode_if_not_none
+
+
+class CSPlatform(enum.Enum):
+    """
+    This enum duplicates `caver.patcher.CSPlatform` in order to avoid always importing `caver` during startup.
+    There's a test ensuring they are identical.
+    """
+
+    FREEWARE = "freeware"
+    TWEAKED = "tweaked"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/randovania/games/cave_story/gui/dialog/game_export_dialog.py
+++ b/randovania/games/cave_story/gui/dialog/game_export_dialog.py
@@ -4,11 +4,9 @@ import dataclasses
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from caver.patcher import CSPlatform
-
 from randovania.game.game_enum import RandovaniaGame
 from randovania.games.cave_story.exporter.game_exporter import CSGameExportParams
-from randovania.games.cave_story.exporter.options import CSPerGameOptions
+from randovania.games.cave_story.exporter.options import CSPerGameOptions, CSPlatform
 from randovania.games.cave_story.gui.generated.cs_game_export_dialog_ui import Ui_CSGameExportDialog
 from randovania.games.cave_story.layout.cs_configuration import CSConfiguration
 from randovania.gui.dialog.game_export_dialog import (

--- a/test/cli/commands/test_export_game.py
+++ b/test/cli/commands/test_export_game.py
@@ -1,11 +1,10 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from caver.patcher import CSPlatform
-
 from randovania.cli.commands import export_game
 from randovania.game.game_enum import RandovaniaGame
 from randovania.games.cave_story.exporter.game_exporter import CSGameExportParams
+from randovania.games.cave_story.exporter.options import CSPlatform
 from randovania.games.dread.exporter.game_exporter import DreadGameExportParams, DreadModPlatform
 
 
@@ -19,6 +18,13 @@ def test_add_parser_arguments_for(game_enum: RandovaniaGame) -> None:
         type=Path,
         required=False,
     )
+
+
+def test_compare_csplatform_enum() -> None:
+    import caver.patcher
+
+    assert [e.name for e in CSPlatform] == [e.name for e in caver.patcher.CSPlatform]
+    assert [e.value for e in CSPlatform] == [e.value for e in caver.patcher.CSPlatform]
 
 
 def test_get_export_params_from_cli_cave_story() -> None:

--- a/test/games/cave_story/gui/test_cs_game_export_dialog.py
+++ b/test/games/cave_story/gui/test_cs_game_export_dialog.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from caver.patcher import CSPlatform
 from PySide6 import QtCore
 
 from randovania.games.cave_story.exporter.game_exporter import CSGameExportParams
-from randovania.games.cave_story.exporter.options import CSPerGameOptions
+from randovania.games.cave_story.exporter.options import CSPerGameOptions, CSPlatform
 from randovania.games.cave_story.gui.dialog.game_export_dialog import CSGameExportDialog
 from randovania.games.cave_story.layout.cs_cosmetic_patches import CSCosmeticPatches
 from randovania.interface_common.options import Options


### PR DESCRIPTION
This also reduces errors when running the GUI with just the `gui` extra.