### PR TITLE
Change expected seed hash to not use bytes

### DIFF
--- a/randovania/game/game_test_data.py
+++ b/randovania/game/game_test_data.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class GameTestData:
     """Contains data and configuration parameters to allow the test suit to assert things properly for this game."""
 
-    expected_seed_hash: bytes
+    expected_seed_hash: str
     """The seed hash expected for the layout generated in test_create_description."""
 
     generator_test_seed_number: int = 0

--- a/randovania/games/am2r/game_data.py
+++ b/randovania/games/am2r/game_data.py
@@ -91,7 +91,7 @@ def _test_data() -> randovania.game.game_test_data.GameTestData:
     from randovania.layout.base.trick_level import LayoutTrickLevel
 
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash=b"h_\xab\xa2\xbf",
+        expected_seed_hash="NBP2XIV7",
         # Some items require shinesparking to reach in vanilla,
         # which due to varying difficulty has been made into a trick
         database_collectable_include_tricks=(("Shinesparking", LayoutTrickLevel.ADVANCED),),

--- a/randovania/games/blank/game_data.py
+++ b/randovania/games/blank/game_data.py
@@ -82,7 +82,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash=b"w\x06\xc3\xf5\xe4",
+        expected_seed_hash="O4DMH5PE",
     )
 
 

--- a/randovania/games/cave_story/game_data.py
+++ b/randovania/games/cave_story/game_data.py
@@ -87,7 +87,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash=b"\x95'\xa0A\xd9",
+        expected_seed_hash="SUT2AQOZ",
         database_collectable_ignore_events=(
             "camp",
             "eventBadEnd",

--- a/randovania/games/dread/game_data.py
+++ b/randovania/games/dread/game_data.py
@@ -85,7 +85,7 @@ def _test_data() -> randovania.game.game_test_data.GameTestData:
     from randovania.layout.base.trick_level import LayoutTrickLevel
 
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash=b"\xf8\xcf\xb2\x1a\x18",
+        expected_seed_hash="7DH3EGQY",
         # Some items require shinesparking to reach in vanilla,
         # which due to varying difficulty has been made into a trick
         database_collectable_include_tricks=(("Speedbooster", LayoutTrickLevel.BEGINNER),),

--- a/randovania/games/factorio/game_data.py
+++ b/randovania/games/factorio/game_data.py
@@ -76,7 +76,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash=b"\x1e3\xb4\xb4Q",
+        expected_seed_hash="DYZ3JNCR",
     )
 
 

--- a/randovania/games/fusion/game_data.py
+++ b/randovania/games/fusion/game_data.py
@@ -89,7 +89,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash=b"|\xf3/\x14u",
+        expected_seed_hash="PTZS6FDV",
     )
 
 

--- a/randovania/games/planets_zebeth/game_data.py
+++ b/randovania/games/planets_zebeth/game_data.py
@@ -75,7 +75,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash=b"\xfd\x9e\x01Y@",
+        expected_seed_hash="7WPACWKA",
     )
 
 

--- a/randovania/games/prime1/game_data.py
+++ b/randovania/games/prime1/game_data.py
@@ -107,7 +107,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash=b"\xd9\x03wTN",
+        expected_seed_hash="3EBXOVCO",
         database_collectable_ignore_events=("Event33",),
     )
 

--- a/randovania/games/prime2/game_data.py
+++ b/randovania/games/prime2/game_data.py
@@ -96,7 +96,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash=b"\x13\xf1\x14 \xec",
+        expected_seed_hash="CPYRIIHM",
         database_collectable_ignore_events=("Event91", "Event92", "Event97"),
     )
 

--- a/randovania/games/prime_hunters/game_data.py
+++ b/randovania/games/prime_hunters/game_data.py
@@ -85,7 +85,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash=b"\xf5\xa1\xd1\x1eP",
+        expected_seed_hash="FV2F64IO",
     )
 
 

--- a/randovania/games/samus_returns/game_data.py
+++ b/randovania/games/samus_returns/game_data.py
@@ -103,7 +103,7 @@ def _test_data() -> randovania.game.game_test_data.GameTestData:
     from randovania.layout.base.trick_level import LayoutTrickLevel
 
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash=b"L\x93\xbb\xee\xa3",
+        expected_seed_hash="JSJ3X3VD",
         # Some items require Spider Boosting to reach in vanilla, but since it is never explained there,
         # it has been made into a trick.
         database_collectable_include_tricks=(("Spider Boost", LayoutTrickLevel.BEGINNER),),

--- a/test/generator/test_generator.py
+++ b/test/generator/test_generator.py
@@ -125,4 +125,4 @@ async def test_create_description(preset_manager, game_enum) -> None:
     result = await generator._create_description(generator_parameters, status_update, 0, world_names)
 
     # Assert
-    assert result.shareable_hash_bytes == game_test_data.expected_seed_hash
+    assert result.shareable_hash == game_test_data.expected_seed_hash


### PR DESCRIPTION
Significantly more readable error messages.
Also fixes Prime Hunter's hash being wrong.