### PR TITLE
GUI: Uniform heights for multiplayer user widgets

### DIFF
--- a/randovania/gui/widgets/multiplayer_session_users_widget.py
+++ b/randovania/gui/widgets/multiplayer_session_users_widget.py
@@ -114,6 +114,7 @@ class MultiplayerSessionUsersWidget(QtWidgets.QTreeWidget):
         self.setContentsMargins(0, 0, 0, 0)
         self.setFrameShape(QtWidgets.QFrame.Shape.Panel)
         self.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Preferred)
+        self.setUniformRowHeights(True)
 
         self.header().setStretchLastSection(False)
         self.headerItem().setText(0, "Name")


### PR DESCRIPTION
don't have hard numbers, but testing via claiming/unclaiming worlds on my 100-world-session in the staging server seems faster