### PR TITLE
Keep original json for LayoutDescription for attaching to Sentry

### DIFF
--- a/randovania/exporter/patch_data_factory.py
+++ b/randovania/exporter/patch_data_factory.py
@@ -88,8 +88,12 @@ class PatchDataFactory[Configuration: BaseConfiguration, CosmeticPatches: BaseCo
 
     def _attach_to_sentry(self) -> None:
         with sentry_sdk.isolation_scope() as scope:
+            description_json = self.description.original_dict
+            if description_json is None:
+                description_json = self.description.as_json(force_spoiler=True)
+
             scope.add_attachment(
-                json.dumps(self.description.as_json(force_spoiler=True)).encode("utf-8"),
+                json.dumps(description_json).encode("utf-8"),
                 filename="rdvgame.json",
                 content_type="application/json",
                 add_to_transactions=True,

--- a/randovania/layout/layout_description.py
+++ b/randovania/layout/layout_description.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import base64
+import copy
+import dataclasses
 import hashlib
 import itertools
 import json
@@ -89,6 +91,7 @@ class LayoutDescription:
     all_patches: dict[int, GamePatches]
     item_order: tuple[str, ...]
     user_modified: bool
+    original_dict: dict | None = dataclasses.field(compare=False, default=None)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "__cached_serialized_patches", None)
@@ -130,6 +133,7 @@ class LayoutDescription:
         if "game_modifications" not in json_dict:
             raise InvalidLayoutDescription("Unable to read details of a race game file")
 
+        original_dict = copy.deepcopy(json_dict)
         json_dict = description_migration.convert_to_current_version(json_dict)
 
         def get_preset(i: int, p: dict) -> Preset:
@@ -169,6 +173,7 @@ class LayoutDescription:
             all_patches=all_patches,
             item_order=json_dict["item_order"],
             user_modified=expected_checksum != actual_checksum,
+            original_dict=original_dict,
         )
 
     @classmethod


### PR DESCRIPTION
For server, as serializing the layout (and particularly the permalink string) can be expensive.