### PR TITLE
Fusion: remove mars version from stable exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Door Lock Randomizer is now available.
 - Fixed: Low-Health alarm now plays correctly when using the alternative Health Display.
 - Fixed: HUD no longer disappears after saving the animals (again).
+- Removed: MARS patcher version no longer appears on title screen.
 
 #### Logic Database
 

--- a/randovania/games/fusion/exporter/game_exporter.py
+++ b/randovania/games/fusion/exporter/game_exporter.py
@@ -53,10 +53,10 @@ class FusionGameExporter(GameExporter[FusionGameExportParams]):
         from mars_patcher import patcher
         from mars_patcher.version import version as mars_patcher_version
 
-        # Add rdv and patcher version to patch data
+        # Always add RDV version with patcher version conditionally to patch data
         text = [
             f"Randovania  : {randovania.VERSION}",
-            f"MARS Patcher: {mars_patcher_version}",
+            f"MARS Patcher: {mars_patcher_version}" if randovania.is_dev_version() else "",
         ]
         for index, line in enumerate(text):
             if len(line) > 30:

--- a/randovania/games/fusion/exporter/game_exporter.py
+++ b/randovania/games/fusion/exporter/game_exporter.py
@@ -53,11 +53,17 @@ class FusionGameExporter(GameExporter[FusionGameExportParams]):
         from mars_patcher import patcher
         from mars_patcher.version import version as mars_patcher_version
 
-        # Always add RDV version with patcher version conditionally to patch data
-        text = [
-            f"Randovania  : {randovania.VERSION}",
-            f"MARS Patcher: {mars_patcher_version}" if randovania.is_dev_version() else "",
-        ]
+        # Always add RDV version, add patcher version only if dev/source
+        if randovania.is_dev_version():
+            text = [
+                f"Randovania  : {randovania.VERSION}",
+                f"MARS Patcher: {mars_patcher_version}",
+            ]
+        else:
+            text = [
+                f"Randovania {randovania.VERSION}",
+            ]
+
         for index, line in enumerate(text):
             if len(line) > 30:
                 text[index] = f"{line[0:27]}..."


### PR DESCRIPTION
patcher version really only useful in dev/source, see related discussion https://discordapp.com/channels/914291389293027329/1362190173953065162/1496481203740737756

<img width="463" height="369" alt="image" src="https://github.com/user-attachments/assets/d6befe0e-4134-48e4-92a1-aae4c4d9f9a4" />

^ ignore the dev123... I just `not` the condition to quickly test