### PR TITLE
Fusion: Bump gerubus gully heist to ludicrous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,9 +77,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ##### Sector 5 (ARC)
 
 - Changed: Nightmare Hub: Flooded Access to Ruined Break Room, raised Jump Bomb Jump from Intermediate to Advanced.
-- Changed: Gerubus Gully: Raised Jump Bomb Jump to Pickup from Intermediate to Advanced.
-- Fixed: Gerubus Gully: To Pickup, added 50/50 Intermediate Movement trick to Shinespark and Power Bomb methods. The game processes item acquisition on every other frame, and the bomb block ejects you underneath after clearing the text if you're still in the climb animation.
-- Added: Gerubus Gully: Added any bombs as alternative to all such 50/50 tricks to Pickup.
+- Changed: Gerubus Gully: Raised the Jump Bomb Jump to the Pickup from Intermediate to Advanced. In addition, you now also need to kill the Gerubus or have Combat Beginner.
+- Changed: Gerubus Gully: Getting the Pickup with Screw Attack now requires either Bombs or Ludicrous Movement. This is due to the fact that the game processes item acquisition on every other frame with it coming down to luck whether you collect the item on the correct frame to escape before the Bomb Block respawns.
+- Added: Gerubus Gully: Getting the Pickup with a Shinespark now requires either Bombs or Ludicrous Movement. See the explanation above as to why.
+- Added: Gerubus Gully: Getting the Pickup with Powerbombs now requires either Bombs, 2 Power Bomb or Ludicrous Movement. See the explanation above as to why.
 - Changed: Gerubus Gully: Raised Shinespark to Pickup trick difficulty from Beginner to Intermediate.
 
 ### Metroid Prime

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -8141,7 +8141,7 @@
                                                                             "data": {
                                                                                 "type": "tricks",
                                                                                 "name": "Movement",
-                                                                                "amount": 2,
+                                                                                "amount": 5,
                                                                                 "negate": false
                                                                             }
                                                                         },
@@ -8250,7 +8250,7 @@
                                                                             "data": {
                                                                                 "type": "tricks",
                                                                                 "name": "Movement",
-                                                                                "amount": 2,
+                                                                                "amount": 5,
                                                                                 "negate": false
                                                                             }
                                                                         },
@@ -8342,7 +8342,7 @@
                                                                             "data": {
                                                                                 "type": "tricks",
                                                                                 "name": "Movement",
-                                                                                "amount": 2,
+                                                                                "amount": 5,
                                                                                 "negate": false
                                                                             }
                                                                         },

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -1237,7 +1237,7 @@ Extra - minimap_coordinates: [{'x': 5, 'y': 4}]
               All of the following:
                   Screw Attack and Knowledge (Intermediate)
                   # Get item mid animation. 50/50 on success: https://youtu.be/bh1TmgiSngk
-                  Movement (Intermediate) or Can Use Any Bombs
+                  Movement (Ludicrous) or Can Use Any Bombs
               All of the following:
                   Can Use Bombs
                   Any of the following:
@@ -1250,12 +1250,12 @@ Extra - minimap_coordinates: [{'x': 5, 'y': 4}]
               All of the following:
                   Can Use Power Bombs
                   # 1 or 2 PBs, depending on 50/50, like SA method
-                  Power Bombs ≥ 2 or Movement (Intermediate) or Can Use Bombs
+                  Power Bombs ≥ 2 or Movement (Ludicrous) or Can Use Bombs
               All of the following:
                   # Shinespark into bomb block: https://youtu.be/3PkI4SCSD3Q
                   Level 3 Keycard and Speed Booster and Knowledge (Intermediate) and Shinespark Tricks (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
                   # 50/50, like for SA method
-                  Movement (Intermediate) or Can Use Any Bombs
+                  Movement (Ludicrous) or Can Use Any Bombs
   > Door to Training Grounds
       Trivial
 


### PR DESCRIPTION
This is due to the fact that the game processes item acquisition on every other frame with it coming down to luck whether you collect the item on the correct frame to escape before the Bomb Block respawns.
Thus there is no consistent setup to get yourself on the correct "collision check frame",  meaning you might end up needing to reset 0 times or 30 times with it being for all intents and purposes outside of your control.