### PR TITLE
Update dependency planets-yapr to v1.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ exporters = [
     "mars-patcher==0.14.2",
 
     # Metroid Planets
-    "planets-yapr==1.0.2",
+    "planets-yapr==1.0.3",
 
     # Metroid Prime 1
     "py_randomprime==1.30.4",

--- a/uv.lock
+++ b/uv.lock
@@ -2041,14 +2041,14 @@ wheels = [
 
 [[package]]
 name = "planets-yapr"
-version = "1.0.2"
+version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pythonnet" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/23/373c819dfe1e8ed1d5c568cf43534cc884be0fca80de8c3c443db0b79f06/planets_yapr-1.0.2.tar.gz", hash = "sha256:1cfefda29efc3d4c937b77b5361f848244422d6192cf70c9009a725eec0541d2", size = 1769634, upload-time = "2026-02-25T18:43:58.289Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/1b/8e7bf0fb59e80239573423fd5b0aad385b118cb838b20c799b76bee3b755/planets_yapr-1.0.3.tar.gz", hash = "sha256:a554910bae4e6f0b2d6e86a8db620ffd1ee2eb975c38e0cacd7dd05625502e53", size = 1770808, upload-time = "2026-05-19T17:02:07.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/e5/81cb3f09aa54f43e6288b1613c0ee27356a477cd98034b44793b905635eb/planets_yapr-1.0.2-py3-none-any.whl", hash = "sha256:0a9f4ac92c9b4224d42a5dd34449520c8d8b6d548fadb628d12464db82438541", size = 1765982, upload-time = "2026-02-25T18:43:56.48Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c8/aa9cf0e76ca119d34e0a90d98cef538d2288bb45327aff963f47f6a9ec0c/planets_yapr-1.0.3-py3-none-any.whl", hash = "sha256:68fab556e1b7111ca4d2cce00183c3fa7228de18fcd794b23ed53a3e7958986e", size = 1766943, upload-time = "2026-05-19T17:02:05.304Z" },
 ]
 
 [[package]]
@@ -3016,7 +3016,7 @@ requires-dist = [
     { name = "peewee", marker = "extra == 'server'", specifier = "<4" },
     { name = "pid", marker = "extra == 'gui'", specifier = ">=3.0.0" },
     { name = "pillow", marker = "extra == 'server'", specifier = ">=9.0.0" },
-    { name = "planets-yapr", marker = "extra == 'exporters'", specifier = "==1.0.2" },
+    { name = "planets-yapr", marker = "extra == 'exporters'", specifier = "==1.0.3" },
     { name = "ppc-asm", marker = "extra == 'exporters'", specifier = ">=1.2.1" },
     { name = "prometheus-fastapi-instrumentator", marker = "extra == 'server'" },
     { name = "py-cord", marker = "extra == 'server'", specifier = ">=2.8,<2.9" },


### PR DESCRIPTION
## Fixes a bug caused by the usage of the pickup type as sprite_index property
sprite_index would be using pickup type instead of the sprite name causing the compiler to fail
ex: `sprite_index = Morph Ball` instead of `sprite_index = spr_ITEM_Morph`

## Fixes a bug caused by having model null in the pickup config
ex: sprite becomes `Nothing` instead of `spr_ITEM_Nothing`
which leads to the bug above

## Implements Screw Attack breaking blocks option (patcher side only for now)
I tried to make it as close as possible from other Metroid titles