### PR TITLE
Trickless for Kraid Upper

### DIFF
--- a/randovania/games/zero_mission/game_data.py
+++ b/randovania/games/zero_mission/game_data.py
@@ -82,7 +82,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="QMV5ZW7E",
+        expected_seed_hash="SCUGMRUQ",
     )
 
 

--- a/randovania/games/zero_mission/logic_database/Kraid.json
+++ b/randovania/games/zero_mission/logic_database/Kraid.json
@@ -328,25 +328,8 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Gauntlet": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Hi-Jump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Use Space Jump"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Have Any Jump Upgrade"
                         },
                         "Door to Sidehopper Hall": {
                             "type": "and",
@@ -830,6 +813,10 @@
                                 "items": [
                                     {
                                         "type": "template",
+                                        "data": "Can Break Single Bomb Blocks"
+                                    },
+                                    {
+                                        "type": "template",
                                         "data": "Can Use Ball Launcher"
                                     }
                                 ]
@@ -870,8 +857,25 @@
                             }
                         },
                         "Door to Upper Corridor": {
-                            "type": "template",
-                            "data": "Climb Ledges"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "PowerGrip",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Space Jump"
+                                    }
+                                ]
+                            }
                         },
                         "Door to Caged Sidehopper Hall": {
                             "type": "resource",

--- a/randovania/games/zero_mission/logic_database/Kraid.json
+++ b/randovania/games/zero_mission/logic_database/Kraid.json
@@ -328,12 +328,24 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Gauntlet": {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Hi-Jump",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Hi-Jump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Space Jump"
+                                    }
+                                ]
                             }
                         },
                         "Door to Sidehopper Hall": {
@@ -341,6 +353,15 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Door to Divided Alcove": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "MorphBall",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -389,12 +410,16 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Space Jump"
                                     }
                                 ]
                             }
                         },
                         "Door to Divided Alcove": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -408,51 +433,8 @@
                                         }
                                     },
                                     {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "IceBeam",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "IBA",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "MidairMorph",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Bounce in Ball"
-                                                }
-                                            ]
-                                        }
+                                        "type": "template",
+                                        "data": "Climb Ledges"
                                     }
                                 ]
                             }
@@ -676,13 +658,22 @@
                             }
                         },
                         "Room Center": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
                                         "type": "template",
-                                        "data": "Can Bounce in Ball"
+                                        "data": "Climb High Ledges"
                                     }
                                 ]
                             }
@@ -839,7 +830,7 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Use Any Bombs"
+                                        "data": "Can Use Ball Launcher"
                                     }
                                 ]
                             }
@@ -879,30 +870,8 @@
                             }
                         },
                         "Door to Upper Corridor": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "PowerGrip",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "SpaceJump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Climb Ledges"
                         },
                         "Door to Caged Sidehopper Hall": {
                             "type": "resource",

--- a/randovania/games/zero_mission/logic_database/Kraid.txt
+++ b/randovania/games/zero_mission/logic_database/Kraid.txt
@@ -61,7 +61,7 @@ Extra - room_id: [0]
   * Blue Door to Corrosive Pool/Door to Elevator to Brinstar
   * Extra - door_idx: (6,)
   > Door to Gauntlet
-      Hi-Jump Boots or Use Space Jump
+      Have Any Jump Upgrade
   > Door to Sidehopper Hall
       Trivial
   > Door to Divided Alcove
@@ -149,14 +149,14 @@ Extra - room_id: [2]
   * Blue Door to Caged Sidehopper Hall/Door to Apex Launcher Hub
   * Extra - door_idx: (14,)
   > Room Center
-      Can Use Ball Launcher
+      Can Break Single Bomb Blocks and Can Use Ball Launcher
 
 > Room Center; Heals? False
   * Layers: default
   > Pickup (Missile Tank)
       Morph Ball
   > Door to Upper Corridor
-      Climb Ledges
+      Power Grip or Use Space Jump
   > Door to Caged Sidehopper Hall
       Morph Ball
 

--- a/randovania/games/zero_mission/logic_database/Kraid.txt
+++ b/randovania/games/zero_mission/logic_database/Kraid.txt
@@ -61,20 +61,20 @@ Extra - room_id: [0]
   * Blue Door to Corrosive Pool/Door to Elevator to Brinstar
   * Extra - door_idx: (6,)
   > Door to Gauntlet
-      Hi-Jump Boots
+      Hi-Jump Boots or Use Space Jump
   > Door to Sidehopper Hall
       Trivial
+  > Door to Divided Alcove
+      Morph Ball
 
 > Door to Sidehopper Hall; Heals? False
   * Layers: default
   * Blue Door to Sidehopper Hall/Door to Elevator to Brinstar
   * Extra - door_idx: (7,)
   > Door to Gauntlet
-      Ice Beam
+      Ice Beam or Use Space Jump
   > Door to Divided Alcove
-      Any of the following:
-          Morph Ball or Mid-Air Morphs (Beginner) or Can Bounce in Ball
-          Ice Beam and Ice Beam Abuse (Beginner)
+      Morph Ball and Climb Ledges
 
 > Door to Divided Alcove; Heals? False
   * Layers: default
@@ -123,7 +123,7 @@ Extra - room_id: [2]
   > Door to Caged Sidehopper Hall
       Trivial
   > Room Center
-      Can Bounce in Ball
+      Morph Ball and Climb High Ledges
 
 > Door to Upper Corridor; Heals? False
   * Layers: default
@@ -149,14 +149,14 @@ Extra - room_id: [2]
   * Blue Door to Caged Sidehopper Hall/Door to Apex Launcher Hub
   * Extra - door_idx: (14,)
   > Room Center
-      Can Use Any Bombs
+      Can Use Ball Launcher
 
 > Room Center; Heals? False
   * Layers: default
   > Pickup (Missile Tank)
       Morph Ball
   > Door to Upper Corridor
-      Power Grip or Space Jump (Unknown Item 2)
+      Climb Ledges
   > Door to Caged Sidehopper Hall
       Morph Ball
 

--- a/randovania/games/zero_mission/logic_database/header.json
+++ b/randovania/games/zero_mission/logic_database/header.json
@@ -850,11 +850,52 @@
                 "requirement": {
                     "type": "and",
                     "data": {
-                        "comment": "TODO: do PBs open launchers?",
+                        "comment": "This template is used when any requirements requires using a Ball Launcher",
                         "items": [
                             {
                                 "type": "template",
                                 "data": "Can Use Bombs"
+                            }
+                        ]
+                    }
+                }
+            },
+            "Can Break Single Bomb Blocks": {
+                "display_name": "Can Break Single Bomb Blocks",
+                "requirement": {
+                    "type": "or",
+                    "data": {
+                        "comment": "Breaking single bomb blocks in a space where Screw Attack can be used to destroy them",
+                        "items": [
+                            {
+                                "type": "template",
+                                "data": "Can Use Any Bombs"
+                            },
+                            {
+                                "type": "and",
+                                "data": {
+                                    "comment": null,
+                                    "items": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": "items",
+                                                "name": "ScrewAttack",
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": "tricks",
+                                                "name": "Knowledge",
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
                             }
                         ]
                     }

--- a/randovania/games/zero_mission/logic_database/header.json
+++ b/randovania/games/zero_mission/logic_database/header.json
@@ -844,6 +844,21 @@
                         ]
                     }
                 }
+            },
+            "Can Use Ball Launcher": {
+                "display_name": "Can Use Ball Launcher",
+                "requirement": {
+                    "type": "and",
+                    "data": {
+                        "comment": "TODO: do PBs open launchers?",
+                        "items": [
+                            {
+                                "type": "template",
+                                "data": "Can Use Bombs"
+                            }
+                        ]
+                    }
+                }
             }
         },
         "damage_reductions": [],
@@ -1097,7 +1112,6 @@
             1
         ],
         "IBA": [
-            1,
             2
         ],
         "Shinespark": [

--- a/randovania/games/zero_mission/logic_database/header.txt
+++ b/randovania/games/zero_mission/logic_database/header.txt
@@ -60,6 +60,10 @@ Templates
       # This template is used when any requirement requires at least 1 Super Missile
       Super Missile Launcher and Super Missiles
 
+* Can Use Ball Launcher:
+      # TODO: do PBs open launchers?
+      Can Use Bombs
+
 ====================
 Dock Weaknesses
 

--- a/randovania/games/zero_mission/logic_database/header.txt
+++ b/randovania/games/zero_mission/logic_database/header.txt
@@ -61,8 +61,14 @@ Templates
       Super Missile Launcher and Super Missiles
 
 * Can Use Ball Launcher:
-      # TODO: do PBs open launchers?
+      # This template is used when any requirements requires using a Ball Launcher
       Can Use Bombs
+
+* Can Break Single Bomb Blocks:
+      Any of the following:
+          # Breaking single bomb blocks in a space where Screw Attack can be used to destroy them
+          Can Use Any Bombs
+          Screw Attack and Knowledge (Beginner)
 
 ====================
 Dock Weaknesses


### PR DESCRIPTION
Rewrote logic to include all trickless logic for the first three rooms in Kraid. Need to add zipline item in another PR before doing the rest of the attic. 

- Kraid/Elevator to Brinstar
- Kraid/Caged Sidehopper Hall
- Kraid/Apex Launcher Hub