### PR TITLE
Fusion: fix defeated typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Logic Database
 
+- Fixed: Typo on "Boss Ridley Defeated" event.
+
 ##### Main Deck
 
 - Changed: Habitation Deck: It's now possible to move from the top right door to the top left entrance after the animals have been freed.

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -1033,7 +1033,7 @@ Hint Features - Core-X
 
 > Event - Neo-Ridley; Heals? False
   * Layers: default
-  * Event Boss Ridley Deafeated
+  * Event Boss Ridley Defeated
   > Pickup (Screw Attack)
       Trivial
 
@@ -1052,7 +1052,7 @@ Hint Features - Core-X
   * Layers: default
   > Door to Ridley Arena Access
       All of the following:
-          After Boss Ridley Deafeated
+          After Boss Ridley Defeated
           Any of the following:
               Space Jump
               # Single wall jump out - https://youtu.be/trYxYGq7PMs

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -597,7 +597,7 @@
                 "extra": {}
             },
             "Ridley": {
-                "long_name": "Boss Ridley Deafeated",
+                "long_name": "Boss Ridley Defeated",
                 "extra": {}
             },
             "OmegaMetroid": {


### PR DESCRIPTION
- event name shows up in resource tabs in data visualizer so didn't put it under a Sector 1 heading in changelog