### PR TITLE
Try to fix macOS/Linux jobs running during merge queue events

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -70,9 +70,9 @@ jobs:
           - ${{ startsWith(github.ref, 'refs/heads/stable') || startsWith(github.ref, 'refs/tags/v') }}
 
         exclude:
-          - is_merge_queue: true
+          - is_merge_queue: "true"
             os: { name: "Linux", image: ubuntu-latest }
-          - is_merge_queue: true
+          - is_merge_queue: "true"
             os: { name: "macOS", image: macos-latest }
 
     runs-on: ${{ matrix.os.image }}
@@ -139,9 +139,9 @@ jobs:
           - ${{ startsWith(github.ref, 'refs/heads/stable') || startsWith(github.ref, 'refs/tags/v') }}
 
         exclude:
-          - is_merge_queue: true
+          - is_merge_queue: "true"
             os: { name: "Linux", image: ubuntu-latest }
-          - is_merge_queue: true
+          - is_merge_queue: "true"
             os: { name: "macOS", image: macos-latest }
 
     runs-on: ${{ matrix.os.image }}


### PR DESCRIPTION
Powered by asking copilot 3 times until it found a possible reason. Don't you love overly complicated YAMLs?