### PR TITLE
Enable text selection in async race room window labels

### DIFF
--- a/randovania/gui/async_race_room_window.py
+++ b/randovania/gui/async_race_room_window.py
@@ -49,11 +49,6 @@ class AsyncRaceRoomWindow(QtWidgets.QMainWindow):
         self.ui = Ui_AsyncRaceRoomWindow()
         self.ui.setupUi(self)
 
-        self.ui.game_details_label.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
-        self.ui.name_label.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
-        self.ui.start_end_date_label.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
-        self.ui.participation_label.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
-
         self._refresh_timer = QtCore.QTimer(self)
         self._refresh_timer.setSingleShot(True)
         self._refresh_timer.timeout.connect(self.refresh_data)

--- a/randovania/gui/generated/async_race_room_window_ui.py
+++ b/randovania/gui/generated/async_race_room_window_ui.py
@@ -37,6 +37,7 @@ class Ui_AsyncRaceRoomWindow(object):
         self.game_details_layout.setContentsMargins(4, 4, 4, 4)
         self.game_details_label = QLabel(self.game_details_group)
         self.game_details_label.setObjectName(u"game_details_label")
+        self.game_details_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
 
         self.game_details_layout.addWidget(self.game_details_label)
 
@@ -60,6 +61,7 @@ class Ui_AsyncRaceRoomWindow(object):
         self.participation_label = QLabel(self.participation_group)
         self.participation_label.setObjectName(u"participation_label")
         self.participation_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.participation_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
 
         self.gridLayout_2.addWidget(self.participation_label, 0, 0, 1, 6)
 
@@ -98,11 +100,13 @@ class Ui_AsyncRaceRoomWindow(object):
 
         self.name_label = QLabel(self.centralwidget)
         self.name_label.setObjectName(u"name_label")
+        self.name_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
 
         self.gridLayout.addWidget(self.name_label, 0, 0, 1, 1)
 
         self.start_end_date_label = QLabel(self.centralwidget)
         self.start_end_date_label.setObjectName(u"start_end_date_label")
+        self.start_end_date_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
 
         self.gridLayout.addWidget(self.start_end_date_label, 0, 1, 1, 1)
 

--- a/randovania/gui/ui_files/async_race_room_window.ui
+++ b/randovania/gui/ui_files/async_race_room_window.ui
@@ -38,6 +38,9 @@
          <property name="text">
           <string>GAME NAME, SEED HASH</string>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
        <item>
@@ -70,6 +73,9 @@
          </property>
          <property name="alignment">
           <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -123,12 +129,18 @@
       <property name="text">
        <string>RACE NAME</string>
       </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
+      </property>
      </widget>
     </item>
     <item row="0" column="1">
      <widget class="QLabel" name="start_end_date_label">
       <property name="text">
        <string>Race End: in &lt;&gt; days, at &lt;&gt;</string>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
       </property>
      </widget>
     </item>


### PR DESCRIPTION
- Added TextSelectableByMouse flags to all informational labels
- Users can now highlight and copy seed hash, room name, dates, and status

fixes #8258