### PR TITLE
Prime 1: Move Spawn Points back to the Docks

### DIFF
--- a/randovania/games/prime1/logic_database/Chozo Ruins.json
+++ b/randovania/games/prime1/logic_database/Chozo Ruins.json
@@ -4932,7 +4932,7 @@
                             0.0
                         ]
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Chozo Ruins",
@@ -4997,7 +4997,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Ruined Shrine": {
                             "type": "and",
@@ -6737,7 +6737,7 @@
                             90.0
                         ]
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Chozo Ruins",
@@ -7236,7 +7236,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Tower of Light Access": {
                             "type": "and",
@@ -8070,7 +8070,7 @@
                             90.0
                         ]
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Chozo Ruins",
@@ -8149,7 +8149,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Tower of Light": {
                             "type": "and",
@@ -9954,7 +9954,7 @@
                             -89.99848
                         ]
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Chozo Ruins",
@@ -10114,7 +10114,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Ruined Gallery": {
                             "type": "and",
@@ -11679,7 +11679,7 @@
                             -89.50709
                         ]
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Chozo Ruins",
@@ -11866,7 +11866,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Gathering Hall": {
                             "type": "and",
@@ -12271,7 +12271,7 @@
                             -89.50709
                         ]
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Chozo Ruins",
@@ -13817,7 +13817,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Watery Hall Access": {
                             "type": "and",
@@ -14909,7 +14909,7 @@
                             0.0
                         ]
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Chozo Ruins",
@@ -14974,7 +14974,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Furnace": {
                             "type": "and",

--- a/randovania/games/prime1/logic_database/Chozo Ruins.txt
+++ b/randovania/games/prime1/logic_database/Chozo Ruins.txt
@@ -801,7 +801,7 @@ Extra - aabb: [-149.03557, -2.303732, 18.729618, -95.536766, 27.518578, 26.91997
   > Door to Ruined Shrine
       Trivial
 
-> Door to Ruined Shrine; Heals? False; Default Node
+> Door to Ruined Shrine; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Ruined Shrine/Door to Tower of Light Access
   * Extra - dock_index: 1
@@ -818,7 +818,7 @@ Extra - aabb: [-149.03557, -2.303732, 18.729618, -95.536766, 27.518578, 26.91997
   * Pickup 110; Category? Minor
   * Extra - position_required: True
 
-> Spawn Point; Heals? False; Spawn Point
+> Spawn Point; Heals? False
   * Layers: default
   > Door to Ruined Shrine
       Trivial
@@ -1098,7 +1098,7 @@ Tower of Light
 Extra - asset_id: 225636855
 Extra - size_index: 0.6
 Extra - aabb: [-174.46513, -93.0821, 4.8231506, -114.339874, 2.7153168, 129.34042]
-> Door to Tower of Light Access; Heals? False; Default Node
+> Door to Tower of Light Access; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Wave Door to Tower of Light Access/Door to Tower of Light
   * Extra - dock_index: 0
@@ -1166,7 +1166,7 @@ Extra - aabb: [-174.46513, -93.0821, 4.8231506, -114.339874, 2.7153168, 129.3404
   > Door to Tower of Light Access
       Trivial
 
-> Spawn Point; Heals? False; Spawn Point
+> Spawn Point; Heals? False
   * Layers: default
   > Door to Tower of Light Access
       Trivial
@@ -1346,7 +1346,7 @@ Tower Chamber
 Extra - asset_id: 297624503
 Extra - size_index: 0.1
 Extra - aabb: [-155.05084, -107.00887, 20.431095, -134.34949, -86.75725, 35.564354]
-> Door to Tower of Light; Heals? False; Default Node
+> Door to Tower of Light; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Wave Door to Tower of Light/Door to Tower Chamber
   * Extra - dock_index: 0
@@ -1367,7 +1367,7 @@ Extra - aabb: [-155.05084, -107.00887, 20.431095, -134.34949, -86.75725, 35.5643
   > Door to Tower of Light
       Trivial
 
-> Spawn Point; Heals? False; Spawn Point
+> Spawn Point; Heals? False
   * Layers: default
   > Door to Tower of Light
       Trivial
@@ -1667,7 +1667,7 @@ Totem Access
 Extra - asset_id: 3934929011
 Extra - size_index: 0.3
 Extra - aabb: [-22.001799, 235.39693, -1.5920587, 41.40501, 292.60748, 11.864963]
-> Door to Ruined Gallery; Heals? False; Default Node
+> Door to Ruined Gallery; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Ruined Gallery/Door to Totem Access
   * Extra - dock_index: 0
@@ -1696,7 +1696,7 @@ Extra - aabb: [-22.001799, 235.39693, -1.5920587, 41.40501, 292.60748, 11.864963
   * Pickup 120; Category? Minor
   * Extra - position_required: True
 
-> Spawn Point; Heals? False; Spawn Point
+> Spawn Point; Heals? False
   * Layers: default
   > Door to Ruined Gallery
       Trivial
@@ -1941,7 +1941,7 @@ Watery Hall Access
 Extra - asset_id: 4008477565
 Extra - size_index: 0.1
 Extra - aabb: [389.6565, -74.64455, 9.903929, 427.8786, 11.788876, 25.766716]
-> Door to Gathering Hall; Heals? False; Default Node
+> Door to Gathering Hall; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Gathering Hall/Door to Watery Hall Access
   * Extra - dock_index: 0
@@ -1976,7 +1976,7 @@ Extra - aabb: [389.6565, -74.64455, 9.903929, 427.8786, 11.788876, 25.766716]
   > Door to Gathering Hall
       Trivial
 
-> Spawn Point; Heals? False; Spawn Point
+> Spawn Point; Heals? False
   * Layers: default
   > Door to Gathering Hall
       Trivial
@@ -2057,7 +2057,7 @@ Extra - aabb: [397.9558, -8.934963, 4.7323303, 483.05167, 117.17189, 59.302334]
               Can Use Bombs
               Knowledge (Beginner) and Can Use Power Bombs
 
-> Door to Watery Hall Access; Heals? False; Default Node
+> Door to Watery Hall Access; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Missile Blast Shield (randomprime) to Watery Hall Access/Door to Watery Hall
   * Extra - dock_index: 1
@@ -2242,7 +2242,7 @@ Extra - aabb: [397.9558, -8.934963, 4.7323303, 483.05167, 117.17189, 59.302334]
   > Pickup (Charge Beam)
       Trivial
 
-> Spawn Point; Heals? False; Spawn Point
+> Spawn Point; Heals? False
   * Layers: default
   > Door to Watery Hall Access
       Trivial
@@ -2458,7 +2458,7 @@ Extra - aabb: [572.72375, -196.47711, 43.99083, 616.3443, -165.0573, 49.753304]
   > Door to Furnace
       Trivial
 
-> Door to Furnace; Heals? False; Default Node
+> Door to Furnace; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Furnace/Door to West Furnace Access
   * Extra - dock_index: 1
@@ -2475,7 +2475,7 @@ Extra - aabb: [572.72375, -196.47711, 43.99083, 616.3443, -165.0573, 49.753304]
   * Pickup 129; Category? Minor
   * Extra - position_required: True
 
-> Spawn Point; Heals? False; Spawn Point
+> Spawn Point; Heals? False
   * Layers: default
   > Door to Furnace
       Trivial


### PR DESCRIPTION
Moving spawn points to seperate nodes requires a preset migration. So i'll revert these for now, and then fix the spawn points for all nodes at once, including a preset migration, in a later PR.