### PR TITLE
Prime 1 MW: Don't read invalid CPlayer at title screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Prime
 
-- Fixed: Observatory: Softlock if upper 1st-pass pirates killed before entering the room
-- Fixed: Training Chamber: Softlock if room unloaded after triggering fight but before killing both ghosts (e.g. wallcrawl)
+- Fixed: When having Randovania connected to the game while on the title screen, it will not throw warnings (Dolphin) or repeatedly disconnect (Nintendont) from the game.
+- Fixed: Observatory: Softlock if the upper 1st-pass pirates are killed before entering the room
+- Fixed: Training Chamber: Softlock if the room unloaded after triggering fight but before killing both ghosts (e.g. wallcrawl)
 - Fixed: GM8E30 (Korean) support
 - Changed: Wavebuster no longer consumes ammo if cancelled due to "point blank range" rule
 - Changed: Updated tournament scan to include 2025 winners

--- a/randovania/game_connection/connector/prime1_remote_connector.py
+++ b/randovania/game_connection/connector/prime1_remote_connector.py
@@ -70,23 +70,31 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
         memory_ops = [
             MemoryOperation(self.version.game_state_pointer, offset=mlvl_offset, read_byte_count=asset_id_size),
             MemoryOperation(cstate_manager_global + self._pending_op_offset, read_byte_count=1),
-            MemoryOperation(cstate_manager_global + cplayer_offset, offset=0, read_byte_count=4),
+            MemoryOperation(cstate_manager_global + cplayer_offset, read_byte_count=4),
         ]
         results = await self.executor.perform_memory_operations(memory_ops)
 
-        pending_op_byte = results[memory_ops[1]]
+        world_asset_id, pending_op_byte, cplayer_pointer = results.values()
 
         has_pending_op = pending_op_byte != b"\x00"
-        current_world = self._current_status_world(results.get(memory_ops[0]), results.get(memory_ops[2]))
+
+        cplayer_vtable = None
+        if cplayer_pointer != b"\x00" * 4:
+            cplayer_memory_op = MemoryOperation(int.from_bytes(cplayer_pointer, "big"), read_byte_count=4)
+            cplayer_vtable = await self.executor.perform_single_memory_operation(cplayer_memory_op)
+
+        current_world = self._current_status_world(world_asset_id, cplayer_vtable)
         return has_pending_op, current_world
 
     async def _memory_op_for_items(
         self,
         items: list[ItemResourceInfo],
     ) -> list[MemoryOperation]:
+        cplayer_state_offset = 0x8B8
+
         op = await self.executor.perform_single_memory_operation(
             MemoryOperation(
-                address=self.version.cstate_manager_global + 0x8B8,
+                address=self.version.cstate_manager_global + cplayer_state_offset,
                 read_byte_count=4,
             )
         )


### PR DESCRIPTION
The `offset=0` causes nintendont to treat the given address as a pointer, dereference it, and read the 4 bytes at the new address. There are a few situations where CPlayer can be null, primarily the title screen and elevators, so in order to not force a disconnect there, let's be safe and manually throw another request to read the vtable.