### PR TITLE
Generator: when out of locations, don't choose actions that don't give locations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Impossible generation cases that are caused due to walking into a point of no return that's impossible to escape from.
 - Fixed: Text such as the Seed Hash in the Async Race window is now selectable via mouse.
 - Fixed: Saving previous versions of presets when modififying no longer fails on certain cases.
+- Fixed: Certain scenarios at the start of generation with low possible actions are now less likely to fail.
 - Removed: The "Consider possible unsafe resources" experimental option has been removed and is now always enabled.
 - Removed: The "Revised door solver" experimental option has been removed and is now always enabled.
 - Added: Added "Create New Preset" button to preset menu to improve UX.


### PR DESCRIPTION
It solved a case where DLR was failing in Echoes because it'd choose to start with Light Beam despite it unlocking nothing.