### PR TITLE
Add Dread preset setting to replace item popups with async messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: Energy Parts are now logical.
 - Added: An option to enable Lua debug logging is available in the Cosmetic Options dialog when "Show Experimental Settings" is enabled (intended for game patcher developers).
+- Added: An option is now available in the "Other" preset settings tab to skip item acquisition popups, replacing them with a short on-screen message instead (similar to receiving Multiworld items).
 
 #### Logic Database
 

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -552,6 +552,7 @@ class DreadPatchDataFactory(PatchDataFactory[DreadConfiguration, DreadCosmeticPa
             "immediate_energy_parts": self.configuration.immediate_energy_parts,
             "enable_remote_lua": self.cosmetic_patches.enable_auto_tracker or self.players_config.is_multiworld,
             "enable_logging": self.cosmetic_patches.enable_debug_logging,
+            "skip_item_popups": self.configuration.skip_item_popups,
             "constant_environment_damage": {
                 "heat": self.configuration.constant_heat_damage,
                 "cold": self.configuration.constant_cold_damage,

--- a/randovania/games/dread/gui/generated/preset_dread_patches_ui.py
+++ b/randovania/games/dread/gui/generated/preset_dread_patches_ui.py
@@ -134,6 +134,17 @@ class Ui_PresetDreadPatches(object):
 
         self.verticalLayout_3.addWidget(self.nerf_power_bombs_label)
 
+        self.skip_item_popups_check = QCheckBox(self.miscellaneous_group)
+        self.skip_item_popups_check.setObjectName(u"skip_item_popups_check")
+
+        self.verticalLayout_3.addWidget(self.skip_item_popups_check)
+
+        self.skip_item_popups_label = QLabel(self.miscellaneous_group)
+        self.skip_item_popups_label.setObjectName(u"skip_item_popups_label")
+        self.skip_item_popups_label.setWordWrap(True)
+
+        self.verticalLayout_3.addWidget(self.skip_item_popups_label)
+
 
         self.scroll_layout.addWidget(self.miscellaneous_group)
 
@@ -173,5 +184,9 @@ class Ui_PresetDreadPatches(object):
         self.nerf_power_bombs_check.setText(QCoreApplication.translate("PresetDreadPatches", u"Power Bomb Limitations", None))
         self.nerf_power_bombs_label.setText(QCoreApplication.translate("PresetDreadPatches", u"The Power Bomb is one of the most powerful abilities in the game, as it can defeat most enemies and some bosses in one hit, as well as open Charge Beam doors, and destroy Enkies. \n"
 "This setting removes the ability to destroy Enkies and open Charge Beam doors, making Ice Missiles and Charge Beam much more valuable. ", None))
+        self.skip_item_popups_check.setText(QCoreApplication.translate("PresetDreadPatches", u"Skip Item Acquisition Popups", None))
+        self.skip_item_popups_label.setText(QCoreApplication.translate("PresetDreadPatches", u"This setting causes the popup dialogs shown when collecting pickups to be skipped. Instead, a message is shown near the top of the screen for several seconds after collecting an \n"
+"item, similar to the messages shown when receiving items in a Multiworld game.\n"
+"              ", None))
     # retranslateUi
 

--- a/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
@@ -20,6 +20,7 @@ _FIELDS = [
     "hanubia_easier_path_to_itorash",
     "x_starts_released",
     "nerf_power_bombs",
+    "skip_item_popups",
 ]
 
 

--- a/randovania/games/dread/gui/ui_files/preset_dread_patches.ui
+++ b/randovania/games/dread/gui/ui_files/preset_dread_patches.ui
@@ -196,6 +196,25 @@ This setting removes the ability to destroy Enkies and open Charge Beam doors, m
              </property>
             </widget>
            </item>
+           <item>
+            <widget class="QCheckBox" name="skip_item_popups_check">
+             <property name="text">
+              <string>Skip Item Acquisition Popups</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="skip_item_popups_label">
+             <property name="text">
+              <string>This setting causes the popup dialogs shown when collecting pickups to be skipped. Instead, a message is shown near the top of the screen for several seconds after collecting an 
+item, similar to the messages shown when receiving items in a Multiworld game.
+              </string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>

--- a/randovania/games/dread/layout/dread_configuration.py
+++ b/randovania/games/dread/layout/dread_configuration.py
@@ -72,6 +72,7 @@ class DreadConfiguration(BaseConfiguration):
     raven_beak_damage_table_handling: DreadRavenBeakDamageMode
     allow_highly_dangerous_logic: bool
     nerf_power_bombs: bool
+    skip_item_popups: bool
     warp_to_start: bool
     april_fools_hints: bool
     freesink: bool

--- a/randovania/games/dread/layout/preset_describer.py
+++ b/randovania/games/dread/layout/preset_describer.py
@@ -105,6 +105,7 @@ class DreadPresetDescriber(GamePresetDescriber):
                 },
                 {
                     "Disabled Power Bomb Limitations": not configuration.nerf_power_bombs,
+                    "Skip Item Acquisition Popups": configuration.skip_item_popups,
                 },
             ],
             "Environmental Damage": _format_environmental_damage(configuration),

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1225,6 +1225,11 @@ def _migrate_v110(preset: dict, game: RandovaniaGame, *, from_layout_description
         preset["configuration"]["adjusted_geron_weaknesses"] = not from_layout_description
 
 
+def _migrate_v111(preset: dict, game: RandovaniaGame, *, from_layout_description: bool) -> None:
+    if game == RandovaniaGame.METROID_DREAD:
+        preset["configuration"]["skip_item_popups"] = False
+
+
 _MIGRATIONS: list[PresetMigration | None] = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -1336,6 +1341,7 @@ _MIGRATIONS: list[PresetMigration | None] = [
     _migrate_v108,  # fusion instant morph
     _migrate_v109,  # remove consider_possible_unsafe_resources and two_sided_door_lock_search
     _migrate_v110,  # fusion: add adjusted geron weaknesses
+    _migrate_v111,  # dread: add skip_item_popups setting
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/test/test_files/log_files/dread/all_settings.rdvgame
+++ b/test/test_files/log_files/dread/all_settings.rdvgame
@@ -10,7 +10,7 @@
         "word_hash": "Armadigger Spittail Armadigger",
         "presets": [
             {
-                "schema_version": 97,
+                "schema_version": 112,
                 "base_preset_uuid": null,
                 "name": "All Settings",
                 "uuid": "38849a5f-ed44-47cc-83a7-8f084ea27612",
@@ -20,30 +20,30 @@
                     "trick_level": {
                         "minimal_logic": false,
                         "specific_levels": {
-                            "CBL": "hypermode",
-                            "Combat": "hypermode",
-                            "CrossSkip": "hypermode",
-                            "DBJ": "hypermode",
-                            "DBoost": "hypermode",
-                            "DiffusionAbuse": "hypermode",
-                            "FlashSkip": "hypermode",
-                            "FloorClip": "hypermode",
-                            "FrozenEnemy": "hypermode",
-                            "GrappleMovement": "hypermode",
-                            "IBJ": "hypermode",
-                            "Knowledge": "hypermode",
-                            "LedgeWarp": "hypermode",
-                            "Movement": "hypermode",
-                            "Pseudo": "hypermode",
-                            "RGrapple": "hypermode",
-                            "SWJ": "hypermode",
-                            "ShortBoost": "hypermode",
-                            "Slide": "hypermode",
-                            "Speedbooster": "hypermode",
-                            "TunnelSlope": "hypermode",
-                            "WBJ": "hypermode",
-                            "WSJ": "hypermode",
-                            "Walljump": "hypermode"
+                            "CBL": "ludicrous",
+                            "Combat": "ludicrous",
+                            "CrossSkip": "ludicrous",
+                            "DBJ": "ludicrous",
+                            "DBoost": "ludicrous",
+                            "DiffusionAbuse": "ludicrous",
+                            "FlashSkip": "ludicrous",
+                            "FloorClip": "ludicrous",
+                            "FrozenEnemy": "ludicrous",
+                            "GrappleMovement": "ludicrous",
+                            "IBJ": "ludicrous",
+                            "Knowledge": "ludicrous",
+                            "LedgeWarp": "ludicrous",
+                            "Movement": "ludicrous",
+                            "Pseudo": "ludicrous",
+                            "RGrapple": "ludicrous",
+                            "SWJ": "ludicrous",
+                            "ShortBoost": "ludicrous",
+                            "Slide": "ludicrous",
+                            "Speedbooster": "ludicrous",
+                            "TunnelSlope": "ludicrous",
+                            "WBJ": "ludicrous",
+                            "WSJ": "ludicrous",
+                            "Walljump": "ludicrous"
                         }
                     },
                     "starting_location": [
@@ -362,9 +362,6 @@
                     "pickup_model_data_source": "random",
                     "logical_resource_action": "randomly",
                     "first_progression_must_be_local": true,
-                    "two_sided_door_lock_search": false,
-                    "minimum_available_locations_for_hint_placement": 5,
-                    "minimum_location_weight_for_hint_placement": 0.1,
                     "dock_rando": {
                         "mode": "docks",
                         "types_state": {
@@ -418,6 +415,7 @@
                     "raven_beak_damage_table_handling": "consistent_high",
                     "allow_highly_dangerous_logic": true,
                     "nerf_power_bombs": true,
+                    "skip_item_popups": true,
                     "warp_to_start": true,
                     "april_fools_hints": false,
                     "freesink": false,
@@ -439,6 +437,14 @@
                         "ghavoran": false,
                         "hanubia": false,
                         "itorash": false
+                    },
+                    "hints": {
+                        "minimum_available_locations_for_hint_placement": 5,
+                        "minimum_location_weight_for_hint_placement": 0.1,
+                        "use_resolver_hints": false,
+                        "specific_pickup_hints": {},
+                        "enable_random_hints": true,
+                        "enable_specific_location_hints": true
                     }
                 }
             }

--- a/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/all_settings/world_1.json
@@ -4226,6 +4226,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": true,
+    "skip_item_popups": true,
     "constant_environment_damage": {
         "heat": 15,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/dread/crazy_settings/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/crazy_settings/world_1.json
@@ -3583,6 +3583,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": null,

--- a/test/test_files/patcher_data/dread/dread/custom_patcher_data/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/custom_patcher_data/world_1.json
@@ -3533,6 +3533,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/dread/custom_start/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/custom_start/world_1.json
@@ -3586,6 +3586,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_1.json
@@ -4078,6 +4078,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_2.json
+++ b/test/test_files/patcher_data/dread/dread/dread_dread_multiworld/world_2.json
@@ -4098,6 +4098,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/dread/elevator_rando/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/elevator_rando/world_1.json
@@ -3957,6 +3957,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/dread/hide_all_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/hide_all_with_nothing/world_1.json
@@ -3797,6 +3797,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/dread/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/starter_preset/world_1.json
@@ -3562,6 +3562,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": null,
         "cold": null,

--- a/test/test_files/patcher_data/dread/dread/vanilla/world_1.json
+++ b/test/test_files/patcher_data/dread/dread/vanilla/world_1.json
@@ -3479,6 +3479,7 @@
     "immediate_energy_parts": false,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": null,
         "cold": null,

--- a/test/test_files/patcher_data/dread/dread_prime1_multiworld/world_1.json
+++ b/test/test_files/patcher_data/dread/dread_prime1_multiworld/world_1.json
@@ -3707,6 +3707,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2+msr/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2+msr/world_4.json
@@ -3817,6 +3817,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_4.json
@@ -3788,6 +3788,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_8.json
+++ b/test/test_files/patcher_data/dread/multi-am2r+cs+dread+prime1+prime2/world_8.json
@@ -4327,6 +4327,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_4.json
+++ b/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_4.json
@@ -3819,6 +3819,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_8.json
+++ b/test/test_files/patcher_data/dread/multi-cs+dread+prime1+prime2/world_8.json
@@ -3820,6 +3820,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,

--- a/test/test_files/patcher_data/dread/multi_coop_am2r+bdg+cs+dread+prime1+echoes+msr/world_4.json
+++ b/test/test_files/patcher_data/dread/multi_coop_am2r+bdg+cs+dread+prime1+echoes+msr/world_4.json
@@ -3879,6 +3879,7 @@
     "immediate_energy_parts": true,
     "enable_remote_lua": true,
     "enable_logging": false,
+    "skip_item_popups": false,
     "constant_environment_damage": {
         "heat": 20,
         "cold": 20,


### PR DESCRIPTION
This PR is directly related to (and depends on) randovania/open-dread-rando-exlaunch#12 and randovania/open-dread-rando#411.

This adds a new preset setting for Metroid Dread in the "Other" tab that allows replacing "Item Acquired" popups with an async message near the top of the screen. The primary motivation for this setting is to make the game feel more fluid and to avoid the several-second-long interruption while waiting for the game to allow dismissing the popup.

The setting defaults to disabled, meaning the vanilla item behavior is left intact without explicit preset changes.

When the setting is enabled, any games generated with the preset will use the new feature in `open-dread-rando-exlaunch` to skip displaying a popup when collecting items. Instead, collecting an item will display a message at the top of the screen for 5 seconds, just like when receiving an item in a Multiworld session. All other behavior pertaining to collecting pickups is left intact. This includes pickup sounds, checkpoints (which normal pickups don't have, but just in case), and incrementing the "current" count of resources like missiles or PB ammunition along with the maximum.

Video of this feature in action:

https://github.com/user-attachments/assets/77f5759d-d239-4263-8c0e-f6db774a3226

I have played two full seeds with this new setting enabled and did not encounter any odd behavior or problems.