### PR TITLE
Fusion: Mark cathedral to save access doors as excluded from DLR

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -2999,7 +2999,7 @@
                         "y": 112.0,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "excluded from DLR due to hatch limitations",
                     "layers": [
                         "default"
                     ],
@@ -3017,7 +3017,7 @@
                         "node": "Door to Cathedral"
                     },
                     "default_dock_weakness": "Open Hatch",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -3596,7 +3596,7 @@
                         "y": 112.0,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "excluded from DLR due to hatch limitations",
                     "layers": [
                         "default"
                     ],
@@ -3613,7 +3613,7 @@
                         "node": "Door to Cathedral Save Access"
                     },
                     "default_dock_weakness": "Open Hatch",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -481,7 +481,8 @@ Extra - minimap_coordinates: [{'x': 6, 'y': 6}, {'x': 6, 'y': 7}, {'x': 6, 'y': 
 
 > Door to Cathedral Save Access; Heals? False
   * Layers: default
-  * Open Hatch to Cathedral Save Access/Door to Cathedral
+  * Open Hatch to Cathedral Save Access/Door to Cathedral; Excluded from Dock Lock Rando
+  * excluded from DLR due to hatch limitations
   * Extra - door_idx: (29, 105)
   > Door to Puyo Corridor
       Trivial
@@ -582,7 +583,8 @@ Extra - room_id: [15]
 Extra - minimap_coordinates: [{'x': 7, 'y': 13}, {'x': 8, 'y': 13}]
 > Door to Cathedral; Heals? False
   * Layers: default
-  * Open Hatch to Cathedral/Door to Cathedral Save Access
+  * Open Hatch to Cathedral/Door to Cathedral Save Access; Excluded from Dock Lock Rando
+  * excluded from DLR due to hatch limitations
   * Extra - door_idx: (35,)
   > Door to Cathedral Save Room
       Trivial


### PR DESCRIPTION
no changelog as this has no user facing change