### PR TITLE
Don't encode permalink when attaching LayoutDescription for Sentry

### DIFF
--- a/randovania/exporter/patch_data_factory.py
+++ b/randovania/exporter/patch_data_factory.py
@@ -89,7 +89,9 @@ class PatchDataFactory[Configuration: BaseConfiguration, CosmeticPatches: BaseCo
     def _attach_to_sentry(self) -> None:
         with sentry_sdk.isolation_scope() as scope:
             scope.add_attachment(
-                json.dumps(self.description.as_json(force_spoiler=True)).encode("utf-8"),
+                json.dumps(
+                    self.description.as_json(force_spoiler=True, include_permalink_str=False),
+                ).encode("utf-8"),
                 filename="rdvgame.json",
                 content_type="application/json",
                 add_to_transactions=True,

--- a/randovania/layout/layout_description.py
+++ b/randovania/layout/layout_description.py
@@ -221,13 +221,13 @@ class LayoutDescription:
 
         return cached_result
 
-    def as_json(self, *, force_spoiler: bool = False) -> dict:
+    def as_json(self, *, force_spoiler: bool = False, include_permalink_str: bool = True) -> dict:
         result: dict = {
             "schema_version": description_migration.CURRENT_VERSION,
             "info": {
                 "randovania_version": self.randovania_version_text,
                 "randovania_version_git": self.randovania_version_git.hex(),
-                "permalink": self.permalink.as_base64_str,
+                "permalink": self.permalink.as_base64_str if include_permalink_str else None,
                 "has_spoiler": self.has_spoiler,
                 "seed": self.generator_parameters.seed_number,
                 "hash": self.shareable_hash,


### PR DESCRIPTION
For server performance, creating the entire permalink string from scratch just for sentry is pointless.