### PR TITLE
Remove generated files as cache keys for UV

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -406,10 +406,4 @@ cache-keys = [
     { file = "README.md" },
     { file = "pyuic.json" },
     { file = "**/*.ui" },
-
-    # Listing these files forces uv to rebuild Randovania every time you run,
-    # but otherwise it's not rebuilt when these are deleted.
-    { file = "randovania/version.py" },
-    { file = "randovania/version_hash.py" },
-    { file = "randovania/data/README.md" },
 ]


### PR DESCRIPTION
Re-building the package every time is quite annoying. I think the main issue was with the self-hosted runner, which I'm gonna trust now works and fix if it doesn't.