### PR TITLE
NetworkClient: don't create aiohttp.ClientSession on tests

### DIFF
--- a/test/gui/lib/test_qt_network_client.py
+++ b/test/gui/lib/test_qt_network_client.py
@@ -16,7 +16,8 @@ from randovania.network_common.session_visibility import MultiplayerSessionVisib
 
 
 @pytest.fixture(name="client")
-async def network_client_fixture(skip_qtbot, mocker, tmpdir):
+def network_client_fixture(skip_qtbot, mocker, tmpdir):
+    mocker.patch("randovania.lib.http_lib.http_session")
     mocker.patch(
         "randovania.get_configuration",
         return_value={
@@ -25,9 +26,7 @@ async def network_client_fixture(skip_qtbot, mocker, tmpdir):
             "discord_client_id": 1234,
         },
     )
-    client = qt_network_client.QtNetworkClient(Path(tmpdir))
-    yield client
-    await client.http.close()
+    return qt_network_client.QtNetworkClient(Path(tmpdir))
 
 
 async def test_handle_network_errors_success(skip_qtbot, qapp):

--- a/test/network_client/test_network_client.py
+++ b/test/network_client/test_network_client.py
@@ -27,7 +27,8 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-async def client(tmp_path):
+def client(tmp_path, mocker: pytest_mock.MockerFixture):
+    mocker.patch("randovania.lib.http_lib.http_session")
     client = NetworkClient(
         tmp_path,
         {
@@ -35,8 +36,7 @@ async def client(tmp_path):
             "socketio_path": "/socket.io",
         },
     )
-    yield client
-    await client.http.close()
+    return client
 
 
 async def test_on_connect_no_restore(tmp_path):


### PR DESCRIPTION
We don't properly cleanup these clients so they end up leaking