### PR TITLE
Fusion: Add animal event back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: Minor adjustment related to Kraid to increase seed variety.
 
+### Metroid Fusion
+
+#### Logic Database
+
+##### Main Deck
+- Changed: Habitation Deck: It's now possible to move from the top right door to the top left entrance after the animals have been freed.
+
 ### Metroid Prime
 
 - Changed: AM2R's Drop Pickups will now use more appropriate models.

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -12501,15 +12501,15 @@
                         "Other to Habitation Ventilation (Upper)": {
                             "type": "or",
                             "data": {
-                                "comment": "Animals causes issues in generation with DLR, removed as an event for now",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "misc",
-                                            "name": "GeneratorHack",
+                                            "type": "events",
+                                            "name": "Animals",
                                             "amount": 1,
-                                            "negate": true
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -12598,13 +12598,13 @@
                         "Door to Habitation Deck Entrance (Upper)": {
                             "type": "or",
                             "data": {
-                                "comment": "Animals causes issues in generation with DLR, removed as an event for now",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "misc",
-                                            "name": "GeneratorHack",
+                                            "type": "events",
+                                            "name": "Animals",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -12612,7 +12612,7 @@
                                 ]
                             }
                         },
-                        "Pickup (Save the Animals)": {
+                        "Event - Activate Animal Controls": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12748,6 +12748,31 @@
                                         }
                                     }
                                 ]
+                            }
+                        }
+                    }
+                },
+                "Event - Activate Animal Controls": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 200.68454661558107,
+                        "y": 376.59770114942535,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "Animals",
+                    "connections": {
+                        "Pickup (Save the Animals)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -2047,8 +2047,7 @@ Hint Features - 1-way Shutter
   > Door to Habitation Deck Entrance (Middle)
       Trivial
   > Other to Habitation Ventilation (Upper)
-      # Animals causes issues in generation with DLR, removed as an event for now
-      Disabled Generator Workaround
+      After Main Deck Animal Controls
   > Above Pickup
       Trivial
 
@@ -2064,9 +2063,8 @@ Hint Features - 1-way Shutter
   * Open Passage to Habitation Ventilation/Other to Habitation Deck (Upper)
   * Extra - door_idx: (163,)
   > Door to Habitation Deck Entrance (Upper)
-      # Animals causes issues in generation with DLR, removed as an event for now
-      Enabled Generator Workaround
-  > Pickup (Save the Animals)
+      After Main Deck Animal Controls
+  > Event - Activate Animal Controls
       Trivial
 
 > Pickup (Save the Animals); Heals? False
@@ -2097,6 +2095,12 @@ Hint Features - 1-way Shutter
       Trivial
   > Other to Habitation Ventilation (Lower)
       Wave Beam
+
+> Event - Activate Animal Controls; Heals? False
+  * Layers: default
+  * Event Main Deck Animal Controls
+  > Pickup (Save the Animals)
+      Trivial
 
 ----------------
 Hornoad Hallway

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -687,6 +687,10 @@
             "RightSiloCheckpointShutter": {
                 "long_name": "Access Right of Silo Checkpoint Shutter",
                 "extra": {}
+            },
+            "Animals": {
+                "long_name": "Main Deck Animal Controls",
+                "extra": {}
             }
         },
         "tricks": {


### PR DESCRIPTION
The event was originally removed as it caused DLR to go in there and get stuck.
Now that we have a pickup there, we can safely add the event back to model the connection between the top docks accurately