### PR TITLE
Dread Cold Room Intro Logic

### DIFF
--- a/randovania/games/dread/logic_database/Artaria.json
+++ b/randovania/games/dread/logic_database/Artaria.json
@@ -21183,6 +21183,58 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Have at least 199 energy",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "ETank",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "EFragment",
+                                                                    "amount": 4,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Movement",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/dread/logic_database/Artaria.txt
+++ b/randovania/games/dread/logic_database/Artaria.txt
@@ -3804,8 +3804,12 @@ Extra - asset_id: collision_camera_062
   * Extra - right_shield_def: None
   > Door to Speed Hallway
       Any of the following:
-          Gravity Suit
+          Gravity Suit or Movement (Intermediate)
           Heat/Cold Runs (Beginner) and Cold Damage ≥ 40
+          All of the following:
+              Movement (Beginner)
+              # Have at least 199 energy
+              Energy Part ≥ 4 or Energy Tank
 
 > Door to Speed Hallway; Heals? False
   * Layers: default


### PR DESCRIPTION
The Cold introduction room in Dread is a room I would like to include in logic without Gravity. Since Heat/Cold runs do not work in logic, I would like to offer that this room be given logic with a movement trick. At beginner with extra energy, or intermediate with no energy. There is no danger to softlocks thanks to respawning enemies on the left, and an energy refill on the right.