### PR TITLE
Fusion Update Elevator Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: Removed game-specific text from the preset editor's header to make information more clear for all games in RDV.
 
+### Metroid Fusion
+
+- Changed: Renamed elevator rooms to be more aligned with where they are in the B.S.L rather than "to" a desitination. Example, "Elevator to Central Nexus" was renamed to "Habitation Deck Elevator". Change should bring more clarity and also help prepare for a future setting.
+
 ### Metroid: Samus Returns
 
 - Fixed: Certain output preferences from old versions of Randovania no longer causes issues on start.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Fusion
 
-- Changed: Renamed elevator rooms to be more aligned with where they are in the B.S.L rather than "to" a desitination. Example, "Elevator to Central Nexus" was renamed to "Habitation Deck Elevator". Change should bring more clarity and also help prepare for a future setting.
+- Changed: Renamed elevator rooms to be more aligned with where they are in the B.S.L rather than their destination in order to bring more clarity. For example, "Elevator to Central Nexus" was renamed to "Habitation Deck Elevator".
 
 ### Metroid: Samus Returns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.5.0] - 2026-03-??
 
-- Nothing yet
+- Nothing yet.
 
 ### Metroid: Samus Returns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.5.0] - 2026-03-??
 
-- Nothing yet.
+- Nothing yet
+
+### Metroid Fusion
+
+- Changed: Renamed elevator rooms to be more aligned with where they are in the B.S.L rather than "to" a desitination. Example, "Elevator to Central Nexus" was renamed to "Habitation Deck Elevator". Change should bring more clarity and also help prepare for a future setting.
 
 ### Metroid: Samus Returns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet
 
-### Metroid Fusion
-
-- Changed: Renamed elevator rooms to be more aligned with where they are in the B.S.L rather than "to" a desitination. Example, "Elevator to Central Nexus" was renamed to "Habitation Deck Elevator". Change should bring more clarity and also help prepare for a future setting.
-
 ### Metroid: Samus Returns
 
 - Fixed: Certain output preferences from old versions of Randovania no longer causes issues on start.

--- a/randovania/games/fusion/assets/migration_data.json
+++ b/randovania/games/fusion/assets/migration_data.json
@@ -671,17 +671,17 @@
     "elevator_rename_doors": {
         "Main Deck/Elevator to Central Nexus/Door to Habitation Deck Save Room": "Main Deck/Habitation Deck Elevator/Door to Habitation Deck Save Room",
         "Main Deck/Habitation Deck Save Room/Door to Elevator to Central Nexus": "Main Deck/Habitation Deck Save Room/Door to Habitation Deck Elevator",
-        "Main Deck/Sector Hub/Door to Elevator to Sector 1 (SRX)": "Main Deck/Sector Hub/Door to Sector Lift 1",
-        "Main Deck/Sector Hub/Door to Elevator to Sector 2 (TRO)": "Main Deck/Sector Hub/Door to Sector Lift 2",
-        "Main Deck/Elevator to Sector 1 (SRX)/Door to Sector Hub": "Main Deck/Sector Lift 1/Door to Sector Hub",
-        "Main Deck/Elevator to Sector 1 (SRX)/Door to Elevator to Sector 3 (PYR)": "Main Deck/Sector Lift 1/Door to Sector Lift 3",
-        "Main Deck/Elevator to Sector 2 (TRO)/Door to Sector Hub": "Main Deck/Sector Lift 2/Door to Sector Hub",
-        "Main Deck/Elevator to Sector 2 (TRO)/Door to Elevator to Sector 4 (AQA)": "Main Deck/Sector Lift 2/Door to Sector Lift 4",
-        "Main Deck/Elevator to Sector 3 (PYR)/Door to Elevator to Sector 1 (SRX)": "Main Deck/Sector Lift 3/Door to Sector Lift 1",
-        "Main Deck/Elevator to Sector 3 (PYR)/Door to Elevator to Sector 5 (ARC)": "Main Deck/Sector Lift 3/Door to Sector Lift 5",
-        "Main Deck/Elevator to Sector 4 (AQA)/Door to Elevator to Sector 2 (TRO)": "Main Deck/Sector Lift 4/Door to Sector Lift 2",
-        "Main Deck/Elevator to Sector 4 (AQA)/Door to Elevator to Sector 6 (NOC)": "Main Deck/Sector Lift 4/Door to Sector Lift 6",
-        "Main Deck/Elevator to Sector 5 (ARC)/Door to Elevator to Sector 3 (PYR)": "Main Deck/Sector Lift 5/Door to Sector Lift 3",
-        "Main Deck/Elevator to Sector 6 (NOC)/Door to Elevator to Sector 4 (AQA)": "Main Deck/Sector Lift 6/Door to Sector Lift 4"
+        "Main Deck/Sector Hub/Door to Elevator to Sector 1 (SRX)": "Main Deck/Sector Hub/Door to Sector Hub Lift 1",
+        "Main Deck/Sector Hub/Door to Elevator to Sector 2 (TRO)": "Main Deck/Sector Hub/Door to Sector Hub Lift 2",
+        "Main Deck/Elevator to Sector 1 (SRX)/Door to Sector Hub": "Main Deck/Sector Hub Lift 1/Door to Sector Hub",
+        "Main Deck/Elevator to Sector 1 (SRX)/Door to Elevator to Sector 3 (PYR)": "Main Deck/Sector Hub Lift 1/Door to Sector Hub Lift 3",
+        "Main Deck/Elevator to Sector 2 (TRO)/Door to Sector Hub": "Main Deck/Sector Hub Lift 2/Door to Sector Hub",
+        "Main Deck/Elevator to Sector 2 (TRO)/Door to Elevator to Sector 4 (AQA)": "Main Deck/Sector Hub Lift 2/Door to Sector Hub Lift 4",
+        "Main Deck/Elevator to Sector 3 (PYR)/Door to Elevator to Sector 1 (SRX)": "Main Deck/Sector Hub Lift 3/Door to Sector Hub Lift 1",
+        "Main Deck/Elevator to Sector 3 (PYR)/Door to Elevator to Sector 5 (ARC)": "Main Deck/Sector Hub Lift 3/Door to Sector Hub Lift 5",
+        "Main Deck/Elevator to Sector 4 (AQA)/Door to Elevator to Sector 2 (TRO)": "Main Deck/Sector Hub Lift 4/Door to Sector Hub Lift 2",
+        "Main Deck/Elevator to Sector 4 (AQA)/Door to Elevator to Sector 6 (NOC)": "Main Deck/Sector Hub Lift 4/Door to Sector Hub Lift 6",
+        "Main Deck/Elevator to Sector 5 (ARC)/Door to Elevator to Sector 3 (PYR)": "Main Deck/Sector Hub Lift 5/Door to Sector Hub Lift 3",
+        "Main Deck/Elevator to Sector 6 (NOC)/Door to Elevator to Sector 4 (AQA)": "Main Deck/Sector Hub Lift 6/Door to Sector Hub Lift 4"
     }
 }

--- a/randovania/games/fusion/assets/migration_data.json
+++ b/randovania/games/fusion/assets/migration_data.json
@@ -667,5 +667,21 @@
             "region": "Sector 6 (NOC)",
             "area_and_node": "Spaceboost Alley/Pickup (Power Bomb Tank 2)"
         }
+    },
+    "elevator_rename_doors": {
+        "Main Deck/Elevator to Central Nexus/Door to Habitation Deck Save Room": "Main Deck/Habitation Deck Elevator/Door to Habitation Deck Save Room",
+        "Main Deck/Habitation Deck Save Room/Door to Elevator to Central Nexus": "Main Deck/Habitation Deck Save Room/Door to Habitation Deck Elevator",
+        "Main Deck/Sector Hub/Door to Elevator to Sector 1 (SRX)": "Main Deck/Sector Hub/Door to Sector Lift 1",
+        "Main Deck/Sector Hub/Door to Elevator to Sector 2 (TRO)": "Main Deck/Sector Hub/Door to Sector Lift 2",
+        "Main Deck/Elevator to Sector 1 (SRX)/Door to Sector Hub": "Main Deck/Sector Lift 1/Door to Sector Hub",
+        "Main Deck/Elevator to Sector 1 (SRX)/Door to Elevator to Sector 3 (PYR)": "Main Deck/Sector Lift 1/Door to Sector Lift 3",
+        "Main Deck/Elevator to Sector 2 (TRO)/Door to Sector Hub": "Main Deck/Sector Lift 2/Door to Sector Hub",
+        "Main Deck/Elevator to Sector 2 (TRO)/Door to Elevator to Sector 4 (AQA)": "Main Deck/Sector Lift 2/Door to Sector Lift 4",
+        "Main Deck/Elevator to Sector 3 (PYR)/Door to Elevator to Sector 1 (SRX)": "Main Deck/Sector Lift 3/Door to Sector Lift 1",
+        "Main Deck/Elevator to Sector 3 (PYR)/Door to Elevator to Sector 5 (ARC)": "Main Deck/Sector Lift 3/Door to Sector Lift 5",
+        "Main Deck/Elevator to Sector 4 (AQA)/Door to Elevator to Sector 2 (TRO)": "Main Deck/Sector Lift 4/Door to Sector Lift 2",
+        "Main Deck/Elevator to Sector 4 (AQA)/Door to Elevator to Sector 6 (NOC)": "Main Deck/Sector Lift 4/Door to Sector Lift 6",
+        "Main Deck/Elevator to Sector 5 (ARC)/Door to Elevator to Sector 3 (PYR)": "Main Deck/Sector Lift 5/Door to Sector Lift 3",
+        "Main Deck/Elevator to Sector 6 (NOC)/Door to Elevator to Sector 4 (AQA)": "Main Deck/Sector Lift 6/Door to Sector Lift 4"
     }
 }

--- a/randovania/games/fusion/game_data.py
+++ b/randovania/games/fusion/game_data.py
@@ -89,7 +89,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="DK57MM44",
+        expected_seed_hash="UCPGVGGT",
     )
 
 

--- a/randovania/games/fusion/game_data.py
+++ b/randovania/games/fusion/game_data.py
@@ -89,7 +89,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="WSC7FIFQ",
+        expected_seed_hash="DK57MM44",
     )
 
 

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -1524,7 +1524,7 @@
                 "unlocked_save_recharge_station": true
             },
             "nodes": {
-                "Door to Elevator to Central Nexus": {
+                "Door to Habitation Deck Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1545,7 +1545,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Central Nexus",
+                        "area": "Habitation Deck Elevator",
                         "node": "Door to Habitation Deck Save Room"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -1582,7 +1582,7 @@
                     },
                     "valid_starting_location": true,
                     "connections": {
-                        "Door to Elevator to Central Nexus": {
+                        "Door to Habitation Deck Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2913,7 +2913,7 @@
                 ]
             },
             "nodes": {
-                "Door to Elevator to Central Nexus": {
+                "Door to Habitation Deck Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2934,7 +2934,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Central Nexus",
+                        "area": "Habitation Deck Elevator",
                         "node": "Door to Habitation Deck Entrance"
                     },
                     "default_dock_weakness": "L2 Hatch",
@@ -3219,7 +3219,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Central Nexus": {
+                        "Door to Habitation Deck Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3259,7 +3259,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Central Nexus": {
+                        "Door to Habitation Deck Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3320,7 +3320,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Central Nexus": {
+                        "Door to Habitation Deck Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13249,7 +13249,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Elevator to Elevator to Central Nexus": {
+                        "Elevator to Habitation Deck Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13258,7 +13258,7 @@
                         }
                     }
                 },
-                "Elevator to Elevator to Central Nexus": {
+                "Elevator to Habitation Deck Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13279,7 +13279,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Central Nexus",
+                        "area": "Habitation Deck Elevator",
                         "node": "Elevator to Elevator to Habitation Deck"
                     },
                     "default_dock_weakness": "Elevator",
@@ -13300,7 +13300,7 @@
                 }
             }
         },
-        "Elevator to Central Nexus": {
+        "Habitation Deck Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -13342,7 +13342,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Habitation Deck Save Room",
-                        "node": "Door to Elevator to Central Nexus"
+                        "node": "Door to Habitation Deck Elevator"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -13382,7 +13382,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Elevator to Habitation Deck",
-                        "node": "Elevator to Elevator to Central Nexus"
+                        "node": "Elevator to Habitation Deck Elevator"
                     },
                     "default_dock_weakness": "Elevator",
                     "exclude_from_dock_rando": false,
@@ -13422,7 +13422,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Habitation Deck Entrance",
-                        "node": "Door to Elevator to Central Nexus"
+                        "node": "Door to Habitation Deck Elevator"
                     },
                     "default_dock_weakness": "L2 Hatch",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -5678,7 +5678,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Sector 2 (TRO)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 2 (TRO) Entrance Elevator",
                         "node": "Elevator to Main Deck"
                     },
                     "default_dock_weakness": "Elevator",
@@ -5829,7 +5829,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Sector 4 (AQA)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 4 (AQA) Entrance Elevator",
                         "node": "Elevator to Main Deck"
                     },
                     "default_dock_weakness": "Elevator",
@@ -5932,7 +5932,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Sector 6 (NOC)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 6 (NOC) Entrance Elevator",
                         "node": "Elevator to Main Deck"
                     },
                     "default_dock_weakness": "Elevator",
@@ -6083,7 +6083,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Sector 1 (SRX)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 1 (SRX) Entrance Elevator",
                         "node": "Elevator to Main Deck"
                     },
                     "default_dock_weakness": "Elevator",
@@ -6234,7 +6234,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Sector 3 (PYR)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 3 (PYR) Entrance Elevator",
                         "node": "Elevator to Main Deck"
                     },
                     "default_dock_weakness": "Elevator",
@@ -6337,7 +6337,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Sector 5 (ARC)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 5 (ARC) Entrance Elevator",
                         "node": "Elevator to Main Deck"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -5416,14 +5416,14 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Sector Lift 2": {
+                        "Door to Sector Hub Lift 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door to Sector Lift 1": {
+                        "Door to Sector Hub Lift 1": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5439,7 +5439,7 @@
                         }
                     }
                 },
-                "Door to Sector Lift 2": {
+                "Door to Sector Hub Lift 2": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5461,7 +5461,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 2",
+                        "area": "Sector Hub Lift 2",
                         "node": "Door to Sector Hub"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -5480,7 +5480,7 @@
                         }
                     }
                 },
-                "Door to Sector Lift 1": {
+                "Door to Sector Hub Lift 1": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5502,7 +5502,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 1",
+                        "area": "Sector Hub Lift 1",
                         "node": "Door to Sector Hub"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -5548,7 +5548,7 @@
                 }
             }
         },
-        "Sector Lift 2": {
+        "Sector Hub Lift 2": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -5591,7 +5591,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Sector Hub",
-                        "node": "Door to Sector Lift 2"
+                        "node": "Door to Sector Hub Lift 2"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5600,7 +5600,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Sector Lift 4": {
+                        "Door to Sector Hub Lift 4": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5616,7 +5616,7 @@
                         }
                     }
                 },
-                "Door to Sector Lift 4": {
+                "Door to Sector Hub Lift 4": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5638,8 +5638,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 4",
-                        "node": "Door to Sector Lift 2"
+                        "area": "Sector Hub Lift 4",
+                        "node": "Door to Sector Hub Lift 2"
                     },
                     "default_dock_weakness": "L1 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5699,7 +5699,7 @@
                 }
             }
         },
-        "Sector Lift 4": {
+        "Sector Hub Lift 4": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -5719,7 +5719,7 @@
                 ]
             },
             "nodes": {
-                "Door to Sector Lift 2": {
+                "Door to Sector Hub Lift 2": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5741,8 +5741,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 2",
-                        "node": "Door to Sector Lift 4"
+                        "area": "Sector Hub Lift 2",
+                        "node": "Door to Sector Hub Lift 4"
                     },
                     "default_dock_weakness": "L1 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5751,7 +5751,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Sector Lift 6": {
+                        "Door to Sector Hub Lift 6": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5767,7 +5767,7 @@
                         }
                     }
                 },
-                "Door to Sector Lift 6": {
+                "Door to Sector Hub Lift 6": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5789,8 +5789,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 6",
-                        "node": "Door to Sector Lift 4"
+                        "area": "Sector Hub Lift 6",
+                        "node": "Door to Sector Hub Lift 4"
                     },
                     "default_dock_weakness": "L2 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5799,7 +5799,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Sector Lift 2": {
+                        "Door to Sector Hub Lift 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5839,7 +5839,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Sector Lift 2": {
+                        "Door to Sector Hub Lift 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5850,7 +5850,7 @@
                 }
             }
         },
-        "Sector Lift 6": {
+        "Sector Hub Lift 6": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -5870,7 +5870,7 @@
                 ]
             },
             "nodes": {
-                "Door to Sector Lift 4": {
+                "Door to Sector Hub Lift 4": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5892,8 +5892,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 4",
-                        "node": "Door to Sector Lift 6"
+                        "area": "Sector Hub Lift 4",
+                        "node": "Door to Sector Hub Lift 6"
                     },
                     "default_dock_weakness": "L2 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5942,7 +5942,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Sector Lift 4": {
+                        "Door to Sector Hub Lift 4": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5953,7 +5953,7 @@
                 }
             }
         },
-        "Sector Lift 1": {
+        "Sector Hub Lift 1": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -5996,7 +5996,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Sector Hub",
-                        "node": "Door to Sector Lift 1"
+                        "node": "Door to Sector Hub Lift 1"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6005,7 +6005,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Sector Lift 3": {
+                        "Door to Sector Hub Lift 3": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6021,7 +6021,7 @@
                         }
                     }
                 },
-                "Door to Sector Lift 3": {
+                "Door to Sector Hub Lift 3": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6043,8 +6043,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 3",
-                        "node": "Door to Sector Lift 1"
+                        "area": "Sector Hub Lift 3",
+                        "node": "Door to Sector Hub Lift 1"
                     },
                     "default_dock_weakness": "L1 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6104,7 +6104,7 @@
                 }
             }
         },
-        "Sector Lift 3": {
+        "Sector Hub Lift 3": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -6124,7 +6124,7 @@
                 ]
             },
             "nodes": {
-                "Door to Sector Lift 1": {
+                "Door to Sector Hub Lift 1": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6146,8 +6146,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 1",
-                        "node": "Door to Sector Lift 3"
+                        "area": "Sector Hub Lift 1",
+                        "node": "Door to Sector Hub Lift 3"
                     },
                     "default_dock_weakness": "L1 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6156,7 +6156,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Sector Lift 5": {
+                        "Door to Sector Hub Lift 5": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6172,7 +6172,7 @@
                         }
                     }
                 },
-                "Door to Sector Lift 5": {
+                "Door to Sector Hub Lift 5": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6194,8 +6194,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 5",
-                        "node": "Door to Sector Lift 3"
+                        "area": "Sector Hub Lift 5",
+                        "node": "Door to Sector Hub Lift 3"
                     },
                     "default_dock_weakness": "L2 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6204,7 +6204,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Sector Lift 1": {
+                        "Door to Sector Hub Lift 1": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6244,7 +6244,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Sector Lift 1": {
+                        "Door to Sector Hub Lift 1": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6255,7 +6255,7 @@
                 }
             }
         },
-        "Sector Lift 5": {
+        "Sector Hub Lift 5": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -6275,7 +6275,7 @@
                 ]
             },
             "nodes": {
-                "Door to Sector Lift 3": {
+                "Door to Sector Hub Lift 3": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6297,8 +6297,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 3",
-                        "node": "Door to Sector Lift 5"
+                        "area": "Sector Hub Lift 3",
+                        "node": "Door to Sector Hub Lift 5"
                     },
                     "default_dock_weakness": "L2 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6347,7 +6347,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Sector Lift 3": {
+                        "Door to Sector Hub Lift 3": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -1655,7 +1655,7 @@
                                 "items": []
                             }
                         },
-                        "Door to Elevator to Operations Deck": {
+                        "Door to Crew Quarters Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1704,7 +1704,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Operations Deck": {
+                "Door to Crew Quarters Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1725,7 +1725,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Operations Deck",
+                        "area": "Crew Quarters Elevator",
                         "node": "Door to Crew Quarters West"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -1930,7 +1930,7 @@
                                 ]
                             }
                         },
-                        "Door to Elevator to Crew Quarters": {
+                        "Door to Operations Deck Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2009,7 +2009,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Crew Quarters": {
+                        "Door to Operations Deck Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2018,7 +2018,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Crew Quarters": {
+                "Door to Operations Deck Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2040,7 +2040,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Crew Quarters",
+                        "area": "Operations Deck Elevator",
                         "node": "Door to Operations Deck"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -2300,7 +2300,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Elevator to Crew Quarters": {
+                        "Door to Operations Deck Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3798,7 +3798,7 @@
                 ]
             },
             "nodes": {
-                "Door to Elevator to Habitation Deck": {
+                "Door to Nexus Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3819,7 +3819,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Habitation Deck",
+                        "area": "Nexus Elevator",
                         "node": "Door to Central Nexus"
                     },
                     "default_dock_weakness": "L2 Hatch",
@@ -3869,7 +3869,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Habitation Deck": {
+                        "Door to Nexus Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5416,14 +5416,14 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Sector 2 (TRO)": {
+                        "Door to Sector Lift 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door to Elevator to Sector 1 (SRX)": {
+                        "Door to Sector Lift 1": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5439,7 +5439,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Sector 2 (TRO)": {
+                "Door to Sector Lift 2": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5461,7 +5461,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 2 (TRO)",
+                        "area": "Sector Lift 2",
                         "node": "Door to Sector Hub"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -5480,7 +5480,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Sector 1 (SRX)": {
+                "Door to Sector Lift 1": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5502,7 +5502,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 1 (SRX)",
+                        "area": "Sector Lift 1",
                         "node": "Door to Sector Hub"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -5548,7 +5548,7 @@
                 }
             }
         },
-        "Elevator to Sector 2 (TRO)": {
+        "Sector Lift 2": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -5591,7 +5591,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Sector Hub",
-                        "node": "Door to Elevator to Sector 2 (TRO)"
+                        "node": "Door to Sector Lift 2"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5600,7 +5600,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Sector 4 (AQA)": {
+                        "Door to Sector Lift 4": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5616,7 +5616,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Sector 4 (AQA)": {
+                "Door to Sector Lift 4": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5638,8 +5638,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 4 (AQA)",
-                        "node": "Door to Elevator to Sector 2 (TRO)"
+                        "area": "Sector Lift 4",
+                        "node": "Door to Sector Lift 2"
                     },
                     "default_dock_weakness": "L1 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5699,7 +5699,7 @@
                 }
             }
         },
-        "Elevator to Sector 4 (AQA)": {
+        "Sector Lift 4": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -5719,7 +5719,7 @@
                 ]
             },
             "nodes": {
-                "Door to Elevator to Sector 2 (TRO)": {
+                "Door to Sector Lift 2": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5741,8 +5741,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 2 (TRO)",
-                        "node": "Door to Elevator to Sector 4 (AQA)"
+                        "area": "Sector Lift 2",
+                        "node": "Door to Sector Lift 4"
                     },
                     "default_dock_weakness": "L1 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5751,7 +5751,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Sector 6 (NOC)": {
+                        "Door to Sector Lift 6": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5767,7 +5767,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Sector 6 (NOC)": {
+                "Door to Sector Lift 6": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5789,8 +5789,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 6 (NOC)",
-                        "node": "Door to Elevator to Sector 4 (AQA)"
+                        "area": "Sector Lift 6",
+                        "node": "Door to Sector Lift 4"
                     },
                     "default_dock_weakness": "L2 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5799,7 +5799,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Sector 2 (TRO)": {
+                        "Door to Sector Lift 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5839,7 +5839,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Sector 2 (TRO)": {
+                        "Door to Sector Lift 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5850,7 +5850,7 @@
                 }
             }
         },
-        "Elevator to Sector 6 (NOC)": {
+        "Sector Lift 6": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -5870,7 +5870,7 @@
                 ]
             },
             "nodes": {
-                "Door to Elevator to Sector 4 (AQA)": {
+                "Door to Sector Lift 4": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5892,8 +5892,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 4 (AQA)",
-                        "node": "Door to Elevator to Sector 6 (NOC)"
+                        "area": "Sector Lift 4",
+                        "node": "Door to Sector Lift 6"
                     },
                     "default_dock_weakness": "L2 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5942,7 +5942,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Sector 4 (AQA)": {
+                        "Door to Sector Lift 4": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5953,7 +5953,7 @@
                 }
             }
         },
-        "Elevator to Sector 1 (SRX)": {
+        "Sector Lift 1": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -5996,7 +5996,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Sector Hub",
-                        "node": "Door to Elevator to Sector 1 (SRX)"
+                        "node": "Door to Sector Lift 1"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6005,7 +6005,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Sector 3 (PYR)": {
+                        "Door to Sector Lift 3": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6021,7 +6021,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Sector 3 (PYR)": {
+                "Door to Sector Lift 3": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6043,8 +6043,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 3 (PYR)",
-                        "node": "Door to Elevator to Sector 1 (SRX)"
+                        "area": "Sector Lift 3",
+                        "node": "Door to Sector Lift 1"
                     },
                     "default_dock_weakness": "L1 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6104,7 +6104,7 @@
                 }
             }
         },
-        "Elevator to Sector 3 (PYR)": {
+        "Sector Lift 3": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -6124,7 +6124,7 @@
                 ]
             },
             "nodes": {
-                "Door to Elevator to Sector 1 (SRX)": {
+                "Door to Sector Lift 1": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6146,8 +6146,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 1 (SRX)",
-                        "node": "Door to Elevator to Sector 3 (PYR)"
+                        "area": "Sector Lift 1",
+                        "node": "Door to Sector Lift 3"
                     },
                     "default_dock_weakness": "L1 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6156,7 +6156,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Sector 5 (ARC)": {
+                        "Door to Sector Lift 5": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6172,7 +6172,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Sector 5 (ARC)": {
+                "Door to Sector Lift 5": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6194,8 +6194,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 5 (ARC)",
-                        "node": "Door to Elevator to Sector 3 (PYR)"
+                        "area": "Sector Lift 5",
+                        "node": "Door to Sector Lift 3"
                     },
                     "default_dock_weakness": "L2 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6204,7 +6204,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Sector 1 (SRX)": {
+                        "Door to Sector Lift 1": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6244,7 +6244,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Sector 1 (SRX)": {
+                        "Door to Sector Lift 1": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6255,7 +6255,7 @@
                 }
             }
         },
-        "Elevator to Sector 5 (ARC)": {
+        "Sector Lift 5": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -6275,7 +6275,7 @@
                 ]
             },
             "nodes": {
-                "Door to Elevator to Sector 3 (PYR)": {
+                "Door to Sector Lift 3": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6297,8 +6297,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 3 (PYR)",
-                        "node": "Door to Elevator to Sector 5 (ARC)"
+                        "area": "Sector Lift 3",
+                        "node": "Door to Sector Lift 5"
                     },
                     "default_dock_weakness": "L2 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6347,7 +6347,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Sector 3 (PYR)": {
+                        "Door to Sector Lift 3": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6659,7 +6659,7 @@
                 ]
             },
             "nodes": {
-                "Other to Elevator to Sector Hub": {
+                "Other to Main Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6680,7 +6680,7 @@
                     "dock_type": "Other",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector Hub",
+                        "area": "Main Elevator",
                         "node": "Elevator to Main Elevator Shaft"
                     },
                     "default_dock_weakness": "Open Passage",
@@ -6730,7 +6730,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Other to Elevator to Sector Hub": {
+                        "Other to Main Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8039,7 +8039,7 @@
                 }
             }
         },
-        "Elevator to Sector Hub": {
+        "Main Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -8083,7 +8083,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Main Elevator Shaft",
-                        "node": "Other to Elevator to Sector Hub"
+                        "node": "Other to Main Elevator"
                     },
                     "default_dock_weakness": "Elevator",
                     "exclude_from_dock_rando": false,
@@ -8124,7 +8124,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Main Elevator Access",
-                        "node": "Other to Elevator to Sector Hub"
+                        "node": "Other to Main Elevator"
                     },
                     "default_dock_weakness": "Destroyed Door",
                     "exclude_from_dock_rando": false,
@@ -8171,7 +8171,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Main Elevator Cache",
-                        "node": "Other to Elevator to Sector Hub"
+                        "node": "Other to Main Elevator"
                     },
                     "default_dock_weakness": "Open Passage",
                     "exclude_from_dock_rando": false,
@@ -8212,7 +8212,7 @@
                 ]
             },
             "nodes": {
-                "Other to Elevator to Sector Hub": {
+                "Other to Main Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8234,7 +8234,7 @@
                     "dock_type": "Other",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector Hub",
+                        "area": "Main Elevator",
                         "node": "Other to Main Elevator Access"
                     },
                     "default_dock_weakness": "Destroyed Door",
@@ -8285,7 +8285,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Other to Elevator to Sector Hub": {
+                        "Other to Main Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11411,7 +11411,7 @@
                 }
             }
         },
-        "Elevator to Crew Quarters": {
+        "Operations Deck Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -11431,7 +11431,7 @@
                 ]
             },
             "nodes": {
-                "Elevator to Elevator to Operations Deck": {
+                "Elevator to Crew Quarters Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -11452,8 +11452,8 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Operations Deck",
-                        "node": "Elevator to Elevator to Crew Quarters"
+                        "area": "Crew Quarters Elevator",
+                        "node": "Elevator to Operations Deck Elevator"
                     },
                     "default_dock_weakness": "Elevator",
                     "exclude_from_dock_rando": false,
@@ -11493,7 +11493,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Operations Deck",
-                        "node": "Door to Elevator to Crew Quarters"
+                        "node": "Door to Operations Deck Elevator"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -11502,7 +11502,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Elevator to Elevator to Operations Deck": {
+                        "Elevator to Crew Quarters Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11513,7 +11513,7 @@
                 }
             }
         },
-        "Elevator to Operations Deck": {
+        "Crew Quarters Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -11533,7 +11533,7 @@
                 ]
             },
             "nodes": {
-                "Elevator to Elevator to Crew Quarters": {
+                "Elevator to Operations Deck Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -11554,8 +11554,8 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Crew Quarters",
-                        "node": "Elevator to Elevator to Operations Deck"
+                        "area": "Operations Deck Elevator",
+                        "node": "Elevator to Crew Quarters Elevator"
                     },
                     "default_dock_weakness": "Elevator",
                     "exclude_from_dock_rando": false,
@@ -11595,7 +11595,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Crew Quarters West",
-                        "node": "Door to Elevator to Operations Deck"
+                        "node": "Door to Crew Quarters Elevator"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -11604,7 +11604,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Elevator to Elevator to Crew Quarters": {
+                        "Elevator to Operations Deck Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12042,7 +12042,7 @@
                 ]
             },
             "nodes": {
-                "Door to Elevator to Tourian (SRX)": {
+                "Door to Restricted Zone Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -12063,7 +12063,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Tourian (SRX)",
+                        "area": "Restricted Zone Elevator",
                         "node": "Door to Restricted Navigation Room"
                     },
                     "default_dock_weakness": "Open Hatch",
@@ -12113,7 +12113,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Tourian (SRX)": {
+                        "Door to Restricted Zone Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12169,7 +12169,7 @@
                 }
             }
         },
-        "Elevator to Tourian (SRX)": {
+        "Restricted Zone Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -12211,7 +12211,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Restricted Navigation Room",
-                        "node": "Door to Elevator to Tourian (SRX)"
+                        "node": "Door to Restricted Zone Elevator"
                     },
                     "default_dock_weakness": "L4 Hatch",
                     "exclude_from_dock_rando": false,
@@ -12220,7 +12220,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Elevator to Elevator to Restricted Zone": {
+                        "Elevator to Tourian Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12229,7 +12229,7 @@
                         }
                     }
                 },
-                "Elevator to Elevator to Restricted Zone": {
+                "Elevator to Tourian Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -12250,8 +12250,8 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Sector 1 (SRX)",
-                        "area": "Elevator to Restricted Zone",
-                        "node": "Elevator to Elevator to Tourian (SRX)"
+                        "area": "Tourian Elevator",
+                        "node": "Elevator to Restricted Zone Elevator"
                     },
                     "default_dock_weakness": "Elevator",
                     "exclude_from_dock_rando": false,
@@ -13128,7 +13128,7 @@
                     "custom_index_group": null,
                     "hint_features": [],
                     "connections": {
-                        "Other to Elevator to Sector Hub": {
+                        "Other to Main Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13137,7 +13137,7 @@
                         }
                     }
                 },
-                "Other to Elevator to Sector Hub": {
+                "Other to Main Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13158,7 +13158,7 @@
                     "dock_type": "Other",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector Hub",
+                        "area": "Main Elevator",
                         "node": "Other to Main Elevator Cache"
                     },
                     "default_dock_weakness": "Open Passage",
@@ -13198,7 +13198,7 @@
                 }
             }
         },
-        "Elevator to Habitation Deck": {
+        "Nexus Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -13240,7 +13240,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Central Nexus",
-                        "node": "Door to Elevator to Habitation Deck"
+                        "node": "Door to Nexus Elevator"
                     },
                     "default_dock_weakness": "L2 Hatch",
                     "exclude_from_dock_rando": false,
@@ -13280,7 +13280,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Habitation Deck Elevator",
-                        "node": "Elevator to Elevator to Habitation Deck"
+                        "node": "Elevator to Nexus Elevator"
                     },
                     "default_dock_weakness": "Elevator",
                     "exclude_from_dock_rando": false,
@@ -13360,7 +13360,7 @@
                         }
                     }
                 },
-                "Elevator to Elevator to Habitation Deck": {
+                "Elevator to Nexus Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13381,7 +13381,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Habitation Deck",
+                        "area": "Nexus Elevator",
                         "node": "Elevator to Habitation Deck Elevator"
                     },
                     "default_dock_weakness": "Elevator",
@@ -13438,7 +13438,7 @@
                                 "items": []
                             }
                         },
-                        "Elevator to Elevator to Habitation Deck": {
+                        "Elevator to Nexus Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -253,9 +253,9 @@ Extra - map_name: Main Deck11
 Extra - room_id: [11]
 Extra - minimap_coordinates: [{'x': 13, 'y': 4}]
 Extra - unlocked_save_recharge_station: True
-> Door to Elevator to Central Nexus; Heals? False
+> Door to Habitation Deck Elevator; Heals? False
   * Layers: default
-  * L0 Hatch to Elevator to Central Nexus/Door to Habitation Deck Save Room
+  * L0 Hatch to Habitation Deck Elevator/Door to Habitation Deck Save Room
   * Extra - door_idx: (24,)
   > Save Station
       Trivial
@@ -264,7 +264,7 @@ Extra - unlocked_save_recharge_station: True
   * Layers: default
   * Extra - X: 10
   * Extra - Y: 10
-  > Door to Elevator to Central Nexus
+  > Door to Habitation Deck Elevator
       Trivial
 
 ----------------
@@ -442,9 +442,9 @@ Habitation Deck Entrance
 Extra - map_name: Main Deck15
 Extra - room_id: [15]
 Extra - minimap_coordinates: [{'x': 11, 'y': 2}, {'x': 11, 'y': 3}, {'x': 11, 'y': 4}]
-> Door to Elevator to Central Nexus; Heals? False
+> Door to Habitation Deck Elevator; Heals? False
   * Layers: default
-  * L2 Hatch to Elevator to Central Nexus/Door to Habitation Deck Entrance
+  * L2 Hatch to Habitation Deck Elevator/Door to Habitation Deck Entrance
   * Extra - door_idx: (30,)
   > Door to Habitation Deck (Lower)
       Trivial
@@ -477,14 +477,14 @@ Extra - minimap_coordinates: [{'x': 11, 'y': 2}, {'x': 11, 'y': 3}, {'x': 11, 'y
   * Layers: default
   * L2 Hatch to Habitation Deck/Door to Habitation Deck Entrance (Lower)
   * Extra - door_idx: (31,)
-  > Door to Elevator to Central Nexus
+  > Door to Habitation Deck Elevator
       Trivial
 
 > Door to Habitation Deck (Middle); Heals? False
   * Layers: default
   * L2 Hatch to Habitation Deck/Door to Habitation Deck Entrance (Middle)
   * Extra - door_idx: (157,)
-  > Door to Elevator to Central Nexus
+  > Door to Habitation Deck Elevator
       Trivial
   > Door to Habitation Deck (Upper)
       Space Jump or Can Freeze Enemies With Any Weapon
@@ -493,7 +493,7 @@ Extra - minimap_coordinates: [{'x': 11, 'y': 2}, {'x': 11, 'y': 3}, {'x': 11, 'y
   * Layers: default
   * L2 Hatch to Habitation Deck/Door to Habitation Deck Entrance (Upper)
   * Extra - door_idx: (158,)
-  > Door to Elevator to Central Nexus
+  > Door to Habitation Deck Elevator
       Trivial
   > Door to Habitation Deck (Middle)
       # Hold left: https://youtu.be/1Vx2aVhG4W0
@@ -2199,38 +2199,38 @@ Extra - minimap_coordinates: [{'x': 12, 'y': 6}, {'x': 12, 'y': 7}]
   * Layers: default
   * L2 Hatch to Central Nexus/Door to Elevator to Habitation Deck
   * Extra - door_idx: (176,)
-  > Elevator to Elevator to Central Nexus
+  > Elevator to Habitation Deck Elevator
       Trivial
 
-> Elevator to Elevator to Central Nexus; Heals? False
+> Elevator to Habitation Deck Elevator; Heals? False
   * Layers: default
-  * Elevator to Elevator to Central Nexus/Elevator to Elevator to Habitation Deck
+  * Elevator to Habitation Deck Elevator/Elevator to Elevator to Habitation Deck
   * Extra - door_idx: (177,)
   > Door to Central Nexus
       Trivial
 
 ----------------
-Elevator to Central Nexus
+Habitation Deck Elevator
 Extra - map_name: Main Deck76
 Extra - room_id: [76]
 Extra - minimap_coordinates: [{'x': 12, 'y': 4}, {'x': 12, 'y': 5}]
 > Door to Habitation Deck Save Room; Heals? False
   * Layers: default
-  * L0 Hatch to Habitation Deck Save Room/Door to Elevator to Central Nexus
+  * L0 Hatch to Habitation Deck Save Room/Door to Habitation Deck Elevator
   * Extra - door_idx: (100,)
   > Door to Habitation Deck Entrance
       Trivial
 
 > Elevator to Elevator to Habitation Deck; Heals? False
   * Layers: default
-  * Elevator to Elevator to Habitation Deck/Elevator to Elevator to Central Nexus
+  * Elevator to Elevator to Habitation Deck/Elevator to Habitation Deck Elevator
   * Extra - door_idx: (178,)
   > Door to Habitation Deck Entrance
       Trivial
 
 > Door to Habitation Deck Entrance; Heals? False
   * Layers: default
-  * L2 Hatch to Habitation Deck Entrance/Door to Elevator to Central Nexus
+  * L2 Hatch to Habitation Deck Entrance/Door to Habitation Deck Elevator
   * Extra - door_idx: (179,)
   > Door to Habitation Deck Save Room
       Trivial

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -805,24 +805,24 @@ Extra - minimap_coordinates: [{'x': 5, 'y': 11}, {'x': 6, 'y': 11}, {'x': 7, 'y'
   * Extra - door_idx: (50,)
   * Extra - X: 24
   * Extra - Y: 18
-  > Door to Sector Lift 2
+  > Door to Sector Hub Lift 2
       Trivial
-  > Door to Sector Lift 1
+  > Door to Sector Hub Lift 1
       Trivial
   > Event - Sector Hub visited
       Trivial
 
-> Door to Sector Lift 2; Heals? False
+> Door to Sector Hub Lift 2; Heals? False
   * Layers: default
-  * L0 Hatch to Sector Lift 2/Door to Sector Hub
+  * L0 Hatch to Sector Hub Lift 2/Door to Sector Hub
   * Extra - door_idx: (51,)
   * Extra - sector_hub_elevator_door: True
   > Elevator to Main Elevator Shaft
       Trivial
 
-> Door to Sector Lift 1; Heals? False
+> Door to Sector Hub Lift 1; Heals? False
   * Layers: default
-  * L0 Hatch to Sector Lift 1/Door to Sector Hub
+  * L0 Hatch to Sector Hub Lift 1/Door to Sector Hub
   * Extra - door_idx: (57,)
   * Extra - sector_hub_elevator_door: True
   > Elevator to Main Elevator Shaft
@@ -835,23 +835,23 @@ Extra - minimap_coordinates: [{'x': 5, 'y': 11}, {'x': 6, 'y': 11}, {'x': 7, 'y'
       Trivial
 
 ----------------
-Sector Lift 2
+Sector Hub Lift 2
 Extra - map_name: Main Deck25
 Extra - room_id: [25]
 Extra - minimap_coordinates: [{'x': 8, 'y': 12}, {'x': 8, 'y': 13}]
 > Door to Sector Hub; Heals? False
   * Layers: default
-  * L0 Hatch to Sector Hub/Door to Sector Lift 2
+  * L0 Hatch to Sector Hub/Door to Sector Hub Lift 2
   * Extra - door_idx: (52,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Sector Lift 4
+  > Door to Sector Hub Lift 4
       Trivial
   > Elevator to Sector 2 (TRO)
       Trivial
 
-> Door to Sector Lift 4; Heals? False
+> Door to Sector Hub Lift 4; Heals? False
   * Layers: default
-  * L1 Hatch to Sector Lift 4/Door to Sector Lift 2
+  * L1 Hatch to Sector Hub Lift 4/Door to Sector Hub Lift 2
   * Extra - door_idx: (53,)
   * Extra - sector_hub_elevator_door: True
   > Door to Sector Hub
@@ -865,43 +865,43 @@ Extra - minimap_coordinates: [{'x': 8, 'y': 12}, {'x': 8, 'y': 13}]
       Trivial
 
 ----------------
-Sector Lift 4
+Sector Hub Lift 4
 Extra - map_name: Main Deck26
 Extra - room_id: [26]
 Extra - minimap_coordinates: [{'x': 9, 'y': 12}, {'x': 9, 'y': 13}]
-> Door to Sector Lift 2; Heals? False
+> Door to Sector Hub Lift 2; Heals? False
   * Layers: default
-  * L1 Hatch to Sector Lift 2/Door to Sector Lift 4
+  * L1 Hatch to Sector Hub Lift 2/Door to Sector Hub Lift 4
   * Extra - door_idx: (54,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Sector Lift 6
+  > Door to Sector Hub Lift 6
       Trivial
   > Elevator to Sector 4 (AQA)
       Trivial
 
-> Door to Sector Lift 6; Heals? False
+> Door to Sector Hub Lift 6; Heals? False
   * Layers: default
-  * L2 Hatch to Sector Lift 6/Door to Sector Lift 4
+  * L2 Hatch to Sector Hub Lift 6/Door to Sector Hub Lift 4
   * Extra - door_idx: (55,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Sector Lift 2
+  > Door to Sector Hub Lift 2
       Trivial
 
 > Elevator to Sector 4 (AQA); Heals? False
   * Layers: default
   * Elevator to Sector 4 (AQA) Entrance Elevator/Elevator to Main Deck
   * Extra - door_idx: (70,)
-  > Door to Sector Lift 2
+  > Door to Sector Hub Lift 2
       Trivial
 
 ----------------
-Sector Lift 6
+Sector Hub Lift 6
 Extra - map_name: Main Deck27
 Extra - room_id: [27]
 Extra - minimap_coordinates: [{'x': 10, 'y': 12}, {'x': 10, 'y': 13}]
-> Door to Sector Lift 4; Heals? False
+> Door to Sector Hub Lift 4; Heals? False
   * Layers: default
-  * L2 Hatch to Sector Lift 4/Door to Sector Lift 6
+  * L2 Hatch to Sector Hub Lift 4/Door to Sector Hub Lift 6
   * Extra - door_idx: (56,)
   * Extra - sector_hub_elevator_door: True
   > Elevator to Sector 6 (NOC)
@@ -911,27 +911,27 @@ Extra - minimap_coordinates: [{'x': 10, 'y': 12}, {'x': 10, 'y': 13}]
   * Layers: default
   * Elevator to Sector 6 (NOC) Entrance Elevator/Elevator to Main Deck
   * Extra - door_idx: (72,)
-  > Door to Sector Lift 4
+  > Door to Sector Hub Lift 4
       Trivial
 
 ----------------
-Sector Lift 1
+Sector Hub Lift 1
 Extra - map_name: Main Deck28
 Extra - room_id: [28]
 Extra - minimap_coordinates: [{'x': 4, 'y': 12}, {'x': 4, 'y': 13}]
 > Door to Sector Hub; Heals? False
   * Layers: default
-  * L0 Hatch to Sector Hub/Door to Sector Lift 1
+  * L0 Hatch to Sector Hub/Door to Sector Hub Lift 1
   * Extra - door_idx: (58,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Sector Lift 3
+  > Door to Sector Hub Lift 3
       Trivial
   > Elevator to Sector 1 (SRX)
       Trivial
 
-> Door to Sector Lift 3; Heals? False
+> Door to Sector Hub Lift 3; Heals? False
   * Layers: default
-  * L1 Hatch to Sector Lift 3/Door to Sector Lift 1
+  * L1 Hatch to Sector Hub Lift 3/Door to Sector Hub Lift 1
   * Extra - door_idx: (59,)
   * Extra - sector_hub_elevator_door: True
   > Door to Sector Hub
@@ -945,43 +945,43 @@ Extra - minimap_coordinates: [{'x': 4, 'y': 12}, {'x': 4, 'y': 13}]
       Trivial
 
 ----------------
-Sector Lift 3
+Sector Hub Lift 3
 Extra - map_name: Main Deck29
 Extra - room_id: [29]
 Extra - minimap_coordinates: [{'x': 3, 'y': 12}, {'x': 3, 'y': 13}]
-> Door to Sector Lift 1; Heals? False
+> Door to Sector Hub Lift 1; Heals? False
   * Layers: default
-  * L1 Hatch to Sector Lift 1/Door to Sector Lift 3
+  * L1 Hatch to Sector Hub Lift 1/Door to Sector Hub Lift 3
   * Extra - door_idx: (60,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Sector Lift 5
+  > Door to Sector Hub Lift 5
       Trivial
   > Elevator to Sector 3 (PYR)
       Trivial
 
-> Door to Sector Lift 5; Heals? False
+> Door to Sector Hub Lift 5; Heals? False
   * Layers: default
-  * L2 Hatch to Sector Lift 5/Door to Sector Lift 3
+  * L2 Hatch to Sector Hub Lift 5/Door to Sector Hub Lift 3
   * Extra - door_idx: (61,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Sector Lift 1
+  > Door to Sector Hub Lift 1
       Trivial
 
 > Elevator to Sector 3 (PYR); Heals? False
   * Layers: default
   * Elevator to Sector 3 (PYR) Entrance Elevator/Elevator to Main Deck
   * Extra - door_idx: (69,)
-  > Door to Sector Lift 1
+  > Door to Sector Hub Lift 1
       Trivial
 
 ----------------
-Sector Lift 5
+Sector Hub Lift 5
 Extra - map_name: Main Deck30
 Extra - room_id: [30]
 Extra - minimap_coordinates: [{'x': 2, 'y': 12}, {'x': 2, 'y': 13}]
-> Door to Sector Lift 3; Heals? False
+> Door to Sector Hub Lift 3; Heals? False
   * Layers: default
-  * L2 Hatch to Sector Lift 3/Door to Sector Lift 5
+  * L2 Hatch to Sector Hub Lift 3/Door to Sector Hub Lift 5
   * Extra - door_idx: (62,)
   * Extra - sector_hub_elevator_door: True
   > Elevator to Sector 5 (ARC)
@@ -991,7 +991,7 @@ Extra - minimap_coordinates: [{'x': 2, 'y': 12}, {'x': 2, 'y': 13}]
   * Layers: default
   * Elevator to Sector 5 (ARC) Entrance Elevator/Elevator to Main Deck
   * Extra - door_idx: (71,)
-  > Door to Sector Lift 3
+  > Door to Sector Hub Lift 3
       Trivial
 
 ----------------

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -278,7 +278,7 @@ Extra - minimap_coordinates: [{'x': 18, 'y': 5}, {'x': 18, 'y': 6}, {'x': 19, 'y
   * Extra - door_idx: (77,)
   > Door to Operations Ventilation
       Trivial
-  > Door to Elevator to Operations Deck
+  > Door to Crew Quarters Elevator
       Trivial
 
 > Door to Operations Ventilation; Heals? False
@@ -288,9 +288,9 @@ Extra - minimap_coordinates: [{'x': 18, 'y': 5}, {'x': 18, 'y': 6}, {'x': 19, 'y
   > Door to Crew Quarters Navigation Room
       Trivial
 
-> Door to Elevator to Operations Deck; Heals? False
+> Door to Crew Quarters Elevator; Heals? False
   * Layers: default
-  * L0 Hatch to Elevator to Operations Deck/Door to Crew Quarters West
+  * L0 Hatch to Crew Quarters Elevator/Door to Crew Quarters West
   * Extra - door_idx: (142,)
   > Door to Crew Quarters Navigation Room
       Trivial
@@ -319,7 +319,7 @@ Extra - minimap_coordinates: [{'x': 17, 'y': 0}, {'x': 17, 'y': 1}, {'x': 17, 'y
   * Extra - door_idx: (27, 172)
   > Other to Operations Ventilation
       After Main Deck Operations Deck Missile Shield
-  > Door to Elevator to Crew Quarters
+  > Door to Operations Deck Elevator
       Trivial
   > Event - Missile Shield
       Any of the following:
@@ -331,12 +331,12 @@ Extra - minimap_coordinates: [{'x': 17, 'y': 0}, {'x': 17, 'y': 1}, {'x': 17, 'y
   * Layers: default
   * L0 Hatch to Operations Deck Recharge Room/Door to Operations Deck
   * Extra - door_idx: (65, 173)
-  > Door to Elevator to Crew Quarters
+  > Door to Operations Deck Elevator
       Trivial
 
-> Door to Elevator to Crew Quarters; Heals? False
+> Door to Operations Deck Elevator; Heals? False
   * Layers: default
-  * L0 Hatch to Elevator to Crew Quarters/Door to Operations Deck
+  * L0 Hatch to Operations Deck Elevator/Door to Operations Deck
   * Extra - door_idx: (141, 174)
   > Door to Operations Deck Navigation Room
       Trivial
@@ -372,7 +372,7 @@ Extra - minimap_coordinates: [{'x': 17, 'y': 0}, {'x': 17, 'y': 1}, {'x': 17, 'y
 
 > Beside Operations Room Hatch; Heals? False
   * Layers: default
-  > Door to Elevator to Crew Quarters
+  > Door to Operations Deck Elevator
       Trivial
   > Door to Operations Room
       After Boss SA-X Defeated
@@ -577,9 +577,9 @@ Central Nexus
 Extra - map_name: Main Deck18
 Extra - room_id: [18]
 Extra - minimap_coordinates: [{'x': 13, 'y': 7}, {'x': 13, 'y': 8}, {'x': 13, 'y': 9}, {'x': 13, 'y': 10}]
-> Door to Elevator to Habitation Deck; Heals? False
+> Door to Nexus Elevator; Heals? False
   * Layers: default
-  * L2 Hatch to Elevator to Habitation Deck/Door to Central Nexus
+  * L2 Hatch to Nexus Elevator/Door to Central Nexus
   * Extra - door_idx: (21,)
   > Door to Station Entrance
       Trivial
@@ -588,7 +588,7 @@ Extra - minimap_coordinates: [{'x': 13, 'y': 7}, {'x': 13, 'y': 8}, {'x': 13, 'y
   * Layers: default
   * Open Hatch to Station Entrance/Door to Central Nexus
   * Extra - door_idx: (36,)
-  > Door to Elevator to Habitation Deck
+  > Door to Nexus Elevator
       Trivial
   > Door to Hornoad Hallway
       Trivial
@@ -805,24 +805,24 @@ Extra - minimap_coordinates: [{'x': 5, 'y': 11}, {'x': 6, 'y': 11}, {'x': 7, 'y'
   * Extra - door_idx: (50,)
   * Extra - X: 24
   * Extra - Y: 18
-  > Door to Elevator to Sector 2 (TRO)
+  > Door to Sector Lift 2
       Trivial
-  > Door to Elevator to Sector 1 (SRX)
+  > Door to Sector Lift 1
       Trivial
   > Event - Sector Hub visited
       Trivial
 
-> Door to Elevator to Sector 2 (TRO); Heals? False
+> Door to Sector Lift 2; Heals? False
   * Layers: default
-  * L0 Hatch to Elevator to Sector 2 (TRO)/Door to Sector Hub
+  * L0 Hatch to Sector Lift 2/Door to Sector Hub
   * Extra - door_idx: (51,)
   * Extra - sector_hub_elevator_door: True
   > Elevator to Main Elevator Shaft
       Trivial
 
-> Door to Elevator to Sector 1 (SRX); Heals? False
+> Door to Sector Lift 1; Heals? False
   * Layers: default
-  * L0 Hatch to Elevator to Sector 1 (SRX)/Door to Sector Hub
+  * L0 Hatch to Sector Lift 1/Door to Sector Hub
   * Extra - door_idx: (57,)
   * Extra - sector_hub_elevator_door: True
   > Elevator to Main Elevator Shaft
@@ -835,23 +835,23 @@ Extra - minimap_coordinates: [{'x': 5, 'y': 11}, {'x': 6, 'y': 11}, {'x': 7, 'y'
       Trivial
 
 ----------------
-Elevator to Sector 2 (TRO)
+Sector Lift 2
 Extra - map_name: Main Deck25
 Extra - room_id: [25]
 Extra - minimap_coordinates: [{'x': 8, 'y': 12}, {'x': 8, 'y': 13}]
 > Door to Sector Hub; Heals? False
   * Layers: default
-  * L0 Hatch to Sector Hub/Door to Elevator to Sector 2 (TRO)
+  * L0 Hatch to Sector Hub/Door to Sector Lift 2
   * Extra - door_idx: (52,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Elevator to Sector 4 (AQA)
+  > Door to Sector Lift 4
       Trivial
   > Elevator to Sector 2 (TRO)
       Trivial
 
-> Door to Elevator to Sector 4 (AQA); Heals? False
+> Door to Sector Lift 4; Heals? False
   * Layers: default
-  * L1 Hatch to Elevator to Sector 4 (AQA)/Door to Elevator to Sector 2 (TRO)
+  * L1 Hatch to Sector Lift 4/Door to Sector Lift 2
   * Extra - door_idx: (53,)
   * Extra - sector_hub_elevator_door: True
   > Door to Sector Hub
@@ -865,43 +865,43 @@ Extra - minimap_coordinates: [{'x': 8, 'y': 12}, {'x': 8, 'y': 13}]
       Trivial
 
 ----------------
-Elevator to Sector 4 (AQA)
+Sector Lift 4
 Extra - map_name: Main Deck26
 Extra - room_id: [26]
 Extra - minimap_coordinates: [{'x': 9, 'y': 12}, {'x': 9, 'y': 13}]
-> Door to Elevator to Sector 2 (TRO); Heals? False
+> Door to Sector Lift 2; Heals? False
   * Layers: default
-  * L1 Hatch to Elevator to Sector 2 (TRO)/Door to Elevator to Sector 4 (AQA)
+  * L1 Hatch to Sector Lift 2/Door to Sector Lift 4
   * Extra - door_idx: (54,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Elevator to Sector 6 (NOC)
+  > Door to Sector Lift 6
       Trivial
   > Elevator to Sector 4 (AQA)
       Trivial
 
-> Door to Elevator to Sector 6 (NOC); Heals? False
+> Door to Sector Lift 6; Heals? False
   * Layers: default
-  * L2 Hatch to Elevator to Sector 6 (NOC)/Door to Elevator to Sector 4 (AQA)
+  * L2 Hatch to Sector Lift 6/Door to Sector Lift 4
   * Extra - door_idx: (55,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Elevator to Sector 2 (TRO)
+  > Door to Sector Lift 2
       Trivial
 
 > Elevator to Sector 4 (AQA); Heals? False
   * Layers: default
   * Elevator to Elevator to Main Deck/Elevator to Main Deck
   * Extra - door_idx: (70,)
-  > Door to Elevator to Sector 2 (TRO)
+  > Door to Sector Lift 2
       Trivial
 
 ----------------
-Elevator to Sector 6 (NOC)
+Sector Lift 6
 Extra - map_name: Main Deck27
 Extra - room_id: [27]
 Extra - minimap_coordinates: [{'x': 10, 'y': 12}, {'x': 10, 'y': 13}]
-> Door to Elevator to Sector 4 (AQA); Heals? False
+> Door to Sector Lift 4; Heals? False
   * Layers: default
-  * L2 Hatch to Elevator to Sector 4 (AQA)/Door to Elevator to Sector 6 (NOC)
+  * L2 Hatch to Sector Lift 4/Door to Sector Lift 6
   * Extra - door_idx: (56,)
   * Extra - sector_hub_elevator_door: True
   > Elevator to Sector 6 (NOC)
@@ -911,27 +911,27 @@ Extra - minimap_coordinates: [{'x': 10, 'y': 12}, {'x': 10, 'y': 13}]
   * Layers: default
   * Elevator to Elevator to Main Deck/Elevator to Main Deck
   * Extra - door_idx: (72,)
-  > Door to Elevator to Sector 4 (AQA)
+  > Door to Sector Lift 4
       Trivial
 
 ----------------
-Elevator to Sector 1 (SRX)
+Sector Lift 1
 Extra - map_name: Main Deck28
 Extra - room_id: [28]
 Extra - minimap_coordinates: [{'x': 4, 'y': 12}, {'x': 4, 'y': 13}]
 > Door to Sector Hub; Heals? False
   * Layers: default
-  * L0 Hatch to Sector Hub/Door to Elevator to Sector 1 (SRX)
+  * L0 Hatch to Sector Hub/Door to Sector Lift 1
   * Extra - door_idx: (58,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Elevator to Sector 3 (PYR)
+  > Door to Sector Lift 3
       Trivial
   > Elevator to Sector 1 (SRX)
       Trivial
 
-> Door to Elevator to Sector 3 (PYR); Heals? False
+> Door to Sector Lift 3; Heals? False
   * Layers: default
-  * L1 Hatch to Elevator to Sector 3 (PYR)/Door to Elevator to Sector 1 (SRX)
+  * L1 Hatch to Sector Lift 3/Door to Sector Lift 1
   * Extra - door_idx: (59,)
   * Extra - sector_hub_elevator_door: True
   > Door to Sector Hub
@@ -945,43 +945,43 @@ Extra - minimap_coordinates: [{'x': 4, 'y': 12}, {'x': 4, 'y': 13}]
       Trivial
 
 ----------------
-Elevator to Sector 3 (PYR)
+Sector Lift 3
 Extra - map_name: Main Deck29
 Extra - room_id: [29]
 Extra - minimap_coordinates: [{'x': 3, 'y': 12}, {'x': 3, 'y': 13}]
-> Door to Elevator to Sector 1 (SRX); Heals? False
+> Door to Sector Lift 1; Heals? False
   * Layers: default
-  * L1 Hatch to Elevator to Sector 1 (SRX)/Door to Elevator to Sector 3 (PYR)
+  * L1 Hatch to Sector Lift 1/Door to Sector Lift 3
   * Extra - door_idx: (60,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Elevator to Sector 5 (ARC)
+  > Door to Sector Lift 5
       Trivial
   > Elevator to Sector 3 (PYR)
       Trivial
 
-> Door to Elevator to Sector 5 (ARC); Heals? False
+> Door to Sector Lift 5; Heals? False
   * Layers: default
-  * L2 Hatch to Elevator to Sector 5 (ARC)/Door to Elevator to Sector 3 (PYR)
+  * L2 Hatch to Sector Lift 5/Door to Sector Lift 3
   * Extra - door_idx: (61,)
   * Extra - sector_hub_elevator_door: True
-  > Door to Elevator to Sector 1 (SRX)
+  > Door to Sector Lift 1
       Trivial
 
 > Elevator to Sector 3 (PYR); Heals? False
   * Layers: default
   * Elevator to Elevator to Main Deck/Elevator to Main Deck
   * Extra - door_idx: (69,)
-  > Door to Elevator to Sector 1 (SRX)
+  > Door to Sector Lift 1
       Trivial
 
 ----------------
-Elevator to Sector 5 (ARC)
+Sector Lift 5
 Extra - map_name: Main Deck30
 Extra - room_id: [30]
 Extra - minimap_coordinates: [{'x': 2, 'y': 12}, {'x': 2, 'y': 13}]
-> Door to Elevator to Sector 3 (PYR); Heals? False
+> Door to Sector Lift 3; Heals? False
   * Layers: default
-  * L2 Hatch to Elevator to Sector 3 (PYR)/Door to Elevator to Sector 5 (ARC)
+  * L2 Hatch to Sector Lift 3/Door to Sector Lift 5
   * Extra - door_idx: (62,)
   * Extra - sector_hub_elevator_door: True
   > Elevator to Sector 5 (ARC)
@@ -991,7 +991,7 @@ Extra - minimap_coordinates: [{'x': 2, 'y': 12}, {'x': 2, 'y': 13}]
   * Layers: default
   * Elevator to Elevator to Main Deck/Elevator to Main Deck
   * Extra - door_idx: (71,)
-  > Door to Elevator to Sector 3 (PYR)
+  > Door to Sector Lift 3
       Trivial
 
 ----------------
@@ -1058,9 +1058,9 @@ Main Elevator Shaft
 Extra - map_name: Main Deck34
 Extra - room_id: [34, 43]
 Extra - minimap_coordinates: [{'x': 6, 'y': 10}]
-> Other to Elevator to Sector Hub; Heals? False
+> Other to Main Elevator; Heals? False
   * Layers: default
-  * Open Passage to Elevator to Sector Hub/Elevator to Main Elevator Shaft
+  * Open Passage to Main Elevator/Elevator to Main Elevator Shaft
   * Extra - door_idx: (75,)
   > Other to Sector Hub
       Trivial
@@ -1069,7 +1069,7 @@ Extra - minimap_coordinates: [{'x': 6, 'y': 10}]
   * Layers: default
   * Open Passage to Sector Hub/Elevator to Main Elevator Shaft
   * Extra - door_idx: (76,)
-  > Other to Elevator to Sector Hub
+  > Other to Main Elevator
       Trivial
 
 ----------------
@@ -1292,20 +1292,20 @@ Hint Features - Data Room
       Trivial
 
 ----------------
-Elevator to Sector Hub
+Main Elevator
 Extra - map_name: Main Deck40
 Extra - room_id: [40, 19]
 Extra - minimap_coordinates: [{'x': 6, 'y': 8}, {'x': 6, 'y': 9}]
 > Elevator to Main Elevator Shaft; Heals? False
   * Layers: default
-  * Elevator to Main Elevator Shaft/Other to Elevator to Sector Hub
+  * Elevator to Main Elevator Shaft/Other to Main Elevator
   * Extra - door_idx: (94, 49)
   > Other to Main Elevator Access
       Trivial
 
 > Other to Main Elevator Access; Heals? False
   * Layers: default
-  * Destroyed Door to Main Elevator Access/Other to Elevator to Sector Hub
+  * Destroyed Door to Main Elevator Access/Other to Main Elevator
   * Extra - door_idx: (95, 40)
   > Elevator to Main Elevator Shaft
       Trivial
@@ -1314,7 +1314,7 @@ Extra - minimap_coordinates: [{'x': 6, 'y': 8}, {'x': 6, 'y': 9}]
 
 > Other to Main Elevator Cache; Heals? False
   * Layers: default
-  * Open Passage to Main Elevator Cache/Other to Elevator to Sector Hub
+  * Open Passage to Main Elevator Cache/Other to Main Elevator
   * Extra - door_idx: (171,)
   > Other to Main Elevator Access
       Trivial
@@ -1324,9 +1324,9 @@ Main Elevator Access
 Extra - map_name: Main Deck42
 Extra - room_id: [42, 41]
 Extra - minimap_coordinates: [{'x': 7, 'y': 8}, {'x': 8, 'y': 8}]
-> Other to Elevator to Sector Hub; Heals? False
+> Other to Main Elevator; Heals? False
   * Layers: default
-  * Destroyed Door to Elevator to Sector Hub/Other to Main Elevator Access
+  * Destroyed Door to Main Elevator/Other to Main Elevator Access
   * Extra - door_idx: (96, 92)
   > Door to Quarantine Junction
       Trivial
@@ -1335,7 +1335,7 @@ Extra - minimap_coordinates: [{'x': 7, 'y': 8}, {'x': 8, 'y': 8}]
   * Layers: default
   * L0 Hatch to Quarantine Junction/Door to Main Elevator Access
   * Extra - door_idx: (97, 93)
-  > Other to Elevator to Sector Hub
+  > Other to Main Elevator
       Trivial
 
 ----------------
@@ -1847,41 +1847,41 @@ Extra - unlocked_save_recharge_station: True
       Trivial
 
 ----------------
-Elevator to Crew Quarters
+Operations Deck Elevator
 Extra - map_name: Main Deck60
 Extra - room_id: [60]
 Extra - minimap_coordinates: [{'x': 19, 'y': 2}, {'x': 19, 'y': 3}]
-> Elevator to Elevator to Operations Deck; Heals? False
+> Elevator to Crew Quarters Elevator; Heals? False
   * Layers: default
-  * Elevator to Elevator to Operations Deck/Elevator to Elevator to Crew Quarters
+  * Elevator to Crew Quarters Elevator/Elevator to Operations Deck Elevator
   * Extra - door_idx: (26,)
   > Door to Operations Deck
       Trivial
 
 > Door to Operations Deck; Heals? False
   * Layers: default
-  * L0 Hatch to Operations Deck/Door to Elevator to Crew Quarters
+  * L0 Hatch to Operations Deck/Door to Operations Deck Elevator
   * Extra - door_idx: (139,)
-  > Elevator to Elevator to Operations Deck
+  > Elevator to Crew Quarters Elevator
       Trivial
 
 ----------------
-Elevator to Operations Deck
+Crew Quarters Elevator
 Extra - map_name: Main Deck61
 Extra - room_id: [61]
 Extra - minimap_coordinates: [{'x': 19, 'y': 4}, {'x': 19, 'y': 5}]
-> Elevator to Elevator to Crew Quarters; Heals? False
+> Elevator to Operations Deck Elevator; Heals? False
   * Layers: default
-  * Elevator to Elevator to Crew Quarters/Elevator to Elevator to Operations Deck
+  * Elevator to Operations Deck Elevator/Elevator to Crew Quarters Elevator
   * Extra - door_idx: (25,)
   > Door to Crew Quarters West
       Trivial
 
 > Door to Crew Quarters West; Heals? False
   * Layers: default
-  * L0 Hatch to Crew Quarters West/Door to Elevator to Operations Deck
+  * L0 Hatch to Crew Quarters West/Door to Crew Quarters Elevator
   * Extra - door_idx: (140,)
-  > Elevator to Elevator to Crew Quarters
+  > Elevator to Operations Deck Elevator
       Trivial
 
 ----------------
@@ -1963,9 +1963,9 @@ Restricted Navigation Room
 Extra - map_name: Main Deck66
 Extra - room_id: [66]
 Extra - minimap_coordinates: [{'x': 6, 'y': 21}]
-> Door to Elevator to Tourian (SRX); Heals? False
+> Door to Restricted Zone Elevator; Heals? False
   * Layers: default
-  * Open Hatch to Elevator to Tourian (SRX)/Door to Restricted Navigation Room
+  * Open Hatch to Restricted Zone Elevator/Door to Restricted Navigation Room
   * Extra - door_idx: (151,)
   > Door to Restricted Airlock
       Trivial
@@ -1974,7 +1974,7 @@ Extra - minimap_coordinates: [{'x': 6, 'y': 21}]
   * Layers: default
   * Open Hatch to Restricted Airlock/Door to Restricted Navigation Room
   * Extra - door_idx: (152,)
-  > Door to Elevator to Tourian (SRX)
+  > Door to Restricted Zone Elevator
       Trivial
   > Navigation Terminal
       Trivial
@@ -1989,20 +1989,20 @@ Extra - minimap_coordinates: [{'x': 6, 'y': 21}]
       Trivial
 
 ----------------
-Elevator to Tourian (SRX)
+Restricted Zone Elevator
 Extra - map_name: Main Deck67
 Extra - room_id: [67]
 Extra - minimap_coordinates: [{'x': 7, 'y': 20}, {'x': 7, 'y': 21}]
 > Door to Restricted Navigation Room; Heals? False
   * Layers: default
-  * L4 Hatch to Restricted Navigation Room/Door to Elevator to Tourian (SRX)
+  * L4 Hatch to Restricted Navigation Room/Door to Restricted Zone Elevator
   * Extra - door_idx: (153,)
-  > Elevator to Elevator to Restricted Zone
+  > Elevator to Tourian Elevator
       Trivial
 
-> Elevator to Elevator to Restricted Zone; Heals? False
+> Elevator to Tourian Elevator; Heals? False
   * Layers: default
-  * Elevator to Elevator to Restricted Zone/Elevator to Elevator to Tourian (SRX)
+  * Elevator to Tourian Elevator/Elevator to Restricted Zone Elevator
   * Extra - door_idx: (154,)
   > Door to Restricted Navigation Room
       Trivial
@@ -2180,31 +2180,31 @@ Extra - minimap_coordinates: [{'x': 5, 'y': 8}]
   * Extra - blockx: 6
   * Extra - blocky: 10
   * Extra - infant_weight: 0.4
-  > Other to Elevator to Sector Hub
+  > Other to Main Elevator
       Trivial
 
-> Other to Elevator to Sector Hub; Heals? False
+> Other to Main Elevator; Heals? False
   * Layers: default
-  * Open Passage to Elevator to Sector Hub/Other to Main Elevator Cache
+  * Open Passage to Main Elevator/Other to Main Elevator Cache
   * Extra - door_idx: (170,)
   > Pickup (Missile Tank)
       Speed Booster and Disabled Entrance Rando
 
 ----------------
-Elevator to Habitation Deck
+Nexus Elevator
 Extra - map_name: Main Deck75
 Extra - room_id: [75]
 Extra - minimap_coordinates: [{'x': 12, 'y': 6}, {'x': 12, 'y': 7}]
 > Door to Central Nexus; Heals? False
   * Layers: default
-  * L2 Hatch to Central Nexus/Door to Elevator to Habitation Deck
+  * L2 Hatch to Central Nexus/Door to Nexus Elevator
   * Extra - door_idx: (176,)
   > Elevator to Habitation Deck Elevator
       Trivial
 
 > Elevator to Habitation Deck Elevator; Heals? False
   * Layers: default
-  * Elevator to Habitation Deck Elevator/Elevator to Elevator to Habitation Deck
+  * Elevator to Habitation Deck Elevator/Elevator to Nexus Elevator
   * Extra - door_idx: (177,)
   > Door to Central Nexus
       Trivial
@@ -2221,9 +2221,9 @@ Extra - minimap_coordinates: [{'x': 12, 'y': 4}, {'x': 12, 'y': 5}]
   > Door to Habitation Deck Entrance
       Trivial
 
-> Elevator to Elevator to Habitation Deck; Heals? False
+> Elevator to Nexus Elevator; Heals? False
   * Layers: default
-  * Elevator to Elevator to Habitation Deck/Elevator to Habitation Deck Elevator
+  * Elevator to Nexus Elevator/Elevator to Habitation Deck Elevator
   * Extra - door_idx: (178,)
   > Door to Habitation Deck Entrance
       Trivial
@@ -2234,7 +2234,7 @@ Extra - minimap_coordinates: [{'x': 12, 'y': 4}, {'x': 12, 'y': 5}]
   * Extra - door_idx: (179,)
   > Door to Habitation Deck Save Room
       Trivial
-  > Elevator to Elevator to Habitation Deck
+  > Elevator to Nexus Elevator
       Trivial
 
 ----------------

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -859,7 +859,7 @@ Extra - minimap_coordinates: [{'x': 8, 'y': 12}, {'x': 8, 'y': 13}]
 
 > Elevator to Sector 2 (TRO); Heals? False
   * Layers: default
-  * Elevator to Elevator to Main Deck/Elevator to Main Deck
+  * Elevator to Sector 2 (TRO) Entrance Elevator/Elevator to Main Deck
   * Extra - door_idx: (68,)
   > Door to Sector Hub
       Trivial
@@ -889,7 +889,7 @@ Extra - minimap_coordinates: [{'x': 9, 'y': 12}, {'x': 9, 'y': 13}]
 
 > Elevator to Sector 4 (AQA); Heals? False
   * Layers: default
-  * Elevator to Elevator to Main Deck/Elevator to Main Deck
+  * Elevator to Sector 4 (AQA) Entrance Elevator/Elevator to Main Deck
   * Extra - door_idx: (70,)
   > Door to Sector Lift 2
       Trivial
@@ -909,7 +909,7 @@ Extra - minimap_coordinates: [{'x': 10, 'y': 12}, {'x': 10, 'y': 13}]
 
 > Elevator to Sector 6 (NOC); Heals? False
   * Layers: default
-  * Elevator to Elevator to Main Deck/Elevator to Main Deck
+  * Elevator to Sector 6 (NOC) Entrance Elevator/Elevator to Main Deck
   * Extra - door_idx: (72,)
   > Door to Sector Lift 4
       Trivial
@@ -939,7 +939,7 @@ Extra - minimap_coordinates: [{'x': 4, 'y': 12}, {'x': 4, 'y': 13}]
 
 > Elevator to Sector 1 (SRX); Heals? False
   * Layers: default
-  * Elevator to Elevator to Main Deck/Elevator to Main Deck
+  * Elevator to Sector 1 (SRX) Entrance Elevator/Elevator to Main Deck
   * Extra - door_idx: (67,)
   > Door to Sector Hub
       Trivial
@@ -969,7 +969,7 @@ Extra - minimap_coordinates: [{'x': 3, 'y': 12}, {'x': 3, 'y': 13}]
 
 > Elevator to Sector 3 (PYR); Heals? False
   * Layers: default
-  * Elevator to Elevator to Main Deck/Elevator to Main Deck
+  * Elevator to Sector 3 (PYR) Entrance Elevator/Elevator to Main Deck
   * Extra - door_idx: (69,)
   > Door to Sector Lift 1
       Trivial
@@ -989,7 +989,7 @@ Extra - minimap_coordinates: [{'x': 2, 'y': 12}, {'x': 2, 'y': 13}]
 
 > Elevator to Sector 5 (ARC); Heals? False
   * Layers: default
-  * Elevator to Elevator to Main Deck/Elevator to Main Deck
+  * Elevator to Sector 5 (ARC) Entrance Elevator/Elevator to Main Deck
   * Extra - door_idx: (71,)
   > Door to Sector Lift 3
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -11726,7 +11726,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 1",
+                        "area": "Sector Hub Lift 1",
                         "node": "Elevator to Sector 1 (SRX)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -8522,7 +8522,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Restricted Zone": {
+                "Door to Tourian Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8543,7 +8543,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1 (SRX)",
-                        "area": "Elevator to Restricted Zone",
+                        "area": "Tourian Elevator",
                         "node": "Door to Ripper Maze"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -9004,7 +9004,7 @@
                                 ]
                             }
                         },
-                        "Door to Elevator to Restricted Zone": {
+                        "Door to Tourian Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9015,7 +9015,7 @@
                 }
             }
         },
-        "Elevator to Restricted Zone": {
+        "Tourian Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -9057,7 +9057,7 @@
                     "default_connection": {
                         "region": "Sector 1 (SRX)",
                         "area": "Ripper Maze",
-                        "node": "Door to Elevator to Restricted Zone"
+                        "node": "Door to Tourian Elevator"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -9066,7 +9066,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Elevator to Elevator to Tourian (SRX)": {
+                        "Elevator to Restricted Zone Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9075,7 +9075,7 @@
                         }
                     }
                 },
-                "Elevator to Elevator to Tourian (SRX)": {
+                "Elevator to Restricted Zone Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -9096,8 +9096,8 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Tourian (SRX)",
-                        "node": "Elevator to Elevator to Restricted Zone"
+                        "area": "Restricted Zone Elevator",
+                        "node": "Elevator to Tourian Elevator"
                     },
                     "default_dock_weakness": "Elevator",
                     "exclude_from_dock_rando": false,
@@ -11726,7 +11726,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 1 (SRX)",
+                        "area": "Sector Lift 1",
                         "node": "Elevator to Sector 1 (SRX)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -388,7 +388,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Main Deck": {
+                        "Door to Sector 1 (SRX) Entrance Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -397,7 +397,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Main Deck": {
+                "Door to Sector 1 (SRX) Entrance Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -418,7 +418,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1 (SRX)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 1 (SRX) Entrance Elevator",
                         "node": "Door to Entrance Navigation Room"
                     },
                     "default_dock_weakness": "Open Hatch",
@@ -481,7 +481,7 @@
                         }
                     },
                     "connections": {
-                        "Door to Elevator to Main Deck": {
+                        "Door to Sector 1 (SRX) Entrance Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11685,7 +11685,7 @@
                 }
             }
         },
-        "Elevator to Main Deck": {
+        "Sector 1 (SRX) Entrance Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -11767,7 +11767,7 @@
                     "default_connection": {
                         "region": "Sector 1 (SRX)",
                         "area": "Entrance Navigation Room",
-                        "node": "Door to Elevator to Main Deck"
+                        "node": "Door to Sector 1 (SRX) Entrance Elevator"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -1673,7 +1673,7 @@ Extra - room_id: [41]
 Extra - minimap_coordinates: [{'x': 1, 'y': 0}, {'x': 1, 'y': 1}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Sector Lift 1/Elevator to Sector 1 (SRX)
+  * Elevator to Sector Hub Lift 1/Elevator to Sector 1 (SRX)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -73,12 +73,12 @@ Extra - minimap_coordinates: [{'x': 2, 'y': 1}]
   * Layers: default
   * Open Hatch to Entrance Save Room/Door to Entrance Navigation Room
   * Extra - door_idx: (6,)
-  > Door to Elevator to Main Deck
+  > Door to Sector 1 (SRX) Entrance Elevator
       Trivial
 
-> Door to Elevator to Main Deck; Heals? False
+> Door to Sector 1 (SRX) Entrance Elevator; Heals? False
   * Layers: default
-  * Open Hatch to Elevator to Main Deck/Door to Entrance Navigation Room
+  * Open Hatch to Sector 1 (SRX) Entrance Elevator/Door to Entrance Navigation Room
   * Extra - door_idx: (87,)
   > Door to Entrance Save Room
       Trivial
@@ -91,7 +91,7 @@ Extra - minimap_coordinates: [{'x': 2, 'y': 1}]
   * Extra - hint_name: Sector1Entrance
   * Extra - location_precision: REGION_ONLY
   * Extra - item_precision: PRECISE_CATEGORY
-  > Door to Elevator to Main Deck
+  > Door to Sector 1 (SRX) Entrance Elevator
       Trivial
 
 ----------------
@@ -1667,7 +1667,7 @@ Hint Features - Multiple Pickups
               Combat (Beginner) and Normal Damage ≥ 60
 
 ----------------
-Elevator to Main Deck
+Sector 1 (SRX) Entrance Elevator
 Extra - map_name: Sector 141
 Extra - room_id: [41]
 Extra - minimap_coordinates: [{'x': 1, 'y': 0}, {'x': 1, 'y': 1}]
@@ -1680,7 +1680,7 @@ Extra - minimap_coordinates: [{'x': 1, 'y': 0}, {'x': 1, 'y': 1}]
 
 > Door to Entrance Navigation Room; Heals? False
   * Layers: default
-  * L0 Hatch to Entrance Navigation Room/Door to Elevator to Main Deck
+  * L0 Hatch to Entrance Navigation Room/Door to Sector 1 (SRX) Entrance Elevator
   * Extra - door_idx: (86,)
   > Elevator to Main Deck
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -1206,9 +1206,9 @@ Hint Features - Climbable Surface
               # SJ damageless: https://youtu.be/M2fDkXlM8LU
               Space Jump and Combat (Expert)
 
-> Door to Elevator to Restricted Zone; Heals? False
+> Door to Tourian Elevator; Heals? False
   * Layers: default
-  * L0 Hatch to Elevator to Restricted Zone/Door to Ripper Maze
+  * L0 Hatch to Tourian Elevator/Door to Ripper Maze
   * Extra - door_idx: (63,)
   > Top of Shaft
       Wall Jump (Beginner) or Have Any Jump Upgrade
@@ -1258,24 +1258,24 @@ Hint Features - Climbable Surface
               Damage Boosts (Beginner) and Normal Damage ≥ 50
               # Dodge: https://youtu.be/X-rHiHQ7Sxw
               Movement (Intermediate)
-  > Door to Elevator to Restricted Zone
+  > Door to Tourian Elevator
       Trivial
 
 ----------------
-Elevator to Restricted Zone
+Tourian Elevator
 Extra - map_name: Sector 131
 Extra - room_id: [31]
 Extra - minimap_coordinates: [{'x': 2, 'y': 11}, {'x': 2, 'y': 12}]
 > Door to Ripper Maze; Heals? False
   * Layers: default
-  * L0 Hatch to Ripper Maze/Door to Elevator to Restricted Zone
+  * L0 Hatch to Ripper Maze/Door to Tourian Elevator
   * Extra - door_idx: (64,)
-  > Elevator to Elevator to Tourian (SRX)
+  > Elevator to Restricted Zone Elevator
       Trivial
 
-> Elevator to Elevator to Tourian (SRX); Heals? False
+> Elevator to Restricted Zone Elevator; Heals? False
   * Layers: default
-  * Elevator to Elevator to Tourian (SRX)/Elevator to Elevator to Restricted Zone
+  * Elevator to Restricted Zone Elevator/Elevator to Tourian Elevator
   * Extra - door_idx: (65,)
   > Door to Ripper Maze
       Trivial
@@ -1673,7 +1673,7 @@ Extra - room_id: [41]
 Extra - minimap_coordinates: [{'x': 1, 'y': 0}, {'x': 1, 'y': 1}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Elevator to Sector 1 (SRX)/Elevator to Sector 1 (SRX)
+  * Elevator to Sector Lift 1/Elevator to Sector 1 (SRX)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -7532,7 +7532,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 2 (TRO)",
+                        "area": "Sector Lift 2",
                         "node": "Elevator to Sector 2 (TRO)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -7532,7 +7532,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 2",
+                        "area": "Sector Hub Lift 2",
                         "node": "Elevator to Sector 2 (TRO)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -586,7 +586,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Main Deck": {
+                        "Door to Sector 2 (TRO) Entrance Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -595,7 +595,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Main Deck": {
+                "Door to Sector 2 (TRO) Entrance Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -616,7 +616,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 2 (TRO)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 2 (TRO) Entrance Elevator",
                         "node": "Door to Entrance Navigation Room"
                     },
                     "default_dock_weakness": "Open Hatch",
@@ -679,7 +679,7 @@
                         }
                     },
                     "connections": {
-                        "Door to Elevator to Main Deck": {
+                        "Door to Sector 2 (TRO) Entrance Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7491,7 +7491,7 @@
                 }
             }
         },
-        "Elevator to Main Deck": {
+        "Sector 2 (TRO) Entrance Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -7573,7 +7573,7 @@
                     "default_connection": {
                         "region": "Sector 2 (TRO)",
                         "area": "Entrance Navigation Room",
-                        "node": "Door to Elevator to Main Deck"
+                        "node": "Door to Sector 2 (TRO) Entrance Elevator"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1149,7 +1149,7 @@ Extra - room_id: [29]
 Extra - minimap_coordinates: [{'x': 2, 'y': 1}, {'x': 2, 'y': 2}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Elevator to Sector 2 (TRO)/Elevator to Sector 2 (TRO)
+  * Elevator to Sector Lift 2/Elevator to Sector 2 (TRO)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -102,12 +102,12 @@ Extra - minimap_coordinates: [{'x': 3, 'y': 2}]
   * Layers: default
   * Open Hatch to Entrance Save Room/Door to Entrance Navigation Room
   * Extra - door_idx: (8,)
-  > Door to Elevator to Main Deck
+  > Door to Sector 2 (TRO) Entrance Elevator
       Trivial
 
-> Door to Elevator to Main Deck; Heals? False
+> Door to Sector 2 (TRO) Entrance Elevator; Heals? False
   * Layers: default
-  * Open Hatch to Elevator to Main Deck/Door to Entrance Navigation Room
+  * Open Hatch to Sector 2 (TRO) Entrance Elevator/Door to Entrance Navigation Room
   * Extra - door_idx: (67,)
   > Door to Entrance Save Room
       Trivial
@@ -120,7 +120,7 @@ Extra - minimap_coordinates: [{'x': 3, 'y': 2}]
   * Extra - hint_name: Sector2Entrance
   * Extra - location_precision: REGION_ONLY
   * Extra - item_precision: PRECISE_CATEGORY
-  > Door to Elevator to Main Deck
+  > Door to Sector 2 (TRO) Entrance Elevator
       Trivial
 
 ----------------
@@ -1143,7 +1143,7 @@ Extra - minimap_coordinates: [{'x': 7, 'y': 6}]
       Trivial
 
 ----------------
-Elevator to Main Deck
+Sector 2 (TRO) Entrance Elevator
 Extra - map_name: Sector 229
 Extra - room_id: [29]
 Extra - minimap_coordinates: [{'x': 2, 'y': 1}, {'x': 2, 'y': 2}]
@@ -1156,7 +1156,7 @@ Extra - minimap_coordinates: [{'x': 2, 'y': 1}, {'x': 2, 'y': 2}]
 
 > Door to Entrance Navigation Room; Heals? False
   * Layers: default
-  * L0 Hatch to Entrance Navigation Room/Door to Elevator to Main Deck
+  * L0 Hatch to Entrance Navigation Room/Door to Sector 2 (TRO) Entrance Elevator
   * Extra - door_idx: (66,)
   > Elevator to Main Deck
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1149,7 +1149,7 @@ Extra - room_id: [29]
 Extra - minimap_coordinates: [{'x': 2, 'y': 1}, {'x': 2, 'y': 2}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Sector Lift 2/Elevator to Sector 2 (TRO)
+  * Elevator to Sector Hub Lift 2/Elevator to Sector 2 (TRO)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -6782,7 +6782,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 3 (PYR)",
+                        "area": "Sector Lift 3",
                         "node": "Elevator to Sector 3 (PYR)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -600,7 +600,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Main Deck": {
+                        "Door to Sector 3 (PYR) Entrance Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -609,7 +609,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Main Deck": {
+                "Door to Sector 3 (PYR) Entrance Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -630,7 +630,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 3 (PYR)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 3 (PYR) Entrance Elevator",
                         "node": "Door to Entrance Navigation Room"
                     },
                     "default_dock_weakness": "Open Hatch",
@@ -693,7 +693,7 @@
                         }
                     },
                     "connections": {
-                        "Door to Elevator to Main Deck": {
+                        "Door to Sector 3 (PYR) Entrance Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6741,7 +6741,7 @@
                 }
             }
         },
-        "Elevator to Main Deck": {
+        "Sector 3 (PYR) Entrance Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -6823,7 +6823,7 @@
                     "default_connection": {
                         "region": "Sector 3 (PYR)",
                         "area": "Entrance Navigation Room",
-                        "node": "Door to Elevator to Main Deck"
+                        "node": "Door to Sector 3 (PYR) Entrance Elevator"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -6782,7 +6782,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 3",
+                        "area": "Sector Hub Lift 3",
                         "node": "Elevator to Sector 3 (PYR)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -938,7 +938,7 @@ Extra - room_id: [20]
 Extra - minimap_coordinates: [{'x': 4, 'y': 1}, {'x': 4, 'y': 2}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Sector Lift 3/Elevator to Sector 3 (PYR)
+  * Elevator to Sector Hub Lift 3/Elevator to Sector 3 (PYR)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -938,7 +938,7 @@ Extra - room_id: [20]
 Extra - minimap_coordinates: [{'x': 4, 'y': 1}, {'x': 4, 'y': 2}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Elevator to Sector 3 (PYR)/Elevator to Sector 3 (PYR)
+  * Elevator to Sector Lift 3/Elevator to Sector 3 (PYR)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -92,12 +92,12 @@ Extra - minimap_coordinates: [{'x': 5, 'y': 2}]
   * Layers: default
   * Open Hatch to Entrance Save Room/Door to Entrance Navigation Room
   * Extra - door_idx: (7,)
-  > Door to Elevator to Main Deck
+  > Door to Sector 3 (PYR) Entrance Elevator
       Trivial
 
-> Door to Elevator to Main Deck; Heals? False
+> Door to Sector 3 (PYR) Entrance Elevator; Heals? False
   * Layers: default
-  * Open Hatch to Elevator to Main Deck/Door to Entrance Navigation Room
+  * Open Hatch to Sector 3 (PYR) Entrance Elevator/Door to Entrance Navigation Room
   * Extra - door_idx: (41,)
   > Door to Entrance Save Room
       Trivial
@@ -110,7 +110,7 @@ Extra - minimap_coordinates: [{'x': 5, 'y': 2}]
   * Extra - hint_name: Sector3Entrance
   * Extra - location_precision: REGION_ONLY
   * Extra - item_precision: PRECISE_CATEGORY
-  > Door to Elevator to Main Deck
+  > Door to Sector 3 (PYR) Entrance Elevator
       Trivial
 
 ----------------
@@ -932,7 +932,7 @@ Hint Features - Extreme Temperatures, Multiple Pickups, 1-way Shutter
               Damage Runs (Intermediate) and Heat Damage ≥ 80
 
 ----------------
-Elevator to Main Deck
+Sector 3 (PYR) Entrance Elevator
 Extra - map_name: Sector 320
 Extra - room_id: [20]
 Extra - minimap_coordinates: [{'x': 4, 'y': 1}, {'x': 4, 'y': 2}]
@@ -945,7 +945,7 @@ Extra - minimap_coordinates: [{'x': 4, 'y': 1}, {'x': 4, 'y': 2}]
 
 > Door to Entrance Navigation Room; Heals? False
   * Layers: default
-  * L0 Hatch to Entrance Navigation Room/Door to Elevator to Main Deck
+  * L0 Hatch to Entrance Navigation Room/Door to Sector 3 (PYR) Entrance Elevator
   * Extra - door_idx: (42,)
   > Elevator to Main Deck
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -10147,7 +10147,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 4",
+                        "area": "Sector Hub Lift 4",
                         "node": "Elevator to Sector 4 (AQA)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -310,7 +310,7 @@
                 ]
             },
             "nodes": {
-                "Door to Elevator to Main Deck": {
+                "Door to Sector 4 (AQA) Entrance Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -331,7 +331,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 4 (AQA)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 4 (AQA) Entrance Elevator",
                         "node": "Door to Entrance Navigation Room"
                     },
                     "default_dock_weakness": "Open Hatch",
@@ -388,7 +388,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Main Deck": {
+                        "Door to Sector 4 (AQA) Entrance Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -434,7 +434,7 @@
                         }
                     },
                     "connections": {
-                        "Door to Elevator to Main Deck": {
+                        "Door to Sector 4 (AQA) Entrance Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -10106,7 +10106,7 @@
                 }
             }
         },
-        "Elevator to Main Deck": {
+        "Sector 4 (AQA) Entrance Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -10188,7 +10188,7 @@
                     "default_connection": {
                         "region": "Sector 4 (AQA)",
                         "area": "Entrance Navigation Room",
-                        "node": "Door to Elevator to Main Deck"
+                        "node": "Door to Sector 4 (AQA) Entrance Elevator"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -10147,7 +10147,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 4 (AQA)",
+                        "area": "Sector Lift 4",
                         "node": "Elevator to Sector 4 (AQA)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -60,9 +60,9 @@ Entrance Navigation Room
 Extra - map_name: Sector 42
 Extra - room_id: [2]
 Extra - minimap_coordinates: [{'x': 19, 'y': 4}]
-> Door to Elevator to Main Deck; Heals? False
+> Door to Sector 4 (AQA) Entrance Elevator; Heals? False
   * Layers: default
-  * Open Hatch to Elevator to Main Deck/Door to Entrance Navigation Room
+  * Open Hatch to Sector 4 (AQA) Entrance Elevator/Door to Entrance Navigation Room
   * Extra - door_idx: (1,)
   > Door to Entrance Save Room
       Trivial
@@ -73,7 +73,7 @@ Extra - minimap_coordinates: [{'x': 19, 'y': 4}]
   * Layers: default
   * Open Hatch to Entrance Save Room/Door to Entrance Navigation Room
   * Extra - door_idx: (7,)
-  > Door to Elevator to Main Deck
+  > Door to Sector 4 (AQA) Entrance Elevator
       Trivial
 
 > Navigation Terminal; Heals? False
@@ -82,7 +82,7 @@ Extra - minimap_coordinates: [{'x': 19, 'y': 4}]
   * Extra - hint_name: Sector4Entrance
   * Extra - location_precision: REGION_ONLY
   * Extra - item_precision: PRECISE_CATEGORY
-  > Door to Elevator to Main Deck
+  > Door to Sector 4 (AQA) Entrance Elevator
       Trivial
 
 ----------------
@@ -1413,7 +1413,7 @@ Hint Features - Security Room
       Trivial
 
 ----------------
-Elevator to Main Deck
+Sector 4 (AQA) Entrance Elevator
 Extra - map_name: Sector 427
 Extra - room_id: [27]
 Extra - minimap_coordinates: [{'x': 20, 'y': 3}, {'x': 20, 'y': 4}]
@@ -1426,7 +1426,7 @@ Extra - minimap_coordinates: [{'x': 20, 'y': 3}, {'x': 20, 'y': 4}]
 
 > Door to Entrance Navigation Room; Heals? False
   * Layers: default
-  * L0 Hatch to Entrance Navigation Room/Door to Elevator to Main Deck
+  * L0 Hatch to Entrance Navigation Room/Door to Sector 4 (AQA) Entrance Elevator
   * Extra - door_idx: (57,)
   > Elevator to Main Deck
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -1419,7 +1419,7 @@ Extra - room_id: [27]
 Extra - minimap_coordinates: [{'x': 20, 'y': 3}, {'x': 20, 'y': 4}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Sector Lift 4/Elevator to Sector 4 (AQA)
+  * Elevator to Sector Hub Lift 4/Elevator to Sector 4 (AQA)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -1419,7 +1419,7 @@ Extra - room_id: [27]
 Extra - minimap_coordinates: [{'x': 20, 'y': 3}, {'x': 20, 'y': 4}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Elevator to Sector 4 (AQA)/Elevator to Sector 4 (AQA)
+  * Elevator to Sector Lift 4/Elevator to Sector 4 (AQA)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -6751,7 +6751,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 5 (ARC)",
+                        "area": "Sector Lift 5",
                         "node": "Elevator to Sector 5 (ARC)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -430,7 +430,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Main Deck": {
+                        "Door to Sector 5 (ARC) Entrance Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -446,7 +446,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Main Deck": {
+                "Door to Sector 5 (ARC) Entrance Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -467,7 +467,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 5 (ARC)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 5 (ARC) Entrance Elevator",
                         "node": "Door to Entrance Navigation Room"
                     },
                     "default_dock_weakness": "Open Hatch",
@@ -6710,7 +6710,7 @@
                 }
             }
         },
-        "Elevator to Main Deck": {
+        "Sector 5 (ARC) Entrance Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -6792,7 +6792,7 @@
                     "default_connection": {
                         "region": "Sector 5 (ARC)",
                         "area": "Entrance Navigation Room",
-                        "node": "Door to Elevator to Main Deck"
+                        "node": "Door to Sector 5 (ARC) Entrance Elevator"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.json
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.json
@@ -6751,7 +6751,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 5",
+                        "area": "Sector Hub Lift 5",
                         "node": "Elevator to Sector 5 (ARC)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -995,7 +995,7 @@ Extra - room_id: [25]
 Extra - minimap_coordinates: [{'x': 0, 'y': 1}, {'x': 0, 'y': 2}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Sector Lift 5/Elevator to Sector 5 (ARC)
+  * Elevator to Sector Hub Lift 5/Elevator to Sector 5 (ARC)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -73,14 +73,14 @@ Extra - minimap_coordinates: [{'x': 1, 'y': 2}]
   * Layers: default
   * Open Hatch to Entrance Save Room/Door to Entrance Navigation Room
   * Extra - door_idx: (6,)
-  > Door to Elevator to Main Deck
+  > Door to Sector 5 (ARC) Entrance Elevator
       Trivial
   > Navigation Terminal
       Trivial
 
-> Door to Elevator to Main Deck; Heals? False
+> Door to Sector 5 (ARC) Entrance Elevator; Heals? False
   * Layers: default
-  * Open Hatch to Elevator to Main Deck/Door to Entrance Navigation Room
+  * Open Hatch to Sector 5 (ARC) Entrance Elevator/Door to Entrance Navigation Room
   * Extra - door_idx: (50,)
   > Door to Entrance Save Room
       Trivial
@@ -989,7 +989,7 @@ Extra - minimap_coordinates: [{'x': 12, 'y': 8}, {'x': 12, 'y': 9}, {'x': 12, 'y
   * Extra - door_idx: (105,)
 
 ----------------
-Elevator to Main Deck
+Sector 5 (ARC) Entrance Elevator
 Extra - map_name: Sector 525
 Extra - room_id: [25]
 Extra - minimap_coordinates: [{'x': 0, 'y': 1}, {'x': 0, 'y': 2}]
@@ -1002,7 +1002,7 @@ Extra - minimap_coordinates: [{'x': 0, 'y': 1}, {'x': 0, 'y': 2}]
 
 > Door to Entrance Navigation Room; Heals? False
   * Layers: default
-  * L0 Hatch to Entrance Navigation Room/Door to Elevator to Main Deck
+  * L0 Hatch to Entrance Navigation Room/Door to Sector 5 (ARC) Entrance Elevator
   * Extra - door_idx: (51,)
   > Elevator to Main Deck
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 5 ARC.txt
+++ b/randovania/games/fusion/logic_database/Sector 5 ARC.txt
@@ -995,7 +995,7 @@ Extra - room_id: [25]
 Extra - minimap_coordinates: [{'x': 0, 'y': 1}, {'x': 0, 'y': 2}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Elevator to Sector 5 (ARC)/Elevator to Sector 5 (ARC)
+  * Elevator to Sector Lift 5/Elevator to Sector 5 (ARC)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -6421,7 +6421,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Elevator to Sector 6 (NOC)",
+                        "area": "Sector Lift 6",
                         "node": "Elevator to Sector 6 (NOC)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -755,7 +755,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Elevator to Main Deck": {
+                        "Door to Sector 6 (NOC) Entrance Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -764,7 +764,7 @@
                         }
                     }
                 },
-                "Door to Elevator to Main Deck": {
+                "Door to Sector 6 (NOC) Entrance Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -785,7 +785,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 6 (NOC)",
-                        "area": "Elevator to Main Deck",
+                        "area": "Sector 6 (NOC) Entrance Elevator",
                         "node": "Door to Entrance Navigation Room"
                     },
                     "default_dock_weakness": "Open Hatch",
@@ -848,7 +848,7 @@
                         }
                     },
                     "connections": {
-                        "Door to Elevator to Main Deck": {
+                        "Door to Sector 6 (NOC) Entrance Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6380,7 +6380,7 @@
                 }
             }
         },
-        "Elevator to Main Deck": {
+        "Sector 6 (NOC) Entrance Elevator": {
             "default_node": null,
             "hint_features": [],
             "extra": {
@@ -6462,7 +6462,7 @@
                     "default_connection": {
                         "region": "Sector 6 (NOC)",
                         "area": "Entrance Navigation Room",
-                        "node": "Door to Elevator to Main Deck"
+                        "node": "Door to Sector 6 (NOC) Entrance Elevator"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.json
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.json
@@ -6421,7 +6421,7 @@
                     "dock_type": "Elevator",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Sector Lift 6",
+                        "area": "Sector Hub Lift 6",
                         "node": "Elevator to Sector 6 (NOC)"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -839,7 +839,7 @@ Extra - room_id: [17]
 Extra - minimap_coordinates: [{'x': 0, 'y': 1}, {'x': 0, 'y': 2}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Elevator to Sector 6 (NOC)/Elevator to Sector 6 (NOC)
+  * Elevator to Sector Lift 6/Elevator to Sector 6 (NOC)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -839,7 +839,7 @@ Extra - room_id: [17]
 Extra - minimap_coordinates: [{'x': 0, 'y': 1}, {'x': 0, 'y': 2}]
 > Elevator to Main Deck; Heals? False
   * Layers: default
-  * Elevator to Sector Lift 6/Elevator to Sector 6 (NOC)
+  * Elevator to Sector Hub Lift 6/Elevator to Sector 6 (NOC)
   * Extra - door_idx: (0,)
   > Door to Entrance Navigation Room
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 6 NOC.txt
+++ b/randovania/games/fusion/logic_database/Sector 6 NOC.txt
@@ -111,12 +111,12 @@ Extra - minimap_coordinates: [{'x': 1, 'y': 2}]
   * Layers: default
   * Open Hatch to Entrance Save Room/Door to Entrance Navigation Room
   * Extra - door_idx: (6,)
-  > Door to Elevator to Main Deck
+  > Door to Sector 6 (NOC) Entrance Elevator
       Trivial
 
-> Door to Elevator to Main Deck; Heals? False
+> Door to Sector 6 (NOC) Entrance Elevator; Heals? False
   * Layers: default
-  * Open Hatch to Elevator to Main Deck/Door to Entrance Navigation Room
+  * Open Hatch to Sector 6 (NOC) Entrance Elevator/Door to Entrance Navigation Room
   * Extra - door_idx: (34,)
   > Door to Entrance Save Room
       Trivial
@@ -129,7 +129,7 @@ Extra - minimap_coordinates: [{'x': 1, 'y': 2}]
   * Extra - hint_name: Sector6Entrance
   * Extra - location_precision: REGION_ONLY
   * Extra - item_precision: PRECISE_CATEGORY
-  > Door to Elevator to Main Deck
+  > Door to Sector 6 (NOC) Entrance Elevator
       Trivial
 
 ----------------
@@ -833,7 +833,7 @@ Hint Features - Core-X, Climbable Surface
       Trivial
 
 ----------------
-Elevator to Main Deck
+Sector 6 (NOC) Entrance Elevator
 Extra - map_name: Sector 617
 Extra - room_id: [17]
 Extra - minimap_coordinates: [{'x': 0, 'y': 1}, {'x': 0, 'y': 2}]
@@ -846,7 +846,7 @@ Extra - minimap_coordinates: [{'x': 0, 'y': 1}, {'x': 0, 'y': 2}]
 
 > Door to Entrance Navigation Room; Heals? False
   * Layers: default
-  * L0 Hatch to Entrance Navigation Room/Door to Elevator to Main Deck
+  * L0 Hatch to Entrance Navigation Room/Door to Sector 6 (NOC) Entrance Elevator
   * Extra - door_idx: (35,)
   > Elevator to Main Deck
       Trivial

--- a/randovania/layout/description_migration.py
+++ b/randovania/layout/description_migration.py
@@ -842,6 +842,20 @@ def _migrate_v39(data: dict) -> None:
                 hint["precision"]["item_feature"] = replacement_features[feature]
 
 
+def _migrate_v40(data: dict) -> None:
+    game_modifications = data["game_modifications"]
+
+    for game in game_modifications:
+        game_name = game["game"]
+        if game_name != "fusion":
+            continue
+
+        doors_to_migrate = migration_data.get_raw_data(RandovaniaGame(game["game"]))["elevator_rename_doors"]
+        for target_door in list(game["dock_weakness"].items()):
+            if target_door[0] in doors_to_migrate:
+                game["dock_weakness"][doors_to_migrate[target_door[0]]] = game["dock_weakness"].pop(target_door[0])
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v2.2.0-6-gbfd37022
     _migrate_v2,  # v2.4.2-16-g735569fd
@@ -882,6 +896,7 @@ _MIGRATIONS = [
     _migrate_v37,  # Refactor how the "locations" field is saved.
     _migrate_v38,  # Redo am2r pickup features
     _migrate_v39,  # Redo msr pickup features
+    _migrate_v40,  # Renamed Fusion elevators, migrated connecting doors
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/test/test_files/log_files/fusion/starting_items.rdvgame
+++ b/test/test_files/log_files/fusion/starting_items.rdvgame
@@ -248,7 +248,7 @@
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Habitation Deck Save Room/Door to Elevator to Central Nexus": {
+                "Main Deck/Habitation Deck Save Room/Door to Habitation Deck Elevator": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
@@ -348,7 +348,7 @@
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Elevator to Central Nexus/Door to Habitation Deck Save Room": {
+                "Main Deck/Habitation Deck Elevator/Door to Habitation Deck Save Room": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },

--- a/test/test_files/log_files/fusion/starting_items.rdvgame
+++ b/test/test_files/log_files/fusion/starting_items.rdvgame
@@ -248,7 +248,7 @@
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Habitation Deck Save Room/Door to Habitation Deck Elevator": {
+                "Main Deck/Habitation Deck Save Room/Door to Elevator to Central Nexus": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
@@ -264,51 +264,51 @@
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Hub/Door to Sector Lift 2": {
+                "Main Deck/Sector Hub/Door to Elevator to Sector 2 (TRO)": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Hub/Door to Sector Lift 1": {
+                "Main Deck/Sector Hub/Door to Elevator to Sector 1 (SRX)": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Lift 2/Door to Sector Hub": {
+                "Main Deck/Elevator to Sector 2 (TRO)/Door to Sector Hub": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Lift 2/Door to Sector Lift 4": {
+                "Main Deck/Elevator to Sector 2 (TRO)/Door to Elevator to Sector 4 (AQA)": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Lift 4/Door to Sector Lift 2": {
+                "Main Deck/Elevator to Sector 4 (AQA)/Door to Elevator to Sector 2 (TRO)": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Lift 4/Door to Sector Lift 6": {
+                "Main Deck/Elevator to Sector 4 (AQA)/Door to Elevator to Sector 6 (NOC)": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Lift 6/Door to Sector Lift 4": {
+                "Main Deck/Elevator to Sector 6 (NOC)/Door to Elevator to Sector 4 (AQA)": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Lift 1/Door to Sector Hub": {
+                "Main Deck/Elevator to Sector 1 (SRX)/Door to Sector Hub": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Lift 1/Door to Sector Lift 3": {
+                "Main Deck/Elevator to Sector 1 (SRX)/Door to Elevator to Sector 3 (PYR)": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Lift 3/Door to Sector Lift 1": {
+                "Main Deck/Elevator to Sector 3 (PYR)/Door to Elevator to Sector 1 (SRX)": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Lift 3/Door to Sector Lift 5": {
+                "Main Deck/Elevator to Sector 3 (PYR)/Door to Elevator to Sector 5 (ARC)": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Lift 5/Door to Sector Lift 3": {
+                "Main Deck/Elevator to Sector 5 (ARC)/Door to Elevator to Sector 3 (PYR)": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
@@ -348,7 +348,7 @@
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Habitation Deck Elevator/Door to Habitation Deck Save Room": {
+                "Main Deck/Elevator to Central Nexus/Door to Habitation Deck Save Room": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },

--- a/test/test_files/log_files/fusion/starting_items.rdvgame
+++ b/test/test_files/log_files/fusion/starting_items.rdvgame
@@ -264,51 +264,51 @@
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Hub/Door to Elevator to Sector 2 (TRO)": {
+                "Main Deck/Sector Hub/Door to Sector Lift 2": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Sector Hub/Door to Elevator to Sector 1 (SRX)": {
+                "Main Deck/Sector Hub/Door to Sector Lift 1": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Elevator to Sector 2 (TRO)/Door to Sector Hub": {
+                "Main Deck/Sector Lift 2/Door to Sector Hub": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Elevator to Sector 2 (TRO)/Door to Elevator to Sector 4 (AQA)": {
+                "Main Deck/Sector Lift 2/Door to Sector Lift 4": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Elevator to Sector 4 (AQA)/Door to Elevator to Sector 2 (TRO)": {
+                "Main Deck/Sector Lift 4/Door to Sector Lift 2": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Elevator to Sector 4 (AQA)/Door to Elevator to Sector 6 (NOC)": {
+                "Main Deck/Sector Lift 4/Door to Sector Lift 6": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Elevator to Sector 6 (NOC)/Door to Elevator to Sector 4 (AQA)": {
+                "Main Deck/Sector Lift 6/Door to Sector Lift 4": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Elevator to Sector 1 (SRX)/Door to Sector Hub": {
+                "Main Deck/Sector Lift 1/Door to Sector Hub": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Elevator to Sector 1 (SRX)/Door to Elevator to Sector 3 (PYR)": {
+                "Main Deck/Sector Lift 1/Door to Sector Lift 3": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Elevator to Sector 3 (PYR)/Door to Elevator to Sector 1 (SRX)": {
+                "Main Deck/Sector Lift 3/Door to Sector Lift 1": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Elevator to Sector 3 (PYR)/Door to Elevator to Sector 5 (ARC)": {
+                "Main Deck/Sector Lift 3/Door to Sector Lift 5": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },
-                "Main Deck/Elevator to Sector 5 (ARC)/Door to Elevator to Sector 3 (PYR)": {
+                "Main Deck/Sector Lift 5/Door to Sector Lift 3": {
                     "type": "Door",
                     "name": "Open Hatch"
                 },

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
@@ -3561,7 +3561,7 @@
         {
             "Area": 0,
             "Room": 76,
-            "Name": "Elevator to Central Nexus"
+            "Name": "Habitation Deck Elevator"
         },
         {
             "Area": 0,

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
@@ -3316,32 +3316,32 @@
         {
             "Area": 0,
             "Room": 25,
-            "Name": "Sector Lift 2"
+            "Name": "Sector Hub Lift 2"
         },
         {
             "Area": 0,
             "Room": 26,
-            "Name": "Sector Lift 4"
+            "Name": "Sector Hub Lift 4"
         },
         {
             "Area": 0,
             "Room": 27,
-            "Name": "Sector Lift 6"
+            "Name": "Sector Hub Lift 6"
         },
         {
             "Area": 0,
             "Room": 28,
-            "Name": "Sector Lift 1"
+            "Name": "Sector Hub Lift 1"
         },
         {
             "Area": 0,
             "Room": 29,
-            "Name": "Sector Lift 3"
+            "Name": "Sector Hub Lift 3"
         },
         {
             "Area": 0,
             "Room": 30,
-            "Name": "Sector Lift 5"
+            "Name": "Sector Hub Lift 5"
         },
         {
             "Area": 0,

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
@@ -3316,32 +3316,32 @@
         {
             "Area": 0,
             "Room": 25,
-            "Name": "Elevator to Sector 2 (TRO)"
+            "Name": "Sector Lift 2"
         },
         {
             "Area": 0,
             "Room": 26,
-            "Name": "Elevator to Sector 4 (AQA)"
+            "Name": "Sector Lift 4"
         },
         {
             "Area": 0,
             "Room": 27,
-            "Name": "Elevator to Sector 6 (NOC)"
+            "Name": "Sector Lift 6"
         },
         {
             "Area": 0,
             "Room": 28,
-            "Name": "Elevator to Sector 1 (SRX)"
+            "Name": "Sector Lift 1"
         },
         {
             "Area": 0,
             "Room": 29,
-            "Name": "Elevator to Sector 3 (PYR)"
+            "Name": "Sector Lift 3"
         },
         {
             "Area": 0,
             "Room": 30,
-            "Name": "Elevator to Sector 5 (ARC)"
+            "Name": "Sector Lift 5"
         },
         {
             "Area": 0,
@@ -3391,12 +3391,12 @@
         {
             "Area": 0,
             "Room": 40,
-            "Name": "Elevator to Sector Hub"
+            "Name": "Main Elevator"
         },
         {
             "Area": 0,
             "Room": 19,
-            "Name": "Elevator to Sector Hub"
+            "Name": "Main Elevator"
         },
         {
             "Area": 0,
@@ -3496,12 +3496,12 @@
         {
             "Area": 0,
             "Room": 60,
-            "Name": "Elevator to Crew Quarters"
+            "Name": "Operations Deck Elevator"
         },
         {
             "Area": 0,
             "Room": 61,
-            "Name": "Elevator to Operations Deck"
+            "Name": "Crew Quarters Elevator"
         },
         {
             "Area": 0,
@@ -3526,7 +3526,7 @@
         {
             "Area": 0,
             "Room": 67,
-            "Name": "Elevator to Tourian (SRX)"
+            "Name": "Restricted Zone Elevator"
         },
         {
             "Area": 0,
@@ -3556,7 +3556,7 @@
         {
             "Area": 0,
             "Room": 75,
-            "Name": "Elevator to Habitation Deck"
+            "Name": "Nexus Elevator"
         },
         {
             "Area": 0,
@@ -3741,7 +3741,7 @@
         {
             "Area": 1,
             "Room": 31,
-            "Name": "Elevator to Restricted Zone"
+            "Name": "Tourian Elevator"
         },
         {
             "Area": 1,

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_nothing/world_1.json
@@ -3791,7 +3791,7 @@
         {
             "Area": 1,
             "Room": 41,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 1 (SRX) Entrance Elevator"
         },
         {
             "Area": 1,
@@ -4016,7 +4016,7 @@
         {
             "Area": 2,
             "Room": 29,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 2 (TRO) Entrance Elevator"
         },
         {
             "Area": 2,
@@ -4251,7 +4251,7 @@
         {
             "Area": 3,
             "Room": 20,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 3 (PYR) Entrance Elevator"
         },
         {
             "Area": 3,
@@ -4481,7 +4481,7 @@
         {
             "Area": 4,
             "Room": 27,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 4 (AQA) Entrance Elevator"
         },
         {
             "Area": 4,
@@ -4706,7 +4706,7 @@
         {
             "Area": 5,
             "Room": 25,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 5 (ARC) Entrance Elevator"
         },
         {
             "Area": 5,
@@ -4921,7 +4921,7 @@
         {
             "Area": 6,
             "Room": 17,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 6 (NOC) Entrance Elevator"
         },
         {
             "Area": 6,

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
@@ -3292,32 +3292,32 @@
         {
             "Area": 0,
             "Room": 25,
-            "Name": "Elevator to Sector 2 (TRO)"
+            "Name": "Sector Lift 2"
         },
         {
             "Area": 0,
             "Room": 26,
-            "Name": "Elevator to Sector 4 (AQA)"
+            "Name": "Sector Lift 4"
         },
         {
             "Area": 0,
             "Room": 27,
-            "Name": "Elevator to Sector 6 (NOC)"
+            "Name": "Sector Lift 6"
         },
         {
             "Area": 0,
             "Room": 28,
-            "Name": "Elevator to Sector 1 (SRX)"
+            "Name": "Sector Lift 1"
         },
         {
             "Area": 0,
             "Room": 29,
-            "Name": "Elevator to Sector 3 (PYR)"
+            "Name": "Sector Lift 3"
         },
         {
             "Area": 0,
             "Room": 30,
-            "Name": "Elevator to Sector 5 (ARC)"
+            "Name": "Sector Lift 5"
         },
         {
             "Area": 0,
@@ -3367,12 +3367,12 @@
         {
             "Area": 0,
             "Room": 40,
-            "Name": "Elevator to Sector Hub"
+            "Name": "Main Elevator"
         },
         {
             "Area": 0,
             "Room": 19,
-            "Name": "Elevator to Sector Hub"
+            "Name": "Main Elevator"
         },
         {
             "Area": 0,
@@ -3472,12 +3472,12 @@
         {
             "Area": 0,
             "Room": 60,
-            "Name": "Elevator to Crew Quarters"
+            "Name": "Operations Deck Elevator"
         },
         {
             "Area": 0,
             "Room": 61,
-            "Name": "Elevator to Operations Deck"
+            "Name": "Crew Quarters Elevator"
         },
         {
             "Area": 0,
@@ -3502,7 +3502,7 @@
         {
             "Area": 0,
             "Room": 67,
-            "Name": "Elevator to Tourian (SRX)"
+            "Name": "Restricted Zone Elevator"
         },
         {
             "Area": 0,
@@ -3532,7 +3532,7 @@
         {
             "Area": 0,
             "Room": 75,
-            "Name": "Elevator to Habitation Deck"
+            "Name": "Nexus Elevator"
         },
         {
             "Area": 0,
@@ -3717,7 +3717,7 @@
         {
             "Area": 1,
             "Room": 31,
-            "Name": "Elevator to Restricted Zone"
+            "Name": "Tourian Elevator"
         },
         {
             "Area": 1,

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
@@ -3767,7 +3767,7 @@
         {
             "Area": 1,
             "Room": 41,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 1 (SRX) Entrance Elevator"
         },
         {
             "Area": 1,
@@ -3992,7 +3992,7 @@
         {
             "Area": 2,
             "Room": 29,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 2 (TRO) Entrance Elevator"
         },
         {
             "Area": 2,
@@ -4227,7 +4227,7 @@
         {
             "Area": 3,
             "Room": 20,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 3 (PYR) Entrance Elevator"
         },
         {
             "Area": 3,
@@ -4457,7 +4457,7 @@
         {
             "Area": 4,
             "Room": 27,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 4 (AQA) Entrance Elevator"
         },
         {
             "Area": 4,
@@ -4682,7 +4682,7 @@
         {
             "Area": 5,
             "Room": 25,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 5 (ARC) Entrance Elevator"
         },
         {
             "Area": 5,
@@ -4897,7 +4897,7 @@
         {
             "Area": 6,
             "Room": 17,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 6 (NOC) Entrance Elevator"
         },
         {
             "Area": 6,

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
@@ -3292,32 +3292,32 @@
         {
             "Area": 0,
             "Room": 25,
-            "Name": "Sector Lift 2"
+            "Name": "Sector Hub Lift 2"
         },
         {
             "Area": 0,
             "Room": 26,
-            "Name": "Sector Lift 4"
+            "Name": "Sector Hub Lift 4"
         },
         {
             "Area": 0,
             "Room": 27,
-            "Name": "Sector Lift 6"
+            "Name": "Sector Hub Lift 6"
         },
         {
             "Area": 0,
             "Room": 28,
-            "Name": "Sector Lift 1"
+            "Name": "Sector Hub Lift 1"
         },
         {
             "Area": 0,
             "Room": 29,
-            "Name": "Sector Lift 3"
+            "Name": "Sector Hub Lift 3"
         },
         {
             "Area": 0,
             "Room": 30,
-            "Name": "Sector Lift 5"
+            "Name": "Sector Hub Lift 5"
         },
         {
             "Area": 0,

--- a/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/all_hidden_with_random/world_1.json
@@ -3537,7 +3537,7 @@
         {
             "Area": 0,
             "Room": 76,
-            "Name": "Elevator to Central Nexus"
+            "Name": "Habitation Deck Elevator"
         },
         {
             "Area": 0,

--- a/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
@@ -3276,32 +3276,32 @@
         {
             "Area": 0,
             "Room": 25,
-            "Name": "Elevator to Sector 2 (TRO)"
+            "Name": "Sector Lift 2"
         },
         {
             "Area": 0,
             "Room": 26,
-            "Name": "Elevator to Sector 4 (AQA)"
+            "Name": "Sector Lift 4"
         },
         {
             "Area": 0,
             "Room": 27,
-            "Name": "Elevator to Sector 6 (NOC)"
+            "Name": "Sector Lift 6"
         },
         {
             "Area": 0,
             "Room": 28,
-            "Name": "Elevator to Sector 1 (SRX)"
+            "Name": "Sector Lift 1"
         },
         {
             "Area": 0,
             "Room": 29,
-            "Name": "Elevator to Sector 3 (PYR)"
+            "Name": "Sector Lift 3"
         },
         {
             "Area": 0,
             "Room": 30,
-            "Name": "Elevator to Sector 5 (ARC)"
+            "Name": "Sector Lift 5"
         },
         {
             "Area": 0,
@@ -3351,12 +3351,12 @@
         {
             "Area": 0,
             "Room": 40,
-            "Name": "Elevator to Sector Hub"
+            "Name": "Main Elevator"
         },
         {
             "Area": 0,
             "Room": 19,
-            "Name": "Elevator to Sector Hub"
+            "Name": "Main Elevator"
         },
         {
             "Area": 0,
@@ -3456,12 +3456,12 @@
         {
             "Area": 0,
             "Room": 60,
-            "Name": "Elevator to Crew Quarters"
+            "Name": "Operations Deck Elevator"
         },
         {
             "Area": 0,
             "Room": 61,
-            "Name": "Elevator to Operations Deck"
+            "Name": "Crew Quarters Elevator"
         },
         {
             "Area": 0,
@@ -3486,7 +3486,7 @@
         {
             "Area": 0,
             "Room": 67,
-            "Name": "Elevator to Tourian (SRX)"
+            "Name": "Restricted Zone Elevator"
         },
         {
             "Area": 0,
@@ -3516,7 +3516,7 @@
         {
             "Area": 0,
             "Room": 75,
-            "Name": "Elevator to Habitation Deck"
+            "Name": "Nexus Elevator"
         },
         {
             "Area": 0,
@@ -3701,7 +3701,7 @@
         {
             "Area": 1,
             "Room": 31,
-            "Name": "Elevator to Restricted Zone"
+            "Name": "Tourian Elevator"
         },
         {
             "Area": 1,

--- a/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
@@ -3276,32 +3276,32 @@
         {
             "Area": 0,
             "Room": 25,
-            "Name": "Sector Lift 2"
+            "Name": "Sector Hub Lift 2"
         },
         {
             "Area": 0,
             "Room": 26,
-            "Name": "Sector Lift 4"
+            "Name": "Sector Hub Lift 4"
         },
         {
             "Area": 0,
             "Room": 27,
-            "Name": "Sector Lift 6"
+            "Name": "Sector Hub Lift 6"
         },
         {
             "Area": 0,
             "Room": 28,
-            "Name": "Sector Lift 1"
+            "Name": "Sector Hub Lift 1"
         },
         {
             "Area": 0,
             "Room": 29,
-            "Name": "Sector Lift 3"
+            "Name": "Sector Hub Lift 3"
         },
         {
             "Area": 0,
             "Room": 30,
-            "Name": "Sector Lift 5"
+            "Name": "Sector Hub Lift 5"
         },
         {
             "Area": 0,

--- a/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
@@ -3751,7 +3751,7 @@
         {
             "Area": 1,
             "Room": 41,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 1 (SRX) Entrance Elevator"
         },
         {
             "Area": 1,
@@ -3976,7 +3976,7 @@
         {
             "Area": 2,
             "Room": 29,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 2 (TRO) Entrance Elevator"
         },
         {
             "Area": 2,
@@ -4211,7 +4211,7 @@
         {
             "Area": 3,
             "Room": 20,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 3 (PYR) Entrance Elevator"
         },
         {
             "Area": 3,
@@ -4441,7 +4441,7 @@
         {
             "Area": 4,
             "Room": 27,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 4 (AQA) Entrance Elevator"
         },
         {
             "Area": 4,
@@ -4666,7 +4666,7 @@
         {
             "Area": 5,
             "Room": 25,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 5 (ARC) Entrance Elevator"
         },
         {
             "Area": 5,
@@ -4881,7 +4881,7 @@
         {
             "Area": 6,
             "Room": 17,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 6 (NOC) Entrance Elevator"
         },
         {
             "Area": 6,

--- a/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/short_intro/world_1.json
@@ -3521,7 +3521,7 @@
         {
             "Area": 0,
             "Room": 76,
-            "Name": "Elevator to Central Nexus"
+            "Name": "Habitation Deck Elevator"
         },
         {
             "Area": 0,

--- a/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
@@ -3746,7 +3746,7 @@
         {
             "Area": 1,
             "Room": 41,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 1 (SRX) Entrance Elevator"
         },
         {
             "Area": 1,
@@ -3971,7 +3971,7 @@
         {
             "Area": 2,
             "Room": 29,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 2 (TRO) Entrance Elevator"
         },
         {
             "Area": 2,
@@ -4206,7 +4206,7 @@
         {
             "Area": 3,
             "Room": 20,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 3 (PYR) Entrance Elevator"
         },
         {
             "Area": 3,
@@ -4436,7 +4436,7 @@
         {
             "Area": 4,
             "Room": 27,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 4 (AQA) Entrance Elevator"
         },
         {
             "Area": 4,
@@ -4661,7 +4661,7 @@
         {
             "Area": 5,
             "Room": 25,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 5 (ARC) Entrance Elevator"
         },
         {
             "Area": 5,
@@ -4876,7 +4876,7 @@
         {
             "Area": 6,
             "Room": 17,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 6 (NOC) Entrance Elevator"
         },
         {
             "Area": 6,

--- a/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
@@ -3516,7 +3516,7 @@
         {
             "Area": 0,
             "Room": 76,
-            "Name": "Elevator to Central Nexus"
+            "Name": "Habitation Deck Elevator"
         },
         {
             "Area": 0,

--- a/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
@@ -3271,32 +3271,32 @@
         {
             "Area": 0,
             "Room": 25,
-            "Name": "Elevator to Sector 2 (TRO)"
+            "Name": "Sector Lift 2"
         },
         {
             "Area": 0,
             "Room": 26,
-            "Name": "Elevator to Sector 4 (AQA)"
+            "Name": "Sector Lift 4"
         },
         {
             "Area": 0,
             "Room": 27,
-            "Name": "Elevator to Sector 6 (NOC)"
+            "Name": "Sector Lift 6"
         },
         {
             "Area": 0,
             "Room": 28,
-            "Name": "Elevator to Sector 1 (SRX)"
+            "Name": "Sector Lift 1"
         },
         {
             "Area": 0,
             "Room": 29,
-            "Name": "Elevator to Sector 3 (PYR)"
+            "Name": "Sector Lift 3"
         },
         {
             "Area": 0,
             "Room": 30,
-            "Name": "Elevator to Sector 5 (ARC)"
+            "Name": "Sector Lift 5"
         },
         {
             "Area": 0,
@@ -3346,12 +3346,12 @@
         {
             "Area": 0,
             "Room": 40,
-            "Name": "Elevator to Sector Hub"
+            "Name": "Main Elevator"
         },
         {
             "Area": 0,
             "Room": 19,
-            "Name": "Elevator to Sector Hub"
+            "Name": "Main Elevator"
         },
         {
             "Area": 0,
@@ -3451,12 +3451,12 @@
         {
             "Area": 0,
             "Room": 60,
-            "Name": "Elevator to Crew Quarters"
+            "Name": "Operations Deck Elevator"
         },
         {
             "Area": 0,
             "Room": 61,
-            "Name": "Elevator to Operations Deck"
+            "Name": "Crew Quarters Elevator"
         },
         {
             "Area": 0,
@@ -3481,7 +3481,7 @@
         {
             "Area": 0,
             "Room": 67,
-            "Name": "Elevator to Tourian (SRX)"
+            "Name": "Restricted Zone Elevator"
         },
         {
             "Area": 0,
@@ -3511,7 +3511,7 @@
         {
             "Area": 0,
             "Room": 75,
-            "Name": "Elevator to Habitation Deck"
+            "Name": "Nexus Elevator"
         },
         {
             "Area": 0,
@@ -3696,7 +3696,7 @@
         {
             "Area": 1,
             "Room": 31,
-            "Name": "Elevator to Restricted Zone"
+            "Name": "Tourian Elevator"
         },
         {
             "Area": 1,

--- a/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starter_preset/world_1.json
@@ -3271,32 +3271,32 @@
         {
             "Area": 0,
             "Room": 25,
-            "Name": "Sector Lift 2"
+            "Name": "Sector Hub Lift 2"
         },
         {
             "Area": 0,
             "Room": 26,
-            "Name": "Sector Lift 4"
+            "Name": "Sector Hub Lift 4"
         },
         {
             "Area": 0,
             "Room": 27,
-            "Name": "Sector Lift 6"
+            "Name": "Sector Hub Lift 6"
         },
         {
             "Area": 0,
             "Room": 28,
-            "Name": "Sector Lift 1"
+            "Name": "Sector Hub Lift 1"
         },
         {
             "Area": 0,
             "Room": 29,
-            "Name": "Sector Lift 3"
+            "Name": "Sector Hub Lift 3"
         },
         {
             "Area": 0,
             "Room": 30,
-            "Name": "Sector Lift 5"
+            "Name": "Sector Hub Lift 5"
         },
         {
             "Area": 0,

--- a/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
@@ -4257,7 +4257,7 @@
         {
             "Area": 1,
             "Room": 41,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 1 (SRX) Entrance Elevator"
         },
         {
             "Area": 1,
@@ -4482,7 +4482,7 @@
         {
             "Area": 2,
             "Room": 29,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 2 (TRO) Entrance Elevator"
         },
         {
             "Area": 2,
@@ -4717,7 +4717,7 @@
         {
             "Area": 3,
             "Room": 20,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 3 (PYR) Entrance Elevator"
         },
         {
             "Area": 3,
@@ -4947,7 +4947,7 @@
         {
             "Area": 4,
             "Room": 27,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 4 (AQA) Entrance Elevator"
         },
         {
             "Area": 4,
@@ -5172,7 +5172,7 @@
         {
             "Area": 5,
             "Room": 25,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 5 (ARC) Entrance Elevator"
         },
         {
             "Area": 5,
@@ -5387,7 +5387,7 @@
         {
             "Area": 6,
             "Room": 17,
-            "Name": "Elevator to Main Deck"
+            "Name": "Sector 6 (NOC) Entrance Elevator"
         },
         {
             "Area": 6,

--- a/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
@@ -3782,32 +3782,32 @@
         {
             "Area": 0,
             "Room": 25,
-            "Name": "Elevator to Sector 2 (TRO)"
+            "Name": "Sector Lift 2"
         },
         {
             "Area": 0,
             "Room": 26,
-            "Name": "Elevator to Sector 4 (AQA)"
+            "Name": "Sector Lift 4"
         },
         {
             "Area": 0,
             "Room": 27,
-            "Name": "Elevator to Sector 6 (NOC)"
+            "Name": "Sector Lift 6"
         },
         {
             "Area": 0,
             "Room": 28,
-            "Name": "Elevator to Sector 1 (SRX)"
+            "Name": "Sector Lift 1"
         },
         {
             "Area": 0,
             "Room": 29,
-            "Name": "Elevator to Sector 3 (PYR)"
+            "Name": "Sector Lift 3"
         },
         {
             "Area": 0,
             "Room": 30,
-            "Name": "Elevator to Sector 5 (ARC)"
+            "Name": "Sector Lift 5"
         },
         {
             "Area": 0,
@@ -3857,12 +3857,12 @@
         {
             "Area": 0,
             "Room": 40,
-            "Name": "Elevator to Sector Hub"
+            "Name": "Main Elevator"
         },
         {
             "Area": 0,
             "Room": 19,
-            "Name": "Elevator to Sector Hub"
+            "Name": "Main Elevator"
         },
         {
             "Area": 0,
@@ -3962,12 +3962,12 @@
         {
             "Area": 0,
             "Room": 60,
-            "Name": "Elevator to Crew Quarters"
+            "Name": "Operations Deck Elevator"
         },
         {
             "Area": 0,
             "Room": 61,
-            "Name": "Elevator to Operations Deck"
+            "Name": "Crew Quarters Elevator"
         },
         {
             "Area": 0,
@@ -3992,7 +3992,7 @@
         {
             "Area": 0,
             "Room": 67,
-            "Name": "Elevator to Tourian (SRX)"
+            "Name": "Restricted Zone Elevator"
         },
         {
             "Area": 0,
@@ -4022,7 +4022,7 @@
         {
             "Area": 0,
             "Room": 75,
-            "Name": "Elevator to Habitation Deck"
+            "Name": "Nexus Elevator"
         },
         {
             "Area": 0,
@@ -4207,7 +4207,7 @@
         {
             "Area": 1,
             "Room": 31,
-            "Name": "Elevator to Restricted Zone"
+            "Name": "Tourian Elevator"
         },
         {
             "Area": 1,

--- a/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
@@ -4027,7 +4027,7 @@
         {
             "Area": 0,
             "Room": 76,
-            "Name": "Elevator to Central Nexus"
+            "Name": "Habitation Deck Elevator"
         },
         {
             "Area": 0,

--- a/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/starting_items/world_1.json
@@ -3782,32 +3782,32 @@
         {
             "Area": 0,
             "Room": 25,
-            "Name": "Sector Lift 2"
+            "Name": "Sector Hub Lift 2"
         },
         {
             "Area": 0,
             "Room": 26,
-            "Name": "Sector Lift 4"
+            "Name": "Sector Hub Lift 4"
         },
         {
             "Area": 0,
             "Room": 27,
-            "Name": "Sector Lift 6"
+            "Name": "Sector Hub Lift 6"
         },
         {
             "Area": 0,
             "Room": 28,
-            "Name": "Sector Lift 1"
+            "Name": "Sector Hub Lift 1"
         },
         {
             "Area": 0,
             "Room": 29,
-            "Name": "Sector Lift 3"
+            "Name": "Sector Hub Lift 3"
         },
         {
             "Area": 0,
             "Room": 30,
-            "Name": "Sector Lift 5"
+            "Name": "Sector Hub Lift 5"
         },
         {
             "Area": 0,


### PR DESCRIPTION
Helps https://github.com/randovania/randovania/issues/8931

### **_Please triple check my spellings and that you are sold on the renames_**

Renamed elevator nodes which also updated the connecitng doors.

Since Fusion RDV files for open sector hub and also unlock save stations were affected by the changes, wrote a migration for those doors affected. I could not see any other previous setting or otherwise that was impacted that needed migration.

DZ mentioned that since the game data hash was impacted by renaming nodes, I have updated that file via the cli command.

Updated changelog

Testing
- Generated and exported games
- Imported a ton of various old RDV games
- Verified changes on old imported RDV games after migration
- Verfied new changes in newley generated games

<img width="1197" height="801" alt="image" src="https://github.com/user-attachments/assets/1c709fdc-0358-439d-9c4a-fa679ecdd569" />

<img width="1197" height="801" alt="image" src="https://github.com/user-attachments/assets/aa6cf466-ab3f-47fe-8c91-f21c27073967" />

<img width="1197" height="801" alt="image" src="https://github.com/user-attachments/assets/e1f99ed5-7e5a-4153-b6ab-d9915e4d0cbe" />
