### PR TITLE
Echoes: Add Dark and Light Ammo Expansions to dark- and light-aligned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.8.0] - 2026-06-??
+
+### Metroid Prime 2: Echoes
+
+- Changed: Dark, Light, and Beam Ammo Expansions are now considered dark-aligned, light-aligned and both, respectively.
+
+
 ## [10.7.0] - 2026-05-02
 
 ### Generator

--- a/randovania/games/prime2/game_data.py
+++ b/randovania/games/prime2/game_data.py
@@ -96,7 +96,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="SRPD77EX",
+        expected_seed_hash="C4JV33FH",
         database_collectable_ignore_events=("Event91", "Event92", "Event97"),
     )
 

--- a/randovania/games/prime2/pickup_database/pickup-database.json
+++ b/randovania/games/prime2/pickup_database/pickup-database.json
@@ -1359,7 +1359,8 @@
                 "beam_related",
                 "expansion",
                 "luminoth",
-                "targeting"
+                "targeting",
+                "dark"
             ],
             "model_name": "DarkBeamAmmoExpansion",
             "offworld_models": {
@@ -1381,7 +1382,8 @@
                 "beam_related",
                 "expansion",
                 "luminoth",
-                "targeting"
+                "targeting",
+                "light"
             ],
             "model_name": "LightBeamAmmoExpansion",
             "offworld_models": {
@@ -1403,7 +1405,9 @@
                 "beam_related",
                 "expansion",
                 "luminoth",
-                "targeting"
+                "targeting",
+                "dark",
+                "light"
             ],
             "model_name": "BeamAmmoExpansion",
             "offworld_models": {


### PR DESCRIPTION
It doesn't make sense for the ammo expansions to not be part of these pickup features.