### PR TITLE
Prime: update max etanks

### DIFF
--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -173,7 +173,7 @@
             },
             "EnergyTank": {
                 "long_name": "Energy Tank",
-                "max_capacity": 200,
+                "max_capacity": 127,
                 "extra": {
                     "item_id": 24
                 }

--- a/test/test_files/patcher_data/prime1/dread_prime1_multiworld/world_2.json
+++ b/test/test_files/patcher_data/prime1/dread_prime1_multiworld/world_2.json
@@ -93,7 +93,7 @@
         },
         "etankCapacity": 100,
         "itemMaxCapacity": {
-            "Energy Tank": 200,
+            "Energy Tank": 127,
             "Power Bomb": 99,
             "Missile": 999,
             "Unknown Item 1": 65536

--- a/test/test_files/patcher_data/prime1/multi-am2r+cs+dread+prime1+prime2+msr/world_3.json
+++ b/test/test_files/patcher_data/prime1/multi-am2r+cs+dread+prime1+prime2+msr/world_3.json
@@ -89,7 +89,7 @@
         },
         "etankCapacity": 100,
         "itemMaxCapacity": {
-            "Energy Tank": 200,
+            "Energy Tank": 127,
             "Power Bomb": 99,
             "Missile": 999,
             "Unknown Item 1": 65536

--- a/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_2.json
+++ b/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_2.json
@@ -89,7 +89,7 @@
         },
         "etankCapacity": 100,
         "itemMaxCapacity": {
-            "Energy Tank": 200,
+            "Energy Tank": 127,
             "Power Bomb": 99,
             "Missile": 999,
             "Unknown Item 1": 65536

--- a/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_6.json
+++ b/test/test_files/patcher_data/prime1/multi-cs+dread+prime1+prime2/world_6.json
@@ -89,7 +89,7 @@
         },
         "etankCapacity": 100,
         "itemMaxCapacity": {
-            "Energy Tank": 200,
+            "Energy Tank": 127,
             "Power Bomb": 99,
             "Missile": 999,
             "Unknown Item 1": 65536

--- a/test/test_files/patcher_data/prime1/multi_coop_am2r+bdg+cs+dread+prime1+echoes+msr/world_5.json
+++ b/test/test_files/patcher_data/prime1/multi_coop_am2r+bdg+cs+dread+prime1+echoes+msr/world_5.json
@@ -89,7 +89,7 @@
         },
         "etankCapacity": 100,
         "itemMaxCapacity": {
-            "Energy Tank": 200,
+            "Energy Tank": 127,
             "Power Bomb": 99,
             "Missile": 999,
             "Unknown Item 1": 65536

--- a/test/test_files/patcher_data/prime1/prime1-vanilla/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1-vanilla/world_1.json
@@ -89,7 +89,7 @@
         },
         "etankCapacity": 100,
         "itemMaxCapacity": {
-            "Energy Tank": 200,
+            "Energy Tank": 127,
             "Power Bomb": 99,
             "Missile": 999,
             "Unknown Item 1": 65536

--- a/test/test_files/patcher_data/prime1/prime1/damage-check/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1/damage-check/world_1.json
@@ -89,7 +89,7 @@
         },
         "etankCapacity": 100,
         "itemMaxCapacity": {
-            "Energy Tank": 200,
+            "Energy Tank": 127,
             "Power Bomb": 99,
             "Missile": 999,
             "Unknown Item 1": 65536

--- a/test/test_files/patcher_data/prime1/prime1_and_2_multi/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_and_2_multi/world_1.json
@@ -93,7 +93,7 @@
         },
         "etankCapacity": 110,
         "itemMaxCapacity": {
-            "Energy Tank": 200,
+            "Energy Tank": 127,
             "Power Bomb": 99,
             "Missile": 999,
             "Unknown Item 1": 65536

--- a/test/test_files/patcher_data/prime1/prime1_crazy_seed/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_crazy_seed/world_1.json
@@ -93,7 +93,7 @@
         },
         "etankCapacity": 78,
         "itemMaxCapacity": {
-            "Energy Tank": 200,
+            "Energy Tank": 127,
             "Power Bomb": 99,
             "Missile": 999,
             "Unknown Item 1": 65536

--- a/test/test_files/patcher_data/prime1/prime1_crazy_seed_one_way_door/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_crazy_seed_one_way_door/world_1.json
@@ -98,7 +98,7 @@
         },
         "etankCapacity": 78,
         "itemMaxCapacity": {
-            "Energy Tank": 200,
+            "Energy Tank": 127,
             "Power Bomb": 99,
             "Missile": 999,
             "Unknown Item 1": 65536

--- a/test/test_files/patcher_data/prime1/prime1_refills/world_1.json
+++ b/test/test_files/patcher_data/prime1/prime1_refills/world_1.json
@@ -89,7 +89,7 @@
         },
         "etankCapacity": 100,
         "itemMaxCapacity": {
-            "Energy Tank": 200,
+            "Energy Tank": 127,
             "Power Bomb": 99,
             "Missile": 999,
             "Unknown Item 1": 65536


### PR DESCRIPTION
https://discordapp.com/channels/914291389293027329/1494003116410933269
sentry reported user making a preset with 200 etanks, error comes from starting etanks being i8 (127).

I do not know how this interacts in-game with starting 127 etanks then collecting another. 