### PR TITLE
Dread: Add probability offset for placing Energy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid Dread
 
 - Changed: Increased likelihood that doors that are logically challenging to reach get locks when using Individual Doors mode to randomize Door Locks.
+- Changed: Increased likelihood of the generator placing Energy Tanks or Energy Parts sooner.
 
 ### Metroid Fusion
 

--- a/randovania/games/dread/game_data.py
+++ b/randovania/games/dread/game_data.py
@@ -85,7 +85,7 @@ def _test_data() -> randovania.game.game_test_data.GameTestData:
     from randovania.layout.base.trick_level import LayoutTrickLevel
 
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="O4VMW5GZ",
+        expected_seed_hash="EUXNKOFR",
         # Some items require shinesparking to reach in vanilla,
         # which due to varying difficulty has been made into a trick
         database_collectable_include_tricks=(("Speedbooster", LayoutTrickLevel.BEGINNER),),

--- a/randovania/games/dread/pickup_database/pickup-database.json
+++ b/randovania/games/dread/pickup_database/pickup-database.json
@@ -852,6 +852,7 @@
                 "samus_returns": "item_energytank"
             },
             "preferred_location_category": "major",
+            "probability_offset": 1.5,
             "progression": [
                 "ETank"
             ],
@@ -874,6 +875,7 @@
                 "samus_returns": "item_energytank"
             },
             "preferred_location_category": "minor",
+            "probability_offset": 1.5,
             "progression": [
                 "EFragment"
             ],


### PR DESCRIPTION
A probability offset it being added for Energy Tanks and Energy Parts for the purpose of increasing the likelihood of boss fights being collected by the generator in an order more similar to what a player might intuitively choose to.

The energy requirements for bosses has a progressive nature, where the first ones must be satisfied first, and the Raven Beak fight is typically the last requirement to beat the game.

With there typically being more energy in the pool than necessary, there are good chances that the player will find energy that was backfilled anyway. Thus, increasing the likelihood of placing energy logically is an attempt at having the logic chain more closely track what a player can reason about being logical.