### PR TITLE
Fix guest user login

### DIFF
--- a/randovania/network_client/network_client.py
+++ b/randovania/network_client/network_client.py
@@ -783,13 +783,14 @@ class NetworkClient:
         return {AuthenticationMethod(r) for r in result}
 
     async def login_as_guest(self, name: str) -> None:
-        async with self.server_post("guest_login", data={"name": name}) as response:
+        if self.connection_state != ConnectionState.Connected:
+            await self.connect_to_server()
+
+        async with self.server_post("guest_login", data={"name": name, "sid": self.sio.get_sid()}) as response:
             response.raise_for_status()
             new_session = await response.json()
 
         await self.on_user_session_updated(new_session)
-        if self.connection_state != ConnectionState.Connected:
-            await self.connect_to_server()
 
     def server_get(
         self,

--- a/randovania/server/user_session.py
+++ b/randovania/server/user_session.py
@@ -49,12 +49,7 @@ def _log_session_info(sa: ServerApp, sid: str, user: User) -> None:
     sa.logger.info(f"Client at {sa.current_client_ip(sid)} is user {user.name} ({user.id}).")
 
 
-async def _create_client_side_session(
-    sa: ServerApp, sid: str | None, user: User | None, session: dict | None = None
-) -> dict:
-
-    # The sid should never be None here
-    assert sid is not None
+async def _create_client_side_session(sa: ServerApp, sid: str, user: User | None, session: dict | None = None) -> dict:
     """
 
     :param user: If the session's user was already retrieved, pass it along to avoid an extra query.
@@ -346,10 +341,8 @@ async def guest_login_post(
         discord_id=None,
     )
 
-    session = {}
-
-    session["user-id"] = user.id
-    await sa.sio.save_session(sid, session)
+    async with sa.sio.session(sid) as session:
+        session["user-id"] = user.id
 
     if sa.is_api_request(request):
         return JSONResponse(await _create_client_side_session(sa, sid, user, session))

--- a/randovania/server/user_session.py
+++ b/randovania/server/user_session.py
@@ -38,12 +38,16 @@ def _encrypt_session_for_user(sa: ServerApp, session: dict) -> str:
 
 def _create_client_side_session_raw(sa: ServerApp, sid: str | None, user: User) -> dict:
     if sid is not None:
-        sa.logger.info(f"Client at {sa.current_client_ip(sid)} is user {user.name} ({user.id}).")
+        _log_session_info(sa, sid, user)
 
     return {
         "sid": sid,
         "user": user.as_json,
     }
+
+
+def _log_session_info(sa: ServerApp, sid: str | None, user: User):
+    sa.logger.info(f"Client at {sa.current_client_ip(sid)} is user {user.name} ({user.id}).")
 
 
 async def _create_client_side_session(
@@ -330,7 +334,9 @@ async def guest_login(sa: ServerAppDep, request: Request) -> Response:
 
 
 @router.post("/guest_login")
-async def guest_login_post(sa: ServerAppDep, request: Request, name: typing.Annotated[str, Form()]) -> Response:
+async def guest_login_post(
+    sa: ServerAppDep, request: Request, name: typing.Annotated[str, Form()], sid: typing.Annotated[str, Form()]
+) -> Response:
     if not sa.app.debug:
         return unable_to_login(sa, request, "Unable to perform login", 400)
 
@@ -342,8 +348,7 @@ async def guest_login_post(sa: ServerAppDep, request: Request, name: typing.Anno
     request.session["user_id"] = user.id
 
     if sa.is_api_request(request):
-        # TODO: get the `sid` from the header? Though all it'll do is send that back to the client
-        return JSONResponse(await _create_client_side_session(sa, None, user, {"user-id": user.id}))
+        return JSONResponse(await _create_client_side_session(sa, sid, user, {"user-id": user.id}))
     else:
         return RedirectResponse(
             request.url_for("browser_me"),

--- a/randovania/server/user_session.py
+++ b/randovania/server/user_session.py
@@ -46,7 +46,7 @@ def _create_client_side_session_raw(sa: ServerApp, sid: str | None, user: User) 
     }
 
 
-def _log_session_info(sa: ServerApp, sid: str | None, user: User):
+def _log_session_info(sa: ServerApp, sid: str, user: User) -> None:
     sa.logger.info(f"Client at {sa.current_client_ip(sid)} is user {user.name} ({user.id}).")
 
 

--- a/randovania/server/user_session.py
+++ b/randovania/server/user_session.py
@@ -346,10 +346,13 @@ async def guest_login_post(
         discord_id=None,
     )
 
-    request.session["user_id"] = user.id
+    session = {}
+
+    session["user-id"] = user.id
+    await sa.sio.save_session(sid, session)
 
     if sa.is_api_request(request):
-        return JSONResponse(await _create_client_side_session(sa, sid, user, {"user-id": user.id}))
+        return JSONResponse(await _create_client_side_session(sa, sid, user, session))
     else:
         return RedirectResponse(
             request.url_for("browser_me"),

--- a/randovania/server/user_session.py
+++ b/randovania/server/user_session.py
@@ -36,9 +36,8 @@ def _encrypt_session_for_user(sa: ServerApp, session: dict) -> str:
     return base64.b85encode(encrypted_session).decode("ascii")
 
 
-def _create_client_side_session_raw(sa: ServerApp, sid: str | None, user: User) -> dict:
-    if sid is not None:
-        _log_session_info(sa, sid, user)
+def _create_client_side_session_raw(sa: ServerApp, sid: str, user: User) -> dict:
+    _log_session_info(sa, sid, user)
 
     return {
         "sid": sid,
@@ -53,13 +52,15 @@ def _log_session_info(sa: ServerApp, sid: str, user: User) -> None:
 async def _create_client_side_session(
     sa: ServerApp, sid: str | None, user: User | None, session: dict | None = None
 ) -> dict:
+
+    # The sid should never be None here
+    assert sid is not None
     """
 
     :param user: If the session's user was already retrieved, pass it along to avoid an extra query.
     :return:
     """
     if session is None:
-        assert sid is not None
         session = await sa.sio.get_session(sid)
 
     if user is None:

--- a/test/network_client/test_network_client.py
+++ b/test/network_client/test_network_client.py
@@ -523,10 +523,11 @@ async def test_login_as_guest(client: NetworkClient):
     client.on_user_session_updated = AsyncMock()
     client.connect_to_server = AsyncMock()
     client.server_post = MagicMock(return_value=MockResponse({"data": 5}, 200))
+    client.sio.get_sid = MagicMock(return_value="1234")
 
     await client.login_as_guest("Foo")
 
-    client.server_post.assert_called_once_with("guest_login", data={"name": "Foo"})
+    client.server_post.assert_called_once_with("guest_login", data={"name": "Foo", "sid": "1234"})
     client.on_user_session_updated.assert_awaited_once_with({"data": 5})
     client.connect_to_server.assert_awaited_once_with()
 

--- a/test/server/test_user_session.py
+++ b/test/server/test_user_session.py
@@ -299,6 +299,40 @@ async def test_restore_user_session_with_discord(mock_sa, fernet, mocker: pytest
     assert result is discord_result
 
 
+async def test_restore_plain_user_session(mock_sa, fernet, mocker: pytest_mock.MockerFixture):
+    session_result = MagicMock()
+
+    mock_create_client_side = mocker.patch(
+        "randovania.server.user_session._create_client_side_session", autospec=True, return_value=session_result
+    )
+
+    mock_sa.sio.save_session = AsyncMock()
+
+    mock_sa.fernet_encrypt = fernet
+
+    session = {
+        "user-id": 1234,
+    }
+
+    plain_user = {
+        "id": 1234,
+        "name": "Foo",
+    }
+
+    User.get_by_id = MagicMock(return_value=plain_user)
+
+    enc_session = fernet.encrypt(json.dumps(session).encode("utf-8"))
+
+    # Run
+    result = await user_session.restore_user_session(mock_sa, "TheSid", enc_session)
+
+    # Assert
+    mock_sa.sio.save_session.assert_called_once_with("TheSid", session)
+    mock_create_client_side.assert_called_once_with(mock_sa, "TheSid", plain_user)
+
+    assert result is session_result
+
+
 async def test_logout(mock_sa, mocker: MockerFixture):
     mock_leave_all_rooms = mocker.patch("randovania.server.multiplayer.session_common.leave_all_rooms", autospec=True)
 
@@ -369,6 +403,8 @@ async def test_guest_login_form(test_client):
 async def test_guest_login_post_valid_json(test_client, clean_database, mocker: pytest_mock.MockerFixture):
     mocker.patch("randovania.server.user_session._log_session_info")
 
+    test_client.sa.sio.save_session = AsyncMock()
+
     response = test_client.post(
         "/guest_login", headers={"Accept": "application/json"}, data={"name": "Foo", "sid": "1234"}
     )
@@ -382,6 +418,8 @@ async def test_guest_login_post_valid_json(test_client, clean_database, mocker: 
 
 
 async def test_guest_login_post_valid_web(test_client, clean_database):
+    test_client.sa.sio.save_session = AsyncMock()
+
     response = test_client.post("/guest_login", data={"name": "Foo", "sid": "1234"}, follow_redirects=False)
     assert response.status_code == 303
     assert response.headers["Location"] == "http://testserver/me"

--- a/test/server/test_user_session.py
+++ b/test/server/test_user_session.py
@@ -398,7 +398,8 @@ async def test_guest_login_form(test_client):
 async def test_guest_login_post_valid_json(test_client, clean_database, mocker: pytest_mock.MockerFixture):
     mocker.patch("randovania.server.user_session._log_session_info")
 
-    test_client.sa.sio.save_session = AsyncMock()
+    test_client.sa.sio.session = MagicMock()
+    test_client.sa.sio.session.return_value.__aenter__.return_value = {}
 
     response = test_client.post(
         "/guest_login", headers={"Accept": "application/json"}, data={"name": "Foo", "sid": "1234"}
@@ -413,7 +414,8 @@ async def test_guest_login_post_valid_json(test_client, clean_database, mocker: 
 
 
 async def test_guest_login_post_valid_web(test_client, clean_database):
-    test_client.sa.sio.save_session = AsyncMock()
+    test_client.sa.sio.session = MagicMock()
+    test_client.sa.sio.session.return_value.__aenter__.return_value = {}
 
     response = test_client.post("/guest_login", data={"name": "Foo", "sid": "1234"}, follow_redirects=False)
     assert response.status_code == 303

--- a/test/server/test_user_session.py
+++ b/test/server/test_user_session.py
@@ -299,7 +299,7 @@ async def test_restore_user_session_with_discord(mock_sa, fernet, mocker: pytest
     assert result is discord_result
 
 
-async def test_restore_plain_user_session(mock_sa, fernet, mocker: pytest_mock.MockerFixture):
+async def test_restore_plain_user_session(mock_sa, fernet, mocker: pytest_mock.MockerFixture, clean_database):
     session_result = MagicMock()
 
     mock_create_client_side = mocker.patch(
@@ -314,12 +314,7 @@ async def test_restore_plain_user_session(mock_sa, fernet, mocker: pytest_mock.M
         "user-id": 1234,
     }
 
-    plain_user = {
-        "id": 1234,
-        "name": "Foo",
-    }
-
-    User.get_by_id = MagicMock(return_value=plain_user)
+    plain_user = User.create(id=1234, name="Foo")
 
     enc_session = fernet.encrypt(json.dumps(session).encode("utf-8"))
 

--- a/test/server/test_user_session.py
+++ b/test/server/test_user_session.py
@@ -366,19 +366,23 @@ async def test_guest_login_form(test_client):
     assert '<input id="name" placeholder="User name to login as" name="name">' in response.text
 
 
-async def test_guest_login_post_valid_json(test_client, clean_database):
-    response = test_client.post("/guest_login", headers={"Accept": "application/json"}, data={"name": "Foo"})
+async def test_guest_login_post_valid_json(test_client, clean_database, mocker: pytest_mock.MockerFixture):
+    mocker.patch("randovania.server.user_session._log_session_info")
+
+    response = test_client.post(
+        "/guest_login", headers={"Accept": "application/json"}, data={"name": "Foo", "sid": "1234"}
+    )
     response.raise_for_status()
     assert response.json() == {
         "encoded_session_b85": ANY,
-        "sid": None,
+        "sid": "1234",
         "user": {"discord_id": None, "id": 1, "name": "Guest: Foo"},
     }
     assert User.get_by_id(1).name == "Guest: Foo"
 
 
 async def test_guest_login_post_valid_web(test_client, clean_database):
-    response = test_client.post("/guest_login", data={"name": "Foo"}, follow_redirects=False)
+    response = test_client.post("/guest_login", data={"name": "Foo", "sid": "1234"}, follow_redirects=False)
     assert response.status_code == 303
     assert response.headers["Location"] == "http://testserver/me"
     assert response.text == ""
@@ -388,7 +392,9 @@ async def test_guest_login_post_valid_web(test_client, clean_database):
 async def test_guest_login_post_not_debug(test_client):
     test_client.sa.app.debug = False
 
-    response = test_client.post("/guest_login", headers={"Accept": "application/json"}, data={"name": "Foo"})
+    response = test_client.post(
+        "/guest_login", headers={"Accept": "application/json"}, data={"name": "Foo", "sid": "1234"}
+    )
     assert response.status_code == 400
     assert response.json() == {"error_message": "Unable to perform login"}
 


### PR DESCRIPTION
When playing around with the guest user for testing some multi-world stuff, I was unable to create a session after creating the user. 

The error message was in the form 
```
  File "/home/ImperatorPrime/Projects/randovania/randovania/gui/main_online_interaction.py", line 200, in _host_game_session
    new_session = await self.network_client.create_new_session(session_name)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ImperatorPrime/Projects/randovania/randovania/network_client/network_client.py", line 689, in create_new_session
    assert self.http.headers["X-Randovania-Sid"] is not None
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
KeyError: 'X-Randovania-Sid'
```

I tracked this down to the on_user_session_updated not adding the X-Randovania-Sid header to the session returned when the user is first created. I changed the guest login to connect first (which would get an sid) and then post to the guest login, properly creating the client session with the sid, which on_user_session_updated uses to correctly set the  X-Randovania-Sid http header. After this fix, I encountered no issues with the guest login. I also tweaked the guest user tests to now support passing in an sid.

I had browsing not work after the first guest user was created, but it seems to go away without a restart. Not sure exactly what's going on there.