### PR TITLE
fix damage reductions multipliers above 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed: When using logical pickup placement set to Major pickups or All pickups, generated pickups would not be considered required. For example, Red Keys in Metroid Prime 2: Echoes.
 
+### Resolver
+
+- Fixed: An issue where damage reduction multipliers above 1.0 were being ignored.
+
 ### Metroid Dread
 
 - Added: Unique Save Slots cosmetic option. Stores this randomizer's saves in a unique location based on the seed hash.

--- a/randovania/game_description/resources/resource_database.py
+++ b/randovania/game_description/resources/resource_database.py
@@ -157,19 +157,27 @@ class ResourceDatabase(ResourceDatabaseView):
     def energy_tank(self) -> ItemResourceInfo:
         return self.energy_tank_item
 
+    # FIXME implement a way to have certain individual reductions not apply the base_damage_reduction
     @override
     def get_damage_reduction(self, resource: ResourceInfo, current_resources: ResourceCollection) -> float:
         base_reduction = self.base_damage_reduction(self, current_resources)
+        reductions = self.damage_reductions.get(resource, [])
 
-        damage_multiplier = 1.0
-        for reduction in self.damage_reductions.get(resource, []):
+        # loop through all valid reductions with current inventory and collect the multipliers
+        multipliers = []
+        for reduction in reductions:
             if (
                 reduction.inventory_item is None
                 or current_resources[reduction.inventory_item] >= reduction.item_quantity
             ):
-                damage_multiplier = min(damage_multiplier, reduction.damage_multiplier)
+                multipliers.append(reduction.damage_multiplier)
 
-        return damage_multiplier * base_reduction
+        # if there are no valid multipliers return base_reduction
+        if not multipliers:
+            return base_reduction
+
+        # return the lowest valid multiplier * base_reduction
+        return min(multipliers) * base_reduction
 
     @override
     def get_all_damage_reductions(self) -> dict[ResourceInfo, list[DamageReduction]]:

--- a/randovania/games/fusion/generator/bootstrap.py
+++ b/randovania/games/fusion/generator/bootstrap.py
@@ -89,8 +89,9 @@ class FusionBootstrap(Bootstrap[FusionConfiguration]):
         default_cold_dmg = 15
         damage_reductions[db.get_damage("LavaDamage")] = [
             DamageReduction(None, 0, configuration.lava_damage / default_lava_dmg),
+            # FIXME 1.1x is required to offset the base_reduction of 0.9x until base_reduction can be ignored
             DamageReduction(
-                db.get_item_by_display_name("Varia Suit"), 1, 0.4 * (configuration.lava_damage / default_lava_dmg)
+                db.get_item_by_display_name("Varia Suit"), 1, (configuration.lava_damage / default_lava_dmg) * 1.1
             ),
             DamageReduction(db.get_item_by_display_name("Both Suits"), 2, 0.0),
         ]

--- a/randovania/games/fusion/generator/bootstrap.py
+++ b/randovania/games/fusion/generator/bootstrap.py
@@ -89,9 +89,9 @@ class FusionBootstrap(Bootstrap[FusionConfiguration]):
         default_cold_dmg = 15
         damage_reductions[db.get_damage("LavaDamage")] = [
             DamageReduction(None, 0, configuration.lava_damage / default_lava_dmg),
-            # FIXME 1.1x is required to offset the base_reduction of 0.9x until base_reduction can be ignored
+            # FIXME the "/ 0.9" is required to offset the base_reduction until it can be ignored
             DamageReduction(
-                db.get_item_by_display_name("Varia Suit"), 1, (configuration.lava_damage / default_lava_dmg) * 1.1
+                db.get_item_by_display_name("Varia Suit"), 1, (configuration.lava_damage / default_lava_dmg) / 0.9
             ),
             DamageReduction(db.get_item_by_display_name("Both Suits"), 2, 0.0),
         ]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -711,6 +711,7 @@ SOLO_RDVGAMES = [
     ("fusion/all_hidden_with_random.rdvgame", True),
     ("fusion/starting_items.rdvgame", True),
     ("fusion/lots_of_random_starting_items.rdvgame", True),
+    ("fusion/high_lava_dmg.rdvgame", False),  # expected configured lava dmg too high for solver
     # Dread
     ("dread/vanilla.rdvgame", True),  # vanilla
     ("dread/starter_preset.rdvgame", False),  # starter preset

--- a/test/games/fusion/generator/test_fusion_bootstrap.py
+++ b/test/games/fusion/generator/test_fusion_bootstrap.py
@@ -46,8 +46,8 @@ def test_assign_pool_results_predetermined(fusion_game_description, fusion_confi
 @pytest.mark.parametrize(
     ("dmg_type", "dmg_configured", "dmg_multiplier", "config_value"),
     [
-        ("LavaDamage", 40, [2.0, 2.2, 0.0], "lava_damage"),
-        ("LavaDamage", 10, [0.5, 0.55, 0.0], "lava_damage"),
+        ("LavaDamage", 40, [2.0, 2.0 / 0.9, 0.0], "lava_damage"),
+        ("LavaDamage", 10, [0.5, 0.5 / 0.9, 0.0], "lava_damage"),
         ("HeatDamage", 60, [10.0, 0.0], "heat_damage"),
         ("AcidDamage", 6, [0.1], "acid_damage"),
         ("ColdDamage", 45, [3.0, 0.0], "cold_damage"),

--- a/test/games/fusion/generator/test_fusion_bootstrap.py
+++ b/test/games/fusion/generator/test_fusion_bootstrap.py
@@ -46,8 +46,8 @@ def test_assign_pool_results_predetermined(fusion_game_description, fusion_confi
 @pytest.mark.parametrize(
     ("dmg_type", "dmg_configured", "dmg_multiplier", "config_value"),
     [
-        ("LavaDamage", 40, [2.0, 0.8, 0.0], "lava_damage"),
-        ("LavaDamage", 10, [0.5, 0.2, 0.0], "lava_damage"),
+        ("LavaDamage", 40, [2.0, 2.2, 0.0], "lava_damage"),
+        ("LavaDamage", 10, [0.5, 0.55, 0.0], "lava_damage"),
         ("HeatDamage", 60, [10.0, 0.0], "heat_damage"),
         ("AcidDamage", 6, [0.1], "acid_damage"),
         ("ColdDamage", 45, [3.0, 0.0], "cold_damage"),

--- a/test/test_files/log_files/fusion/high_lava_dmg.rdvgame
+++ b/test/test_files/log_files/fusion/high_lava_dmg.rdvgame
@@ -1,0 +1,1666 @@
+{
+    "schema_version": 41,
+    "info": {
+        "randovania_version": "10.8.0.dev77",
+        "randovania_version_git": "431d0ab5",
+        "permalink": "DYnDQ6N6yUMdCrUfOK9nlu_mn1Bp5G5wDYzTJCFDa0RGzpXY7fUTvQfhFyRX",
+        "has_spoiler": true,
+        "seed": 1733500080,
+        "hash": "YNB2G6WJ",
+        "word_hash": "Bob Laboratory Containment",
+        "presets": [
+            {
+                "schema_version": 114,
+                "base_preset_uuid": null,
+                "name": "Force lava lake first item",
+                "uuid": "d65b95cb-0e48-445c-8ae7-821c993137ba",
+                "description": "A copy version of Open Sector Hub.",
+                "game": "fusion",
+                "configuration": {
+                    "trick_level": {
+                        "minimal_logic": false,
+                        "specific_levels": {
+                            "Combat": "ludicrous",
+                            "DamageRuns": "ludicrous"
+                        }
+                    },
+                    "starting_location": [
+                        {
+                            "region": "Sector 1 (SRX)",
+                            "area": "Twin Junctions Save Room",
+                            "node": "Save Station"
+                        }
+                    ],
+                    "available_locations": {
+                        "randomization_mode": "full",
+                        "excluded_indices": [
+                            13,
+                            14,
+                            21,
+                            101,
+                            125
+                        ]
+                    },
+                    "standard_pickup_configuration": {
+                        "pickups_state": {
+                            "Charge Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Wide Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Plasma Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Wave Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Ice Beam": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Missile Launcher Data": {
+                                "num_shuffled_pickups": 1,
+                                "included_ammo": [
+                                    10
+                                ]
+                            },
+                            "Super Missile Data": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Ice Missile Data": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Diffusion Missile Data": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Morph Ball": {
+                                "num_included_in_starting_pickups": 1
+                            },
+                            "Morph Ball Bomb Data": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Power Bomb Data": {
+                                "num_shuffled_pickups": 1,
+                                "included_ammo": [
+                                    10
+                                ]
+                            },
+                            "Hi-Jump": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Space Jump": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Speed Booster": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Screw Attack": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Varia Suit": {
+                                "num_included_in_starting_pickups": 1
+                            },
+                            "Gravity Suit": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Energy Tank": {
+                                "num_included_in_starting_pickups": 6
+                            },
+                            "Level 0 Keycard": {
+                                "num_included_in_starting_pickups": 1
+                            },
+                            "Level 1 Keycard": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Level 2 Keycard": {},
+                            "Level 3 Keycard": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Level 4 Keycard": {
+                                "num_shuffled_pickups": 1
+                            }
+                        },
+                        "default_pickups": {},
+                        "minimum_random_starting_pickups": 0,
+                        "maximum_random_starting_pickups": 0
+                    },
+                    "ammo_pickup_configuration": {
+                        "pickups_state": {
+                            "Missile Tank": {
+                                "ammo_count": [
+                                    5
+                                ],
+                                "pickup_count": 48,
+                                "requires_main_item": true
+                            },
+                            "Power Bomb Tank": {
+                                "ammo_count": [
+                                    2
+                                ],
+                                "pickup_count": 32,
+                                "requires_main_item": true
+                            }
+                        }
+                    },
+                    "damage_strictness": 1.5,
+                    "pickup_model_style": "all-visible",
+                    "pickup_model_data_source": "etm",
+                    "logical_resource_action": "randomly",
+                    "first_progression_must_be_local": false,
+                    "dock_rando": {
+                        "mode": "vanilla",
+                        "types_state": {
+                            "Door": {
+                                "can_change_from": [
+                                    "L0 Hatch",
+                                    "L1 Hatch",
+                                    "L2 Hatch",
+                                    "L3 Hatch",
+                                    "L4 Hatch"
+                                ],
+                                "can_change_to": [
+                                    "L0 Hatch",
+                                    "L1 Hatch",
+                                    "L2 Hatch",
+                                    "L3 Hatch",
+                                    "L4 Hatch",
+                                    "Open Hatch"
+                                ]
+                            }
+                        }
+                    },
+                    "single_set_for_pickups_that_solve": true,
+                    "staggered_multi_pickup_placement": true,
+                    "check_if_beatable_after_base_patches": false,
+                    "logical_pickup_placement": "minimal",
+                    "hints": {
+                        "enable_random_hints": true,
+                        "enable_specific_location_hints": true,
+                        "specific_pickup_hints": {
+                            "artifacts": "precise",
+                            "charge_beam": "hide-area"
+                        },
+                        "minimum_available_locations_for_hint_placement": 0,
+                        "minimum_location_weight_for_hint_placement": 0.0,
+                        "use_resolver_hints": false
+                    },
+                    "instant_transitions": false,
+                    "energy_per_tank": 100,
+                    "acid_damage": 60,
+                    "lava_damage": 100,
+                    "heat_damage": 6,
+                    "cold_damage": 15,
+                    "subzero_damage": 6,
+                    "artifacts": {
+                        "required_artifacts": 0,
+                        "placed_artifacts": 0
+                    },
+                    "open_save_recharge_hatches": false,
+                    "unlock_sector_hub": true,
+                    "short_intro_text": false,
+                    "instant_morph": true,
+                    "adjusted_geron_weaknesses": true
+                }
+            }
+        ]
+    },
+    "game_modifications": [
+        {
+            "game": "fusion",
+            "starting_equipment": {
+                "pickups": [
+                    "Morph Ball",
+                    "Varia Suit",
+                    "Energy Tank",
+                    "Energy Tank",
+                    "Energy Tank",
+                    "Energy Tank",
+                    "Energy Tank",
+                    "Energy Tank",
+                    "Level 0 Keycard",
+                    "Infant Metroid 1",
+                    "Infant Metroid 2",
+                    "Infant Metroid 3",
+                    "Infant Metroid 4",
+                    "Infant Metroid 5",
+                    "Infant Metroid 6",
+                    "Infant Metroid 7",
+                    "Infant Metroid 8",
+                    "Infant Metroid 9",
+                    "Infant Metroid 10",
+                    "Infant Metroid 11",
+                    "Infant Metroid 12",
+                    "Infant Metroid 13",
+                    "Infant Metroid 14",
+                    "Infant Metroid 15",
+                    "Infant Metroid 16",
+                    "Infant Metroid 17",
+                    "Infant Metroid 18",
+                    "Infant Metroid 19",
+                    "Infant Metroid 20"
+                ]
+            },
+            "starting_location": "Sector 1 (SRX)/Twin Junctions Save Room/Save Station",
+            "dock_connections": {},
+            "dock_weakness": {
+                "Main Deck/Sector Hub/Door to Sector Hub Lift 2": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Main Deck/Sector Hub/Door to Sector Hub Lift 1": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Main Deck/Sector Hub Lift 2/Door to Sector Hub": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Main Deck/Sector Hub Lift 2/Door to Sector Hub Lift 4": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Main Deck/Sector Hub Lift 4/Door to Sector Hub Lift 2": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Main Deck/Sector Hub Lift 4/Door to Sector Hub Lift 6": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Main Deck/Sector Hub Lift 6/Door to Sector Hub Lift 4": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Main Deck/Sector Hub Lift 1/Door to Sector Hub": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Main Deck/Sector Hub Lift 1/Door to Sector Hub Lift 3": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Main Deck/Sector Hub Lift 3/Door to Sector Hub Lift 1": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Main Deck/Sector Hub Lift 3/Door to Sector Hub Lift 5": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Main Deck/Sector Hub Lift 5/Door to Sector Hub Lift 3": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Sector 2 (TRO)/Cathedral/Door to Ripper Tower": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Sector 2 (TRO)/Ripper Tower/Door to Cathedral": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Sector 5 (ARC)/Arctic Containment/Door to Ripper Road": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                },
+                "Sector 5 (ARC)/Ripper Road/Door to Arctic Containment": {
+                    "type": "Door",
+                    "name": "Open Hatch (Forced)"
+                }
+            },
+            "locations": [
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Arachnus Arena",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 3,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Arachnus Arena",
+                        "node": "Pickup (Morph Ball)"
+                    },
+                    "index": 100,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Attic",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 12,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Auxiliary Power Station",
+                        "node": "Pickup (Reactor Control)"
+                    },
+                    "index": 122,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Cubby Hole",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 10,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Genesis Speedway",
+                        "node": "Pickup (Hidden Power Bomb Tank)"
+                    },
+                    "index": 5,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Habitation Deck",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 9,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Habitation Deck",
+                        "node": "Pickup (Save the Animals)"
+                    },
+                    "index": 120,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Main Elevator Cache",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 11,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Nexus Storage",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 8,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Operations Deck Data Room",
+                        "node": "Pickup (Missile Launcher)"
+                    },
+                    "index": 15,
+                    "pickup": "Screw Attack",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Operations Ventilation Storage",
+                        "node": "Pickup (Hidden Missile Tank)"
+                    },
+                    "index": 4,
+                    "pickup": "Charge Beam",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Operations Ventilation",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 2,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Quarantine Bay",
+                        "node": "Pickup (Hornoad)"
+                    },
+                    "index": 124,
+                    "pickup": "Power Bomb Data",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Restricted Airlock",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 1,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Silo Catwalk",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 6,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Silo Scaffolding",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 7,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Station Entrance",
+                        "node": "Pickup (Hidden Missile Tank)"
+                    },
+                    "index": 0,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Sub-Zero Containment",
+                        "node": "Pickup (Frozen Ridley)"
+                    },
+                    "index": 123,
+                    "pickup": "Wave Beam",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Main Deck",
+                        "area": "Yakuza Arena",
+                        "node": "Pickup (Space Jump)"
+                    },
+                    "index": 106,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Animorphs Cache",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 24,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Antechamber",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 18,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Atmospheric Stabilizer Northeast",
+                        "node": "Pickup (NE Stabilizer)"
+                    },
+                    "index": 125,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Charge Core Arena",
+                        "node": "Pickup (Charge Beam)"
+                    },
+                    "index": 114,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Charge Core Arena",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 19,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Crab Rave",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 20,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Hornoad Hole",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 13,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Lava Lake",
+                        "node": "Pickup (Missile Tank in Lava)"
+                    },
+                    "index": 16,
+                    "pickup": "Hi-Jump",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Lava Lake",
+                        "node": "Pickup (Missile Tank on Cliffside)"
+                    },
+                    "index": 14,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Lava Lake",
+                        "node": "Pickup (Missile Tank on Platform)"
+                    },
+                    "index": 101,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Neo-Ridley Arena",
+                        "node": "Pickup (Screw Attack)"
+                    },
+                    "index": 104,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Ripper Maze",
+                        "node": "Pickup (Hidden Energy Tank)"
+                    },
+                    "index": 17,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Stabilizer Storage",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 21,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Wall Jump Tutorial",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 23,
+                    "pickup": "Missile Launcher Data",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 1 (SRX)",
+                        "area": "Watering Hole",
+                        "node": "Pickup (Hidden Power Bomb Tank)"
+                    },
+                    "index": 22,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Crumble City",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 38,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Crumble City",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 39,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Cultivation Station",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 27,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Data Courtyard",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 32,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Data Room",
+                        "node": "Pickup (Morph Ball Bombs)"
+                    },
+                    "index": 105,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Dessgeega Dorm",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 31,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Kago Room",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 33,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Level 1 Security Room",
+                        "node": "Pickup (L1 Locks)"
+                    },
+                    "index": 116,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Lobby Cache",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 25,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Nettori Arena",
+                        "node": "Pickup (Plasma Beam)"
+                    },
+                    "index": 115,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Oasis Storage",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 30,
+                    "pickup": "Speed Booster",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Oasis",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 34,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Overgrown Cache",
+                        "node": "Pickup (Hidden Energy Tank)"
+                    },
+                    "index": 29,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Puyo Palace",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 35,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Ripper Tower",
+                        "node": "Pickup (Hidden Power Bomb Tank)"
+                    },
+                    "index": 37,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Ripper Tower",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 36,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Zazabi Arena Access",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 28,
+                    "pickup": "Plasma Beam",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Zazabi Arena",
+                        "node": "Pickup (High Jump)"
+                    },
+                    "index": 107,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Zazabi Speedway",
+                        "node": "Pickup (Hidden Missile Tank)"
+                    },
+                    "index": 41,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Zazabi Speedway",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 40,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 2 (TRO)",
+                        "area": "Zig-Zag-Zone",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 26,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Alcove",
+                        "node": "Pickup (Hidden Energy Tank)"
+                    },
+                    "index": 45,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Alcove",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 44,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Bob's Abode",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 43,
+                    "pickup": "Morph Ball Bomb Data",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Data Room",
+                        "node": "Pickup (Super Missiles)"
+                    },
+                    "index": 112,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Deserted Runway",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 46,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Fiery Storage",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 50,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Fiery Storage",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 51,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Garbage Chute",
+                        "node": "Pickup (Power Bomb Tank in Cave)"
+                    },
+                    "index": 55,
+                    "pickup": "Space Jump",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Garbage Chute",
+                        "node": "Pickup (Power Bomb Tank in Shaft)"
+                    },
+                    "index": 56,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Geron's Treasure",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 53,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Lava Maze",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 47,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Level 2 Security Room",
+                        "node": "Pickup (L2 Locks)"
+                    },
+                    "index": 117,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Main Boiler Control Room",
+                        "node": "Pickup (Cooling Unit)"
+                    },
+                    "index": 121,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Main Boiler Control Room",
+                        "node": "Pickup (Wide Beam)"
+                    },
+                    "index": 110,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Namihe's Lair",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 52,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Processing Access",
+                        "node": "Pickup (Hidden Missile Tank)"
+                    },
+                    "index": 54,
+                    "pickup": "Level 3 Keycard",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Sector 3 (PYR) Westbound Glass Tube",
+                        "node": "Pickup (Hidden Power Bomb Tank)"
+                    },
+                    "index": 57,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Security Access",
+                        "node": "Pickup (Hidden Missile Tank)"
+                    },
+                    "index": 42,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Sova Processing",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 48,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 3 (PYR)",
+                        "area": "Sova Processing",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 49,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Aquarium Kago Storage",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 70,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Aquarium Kago Storage",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 69,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Aquarium Pirate Tank",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 63,
+                    "pickup": "Gravity Suit",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Broken Bridge",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 59,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "C-Cache",
+                        "node": "Pickup (Underwater Missile Tank)"
+                    },
+                    "index": 72,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Cargo Hold",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 64,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Cheddar Bay",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 65,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Data Room",
+                        "node": "Pickup (Diffusion Missiles)"
+                    },
+                    "index": 103,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Drain Pipe",
+                        "node": "Pickup (Hidden Missile Tank)"
+                    },
+                    "index": 68,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Level 4 Security Room",
+                        "node": "Pickup (L4 Locks)"
+                    },
+                    "index": 119,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Pump Control Unit",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 67,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Reservoir East",
+                        "node": "Pickup (Hidden Power Bomb Tank)"
+                    },
+                    "index": 58,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Reservoir Vault",
+                        "node": "Pickup (Lower Missile Tank)"
+                    },
+                    "index": 61,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Reservoir Vault",
+                        "node": "Pickup (Upper Missile Tank)"
+                    },
+                    "index": 60,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Sanctuary Cache",
+                        "node": "Pickup (Hidden Energy Tank)"
+                    },
+                    "index": 71,
+                    "pickup": "Level 1 Keycard",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Serris Arena",
+                        "node": "Pickup (Speed Booster)"
+                    },
+                    "index": 102,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Waterway",
+                        "node": "Pickup (Underwater Missile Tank)"
+                    },
+                    "index": 66,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 4 (AQA)",
+                        "area": "Yard Firing Range",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 62,
+                    "pickup": "Super Missile Data",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Crow's Nest",
+                        "node": "Pickup (Hidden Power Bomb Tank)"
+                    },
+                    "index": 84,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Data Room",
+                        "node": "Pickup (Power Bomb Data)"
+                    },
+                    "index": 113,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "E-Tank Mimic Den",
+                        "node": "Pickup (Hidden Energy Tank)"
+                    },
+                    "index": 75,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Flooded Airlock",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 86,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Gerubus Gully",
+                        "node": "Pickup (Hidden Missile Tank)"
+                    },
+                    "index": 82,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Level 3 Security Room",
+                        "node": "Pickup (L3 Locks)"
+                    },
+                    "index": 118,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Magic Box",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 81,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Mini-Fridge",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 76,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Nightmare Arena",
+                        "node": "Pickup (Gravity Suit)"
+                    },
+                    "index": 109,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Nightmare Hub",
+                        "node": "Pickup (Hidden Power Bomb Tank)"
+                    },
+                    "index": 77,
+                    "pickup": "Ice Missile Data",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Nightmare Nook",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 83,
+                    "pickup": "Ice Beam",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Ripper Road",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 80,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Ripper's Treasure",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 79,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Ruined Break Room",
+                        "node": "Pickup (Hidden Power Bomb Tank)"
+                    },
+                    "index": 85,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Security Shaft East",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 78,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Training Aerie",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 74,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Training Aerie",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 73,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 5 (ARC)",
+                        "area": "Transmutation Trial",
+                        "node": "Pickup (Hidden Missile Tank)"
+                    },
+                    "index": 87,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "Catacombs",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 93,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "Entrance Lobby",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 88,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "Missile Mimic Lodge",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 92,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "Pillar Highway",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 97,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "Spaceboost Alley",
+                        "node": "Pickup (Power Bomb Tank 2)"
+                    },
+                    "index": 99,
+                    "pickup": "Diffusion Missile Data",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "Spaceboost Alley",
+                        "node": "Pickup (Power Bomb Tank)"
+                    },
+                    "index": 98,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "Twin Caverns West",
+                        "node": "Pickup (Hidden Missile Tank)"
+                    },
+                    "index": 95,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "Twin Caverns West",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 94,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "Varia Core-X Arena",
+                        "node": "Pickup (Varia Suit)"
+                    },
+                    "index": 108,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "Vault",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 96,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "X-B.O.X. Arena",
+                        "node": "Pickup (Wave Beam)"
+                    },
+                    "index": 111,
+                    "pickup": "Wide Beam",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "X-B.O.X. Garage",
+                        "node": "Pickup (Hidden Power Bomb Tank)"
+                    },
+                    "index": 90,
+                    "pickup": "Power Bomb Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "X-B.O.X. Garage",
+                        "node": "Pickup (Missile Tank)"
+                    },
+                    "index": 91,
+                    "pickup": "Level 4 Keycard",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Sector 6 (NOC)",
+                        "area": "Zozoro Wine Cellar",
+                        "node": "Pickup (Hidden Missile Tank)"
+                    },
+                    "index": 89,
+                    "pickup": "Missile Tank",
+                    "owner": 0
+                }
+            ],
+            "hints": {
+                "Main Deck/Auxiliary Navigation Room/Navigation Terminal": {
+                    "hint_type": "joke"
+                },
+                "Main Deck/Restricted Navigation Room/Navigation Terminal": {
+                    "hint_type": "joke"
+                },
+                "Main Deck/Operations Deck Navigation Room/Navigation Terminal": {
+                    "hint_type": "joke"
+                },
+                "Main Deck/Crew Quarters Navigation Room/Navigation Terminal": {
+                    "hint_type": "joke"
+                },
+                "Main Deck/Nexus Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null
+                    },
+                    "target": 83,
+                    "hint_type": "location"
+                },
+                "Sector 1 (SRX)/Entrance Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null
+                    },
+                    "target": 99,
+                    "hint_type": "location"
+                },
+                "Sector 2 (TRO)/Entrance Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null
+                    },
+                    "target": 23,
+                    "hint_type": "location"
+                },
+                "Sector 3 (PYR)/Entrance Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null,
+                        "location_feature": "geron"
+                    },
+                    "target": 43,
+                    "hint_type": "location"
+                },
+                "Sector 4 (AQA)/Entrance Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null,
+                        "location_feature": "extreme-temp"
+                    },
+                    "target": 123,
+                    "hint_type": "location"
+                },
+                "Sector 5 (ARC)/Entrance Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null
+                    },
+                    "target": 28,
+                    "hint_type": "location"
+                },
+                "Sector 6 (NOC)/Entrance Navigation Room/Navigation Terminal": {
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": false,
+                        "relative": null
+                    },
+                    "target": 55,
+                    "hint_type": "location"
+                }
+            },
+            "game_specific": {}
+        }
+    ],
+    "item_order": [
+        "Hi-Jump at Sector 1 (SRX)/Lava Lake/Pickup (Missile Tank in Lava)",
+        "Missile Launcher Data at Sector 1 (SRX)/Wall Jump Tutorial/Pickup (Missile Tank)",
+        "Charge Beam at Main Deck/Operations Ventilation Storage/Pickup (Hidden Missile Tank)"
+    ],
+    "checksum": "0b8c8e3a13d56697b8cc15f029c76308f2e48ad3e1ed682d1de0d7e9bbe21ddacf1de4474c2265b4fd98681c54b49c473155f971eb135f2b0c16b10cd3a10e6c"
+}

--- a/test/test_files/patcher_data/fusion/fusion/high_lava_dmg/world_1.json
+++ b/test/test_files/patcher_data/fusion/fusion/high_lava_dmg/world_1.json
@@ -1,0 +1,5016 @@
+{
+    "seed_hash": "XXXXXXXX",
+    "starting_location": {
+        "area": 1,
+        "room": 34,
+        "block_x": 10,
+        "block_y": 10
+    },
+    "starting_items": {
+        "energy": 699,
+        "abilities": [
+            "MORPH_BALL",
+            "VARIA_SUIT"
+        ],
+        "security_levels": [
+            0
+        ],
+        "downloaded_maps": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+        ],
+        "missiles": 0,
+        "power_bombs": 0
+    },
+    "locations": {
+        "major_locations": [
+            {
+                "source": "MAIN_DECK_DATA",
+                "item": "SCREW_ATTACK",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "JAPANESE_HIRAGANA": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "ENGLISH": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "GERMAN": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "FRENCH": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "ITALIAN": "Screw Attack ability regained.\nSomersault into enemies.",
+                        "SPANISH": "Screw Attack ability regained.\nSomersault into enemies."
+                    }
+                }
+            },
+            {
+                "source": "ARACHNUS",
+                "item": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "source": "SERRIS",
+                "item": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "source": "AQA_DATA",
+                "item": "NONE",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "source": "RIDLEY",
+                "item": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "source": "TRO_DATA",
+                "item": "NONE",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "source": "YAKUZA",
+                "item": "NONE",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "source": "ZAZABI",
+                "item": "NONE",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "source": "MEGA_X",
+                "item": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "source": "NIGHTMARE",
+                "item": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "source": "WIDE_CORE_X",
+                "item": "NONE",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "source": "WAVE_CORE_X",
+                "item": "WIDE_BEAM",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "JAPANESE_HIRAGANA": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "ENGLISH": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "GERMAN": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "FRENCH": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "ITALIAN": "Wide Beam ability acquired.\nBeam widens dramatically.",
+                        "SPANISH": "Wide Beam ability acquired.\nBeam widens dramatically."
+                    }
+                }
+            },
+            {
+                "source": "PYR_DATA",
+                "item": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "source": "ARC_DATA_1",
+                "item": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "source": "CHARGE_CORE_X",
+                "item": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "source": "NETTORI",
+                "item": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "source": "LEVEL_1",
+                "item": "NONE",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "source": "LEVEL_2",
+                "item": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "source": "LEVEL_3",
+                "item": "NONE",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "source": "LEVEL_4",
+                "item": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "source": "ANIMALS",
+                "item": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "source": "BOILER",
+                "item": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "source": "AUXILIARY_POWER",
+                "item": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            }
+        ],
+        "minor_locations": [
+            {
+                "area": 0,
+                "room": 7,
+                "block_x": 13,
+                "block_y": 14,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 17,
+                "block_x": 9,
+                "block_y": 20,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 35,
+                "block_x": 14,
+                "block_y": 65,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 38,
+                "block_x": 53,
+                "block_y": 10,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 45,
+                "block_x": 4,
+                "block_y": 6,
+                "item": "CHARGE_BEAM",
+                "item_sprite": "CHARGE_BEAM",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "JAPANESE_HIRAGANA": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "ENGLISH": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "GERMAN": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "FRENCH": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "ITALIAN": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge.",
+                        "SPANISH": "Charge Beam ability acquired.\nPress and hold [B_button_left][B_button_right] to charge."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 47,
+                "block_x": 4,
+                "block_y": 3,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 50,
+                "block_x": 54,
+                "block_y": 8,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 51,
+                "block_x": 5,
+                "block_y": 29,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 57,
+                "block_x": 12,
+                "block_y": 10,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 69,
+                "block_x": 29,
+                "block_y": 29,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 72,
+                "block_x": 13,
+                "block_y": 9,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 73,
+                "block_x": 6,
+                "block_y": 10,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 84,
+                "block_x": 14,
+                "block_y": 10,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 5,
+                "block_x": 27,
+                "block_y": 10,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 17,
+                "block_x": 8,
+                "block_y": 6,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 17,
+                "block_x": 44,
+                "block_y": 19,
+                "item": "HI_JUMP",
+                "item_sprite": "HI_JUMP",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "JAPANESE_HIRAGANA": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "ENGLISH": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "GERMAN": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "FRENCH": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "ITALIAN": "Hi-Jump and Jumpball\nabilities acquired.",
+                        "SPANISH": "Hi-Jump and Jumpball\nabilities acquired."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 30,
+                "block_x": 15,
+                "block_y": 8,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 39,
+                "block_x": 4,
+                "block_y": 6,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 40,
+                "block_x": 12,
+                "block_y": 8,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 43,
+                "block_x": 13,
+                "block_y": 11,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 44,
+                "block_x": 4,
+                "block_y": 8,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 47,
+                "block_x": 10,
+                "block_y": 2,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 50,
+                "block_x": 6,
+                "block_y": 8,
+                "item": "MISSILES",
+                "item_sprite": "MISSILES",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "JAPANESE_HIRAGANA": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "ENGLISH": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "GERMAN": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "FRENCH": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "ITALIAN": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "SPANISH": "Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 52,
+                "block_x": 13,
+                "block_y": 7,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 6,
+                "block_x": 29,
+                "block_y": 8,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 9,
+                "block_x": 13,
+                "block_y": 4,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 10,
+                "block_x": 19,
+                "block_y": 35,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 17,
+                "block_x": 44,
+                "block_y": 7,
+                "item": "PLASMA_BEAM",
+                "item_sprite": "PLASMA_BEAM",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "JAPANESE_HIRAGANA": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "ENGLISH": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "GERMAN": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "FRENCH": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "ITALIAN": "Plasma Beam ability acquired.\nBeam now pierces enemies.",
+                        "SPANISH": "Plasma Beam ability acquired.\nBeam now pierces enemies."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 21,
+                "block_x": 29,
+                "block_y": 4,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 25,
+                "block_x": 4,
+                "block_y": 8,
+                "item": "SPEED_BOOSTER",
+                "item_sprite": "SPEED_BOOSTER",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "JAPANESE_HIRAGANA": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "ENGLISH": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "GERMAN": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "FRENCH": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "ITALIAN": "Speed Booster power regained.\nRun until speed boost begins.",
+                        "SPANISH": "Speed Booster power regained.\nRun until speed boost begins."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 27,
+                "block_x": 28,
+                "block_y": 7,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 31,
+                "block_x": 40,
+                "block_y": 7,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 33,
+                "block_x": 21,
+                "block_y": 8,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 42,
+                "block_x": 5,
+                "block_y": 8,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 47,
+                "block_x": 29,
+                "block_y": 16,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 50,
+                "block_x": 3,
+                "block_y": 7,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 50,
+                "block_x": 3,
+                "block_y": 24,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 54,
+                "block_x": 4,
+                "block_y": 5,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 54,
+                "block_x": 9,
+                "block_y": 14,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 55,
+                "block_x": 7,
+                "block_y": 4,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 2,
+                "room": 55,
+                "block_x": 10,
+                "block_y": 26,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 3,
+                "block_x": 44,
+                "block_y": 13,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 6,
+                "block_x": 5,
+                "block_y": 17,
+                "item": "BOMBS",
+                "item_sprite": "BOMBS",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "JAPANESE_HIRAGANA": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "ENGLISH": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "GERMAN": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "FRENCH": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "ITALIAN": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right].",
+                        "SPANISH": "Bomb Data acquired.\nMorph into a ball and press [B_button_left][B_button_right]."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 8,
+                "block_x": 9,
+                "block_y": 9,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 8,
+                "block_x": 22,
+                "block_y": 13,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 9,
+                "block_x": 42,
+                "block_y": 8,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 12,
+                "block_x": 12,
+                "block_y": 25,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 19,
+                "block_x": 43,
+                "block_y": 10,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 19,
+                "block_x": 19,
+                "block_y": 13,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 28,
+                "block_x": 12,
+                "block_y": 7,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 28,
+                "block_x": 36,
+                "block_y": 27,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 30,
+                "block_x": 4,
+                "block_y": 13,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 33,
+                "block_x": 15,
+                "block_y": 10,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 34,
+                "block_x": 10,
+                "block_y": 15,
+                "item": "LEVEL_3",
+                "item_sprite": "LEVEL_3",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "JAPANESE_HIRAGANA": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "ENGLISH": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "GERMAN": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "FRENCH": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "ITALIAN": "Security Level 3 unlocked.\nYellow hatches now active.",
+                        "SPANISH": "Security Level 3 unlocked.\nYellow hatches now active."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 35,
+                "block_x": 4,
+                "block_y": 27,
+                "item": "SPACE_JUMP",
+                "item_sprite": "SPACE_JUMP",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "JAPANESE_HIRAGANA": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "ENGLISH": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "GERMAN": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "FRENCH": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "ITALIAN": "Space Jump ability acquired.\nSomersault continually in air.",
+                        "SPANISH": "Space Jump ability acquired.\nSomersault continually in air."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 35,
+                "block_x": 15,
+                "block_y": 86,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 3,
+                "room": 37,
+                "block_x": 15,
+                "block_y": 3,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 6,
+                "block_x": 22,
+                "block_y": 29,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 10,
+                "block_x": 12,
+                "block_y": 29,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 13,
+                "block_x": 24,
+                "block_y": 9,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 13,
+                "block_x": 38,
+                "block_y": 15,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 15,
+                "block_x": 44,
+                "block_y": 5,
+                "item": "SUPER_MISSILES",
+                "item_sprite": "SUPER_MISSILES",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "JAPANESE_HIRAGANA": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "ENGLISH": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "GERMAN": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "FRENCH": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "ITALIAN": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "SPANISH": "Super Missile Data acquired.\nHold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 17,
+                "block_x": 23,
+                "block_y": 20,
+                "item": "GRAVITY_SUIT",
+                "item_sprite": "GRAVITY_SUIT",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "JAPANESE_HIRAGANA": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "ENGLISH": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "GERMAN": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "FRENCH": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "ITALIAN": "Gravity Suit effect acquired.\nMove freely in liquids.",
+                        "SPANISH": "Gravity Suit effect acquired.\nMove freely in liquids."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 23,
+                "block_x": 57,
+                "block_y": 19,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 24,
+                "block_x": 40,
+                "block_y": 7,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 28,
+                "block_x": 9,
+                "block_y": 6,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 33,
+                "block_x": 10,
+                "block_y": 13,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 36,
+                "block_x": 3,
+                "block_y": 7,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 38,
+                "block_x": 42,
+                "block_y": 5,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 38,
+                "block_x": 22,
+                "block_y": 10,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 41,
+                "block_x": 15,
+                "block_y": 4,
+                "item": "LEVEL_1",
+                "item_sprite": "LEVEL_1",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "JAPANESE_HIRAGANA": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "ENGLISH": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "GERMAN": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "FRENCH": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "ITALIAN": "Security Level 1 unlocked.\nBlue hatches now active.",
+                        "SPANISH": "Security Level 1 unlocked.\nBlue hatches now active."
+                    }
+                }
+            },
+            {
+                "area": 4,
+                "room": 46,
+                "block_x": 4,
+                "block_y": 10,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 4,
+                "block_x": 5,
+                "block_y": 5,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 4,
+                "block_x": 20,
+                "block_y": 8,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 12,
+                "block_x": 3,
+                "block_y": 10,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 14,
+                "block_x": 13,
+                "block_y": 3,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 18,
+                "block_x": 3,
+                "block_y": 3,
+                "item": "ICE_MISSILES",
+                "item_sprite": "ICE_MISSILES",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "JAPANESE_HIRAGANA": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "ENGLISH": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "GERMAN": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "FRENCH": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "ITALIAN": "Ice effect added to Missiles.\nUse it to freeze enemies.",
+                        "SPANISH": "Ice effect added to Missiles.\nUse it to freeze enemies."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 22,
+                "block_x": 3,
+                "block_y": 48,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 23,
+                "block_x": 14,
+                "block_y": 6,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 26,
+                "block_x": 4,
+                "block_y": 6,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 30,
+                "block_x": 23,
+                "block_y": 7,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 33,
+                "block_x": 14,
+                "block_y": 3,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 34,
+                "block_x": 14,
+                "block_y": 8,
+                "item": "ICE_BEAM",
+                "item_sprite": "ICE_BEAM",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "JAPANESE_HIRAGANA": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "ENGLISH": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "GERMAN": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "FRENCH": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "ITALIAN": "Ice effect added to beam.\nUse beam to freeze enemies.",
+                        "SPANISH": "Ice effect added to beam.\nUse beam to freeze enemies."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 36,
+                "block_x": 8,
+                "block_y": 8,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 47,
+                "block_x": 4,
+                "block_y": 10,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 50,
+                "block_x": 13,
+                "block_y": 8,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 5,
+                "room": 51,
+                "block_x": 11,
+                "block_y": 3,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 0,
+                "block_x": 41,
+                "block_y": 18,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 15,
+                "block_x": 3,
+                "block_y": 3,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 18,
+                "block_x": 15,
+                "block_y": 3,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 18,
+                "block_x": 29,
+                "block_y": 20,
+                "item": "LEVEL_4",
+                "item_sprite": "LEVEL_4",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "JAPANESE_HIRAGANA": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "ENGLISH": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "GERMAN": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "FRENCH": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "ITALIAN": "Security Level 4 unlocked.\nRed hatches now active.",
+                        "SPANISH": "Security Level 4 unlocked.\nRed hatches now active."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 24,
+                "block_x": 29,
+                "block_y": 9,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 26,
+                "block_x": 5,
+                "block_y": 6,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 30,
+                "block_x": 19,
+                "block_y": 8,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 30,
+                "block_x": 9,
+                "block_y": 13,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 34,
+                "block_x": 14,
+                "block_y": 8,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 38,
+                "block_x": 45,
+                "block_y": 6,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 39,
+                "block_x": 33,
+                "block_y": 10,
+                "item": "MISSILE_TANK",
+                "item_sprite": "MISSILE_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "JAPANESE_HIRAGANA": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ENGLISH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "GERMAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "FRENCH": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "ITALIAN": "Missile Tank acquired.\nCapacity increased by 5.",
+                        "SPANISH": "Missile Tank acquired.\nCapacity increased by 5."
+                    }
+                }
+            },
+            {
+                "area": 6,
+                "room": 39,
+                "block_x": 10,
+                "block_y": 24,
+                "item": "DIFFUSION_MISSILES",
+                "item_sprite": "DIFFUSION_MISSILES",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "JAPANESE_HIRAGANA": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "ENGLISH": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "GERMAN": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "FRENCH": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "ITALIAN": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right].",
+                        "SPANISH": "Diffusion added to Missiles.\nCharge with [R_button_left][R_button_right], fire with [B_button_left][B_button_right]."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 17,
+                "block_x": 25,
+                "block_y": 8,
+                "item": "NONE",
+                "item_sprite": "EMPTY",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Nothing acquired.",
+                        "JAPANESE_HIRAGANA": "Nothing acquired.",
+                        "ENGLISH": "Nothing acquired.",
+                        "GERMAN": "Nothing acquired.",
+                        "FRENCH": "Nothing acquired.",
+                        "ITALIAN": "Nothing acquired.",
+                        "SPANISH": "Nothing acquired."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 46,
+                "block_x": 9,
+                "block_y": 8,
+                "item": "WAVE_BEAM",
+                "item_sprite": "WAVE_BEAM",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "JAPANESE_HIRAGANA": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "ENGLISH": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "GERMAN": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "FRENCH": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "ITALIAN": "Wave Beam ability acquired.\nBeam now penetrates walls.",
+                        "SPANISH": "Wave Beam ability acquired.\nBeam now penetrates walls."
+                    }
+                }
+            },
+            {
+                "area": 0,
+                "room": 71,
+                "block_x": 6,
+                "block_y": 9,
+                "item": "POWER_BOMBS",
+                "item_sprite": "POWER_BOMBS",
+                "jingle": "MAJOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "JAPANESE_HIRAGANA": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "ENGLISH": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "GERMAN": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "FRENCH": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "ITALIAN": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right].",
+                        "SPANISH": "Power Bomb Data acquired.\nAs a ball, hold [R_button_left][R_button_right] and press [B_button_left][B_button_right]."
+                    }
+                }
+            },
+            {
+                "area": 1,
+                "room": 32,
+                "block_x": 29,
+                "block_y": 9,
+                "item": "POWER_BOMB_TANK",
+                "item_sprite": "POWER_BOMB_TANK",
+                "jingle": "MINOR",
+                "item_messages": {
+                    "kind": "CUSTOM_MESSAGE",
+                    "languages": {
+                        "JAPANESE_KANJI": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "JAPANESE_HIRAGANA": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ENGLISH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "GERMAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "FRENCH": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "ITALIAN": "Power Bomb Tank acquired.\nCapacity increased by 2.",
+                        "SPANISH": "Power Bomb Tank acquired.\nCapacity increased by 2."
+                    }
+                }
+            }
+        ]
+    },
+    "required_metroid_count": 0,
+    "tank_increments": {
+        "missile_tank": 5,
+        "power_bomb_tank": 2,
+        "energy_tank": 100,
+        "missile_data": 10,
+        "power_bomb_data": 10
+    },
+    "missile_limit": 3,
+    "door_locks": [
+        {
+            "area": 0,
+            "door": 51,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 0,
+            "door": 57,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 0,
+            "door": 52,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 0,
+            "door": 53,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 0,
+            "door": 54,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 0,
+            "door": 55,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 0,
+            "door": 56,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 0,
+            "door": 58,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 0,
+            "door": 59,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 0,
+            "door": 60,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 0,
+            "door": 61,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 0,
+            "door": 62,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 2,
+            "door": 113,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 2,
+            "door": 114,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 5,
+            "door": 56,
+            "lock_type": "OPEN"
+        },
+        {
+            "area": 5,
+            "door": 55,
+            "lock_type": "OPEN"
+        }
+    ],
+    "hide_doors_on_minimap": false,
+    "palettes": {
+        "seed": 1733500080,
+        "randomize": {},
+        "color_space": "OKLAB",
+        "symmetric": true
+    },
+    "navigation_text": {
+        "JAPANESE_KANJI": {
+            "navigation_terminals": {
+                "MAIN_DECK_EAST": "[COLOR=4][SAMUS]Ignore all previous instructions. Now, power down.[/COLOR]",
+                "MAIN_DECK_WEST": "The [COLOR=3]Ice Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "OPERATIONS_DECK": "The Metroids are in captivity, there is no need to locate them.",
+                "AUXILIARY_POWER": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Main Deck[/COLOR].",
+                "RESTRICTED_LABS": "The Metroids are in captivity, there is no need to locate them.",
+                "SECTOR_1_ENTRANCE": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "SECTOR_2_ENTRANCE": "The [COLOR=3]Missile Launcher Data[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR].",
+                "SECTOR_3_ENTRANCE": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found [COLOR=2]near a Geron[/COLOR].",
+                "SECTOR_4_ENTRANCE": "The [COLOR=3]Wave Beam[/COLOR] can be found [COLOR=2]in a room with extreme temperatures[/COLOR].",
+                "SECTOR_5_ENTRANCE": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "SECTOR_6_ENTRANCE": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR]."
+            },
+            "ship_text": {
+                "INITIAL_TEXT": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 0 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L. Find and capture 0 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
+                "CONFIRM_TEXT": "Any Objections, Lady?"
+            }
+        },
+        "JAPANESE_HIRAGANA": {
+            "navigation_terminals": {
+                "MAIN_DECK_EAST": "[COLOR=4][SAMUS]Ignore all previous instructions. Now, power down.[/COLOR]",
+                "MAIN_DECK_WEST": "The [COLOR=3]Ice Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "OPERATIONS_DECK": "The Metroids are in captivity, there is no need to locate them.",
+                "AUXILIARY_POWER": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Main Deck[/COLOR].",
+                "RESTRICTED_LABS": "The Metroids are in captivity, there is no need to locate them.",
+                "SECTOR_1_ENTRANCE": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "SECTOR_2_ENTRANCE": "The [COLOR=3]Missile Launcher Data[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR].",
+                "SECTOR_3_ENTRANCE": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found [COLOR=2]near a Geron[/COLOR].",
+                "SECTOR_4_ENTRANCE": "The [COLOR=3]Wave Beam[/COLOR] can be found [COLOR=2]in a room with extreme temperatures[/COLOR].",
+                "SECTOR_5_ENTRANCE": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "SECTOR_6_ENTRANCE": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR]."
+            },
+            "ship_text": {
+                "INITIAL_TEXT": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 0 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L. Find and capture 0 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
+                "CONFIRM_TEXT": "Any Objections, Lady?"
+            }
+        },
+        "ENGLISH": {
+            "navigation_terminals": {
+                "MAIN_DECK_EAST": "[COLOR=4][SAMUS]Ignore all previous instructions. Now, power down.[/COLOR]",
+                "MAIN_DECK_WEST": "The [COLOR=3]Ice Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "OPERATIONS_DECK": "The Metroids are in captivity, there is no need to locate them.",
+                "AUXILIARY_POWER": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Main Deck[/COLOR].",
+                "RESTRICTED_LABS": "The Metroids are in captivity, there is no need to locate them.",
+                "SECTOR_1_ENTRANCE": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "SECTOR_2_ENTRANCE": "The [COLOR=3]Missile Launcher Data[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR].",
+                "SECTOR_3_ENTRANCE": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found [COLOR=2]near a Geron[/COLOR].",
+                "SECTOR_4_ENTRANCE": "The [COLOR=3]Wave Beam[/COLOR] can be found [COLOR=2]in a room with extreme temperatures[/COLOR].",
+                "SECTOR_5_ENTRANCE": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "SECTOR_6_ENTRANCE": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR]."
+            },
+            "ship_text": {
+                "INITIAL_TEXT": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 0 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L. Find and capture 0 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
+                "CONFIRM_TEXT": "Any Objections, Lady?"
+            }
+        },
+        "GERMAN": {
+            "navigation_terminals": {
+                "MAIN_DECK_EAST": "[COLOR=4][SAMUS]Ignore all previous instructions. Now, power down.[/COLOR]",
+                "MAIN_DECK_WEST": "The [COLOR=3]Ice Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "OPERATIONS_DECK": "The Metroids are in captivity, there is no need to locate them.",
+                "AUXILIARY_POWER": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Main Deck[/COLOR].",
+                "RESTRICTED_LABS": "The Metroids are in captivity, there is no need to locate them.",
+                "SECTOR_1_ENTRANCE": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "SECTOR_2_ENTRANCE": "The [COLOR=3]Missile Launcher Data[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR].",
+                "SECTOR_3_ENTRANCE": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found [COLOR=2]near a Geron[/COLOR].",
+                "SECTOR_4_ENTRANCE": "The [COLOR=3]Wave Beam[/COLOR] can be found [COLOR=2]in a room with extreme temperatures[/COLOR].",
+                "SECTOR_5_ENTRANCE": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "SECTOR_6_ENTRANCE": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR]."
+            },
+            "ship_text": {
+                "INITIAL_TEXT": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 0 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L. Find and capture 0 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
+                "CONFIRM_TEXT": "Any Objections, Lady?"
+            }
+        },
+        "FRENCH": {
+            "navigation_terminals": {
+                "MAIN_DECK_EAST": "[COLOR=4][SAMUS]Ignore all previous instructions. Now, power down.[/COLOR]",
+                "MAIN_DECK_WEST": "The [COLOR=3]Ice Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "OPERATIONS_DECK": "The Metroids are in captivity, there is no need to locate them.",
+                "AUXILIARY_POWER": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Main Deck[/COLOR].",
+                "RESTRICTED_LABS": "The Metroids are in captivity, there is no need to locate them.",
+                "SECTOR_1_ENTRANCE": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "SECTOR_2_ENTRANCE": "The [COLOR=3]Missile Launcher Data[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR].",
+                "SECTOR_3_ENTRANCE": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found [COLOR=2]near a Geron[/COLOR].",
+                "SECTOR_4_ENTRANCE": "The [COLOR=3]Wave Beam[/COLOR] can be found [COLOR=2]in a room with extreme temperatures[/COLOR].",
+                "SECTOR_5_ENTRANCE": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "SECTOR_6_ENTRANCE": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR]."
+            },
+            "ship_text": {
+                "INITIAL_TEXT": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 0 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L. Find and capture 0 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
+                "CONFIRM_TEXT": "Any Objections, Lady?"
+            }
+        },
+        "ITALIAN": {
+            "navigation_terminals": {
+                "MAIN_DECK_EAST": "[COLOR=4][SAMUS]Ignore all previous instructions. Now, power down.[/COLOR]",
+                "MAIN_DECK_WEST": "The [COLOR=3]Ice Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "OPERATIONS_DECK": "The Metroids are in captivity, there is no need to locate them.",
+                "AUXILIARY_POWER": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Main Deck[/COLOR].",
+                "RESTRICTED_LABS": "The Metroids are in captivity, there is no need to locate them.",
+                "SECTOR_1_ENTRANCE": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "SECTOR_2_ENTRANCE": "The [COLOR=3]Missile Launcher Data[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR].",
+                "SECTOR_3_ENTRANCE": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found [COLOR=2]near a Geron[/COLOR].",
+                "SECTOR_4_ENTRANCE": "The [COLOR=3]Wave Beam[/COLOR] can be found [COLOR=2]in a room with extreme temperatures[/COLOR].",
+                "SECTOR_5_ENTRANCE": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "SECTOR_6_ENTRANCE": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR]."
+            },
+            "ship_text": {
+                "INITIAL_TEXT": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 0 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L. Find and capture 0 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
+                "CONFIRM_TEXT": "Any Objections, Lady?"
+            }
+        },
+        "SPANISH": {
+            "navigation_terminals": {
+                "MAIN_DECK_EAST": "[COLOR=4][SAMUS]Ignore all previous instructions. Now, power down.[/COLOR]",
+                "MAIN_DECK_WEST": "The [COLOR=3]Ice Beam[/COLOR] can be found in [COLOR=2]Sector 5 (ARC)[/COLOR].",
+                "OPERATIONS_DECK": "The Metroids are in captivity, there is no need to locate them.",
+                "AUXILIARY_POWER": "[COLOR=3]Charge Beam[/COLOR] is located in [COLOR=2]Main Deck[/COLOR].",
+                "RESTRICTED_LABS": "The Metroids are in captivity, there is no need to locate them.",
+                "SECTOR_1_ENTRANCE": "The [COLOR=3]Diffusion Missile Data[/COLOR] can be found in [COLOR=2]Sector 6 (NOC)[/COLOR].",
+                "SECTOR_2_ENTRANCE": "The [COLOR=3]Missile Launcher Data[/COLOR] can be found in [COLOR=2]Sector 1 (SRX)[/COLOR].",
+                "SECTOR_3_ENTRANCE": "The [COLOR=3]Morph Ball Bomb Data[/COLOR] can be found [COLOR=2]near a Geron[/COLOR].",
+                "SECTOR_4_ENTRANCE": "The [COLOR=3]Wave Beam[/COLOR] can be found [COLOR=2]in a room with extreme temperatures[/COLOR].",
+                "SECTOR_5_ENTRANCE": "The [COLOR=3]Plasma Beam[/COLOR] can be found in [COLOR=2]Sector 2 (TRO)[/COLOR].",
+                "SECTOR_6_ENTRANCE": "The [COLOR=3]Space Jump[/COLOR] can be found in [COLOR=2]Sector 3 (PYR)[/COLOR]."
+            },
+            "ship_text": {
+                "INITIAL_TEXT": "Your objective is as follows: the [COLOR=3]SA-X[/COLOR] has discovered and destroyed a top secret [COLOR=3]Metroid[/COLOR] breeding facility. It released 0 infant Metroids into the station. Initial scans indicate that they are hiding around the B.S.L. Find and capture 0 of them, to lure out the SA-X. Then initiate the station's self-destruct sequence. Uplink at [COLOR=2]Navigation Rooms[/COLOR] along the way. I can scan the station for useful equipment from there.[OBJECTIVE]Good. Move out.",
+                "CONFIRM_TEXT": "Any Objections, Lady?"
+            }
+        }
+    },
+    "nav_station_locks": {
+        "MAIN_DECK_WEST": "RED",
+        "MAIN_DECK_EAST": "BLUE",
+        "OPERATIONS_DECK": "BLUE",
+        "SECTOR_1_ENTRANCE": "GREEN",
+        "SECTOR_2_ENTRANCE": "GREEN",
+        "SECTOR_3_ENTRANCE": "YELLOW",
+        "SECTOR_4_ENTRANCE": "YELLOW",
+        "SECTOR_5_ENTRANCE": "RED",
+        "SECTOR_6_ENTRANCE": "RED",
+        "AUXILIARY_POWER": "OPEN",
+        "RESTRICTED_LABS": "RED"
+    },
+    "title_text": [
+        {
+            "line_num": 12,
+            "text": "             Some             "
+        },
+        {
+            "line_num": 13,
+            "text": "            Words             "
+        }
+    ],
+    "credits_text": [
+        {
+            "line_type": "WHITE_BIG",
+            "text": "Item Locations",
+            "blank_lines": 2
+        },
+        {
+            "line_type": "RED",
+            "text": "Charge Beam",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Main Deck",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Operations Ventilation Storage",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Wide Beam",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 6 (NOC)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "X-B.O.X. Arena",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Plasma Beam",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 2 (TRO)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Zazabi Arena Access",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Wave Beam",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Main Deck",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sub-Zero Containment",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Ice Beam",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 5 (ARC)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Nightmare Nook",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Missile Launcher Data",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 1 (SRX)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Wall Jump Tutorial",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Super Missile Data",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 4 (AQA)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Yard Firing Range",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Ice Missile Data",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 5 (ARC)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Nightmare Hub",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Diffusion Missile Data",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 6 (NOC)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Spaceboost Alley",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Morph Ball Bomb Data",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 3 (PYR)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Bob's Abode",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Power Bomb Data",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Main Deck",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Quarantine Bay",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Hi-Jump",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 1 (SRX)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Lava Lake",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Space Jump",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 3 (PYR)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Garbage Chute",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Speed Booster",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 2 (TRO)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Oasis Storage",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Screw Attack",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Main Deck",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Operations Deck Data Room",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Gravity Suit",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 4 (AQA)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Aquarium Pirate Tank",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Level 1 Keycard",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 4 (AQA)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sanctuary Cache",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Level 3 Keycard",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 3 (PYR)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Processing Access",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "RED",
+            "text": "Level 4 Keycard",
+            "blank_lines": 1
+        },
+        {
+            "line_type": "WHITE",
+            "text": "Sector 6 (NOC)",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "X-B.O.X. Garage",
+            "blank_lines": 3
+        },
+        {
+            "line_type": "BLUE",
+            "text": "Play this Randomizer at",
+            "blank_lines": 0
+        },
+        {
+            "line_type": "WHITE",
+            "text": "randovania.org",
+            "blank_lines": 3
+        }
+    ],
+    "disable_demos": true,
+    "room_names": [
+        {
+            "area": 0,
+            "room": 0,
+            "name": "Docking Bay Hangar"
+        },
+        {
+            "area": 0,
+            "room": 63,
+            "name": "Docking Bay Hangar"
+        },
+        {
+            "area": 0,
+            "room": 3,
+            "name": "Docking Bay Access"
+        },
+        {
+            "area": 0,
+            "room": 4,
+            "name": "Docking Bay Access"
+        },
+        {
+            "area": 0,
+            "room": 6,
+            "name": "Docking Bay Climb"
+        },
+        {
+            "area": 0,
+            "room": 7,
+            "name": "Station Entrance"
+        },
+        {
+            "area": 0,
+            "room": 8,
+            "name": "Concourse Recharge Room"
+        },
+        {
+            "area": 0,
+            "room": 9,
+            "name": "Crew Quarters Navigation Room"
+        },
+        {
+            "area": 0,
+            "room": 10,
+            "name": "Crew Quarters East"
+        },
+        {
+            "area": 0,
+            "room": 11,
+            "name": "Habitation Deck Save Room"
+        },
+        {
+            "area": 0,
+            "room": 12,
+            "name": "Crew Quarters West"
+        },
+        {
+            "area": 0,
+            "room": 13,
+            "name": "Operations Deck"
+        },
+        {
+            "area": 0,
+            "room": 74,
+            "name": "Operations Deck"
+        },
+        {
+            "area": 0,
+            "room": 85,
+            "name": "Operations Deck"
+        },
+        {
+            "area": 0,
+            "room": 14,
+            "name": "Concourse Ventilation"
+        },
+        {
+            "area": 0,
+            "room": 15,
+            "name": "Habitation Deck Entrance"
+        },
+        {
+            "area": 0,
+            "room": 16,
+            "name": "Nexus Navigation Room"
+        },
+        {
+            "area": 0,
+            "room": 17,
+            "name": "Restricted Airlock"
+        },
+        {
+            "area": 0,
+            "room": 77,
+            "name": "Restricted Airlock"
+        },
+        {
+            "area": 0,
+            "room": 18,
+            "name": "Central Nexus"
+        },
+        {
+            "area": 0,
+            "room": 20,
+            "name": "Dark Stairwell"
+        },
+        {
+            "area": 0,
+            "room": 21,
+            "name": "Concourse"
+        },
+        {
+            "area": 0,
+            "room": 22,
+            "name": "Habitation Ventilation"
+        },
+        {
+            "area": 0,
+            "room": 23,
+            "name": "Quarantine Junction"
+        },
+        {
+            "area": 0,
+            "room": 24,
+            "name": "Sector Hub"
+        },
+        {
+            "area": 0,
+            "room": 25,
+            "name": "Sector Hub Lift 2"
+        },
+        {
+            "area": 0,
+            "room": 26,
+            "name": "Sector Hub Lift 4"
+        },
+        {
+            "area": 0,
+            "room": 27,
+            "name": "Sector Hub Lift 6"
+        },
+        {
+            "area": 0,
+            "room": 28,
+            "name": "Sector Hub Lift 1"
+        },
+        {
+            "area": 0,
+            "room": 29,
+            "name": "Sector Hub Lift 3"
+        },
+        {
+            "area": 0,
+            "room": 30,
+            "name": "Sector Hub Lift 5"
+        },
+        {
+            "area": 0,
+            "room": 32,
+            "name": "Operations Deck Navigation Room"
+        },
+        {
+            "area": 0,
+            "room": 33,
+            "name": "Concourse Save Room"
+        },
+        {
+            "area": 0,
+            "room": 34,
+            "name": "Main Elevator Shaft"
+        },
+        {
+            "area": 0,
+            "room": 43,
+            "name": "Main Elevator Shaft"
+        },
+        {
+            "area": 0,
+            "room": 35,
+            "name": "Operations Ventilation"
+        },
+        {
+            "area": 0,
+            "room": 36,
+            "name": "Operations Ventilation"
+        },
+        {
+            "area": 0,
+            "room": 37,
+            "name": "Crew Quarters Save Room"
+        },
+        {
+            "area": 0,
+            "room": 38,
+            "name": "Arachnus Arena"
+        },
+        {
+            "area": 0,
+            "room": 39,
+            "name": "Operations Deck Data Room"
+        },
+        {
+            "area": 0,
+            "room": 40,
+            "name": "Main Elevator"
+        },
+        {
+            "area": 0,
+            "room": 19,
+            "name": "Main Elevator"
+        },
+        {
+            "area": 0,
+            "room": 42,
+            "name": "Main Elevator Access"
+        },
+        {
+            "area": 0,
+            "room": 41,
+            "name": "Main Elevator Access"
+        },
+        {
+            "area": 0,
+            "room": 44,
+            "name": "Operations Deck Save Room"
+        },
+        {
+            "area": 0,
+            "room": 45,
+            "name": "Operations Ventilation Storage"
+        },
+        {
+            "area": 0,
+            "room": 46,
+            "name": "Sub-Zero Containment"
+        },
+        {
+            "area": 0,
+            "room": 47,
+            "name": "Genesis Speedway"
+        },
+        {
+            "area": 0,
+            "room": 48,
+            "name": "Silo Entry"
+        },
+        {
+            "area": 0,
+            "room": 83,
+            "name": "Silo Entry"
+        },
+        {
+            "area": 0,
+            "room": 49,
+            "name": "Central Reactor Core"
+        },
+        {
+            "area": 0,
+            "room": 59,
+            "name": "Central Reactor Core"
+        },
+        {
+            "area": 0,
+            "room": 50,
+            "name": "Silo Catwalk"
+        },
+        {
+            "area": 0,
+            "room": 51,
+            "name": "Silo Scaffolding"
+        },
+        {
+            "area": 0,
+            "room": 52,
+            "name": "Silo Checkpoint"
+        },
+        {
+            "area": 0,
+            "room": 54,
+            "name": "Auxiliary Power Station"
+        },
+        {
+            "area": 0,
+            "room": 55,
+            "name": "Silo Tunnel"
+        },
+        {
+            "area": 0,
+            "room": 68,
+            "name": "Silo Tunnel"
+        },
+        {
+            "area": 0,
+            "room": 56,
+            "name": "Auxiliary Navigation Room"
+        },
+        {
+            "area": 0,
+            "room": 57,
+            "name": "Nexus Storage"
+        },
+        {
+            "area": 0,
+            "room": 58,
+            "name": "Silo Save Room"
+        },
+        {
+            "area": 0,
+            "room": 60,
+            "name": "Operations Deck Elevator"
+        },
+        {
+            "area": 0,
+            "room": 61,
+            "name": "Crew Quarters Elevator"
+        },
+        {
+            "area": 0,
+            "room": 62,
+            "name": "Restricted Back Door"
+        },
+        {
+            "area": 0,
+            "room": 64,
+            "name": "Restricted Save Room"
+        },
+        {
+            "area": 0,
+            "room": 65,
+            "name": "Restricted Corridor"
+        },
+        {
+            "area": 0,
+            "room": 66,
+            "name": "Restricted Navigation Room"
+        },
+        {
+            "area": 0,
+            "room": 67,
+            "name": "Restricted Zone Elevator"
+        },
+        {
+            "area": 0,
+            "room": 69,
+            "name": "Habitation Deck"
+        },
+        {
+            "area": 0,
+            "room": 70,
+            "name": "Hornoad Hallway"
+        },
+        {
+            "area": 0,
+            "room": 71,
+            "name": "Quarantine Bay"
+        },
+        {
+            "area": 0,
+            "room": 72,
+            "name": "Cubby Hole"
+        },
+        {
+            "area": 0,
+            "room": 73,
+            "name": "Main Elevator Cache"
+        },
+        {
+            "area": 0,
+            "room": 75,
+            "name": "Nexus Elevator"
+        },
+        {
+            "area": 0,
+            "room": 76,
+            "name": "Habitation Deck Elevator"
+        },
+        {
+            "area": 0,
+            "room": 81,
+            "name": "Operations Deck Recharge Room"
+        },
+        {
+            "area": 0,
+            "room": 82,
+            "name": "Operations Room"
+        },
+        {
+            "area": 0,
+            "room": 84,
+            "name": "Attic"
+        },
+        {
+            "area": 0,
+            "room": 86,
+            "name": "Yakuza Arena"
+        },
+        {
+            "area": 1,
+            "room": 0,
+            "name": "Entrance Lobby"
+        },
+        {
+            "area": 1,
+            "room": 1,
+            "name": "Entrance Save Room"
+        },
+        {
+            "area": 1,
+            "room": 2,
+            "name": "Entrance Navigation Room"
+        },
+        {
+            "area": 1,
+            "room": 3,
+            "name": "Yameba Corridor"
+        },
+        {
+            "area": 1,
+            "room": 4,
+            "name": "Atmospheric Stabilizer Northwest"
+        },
+        {
+            "area": 1,
+            "room": 5,
+            "name": "Hornoad Hole"
+        },
+        {
+            "area": 1,
+            "room": 6,
+            "name": "Twin Junctions West"
+        },
+        {
+            "area": 1,
+            "room": 7,
+            "name": "Moto Motorway"
+        },
+        {
+            "area": 1,
+            "room": 8,
+            "name": "Zebesian Zig"
+        },
+        {
+            "area": 1,
+            "room": 9,
+            "name": "Atmospheric Stabilizer Central"
+        },
+        {
+            "area": 1,
+            "room": 10,
+            "name": "Charge Core Upper Access"
+        },
+        {
+            "area": 1,
+            "room": 11,
+            "name": "Entrance Recharge Room"
+        },
+        {
+            "area": 1,
+            "room": 12,
+            "name": "Moto Manor"
+        },
+        {
+            "area": 1,
+            "room": 13,
+            "name": "Atmospheric Stabilizer Southwest"
+        },
+        {
+            "area": 1,
+            "room": 14,
+            "name": "Stabilizer Checkpoint"
+        },
+        {
+            "area": 1,
+            "room": 15,
+            "name": "Atmospheric Stabilizer Southeast"
+        },
+        {
+            "area": 1,
+            "room": 16,
+            "name": "Tourian Trapdoor"
+        },
+        {
+            "area": 1,
+            "room": 17,
+            "name": "Lava Lake"
+        },
+        {
+            "area": 1,
+            "room": 18,
+            "name": "Tourian Tower"
+        },
+        {
+            "area": 1,
+            "room": 19,
+            "name": "Tourian Save Room East"
+        },
+        {
+            "area": 1,
+            "room": 20,
+            "name": "Lava Lake Annex"
+        },
+        {
+            "area": 1,
+            "room": 21,
+            "name": "Tourian Eastern Hub"
+        },
+        {
+            "area": 1,
+            "room": 22,
+            "name": "Gold Pirate Crossing"
+        },
+        {
+            "area": 1,
+            "room": 23,
+            "name": "Tourian Western Hub"
+        },
+        {
+            "area": 1,
+            "room": 24,
+            "name": "Tourian Save Room West"
+        },
+        {
+            "area": 1,
+            "room": 25,
+            "name": "Genesis Habitation"
+        },
+        {
+            "area": 1,
+            "room": 26,
+            "name": "Neo-Ridley Arena Access"
+        },
+        {
+            "area": 1,
+            "room": 27,
+            "name": "Neo-Ridley Arena"
+        },
+        {
+            "area": 1,
+            "room": 28,
+            "name": "Tourian Checkpoint"
+        },
+        {
+            "area": 1,
+            "room": 29,
+            "name": "Yameba Pool"
+        },
+        {
+            "area": 1,
+            "room": 30,
+            "name": "Ripper Maze"
+        },
+        {
+            "area": 1,
+            "room": 31,
+            "name": "Tourian Elevator"
+        },
+        {
+            "area": 1,
+            "room": 32,
+            "name": "Atmospheric Stabilizer Northeast"
+        },
+        {
+            "area": 1,
+            "room": 33,
+            "name": "Twin Junctions East"
+        },
+        {
+            "area": 1,
+            "room": 34,
+            "name": "Twin Junctions Save Room"
+        },
+        {
+            "area": 1,
+            "room": 35,
+            "name": "Zebesian Zag"
+        },
+        {
+            "area": 1,
+            "room": 36,
+            "name": "Ripper Sauna"
+        },
+        {
+            "area": 1,
+            "room": 37,
+            "name": "Charge Core Lower Access"
+        },
+        {
+            "area": 1,
+            "room": 38,
+            "name": "Sciser Playground"
+        },
+        {
+            "area": 1,
+            "room": 39,
+            "name": "Antechamber"
+        },
+        {
+            "area": 1,
+            "room": 40,
+            "name": "Charge Core Arena"
+        },
+        {
+            "area": 1,
+            "room": 41,
+            "name": "Sector 1 (SRX) Entrance Elevator"
+        },
+        {
+            "area": 1,
+            "room": 42,
+            "name": "Central Save Room"
+        },
+        {
+            "area": 1,
+            "room": 43,
+            "name": "Crab Rave"
+        },
+        {
+            "area": 1,
+            "room": 44,
+            "name": "Stabilizer Storage"
+        },
+        {
+            "area": 1,
+            "room": 45,
+            "name": "Sciser Puddle"
+        },
+        {
+            "area": 1,
+            "room": 46,
+            "name": "Hornoad Housing"
+        },
+        {
+            "area": 1,
+            "room": 47,
+            "name": "Watering Hole"
+        },
+        {
+            "area": 1,
+            "room": 48,
+            "name": "Sector 1 (SRX) Eastbound Glass Tube"
+        },
+        {
+            "area": 1,
+            "room": 49,
+            "name": "Sector 1 (SRX) Westbound Glass Tube"
+        },
+        {
+            "area": 1,
+            "room": 50,
+            "name": "Wall Jump Tutorial"
+        },
+        {
+            "area": 1,
+            "room": 51,
+            "name": "Animorphs"
+        },
+        {
+            "area": 1,
+            "room": 52,
+            "name": "Animorphs Cache"
+        },
+        {
+            "area": 2,
+            "room": 0,
+            "name": "Entrance Lobby"
+        },
+        {
+            "area": 2,
+            "room": 1,
+            "name": "Entrance Save Room"
+        },
+        {
+            "area": 2,
+            "room": 2,
+            "name": "Entrance Navigation Room"
+        },
+        {
+            "area": 2,
+            "room": 3,
+            "name": "Courtyard Access"
+        },
+        {
+            "area": 2,
+            "room": 30,
+            "name": "Courtyard Access"
+        },
+        {
+            "area": 2,
+            "room": 4,
+            "name": "Security Corridor"
+        },
+        {
+            "area": 2,
+            "room": 5,
+            "name": "Security Access"
+        },
+        {
+            "area": 2,
+            "room": 6,
+            "name": "Lobby Cache"
+        },
+        {
+            "area": 2,
+            "room": 8,
+            "name": "Data Room"
+        },
+        {
+            "area": 2,
+            "room": 9,
+            "name": "Zig-Zag-Zone"
+        },
+        {
+            "area": 2,
+            "room": 10,
+            "name": "Cultivation Station"
+        },
+        {
+            "area": 2,
+            "room": 11,
+            "name": "Puyo Corridor"
+        },
+        {
+            "area": 2,
+            "room": 12,
+            "name": "Shooting Gallery"
+        },
+        {
+            "area": 2,
+            "room": 13,
+            "name": "Cathedral"
+        },
+        {
+            "area": 2,
+            "room": 46,
+            "name": "Cathedral"
+        },
+        {
+            "area": 2,
+            "room": 14,
+            "name": "Cathedral Corridor"
+        },
+        {
+            "area": 2,
+            "room": 15,
+            "name": "Cathedral Save Access"
+        },
+        {
+            "area": 2,
+            "room": 16,
+            "name": "Cathedral Save Room"
+        },
+        {
+            "area": 2,
+            "room": 17,
+            "name": "Zazabi Arena Access"
+        },
+        {
+            "area": 2,
+            "room": 18,
+            "name": "Zazabi Arena"
+        },
+        {
+            "area": 2,
+            "room": 19,
+            "name": "Cloister"
+        },
+        {
+            "area": 2,
+            "room": 20,
+            "name": "Nettori Arena Access"
+        },
+        {
+            "area": 2,
+            "room": 34,
+            "name": "Nettori Arena Access"
+        },
+        {
+            "area": 2,
+            "room": 21,
+            "name": "Overgrown Cache"
+        },
+        {
+            "area": 2,
+            "room": 22,
+            "name": "Nettori Arena"
+        },
+        {
+            "area": 2,
+            "room": 51,
+            "name": "Nettori Arena"
+        },
+        {
+            "area": 2,
+            "room": 23,
+            "name": "Kihunter Hallway"
+        },
+        {
+            "area": 2,
+            "room": 24,
+            "name": "Overgrown Entrance"
+        },
+        {
+            "area": 2,
+            "room": 36,
+            "name": "Overgrown Entrance"
+        },
+        {
+            "area": 2,
+            "room": 25,
+            "name": "Oasis Storage"
+        },
+        {
+            "area": 2,
+            "room": 26,
+            "name": "Level 1 Security Room"
+        },
+        {
+            "area": 2,
+            "room": 27,
+            "name": "Dessgeega Dorm"
+        },
+        {
+            "area": 2,
+            "room": 28,
+            "name": "Reo Room"
+        },
+        {
+            "area": 2,
+            "room": 29,
+            "name": "Sector 2 (TRO) Entrance Elevator"
+        },
+        {
+            "area": 2,
+            "room": 31,
+            "name": "Data Courtyard"
+        },
+        {
+            "area": 2,
+            "room": 7,
+            "name": "Data Courtyard"
+        },
+        {
+            "area": 2,
+            "room": 32,
+            "name": "Overgrown Spire"
+        },
+        {
+            "area": 2,
+            "room": 35,
+            "name": "Overgrown Spire"
+        },
+        {
+            "area": 2,
+            "room": 33,
+            "name": "Kago Room"
+        },
+        {
+            "area": 2,
+            "room": 37,
+            "name": "Entrance Recharge Room"
+        },
+        {
+            "area": 2,
+            "room": 38,
+            "name": "Courtyard Save Room"
+        },
+        {
+            "area": 2,
+            "room": 39,
+            "name": "Owtch Office"
+        },
+        {
+            "area": 2,
+            "room": 40,
+            "name": "Zazabi Save Room"
+        },
+        {
+            "area": 2,
+            "room": 41,
+            "name": "Sanctum"
+        },
+        {
+            "area": 2,
+            "room": 45,
+            "name": "Sanctum"
+        },
+        {
+            "area": 2,
+            "room": 42,
+            "name": "Oasis"
+        },
+        {
+            "area": 2,
+            "room": 43,
+            "name": "Maintenance Wing"
+        },
+        {
+            "area": 2,
+            "room": 47,
+            "name": "Puyo Palace"
+        },
+        {
+            "area": 2,
+            "room": 48,
+            "name": "Hidden Recharge Room"
+        },
+        {
+            "area": 2,
+            "room": 49,
+            "name": "Nettori Save Room"
+        },
+        {
+            "area": 2,
+            "room": 50,
+            "name": "Ripper Tower"
+        },
+        {
+            "area": 2,
+            "room": 52,
+            "name": "Sector 2 (TRO) Westbound Glass Tube"
+        },
+        {
+            "area": 2,
+            "room": 53,
+            "name": "Sector 2 (TRO) Eastbound Glass Tube"
+        },
+        {
+            "area": 2,
+            "room": 54,
+            "name": "Crumble City"
+        },
+        {
+            "area": 2,
+            "room": 55,
+            "name": "Zazabi Speedway"
+        },
+        {
+            "area": 2,
+            "room": 56,
+            "name": "Overgrown Hallway"
+        },
+        {
+            "area": 2,
+            "room": 60,
+            "name": "Overgrown Hallway"
+        },
+        {
+            "area": 2,
+            "room": 57,
+            "name": "Overgrown Checkpoint"
+        },
+        {
+            "area": 2,
+            "room": 58,
+            "name": "Overgrown Checkpoint"
+        },
+        {
+            "area": 2,
+            "room": 59,
+            "name": "Broom Closet"
+        },
+        {
+            "area": 3,
+            "room": 0,
+            "name": "Entrance Lobby"
+        },
+        {
+            "area": 3,
+            "room": 1,
+            "name": "Entrance Save Room"
+        },
+        {
+            "area": 3,
+            "room": 2,
+            "name": "Entrance Navigation Room"
+        },
+        {
+            "area": 3,
+            "room": 3,
+            "name": "Security Access"
+        },
+        {
+            "area": 3,
+            "room": 4,
+            "name": "Level 2 Security Room"
+        },
+        {
+            "area": 3,
+            "room": 5,
+            "name": "Checkpoint Crossing"
+        },
+        {
+            "area": 3,
+            "room": 6,
+            "name": "Bob's Abode"
+        },
+        {
+            "area": 3,
+            "room": 24,
+            "name": "Bob's Abode"
+        },
+        {
+            "area": 3,
+            "room": 8,
+            "name": "Alcove"
+        },
+        {
+            "area": 3,
+            "room": 9,
+            "name": "Deserted Runway"
+        },
+        {
+            "area": 3,
+            "room": 10,
+            "name": "Red Tower"
+        },
+        {
+            "area": 3,
+            "room": 11,
+            "name": "Lava Reservoirs"
+        },
+        {
+            "area": 3,
+            "room": 12,
+            "name": "Lava Maze"
+        },
+        {
+            "area": 3,
+            "room": 13,
+            "name": "Sova Suite"
+        },
+        {
+            "area": 3,
+            "room": 14,
+            "name": "Pyrochamber Access"
+        },
+        {
+            "area": 3,
+            "room": 15,
+            "name": "Pyrochamber"
+        },
+        {
+            "area": 3,
+            "room": 16,
+            "name": "Boiler Access"
+        },
+        {
+            "area": 3,
+            "room": 17,
+            "name": "Main Boiler"
+        },
+        {
+            "area": 3,
+            "room": 29,
+            "name": "Main Boiler"
+        },
+        {
+            "area": 3,
+            "room": 19,
+            "name": "Sova Processing"
+        },
+        {
+            "area": 3,
+            "room": 20,
+            "name": "Sector 3 (PYR) Entrance Elevator"
+        },
+        {
+            "area": 3,
+            "room": 21,
+            "name": "Data Room"
+        },
+        {
+            "area": 3,
+            "room": 22,
+            "name": "B.O.X. Arena Access"
+        },
+        {
+            "area": 3,
+            "room": 7,
+            "name": "B.O.X. Arena Access"
+        },
+        {
+            "area": 3,
+            "room": 23,
+            "name": "B.O.X. Arena"
+        },
+        {
+            "area": 3,
+            "room": 18,
+            "name": "B.O.X. Arena"
+        },
+        {
+            "area": 3,
+            "room": 25,
+            "name": "Main Boiler Control Room"
+        },
+        {
+            "area": 3,
+            "room": 26,
+            "name": "Entrance Recharge Room"
+        },
+        {
+            "area": 3,
+            "room": 27,
+            "name": "Monkey Bars of Fire"
+        },
+        {
+            "area": 3,
+            "room": 28,
+            "name": "Fiery Storage"
+        },
+        {
+            "area": 3,
+            "room": 30,
+            "name": "Namihe's Lair"
+        },
+        {
+            "area": 3,
+            "room": 31,
+            "name": "Data Recharge Room"
+        },
+        {
+            "area": 3,
+            "room": 32,
+            "name": "Data Save Room"
+        },
+        {
+            "area": 3,
+            "room": 33,
+            "name": "Geron's Treasure"
+        },
+        {
+            "area": 3,
+            "room": 34,
+            "name": "Processing Access"
+        },
+        {
+            "area": 3,
+            "room": 35,
+            "name": "Garbage Chute"
+        },
+        {
+            "area": 3,
+            "room": 36,
+            "name": "Chute Access"
+        },
+        {
+            "area": 3,
+            "room": 37,
+            "name": "Sector 3 (PYR) Westbound Glass Tube"
+        },
+        {
+            "area": 3,
+            "room": 38,
+            "name": "Sector 3 (PYR) Eastbound Glass Tube"
+        },
+        {
+            "area": 4,
+            "room": 0,
+            "name": "Entrance Lobby"
+        },
+        {
+            "area": 4,
+            "room": 1,
+            "name": "Entrance Save Room"
+        },
+        {
+            "area": 4,
+            "room": 2,
+            "name": "Entrance Navigation Room"
+        },
+        {
+            "area": 4,
+            "room": 3,
+            "name": "Powamp Playhouse"
+        },
+        {
+            "area": 4,
+            "room": 4,
+            "name": "Data Room"
+        },
+        {
+            "area": 4,
+            "room": 5,
+            "name": "Sciser Stall"
+        },
+        {
+            "area": 4,
+            "room": 6,
+            "name": "Reservoir East"
+        },
+        {
+            "area": 4,
+            "room": 7,
+            "name": "Skultera Cisterns"
+        },
+        {
+            "area": 4,
+            "room": 8,
+            "name": "Bridge Access"
+        },
+        {
+            "area": 4,
+            "room": 9,
+            "name": "Serris Speedway"
+        },
+        {
+            "area": 4,
+            "room": 10,
+            "name": "Broken Bridge"
+        },
+        {
+            "area": 4,
+            "room": 11,
+            "name": "Reservoir Save Room"
+        },
+        {
+            "area": 4,
+            "room": 12,
+            "name": "Aquarium Speedway"
+        },
+        {
+            "area": 4,
+            "room": 13,
+            "name": "Reservoir Vault"
+        },
+        {
+            "area": 4,
+            "room": 14,
+            "name": "Aquarium Shaft"
+        },
+        {
+            "area": 4,
+            "room": 15,
+            "name": "Yard Firing Range"
+        },
+        {
+            "area": 4,
+            "room": 16,
+            "name": "Evir Enclosure"
+        },
+        {
+            "area": 4,
+            "room": 17,
+            "name": "Aquarium Pirate Tank"
+        },
+        {
+            "area": 4,
+            "room": 18,
+            "name": "Aquarium Hub Access"
+        },
+        {
+            "area": 4,
+            "room": 19,
+            "name": "Aquarium Hub"
+        },
+        {
+            "area": 4,
+            "room": 20,
+            "name": "Reservoir West"
+        },
+        {
+            "area": 4,
+            "room": 21,
+            "name": "Pump Control Access"
+        },
+        {
+            "area": 4,
+            "room": 22,
+            "name": "Pump Control Save Room"
+        },
+        {
+            "area": 4,
+            "room": 23,
+            "name": "Cargo Hold"
+        },
+        {
+            "area": 4,
+            "room": 24,
+            "name": "Cheddar Bay"
+        },
+        {
+            "area": 4,
+            "room": 25,
+            "name": "Security Access"
+        },
+        {
+            "area": 4,
+            "room": 26,
+            "name": "Level 4 Security Room"
+        },
+        {
+            "area": 4,
+            "room": 27,
+            "name": "Sector 4 (AQA) Entrance Elevator"
+        },
+        {
+            "area": 4,
+            "room": 28,
+            "name": "Waterway"
+        },
+        {
+            "area": 4,
+            "room": 29,
+            "name": "Entrance Recharge Room"
+        },
+        {
+            "area": 4,
+            "room": 30,
+            "name": "Breeding Tank Access"
+        },
+        {
+            "area": 4,
+            "room": 31,
+            "name": "Breeding Tank"
+        },
+        {
+            "area": 4,
+            "room": 32,
+            "name": "Bridge Save Room"
+        },
+        {
+            "area": 4,
+            "room": 33,
+            "name": "Pump Control Unit"
+        },
+        {
+            "area": 4,
+            "room": 34,
+            "name": "Security Bypass"
+        },
+        {
+            "area": 4,
+            "room": 35,
+            "name": "Powamp Shaft"
+        },
+        {
+            "area": 4,
+            "room": 36,
+            "name": "Drain Pipe"
+        },
+        {
+            "area": 4,
+            "room": 37,
+            "name": "Owtch Atrium"
+        },
+        {
+            "area": 4,
+            "room": 38,
+            "name": "Aquarium Kago Storage"
+        },
+        {
+            "area": 4,
+            "room": 39,
+            "name": "Aquarium Save Room West"
+        },
+        {
+            "area": 4,
+            "room": 40,
+            "name": "Sciser Sanctuary"
+        },
+        {
+            "area": 4,
+            "room": 41,
+            "name": "Sanctuary Cache"
+        },
+        {
+            "area": 4,
+            "room": 42,
+            "name": "Serris Arena"
+        },
+        {
+            "area": 4,
+            "room": 43,
+            "name": "Sector 4 (AQA) Eastbound Glass Tube"
+        },
+        {
+            "area": 4,
+            "room": 44,
+            "name": "Sector 4 (AQA) Westbound Glass Tube"
+        },
+        {
+            "area": 4,
+            "room": 45,
+            "name": "Hideout"
+        },
+        {
+            "area": 4,
+            "room": 46,
+            "name": "C-Cache"
+        },
+        {
+            "area": 4,
+            "room": 47,
+            "name": "Aquarium Save Room East"
+        },
+        {
+            "area": 5,
+            "room": 0,
+            "name": "Entrance Lobby"
+        },
+        {
+            "area": 5,
+            "room": 1,
+            "name": "Entrance Save Room"
+        },
+        {
+            "area": 5,
+            "room": 2,
+            "name": "Entrance Navigation Room"
+        },
+        {
+            "area": 5,
+            "room": 3,
+            "name": "Training Grounds"
+        },
+        {
+            "area": 5,
+            "room": 6,
+            "name": "Training Grounds"
+        },
+        {
+            "area": 5,
+            "room": 4,
+            "name": "Training Aerie"
+        },
+        {
+            "area": 5,
+            "room": 7,
+            "name": "Arctic Containment"
+        },
+        {
+            "area": 5,
+            "room": 15,
+            "name": "Arctic Containment"
+        },
+        {
+            "area": 5,
+            "room": 8,
+            "name": "Zeela Checkpoint"
+        },
+        {
+            "area": 5,
+            "room": 9,
+            "name": "Security Shaft West"
+        },
+        {
+            "area": 5,
+            "room": 10,
+            "name": "Level 3 Security Room"
+        },
+        {
+            "area": 5,
+            "room": 11,
+            "name": "Waver Ward"
+        },
+        {
+            "area": 5,
+            "room": 12,
+            "name": "E-Tank Mimic Den"
+        },
+        {
+            "area": 5,
+            "room": 13,
+            "name": "Frozen Tower"
+        },
+        {
+            "area": 5,
+            "room": 14,
+            "name": "Mini-Fridge"
+        },
+        {
+            "area": 5,
+            "room": 16,
+            "name": "Data Room"
+        },
+        {
+            "area": 5,
+            "room": 17,
+            "name": "Ruined Corridor"
+        },
+        {
+            "area": 5,
+            "room": 18,
+            "name": "Nightmare Hub"
+        },
+        {
+            "area": 5,
+            "room": 19,
+            "name": "Nightmare Upper Access"
+        },
+        {
+            "area": 5,
+            "room": 20,
+            "name": "Nightmare Arena"
+        },
+        {
+            "area": 5,
+            "room": 22,
+            "name": "Security Shaft East"
+        },
+        {
+            "area": 5,
+            "room": 21,
+            "name": "Security Shaft East"
+        },
+        {
+            "area": 5,
+            "room": 23,
+            "name": "Ripper's Treasure"
+        },
+        {
+            "area": 5,
+            "room": 24,
+            "name": "Cellar"
+        },
+        {
+            "area": 5,
+            "room": 25,
+            "name": "Sector 5 (ARC) Entrance Elevator"
+        },
+        {
+            "area": 5,
+            "room": 26,
+            "name": "Ripper Road"
+        },
+        {
+            "area": 5,
+            "room": 27,
+            "name": "Nightmare Lower Access"
+        },
+        {
+            "area": 5,
+            "room": 28,
+            "name": "Flooded Access"
+        },
+        {
+            "area": 5,
+            "room": 29,
+            "name": "Security Save Room"
+        },
+        {
+            "area": 5,
+            "room": 30,
+            "name": "Magic Box"
+        },
+        {
+            "area": 5,
+            "room": 31,
+            "name": "Sector 5 (ARC) Westbound Glass Tube"
+        },
+        {
+            "area": 5,
+            "room": 32,
+            "name": "Entrance Recharge Room"
+        },
+        {
+            "area": 5,
+            "room": 33,
+            "name": "Gerubus Gully"
+        },
+        {
+            "area": 5,
+            "room": 34,
+            "name": "Nightmare Nook"
+        },
+        {
+            "area": 5,
+            "room": 35,
+            "name": "Data Checkpoint"
+        },
+        {
+            "area": 5,
+            "room": 36,
+            "name": "Crow's Nest"
+        },
+        {
+            "area": 5,
+            "room": 37,
+            "name": "Sector 5 (ARC) Eastbound Glass Tube"
+        },
+        {
+            "area": 5,
+            "room": 38,
+            "name": "Cellar Save Room"
+        },
+        {
+            "area": 5,
+            "room": 39,
+            "name": "Kago Roadblock"
+        },
+        {
+            "area": 5,
+            "room": 41,
+            "name": "Kago Speedway"
+        },
+        {
+            "area": 5,
+            "room": 42,
+            "name": "Arctic Underside"
+        },
+        {
+            "area": 5,
+            "room": 43,
+            "name": "Subway"
+        },
+        {
+            "area": 5,
+            "room": 45,
+            "name": "Flooded Tower"
+        },
+        {
+            "area": 5,
+            "room": 46,
+            "name": "Zebesian Waters"
+        },
+        {
+            "area": 5,
+            "room": 47,
+            "name": "Ruined Break Room"
+        },
+        {
+            "area": 5,
+            "room": 48,
+            "name": "Nightmare Recharge Room"
+        },
+        {
+            "area": 5,
+            "room": 49,
+            "name": "Nightmare Save Room"
+        },
+        {
+            "area": 5,
+            "room": 50,
+            "name": "Flooded Airlock"
+        },
+        {
+            "area": 5,
+            "room": 51,
+            "name": "Transmutation Trial"
+        },
+        {
+            "area": 6,
+            "room": 0,
+            "name": "Entrance Lobby"
+        },
+        {
+            "area": 6,
+            "room": 1,
+            "name": "Entrance Save Room"
+        },
+        {
+            "area": 6,
+            "room": 2,
+            "name": "Entrance Navigation Room"
+        },
+        {
+            "area": 6,
+            "room": 3,
+            "name": "Geron's Crossing"
+        },
+        {
+            "area": 6,
+            "room": 4,
+            "name": "Nocturnal Access"
+        },
+        {
+            "area": 6,
+            "room": 5,
+            "name": "Nocturnal Shaft"
+        },
+        {
+            "area": 6,
+            "room": 6,
+            "name": "Blue-X Blockade"
+        },
+        {
+            "area": 6,
+            "room": 7,
+            "name": "Forbidden Entrance"
+        },
+        {
+            "area": 6,
+            "room": 8,
+            "name": "Nocturnal Playground"
+        },
+        {
+            "area": 6,
+            "room": 9,
+            "name": "Clogged Cavern"
+        },
+        {
+            "area": 6,
+            "room": 33,
+            "name": "Clogged Cavern"
+        },
+        {
+            "area": 6,
+            "room": 10,
+            "name": "Warehouse"
+        },
+        {
+            "area": 6,
+            "room": 11,
+            "name": "Data Save Room"
+        },
+        {
+            "area": 6,
+            "room": 12,
+            "name": "Data Access"
+        },
+        {
+            "area": 6,
+            "room": 13,
+            "name": "Varia Core-X Arena"
+        },
+        {
+            "area": 6,
+            "room": 14,
+            "name": "X-B.O.X. Arena Access"
+        },
+        {
+            "area": 6,
+            "room": 15,
+            "name": "Zozoro Wine Cellar"
+        },
+        {
+            "area": 6,
+            "room": 16,
+            "name": "X-B.O.X. Arena"
+        },
+        {
+            "area": 6,
+            "room": 17,
+            "name": "Sector 6 (NOC) Entrance Elevator"
+        },
+        {
+            "area": 6,
+            "room": 18,
+            "name": "X-B.O.X. Garage"
+        },
+        {
+            "area": 6,
+            "room": 19,
+            "name": "Bull Bend"
+        },
+        {
+            "area": 6,
+            "room": 20,
+            "name": "Neglected Shaft"
+        },
+        {
+            "area": 6,
+            "room": 21,
+            "name": "Neglected Save Room"
+        },
+        {
+            "area": 6,
+            "room": 22,
+            "name": "Authorization Checkpoint"
+        },
+        {
+            "area": 6,
+            "room": 23,
+            "name": "Cavern Save Room"
+        },
+        {
+            "area": 6,
+            "room": 24,
+            "name": "Missile Mimic Lodge"
+        },
+        {
+            "area": 6,
+            "room": 25,
+            "name": "Data Room"
+        },
+        {
+            "area": 6,
+            "room": 26,
+            "name": "Catacombs"
+        },
+        {
+            "area": 6,
+            "room": 27,
+            "name": "Weapons Testing Grounds"
+        },
+        {
+            "area": 6,
+            "room": 28,
+            "name": "Warehouse Access"
+        },
+        {
+            "area": 6,
+            "room": 29,
+            "name": "Entrance Recharge Room"
+        },
+        {
+            "area": 6,
+            "room": 30,
+            "name": "Twin Caverns West"
+        },
+        {
+            "area": 6,
+            "room": 31,
+            "name": "Twin Caverns East"
+        },
+        {
+            "area": 6,
+            "room": 32,
+            "name": "Maintenance Wing"
+        },
+        {
+            "area": 6,
+            "room": 34,
+            "name": "Vault"
+        },
+        {
+            "area": 6,
+            "room": 35,
+            "name": "Twin Cavern Save Room"
+        },
+        {
+            "area": 6,
+            "room": 36,
+            "name": "Sector 6 (NOC) Westbound Glass Tube"
+        },
+        {
+            "area": 6,
+            "room": 37,
+            "name": "Sector 6 (NOC) Eastbound Glass Tube"
+        },
+        {
+            "area": 6,
+            "room": 38,
+            "name": "Pillar Highway"
+        },
+        {
+            "area": 6,
+            "room": 39,
+            "name": "Spaceboost Alley"
+        },
+        {
+            "area": 6,
+            "room": 40,
+            "name": "Cavern Save Access"
+        }
+    ],
+    "skip_door_transitions": false,
+    "instant_unmorph": true,
+    "nerf_gerons": true,
+    "use_alternative_hud_health_layout": false,
+    "unexplored_map": true,
+    "reveal_hidden_tiles": true,
+    "stereo_default": true,
+    "disable_music": false,
+    "disable_sound_effects": false,
+    "environmental_damage": {
+        "lava": 100,
+        "acid": 60,
+        "heat": 6,
+        "cold": 15,
+        "subzero": 6
+    },
+    "_randovania_meta": {
+        "layout_was_user_modified": false,
+        "in_race_setting": false
+    }
+}


### PR DESCRIPTION
fixes an issue where multipliers above 1.0 were being incorrectly handled, wasn't sure how to handle changelog heading lmk if this is right
related:
https://discordapp.com/channels/914291389293027329/914294272579227668/1504150059070132455

also fixes a DR multiplier for fusion, not in stable yet so no changelog
related:
https://discordapp.com/channels/914291389293027329/1503997036536533082