### PR TITLE
Fusion: Remove generator hack going down clogged cavern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,10 +50,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Logic Database
 
 ##### Main Deck
+
 - Changed: Habitation Deck: It's now possible to move from the top right door to the top left entrance after the animals have been freed.
 
 ##### Sector 2 (TRO)
+
 - Fixed: Oasis is now included in the "near an extendable pillar" featural hint category.
+
+##### Sector 6
+
+- Changed: Clogged Cavern: Going down via the Speed Booster Blocks doesn't require Charge Beam or Intermediate Shinesparking anymore.
 
 ### Metroid Prime
 

--- a/randovania/games/fusion/game_data.py
+++ b/randovania/games/fusion/game_data.py
@@ -89,7 +89,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="M2MZQM34",
+        expected_seed_hash="DYXIFHO7",
     )
 
 

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -3520,41 +3520,6 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "misc",
-                                                        "name": "GeneratorHack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": "Generator traps itself and doesn't dare killing Varia Core-X to get out",
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "ShinesparkTrick",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "ChargeBeam",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
                                                 }
                                             ]
                                         }

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -458,10 +458,7 @@ Extra - minimap_coordinates: [{'x': 7, 'y': 7}, {'x': 7, 'y': 8}, {'x': 8, 'y': 
   * Extra - door_idx: (17, 72)
   > Door to Catacombs
       Any of the following:
-          All of the following:
-              Speed Booster and Enabled Generator Workaround
-              # Generator traps itself and doesn't dare killing Varia Core-X to get out
-              Charge Beam or Shinespark Tricks (Intermediate)
+          Speed Booster
           # These blocks disappear after defeating Mega Core
           After Boss Varia Core-X Defeated and Knowledge (Intermediate)
 


### PR DESCRIPTION
With (I presume) consider unsafe being defaulted now, the generator does not have any issues anymore giving pickups to defeat varia-core