### PR TITLE
Increase Precision for Standard Pickup Priority

### DIFF
--- a/randovania/layout/base/standard_pickup_state.py
+++ b/randovania/layout/base/standard_pickup_state.py
@@ -21,7 +21,7 @@ PRIORITY_LIMITS = {
     "if_different": 1.0,
     "min": 0.0,
     "max": 10.0,
-    "precision": 1.0,
+    "precision": 2.0,
 }
 
 


### PR DESCRIPTION
Some of our builtin priorities have a precision of 2 (e.g. very low = 0.25)
right now these don't encode properly, so we increase let's increase it


Things that i've tested:
- print the generator params for both importing an rdvgame and creating one based on permalink, which are the same minus ordering of tricks (shouldnt make a difference?)
- gen a game with a few whacky very low priorities and import it back => works

Things that still bother me:
- need to write test that checks all our builtin priorities to ensure they roundtrip properly
- Importing this whacky rdvgame and trying to regenerate it based on the new permalink rdv spits out *still* fails: 
[2025-10-04-23-43-01_Fusion_Diffusion Dachora Fune.json](https://github.com/user-attachments/files/23286274/2025-10-04-23-43-01_Fusion_Diffusion.Dachora.Fune.json)
  Not sure why. The generator params seem to be the same minus the thing mentioned above. But the good news i guess is that they generate *completely* different seeds now. As in, the first action is already different. Maybe I'm doing something wrong there? 