### PR TITLE
refactor PrimeTrilogyTeleporterConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid Prime 2: Echoes
 
 - Changed: Dark, Light, and Beam Ammo Expansions are now considered dark-aligned, light-aligned and both, respectively.
+- Removed: A setting that disabled all room names on the map when elevators are randomized. This setting is redundant, since elevator rooms are not revealed on the map at all when randomized.
 
 #### Logic Database
 

--- a/randovania/games/common/prime_family/layout/lib/prime_trilogy_teleporters.py
+++ b/randovania/games/common/prime_family/layout/lib/prime_trilogy_teleporters.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import override
 
-from randovania.game.game_enum import RandovaniaGame
 from randovania.game_description import default_database
+from randovania.game_description.db.area_identifier import AreaIdentifier
 from randovania.game_description.db.node_identifier import NodeIdentifier
 from randovania.layout.lib.teleporters import TeleporterConfiguration, TeleporterShuffleMode
 
@@ -11,49 +12,13 @@ from randovania.layout.lib.teleporters import TeleporterConfiguration, Teleporte
 @dataclasses.dataclass(frozen=True)
 class PrimeTrilogyTeleporterConfiguration(TeleporterConfiguration):
     skip_final_bosses: bool
-    allow_unvisited_room_names: bool
-
-    def get_credits_node(self) -> NodeIdentifier:
-        match self.game:
-            case RandovaniaGame.METROID_PRIME:
-                return NodeIdentifier.create("End of Game", "Credits", "Event - Credits")
-            case RandovaniaGame.METROID_PRIME_ECHOES:
-                return NodeIdentifier.create("Temple Grounds", "Credits", "Event - Dark Samus 3 and 4")
-            case _:
-                raise ValueError(f"Unsupported game {self.game}")
 
     @property
-    def can_use_unvisited_room_names(self) -> bool:
-        return self.is_vanilla or self.allow_unvisited_room_names
+    def specific_valid_targets(self) -> dict[AreaIdentifier, NodeIdentifier]:
+        """Some areas are weird and need specific overrides for `valid_targets`"""
+        return {}
 
-    @property
-    def static_teleporters(self) -> dict[NodeIdentifier, NodeIdentifier]:
-        static = {}
-        if self.game == RandovaniaGame.METROID_PRIME:
-            credits_node = self.get_credits_node()
-            if self.skip_final_bosses:
-                crater = NodeIdentifier.create("Tallon Overworld", "Artifact Temple", "Teleporter to Impact Crater")
-                static[crater] = credits_node
-            elif self.mode in [
-                TeleporterShuffleMode.ONE_WAY_TELEPORTER,
-                TeleporterShuffleMode.ONE_WAY_TELEPORTER_REPLACEMENT,
-            ]:
-                # We need to always have the possibility of having credits as a target.
-                # On two-way, this is ensured by this teleporter always having this assignment.
-                # On one-way-anywhere, this can be ensured as there is a dedicated credits target available.
-                # But on these two one-way modes, there is not, so let's statically assign it to ensure that
-                # one elevator always leads to credits.
-                essence = NodeIdentifier.create("Impact Crater", "Metroid Prime Lair", "Teleporter to Credits")
-                static[essence] = credits_node
-        elif self.game == RandovaniaGame.METROID_PRIME_ECHOES:
-            if self.skip_final_bosses:
-                gateway = NodeIdentifier.create("Sky Temple Grounds", "Sky Temple Gateway", "Elevator to Sky Temple")
-                static[gateway] = self.get_credits_node()
-        else:
-            raise ValueError(f"Unsupported game {self.game}")
-
-        return static
-
+    @override
     @property
     def valid_targets(self) -> list[NodeIdentifier]:
         original = super().valid_targets
@@ -72,10 +37,11 @@ class PrimeTrilogyTeleporterConfiguration(TeleporterConfiguration):
                 # Valid destinations must be valid starting areas
                 if area.has_start_node():
                     result.append(identifier)
-                # Hack for Metroid Prime 1, where the scripting for Metroid Prime Lair is dependent
-                # on the previous room
-                elif area.name == "Metroid Prime Lair":
-                    result.append(NodeIdentifier.create("Impact Crater", "Subchamber Five", "Dock to Subchamber Four"))
+
+                if identifier.area_identifier in self.specific_valid_targets:
+                    result.append(self.specific_valid_targets[identifier.area_identifier])
+
             return result
+
         else:
             return original

--- a/randovania/games/prime1/layout/prime_configuration.py
+++ b/randovania/games/prime1/layout/prime_configuration.py
@@ -6,10 +6,8 @@ from enum import Enum
 from randovania.bitpacking.bitpacking import BitPackDataclass, BitPackEnum
 from randovania.bitpacking.json_dataclass import JsonDataclass
 from randovania.game.game_enum import RandovaniaGame
-from randovania.games.common.prime_family.layout.lib.prime_trilogy_teleporters import (
-    PrimeTrilogyTeleporterConfiguration,
-)
 from randovania.games.prime1.layout.artifact_mode import LayoutArtifactMode
+from randovania.games.prime1.layout.prime_teleporters import PrimeTeleporterConfiguration
 from randovania.layout.base.base_configuration import BaseConfiguration
 from randovania.lib import enum_lib
 
@@ -83,7 +81,7 @@ class EnemyAttributeRandomizer(BitPackDataclass, JsonDataclass):
 
 @dataclasses.dataclass(frozen=True)
 class PrimeConfiguration(BaseConfiguration):
-    teleporters: PrimeTrilogyTeleporterConfiguration
+    teleporters: PrimeTeleporterConfiguration
     energy_per_tank: int = dataclasses.field(metadata={"min": 1, "max": 1000, "precision": 1})
     artifact_target: LayoutArtifactMode
     artifact_required: LayoutArtifactMode

--- a/randovania/games/prime1/layout/prime_teleporters.py
+++ b/randovania/games/prime1/layout/prime_teleporters.py
@@ -1,0 +1,51 @@
+import dataclasses
+from typing import override
+
+from randovania.game_description.db.area_identifier import AreaIdentifier
+from randovania.game_description.db.node_identifier import NodeIdentifier
+from randovania.games.common.prime_family.layout.lib.prime_trilogy_teleporters import (
+    PrimeTrilogyTeleporterConfiguration,
+)
+from randovania.layout.lib.teleporters import TeleporterShuffleMode
+
+
+@dataclasses.dataclass(frozen=True)
+class PrimeTeleporterConfiguration(PrimeTrilogyTeleporterConfiguration):
+    def get_credits_node(self) -> NodeIdentifier:
+        return NodeIdentifier.create("End of Game", "Credits", "Event - Credits")
+
+    @override
+    @property
+    def static_teleporters(self) -> dict[NodeIdentifier, NodeIdentifier]:
+        static = {}
+        credits_node = self.get_credits_node()
+
+        if self.skip_final_bosses:
+            crater = NodeIdentifier.create("Tallon Overworld", "Artifact Temple", "Teleporter to Impact Crater")
+            static[crater] = credits_node
+        elif self.mode in [
+            TeleporterShuffleMode.ONE_WAY_TELEPORTER,
+            TeleporterShuffleMode.ONE_WAY_TELEPORTER_REPLACEMENT,
+        ]:
+            # We need to always have the possibility of having credits as a target.
+            # On two-way, this is ensured by this teleporter always having this assignment.
+            # On one-way-anywhere, this can be ensured as there is a dedicated credits target available.
+            # But on these two one-way modes, there is not, so let's statically assign it to ensure that
+            # one elevator always leads to credits.
+            essence = NodeIdentifier.create("Impact Crater", "Metroid Prime Lair", "Teleporter to Credits")
+            static[essence] = credits_node
+
+        return static
+
+    @override
+    @property
+    def specific_valid_targets(self) -> dict[AreaIdentifier, NodeIdentifier]:
+        targets = {}
+
+        # Hack for Metroid Prime 1, where the scripting for Metroid Prime Lair is dependent
+        # on the previous room
+        lair = AreaIdentifier("Impact Crater", "Metroid Prime Lair")
+        subchamber4_dock = NodeIdentifier.create("Impact Crater", "Subchamber Five", "Dock to Subchamber Four")
+        targets[lair] = subchamber4_dock
+
+        return targets

--- a/randovania/games/prime2/exporter/patch_data_factory.py
+++ b/randovania/games/prime2/exporter/patch_data_factory.py
@@ -686,10 +686,7 @@ class EchoesPatchDataFactory(PatchDataFactory[EchoesConfiguration, EchoesCosmeti
                 "visor": default_pickups[pickup_category_visors].name,
                 "beam": default_pickups[pickup_category_beams].name,
             },
-            "unvisited_room_names": (
-                self.configuration.teleporters.can_use_unvisited_room_names
-                and self.cosmetic_patches.unvisited_room_names
-            ),
+            "unvisited_room_names": self.cosmetic_patches.unvisited_room_names,
             "teleporter_sounds": should_keep_elevator_sounds(self.configuration),
             "dangerous_energy_tank": self.configuration.dangerous_energy_tank,
         }
@@ -733,9 +730,7 @@ class EchoesPatchDataFactory(PatchDataFactory[EchoesConfiguration, EchoesCosmeti
 
         result["logbook_patches"] = self.create_logbook_patches()
 
-        if not self.configuration.teleporters.is_vanilla and (
-            self.cosmetic_patches.unvisited_room_names and self.configuration.teleporters.can_use_unvisited_room_names
-        ):
+        if not self.configuration.teleporters.is_vanilla and self.cosmetic_patches.unvisited_room_names:
             exclude_map_ids = _ELEVATOR_ROOMS_MAP_ASSET_IDS
         else:
             exclude_map_ids = []

--- a/randovania/games/prime2/gui/generated/preset_teleporters_prime2_ui.py
+++ b/randovania/games/prime2/gui/generated/preset_teleporters_prime2_ui.py
@@ -39,7 +39,7 @@ class Ui_PresetTeleportersPrime2(object):
         self.teleporter_scroll_area.setWidgetResizable(True)
         self.teleporter_scroll_area_contents = QWidget()
         self.teleporter_scroll_area_contents.setObjectName(u"teleporter_scroll_area_contents")
-        self.teleporter_scroll_area_contents.setGeometry(QRect(0, 0, 524, 471))
+        self.teleporter_scroll_area_contents.setGeometry(QRect(0, 0, 534, 470))
         self.teleporters_layout = QVBoxLayout(self.teleporter_scroll_area_contents)
         self.teleporters_layout.setSpacing(6)
         self.teleporters_layout.setContentsMargins(11, 11, 11, 11)
@@ -88,18 +88,6 @@ class Ui_PresetTeleportersPrime2(object):
 
         self.teleporters_layout.addWidget(self.teleporters_line_4)
 
-        self.teleporters_allow_unvisited_names_check = QCheckBox(self.teleporter_scroll_area_contents)
-        self.teleporters_allow_unvisited_names_check.setObjectName(u"teleporters_allow_unvisited_names_check")
-
-        self.teleporters_layout.addWidget(self.teleporters_allow_unvisited_names_check)
-
-        self.teleporters_line_3 = QFrame(self.teleporter_scroll_area_contents)
-        self.teleporters_line_3.setObjectName(u"teleporters_line_3")
-        self.teleporters_line_3.setFrameShape(QFrame.Shape.HLine)
-        self.teleporters_line_3.setFrameShadow(QFrame.Shadow.Sunken)
-
-        self.teleporters_layout.addWidget(self.teleporters_line_3)
-
         self.teleporters_help_list_label = QLabel(self.teleporter_scroll_area_contents)
         self.teleporters_help_list_label.setObjectName(u"teleporters_help_list_label")
         self.teleporters_help_list_label.setWordWrap(True)
@@ -143,7 +131,6 @@ class Ui_PresetTeleportersPrime2(object):
         self.teleporters_help_sound_bug_label.setText(QCoreApplication.translate("PresetTeleportersPrime2", u"These settings will cause the teleporter cutscenes to be silent in order to avoid a different game bug.", None))
         self.skip_final_bosses_check.setText(QCoreApplication.translate("PresetTeleportersPrime2", u"Go directly to credits from Sky Temple Gateway", None))
         self.skip_final_bosses_label.setText(QCoreApplication.translate("PresetTeleportersPrime2", u"<html><head/><body><p>Change the light beam in Sky Temple Gateway to go directly to the credits, skipping the final bosses.</p><p>This changes the requirements to <span style=\" font-weight:600;\">not need the final bosses</span>, turning certain items optional such as Screw Attack and Spider Ball.</p></body></html>", None))
-        self.teleporters_allow_unvisited_names_check.setText(QCoreApplication.translate("PresetTeleportersPrime2", u"Allow \"Always display room names on map\" when teleporters are shuffled", None))
         self.teleporters_help_list_label.setText(QCoreApplication.translate("PresetTeleportersPrime2", u"<html><head/><body><p>Shuffling Sky Temple Gateway, Sky Temple Energy Controller, Aerie and Aerie Transport Station is possible, but they're not included by default as they behave somewhat differently to other teleporters.</p><p>The teleporter in Aerie Transport Station is only available after you defeat Dark Samus 2.</p><p>When shuffling Sky Temple Energy Controller, you <span style=\" font-weight:600;\">must</span> enter Sky Temple Gateway via an teleporter otherwise the game will crash.</p><p><span style=\" font-style:italic;\">Warning</span>: Entering Sky Temple Energy Controller from elsewhere causes the game to be stuck in a black screen in unknown conditions. The game is still running, so you can blindly use the menu mod to work around this issue.</p></body></html>", None))
         self.teleporters_source_group.setTitle(QCoreApplication.translate("PresetTeleportersPrime2", u"Elevators to randomize", None))
         self.teleporters_target_group.setTitle(QCoreApplication.translate("PresetTeleportersPrime2", u"Valid teleporter targets", None))

--- a/randovania/games/prime2/gui/preset_settings/echoes_teleporters_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_teleporters_tab.py
@@ -148,13 +148,6 @@ class PresetTeleportersPrime2(PresetTeleporterTab[EchoesConfiguration], Ui_Prese
                 skip_final_bosses=checked,
             )
 
-    def _update_allow_unvisited_names(self, checked: bool) -> None:
-        with self._editor as editor:
-            editor.layout_configuration_teleporters = dataclasses.replace(
-                editor.configuration.teleporters,
-                allow_unvisited_room_names=checked,
-            )
-
     def on_preset_changed(self, preset: Preset[EchoesConfiguration]) -> None:
         config = preset.configuration
         config_teleporters = config.teleporters

--- a/randovania/games/prime2/gui/preset_settings/echoes_teleporters_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_teleporters_tab.py
@@ -76,10 +76,6 @@ class PresetTeleportersPrime2(PresetTeleporterTab[EchoesConfiguration], Ui_Prese
     ):
         super().__init__(editor, game_description, window_manager)
         signal_handling.on_checked(self.skip_final_bosses_check, self._update_require_final_bosses)
-        signal_handling.on_checked(
-            self.teleporters_allow_unvisited_names_check,
-            self._update_allow_unvisited_names,
-        )
 
     def setup_ui(self) -> None:
         self.setupUi(self)
@@ -214,7 +210,6 @@ class PresetTeleportersPrime2(PresetTeleporterTab[EchoesConfiguration], Ui_Prese
                 dest_check.setChecked(origin_check.isChecked())
 
         sound_bug_warning = not should_keep_elevator_sounds(config)
-        self.teleporters_allow_unvisited_names_check.setChecked(config_teleporters.allow_unvisited_room_names)
         self.teleporters_help_sound_bug_label.setVisible(sound_bug_warning)
         self.skip_final_bosses_check.setChecked(config_teleporters.skip_final_bosses)
 

--- a/randovania/games/prime2/gui/ui_files/preset_teleporters_prime2.ui
+++ b/randovania/games/prime2/gui/ui_files/preset_teleporters_prime2.ui
@@ -43,8 +43,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>524</width>
-         <height>471</height>
+         <width>534</width>
+         <height>470</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="teleporters_layout">
@@ -112,20 +112,6 @@
         </item>
         <item>
          <widget class="Line" name="teleporters_line_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="teleporters_allow_unvisited_names_check">
-          <property name="text">
-           <string>Allow &quot;Always display room names on map&quot; when teleporters are shuffled</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Line" name="teleporters_line_3">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>

--- a/randovania/games/prime2/layout/echoes_configuration.py
+++ b/randovania/games/prime2/layout/echoes_configuration.py
@@ -6,10 +6,8 @@ from enum import Enum
 from randovania.bitpacking.bitpacking import BitPackDataclass, BitPackEnum
 from randovania.bitpacking.json_dataclass import JsonDataclass
 from randovania.game.game_enum import RandovaniaGame
-from randovania.games.common.prime_family.layout.lib.prime_trilogy_teleporters import (
-    PrimeTrilogyTeleporterConfiguration,
-)
 from randovania.games.prime2.layout.beam_configuration import BeamConfiguration
+from randovania.games.prime2.layout.echoes_teleporters import EchoesTeleporterConfiguration
 from randovania.games.prime2.layout.translator_configuration import TranslatorConfiguration
 from randovania.layout.base.base_configuration import BaseConfiguration
 
@@ -58,7 +56,7 @@ class EchoesNewPatcher(BitPackEnum, Enum):
 
 @dataclasses.dataclass(frozen=True)
 class EchoesConfiguration(BaseConfiguration):
-    teleporters: PrimeTrilogyTeleporterConfiguration
+    teleporters: EchoesTeleporterConfiguration
     sky_temple_keys: LayoutSkyTempleKeyMode
     translator_configuration: TranslatorConfiguration
     beam_configuration: BeamConfiguration

--- a/randovania/games/prime2/layout/echoes_teleporters.py
+++ b/randovania/games/prime2/layout/echoes_teleporters.py
@@ -1,0 +1,21 @@
+import dataclasses
+from typing import override
+
+from randovania.game_description.db.node_identifier import NodeIdentifier
+from randovania.games.common.prime_family.layout.lib.prime_trilogy_teleporters import (
+    PrimeTrilogyTeleporterConfiguration,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class EchoesTeleporterConfiguration(PrimeTrilogyTeleporterConfiguration):
+    @override
+    @property
+    def static_teleporters(self) -> dict[NodeIdentifier, NodeIdentifier]:
+        static = {}
+
+        if self.skip_final_bosses:
+            gateway = NodeIdentifier.create("Sky Temple Grounds", "Sky Temple Gateway", "Elevator to Sky Temple")
+            static[gateway] = NodeIdentifier.create("Temple Grounds", "Credits", "Event - Dark Samus 3 and 4")
+
+        return static

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1246,6 +1246,11 @@ def _migrate_v113(preset: dict, game: RandovaniaGame, *, from_layout_description
         preset["configuration"]["subzero_damage"] = 6
 
 
+def _migrate_v114(preset: dict, game: RandovaniaGame, *, from_layout_description: bool) -> None:
+    if game in {RandovaniaGame.METROID_PRIME, RandovaniaGame.METROID_PRIME_ECHOES}:
+        preset["configuration"]["teleporters"].pop("allow_unvisited_room_names")
+
+
 _MIGRATIONS: list[PresetMigration | None] = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -1360,6 +1365,7 @@ _MIGRATIONS: list[PresetMigration | None] = [
     _migrate_v111,  # dread: add skip_item_popups setting
     _migrate_v112,  # echoes new patcher only
     _migrate_v113,  # fusion: add environmental damage
+    _migrate_v114,  # prime/echoes: remove `allow_unvisited_room_names` in teleporter config
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/test/games/prime2/generator/test_echoes_bootstrap.py
+++ b/test/games/prime2/generator/test_echoes_bootstrap.py
@@ -9,11 +9,9 @@ import pytest
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.game_description.resources.resource_type import ResourceType
-from randovania.games.common.prime_family.layout.lib.prime_trilogy_teleporters import (
-    PrimeTrilogyTeleporterConfiguration,
-)
 from randovania.games.prime2.generator.bootstrap import EchoesBootstrap
 from randovania.games.prime2.layout.echoes_configuration import LayoutSkyTempleKeyMode
+from randovania.games.prime2.layout.echoes_teleporters import EchoesTeleporterConfiguration
 from randovania.generator.pickup_pool import pool_creator
 
 _GUARDIAN_INDICES = [
@@ -38,7 +36,7 @@ def test_misc_resources_for_configuration(
     vanilla_teleporters: bool,
 ):
     # Setup
-    teleporters = MagicMock(spec=PrimeTrilogyTeleporterConfiguration)
+    teleporters = MagicMock(spec=EchoesTeleporterConfiguration)
     configuration = dataclasses.replace(default_echoes_configuration, teleporters=teleporters)
     teleporters.is_vanilla = vanilla_teleporters
     great_resource = echoes_resource_database.get_by_type_and_index(ResourceType.MISC, "VanillaGreatTempleEmeraldGate")

--- a/test/layout/test_echoes_configuration.py
+++ b/test/layout/test_echoes_configuration.py
@@ -10,11 +10,9 @@ import pytest
 from randovania.bitpacking import bitpacking
 from randovania.bitpacking.bitpacking import BitPackDecoder, BitPackValue
 from randovania.game.game_enum import RandovaniaGame
-from randovania.games.common.prime_family.layout.lib.prime_trilogy_teleporters import (
-    PrimeTrilogyTeleporterConfiguration,
-)
 from randovania.games.prime2.layout.beam_configuration import BeamConfiguration
 from randovania.games.prime2.layout.echoes_configuration import EchoesConfiguration, LayoutSkyTempleKeyMode
+from randovania.games.prime2.layout.echoes_teleporters import EchoesTeleporterConfiguration
 from randovania.games.prime2.layout.translator_configuration import TranslatorConfiguration
 from randovania.layout.base.ammo_pickup_configuration import AmmoPickupConfiguration
 from randovania.layout.base.available_locations import AvailableLocationsConfiguration
@@ -95,7 +93,7 @@ def layout_config_with_data(request, default_echoes_configuration):
         "available_locations": AvailableLocationsConfiguration,
         "standard_pickup_configuration": StandardPickupConfiguration,
         "ammo_pickup_configuration": AmmoPickupConfiguration,
-        "teleporters": PrimeTrilogyTeleporterConfiguration,
+        "teleporters": EchoesTeleporterConfiguration,
         "translator_configuration": TranslatorConfiguration,
         "hints": HintConfiguration,
         "beam_configuration": BeamConfiguration,

--- a/test/layout/test_teleporters.py
+++ b/test/layout/test_teleporters.py
@@ -9,9 +9,7 @@ from randovania.bitpacking.bitpacking import BitPackDecoder
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_description.db.area_identifier import AreaIdentifier
 from randovania.game_description.db.node_identifier import NodeIdentifier
-from randovania.games.common.prime_family.layout.lib.prime_trilogy_teleporters import (
-    PrimeTrilogyTeleporterConfiguration,
-)
+from randovania.games.prime2.layout.echoes_teleporters import EchoesTeleporterConfiguration
 from randovania.layout.lib.teleporters import (
     TeleporterConfiguration,
     TeleporterList,
@@ -21,10 +19,10 @@ from randovania.layout.lib.teleporters import (
 
 
 class Data(NamedTuple):
-    reference: TeleporterConfiguration | PrimeTrilogyTeleporterConfiguration
+    reference: TeleporterConfiguration | EchoesTeleporterConfiguration
     encoded: bytes
     bit_count: int
-    expected: TeleporterConfiguration | PrimeTrilogyTeleporterConfiguration
+    expected: TeleporterConfiguration | EchoesTeleporterConfiguration
     description: str
     num_valid_targets: int
 
@@ -33,10 +31,10 @@ def _m(
     encoded: bytes,
     bit_count: int,
     description: str,
+    *,
     num_valid_targets: int = 22,
     mode: str = "vanilla",
     skip_final_bosses=False,
-    allow_unvisited_room_names=True,
     excluded_teleporters=None,
     excluded_targets=None,
 ):
@@ -52,7 +50,6 @@ def _m(
         "json": {
             "mode": mode,
             "skip_final_bosses": skip_final_bosses,
-            "allow_unvisited_room_names": allow_unvisited_room_names,
             "excluded_teleporters": excluded_teleporters,
             "excluded_targets": excluded_targets,
         },
@@ -150,10 +147,9 @@ def test_generic_data(request):
 )
 def test_echoes_data(request):
     game = RandovaniaGame.METROID_PRIME_ECHOES
-    reference = PrimeTrilogyTeleporterConfiguration(
+    reference = EchoesTeleporterConfiguration(
         mode=TeleporterShuffleMode.VANILLA,
         skip_final_bosses=False,
-        allow_unvisited_room_names=False,
         excluded_teleporters=TeleporterList((), game),
         excluded_targets=TeleporterTargetList((), game),
     )
@@ -161,17 +157,16 @@ def test_echoes_data(request):
         reference=reference,
         encoded=request.param["encoded"],
         bit_count=request.param["bit_count"],
-        expected=PrimeTrilogyTeleporterConfiguration.from_json(request.param["json"], game=game),
+        expected=EchoesTeleporterConfiguration.from_json(request.param["json"], game=game),
         description=request.param["description"],
         num_valid_targets=request.param["num_valid_targets"],
     )
 
 
 def test_valid_targets_echoes(test_echoes_data):
-    config = PrimeTrilogyTeleporterConfiguration(
+    config = EchoesTeleporterConfiguration(
         mode=test_echoes_data.expected.mode,
         skip_final_bosses=False,
-        allow_unvisited_room_names=False,
         excluded_teleporters=test_echoes_data.expected.excluded_teleporters,
         excluded_targets=test_echoes_data.expected.excluded_targets,
     )
@@ -192,7 +187,7 @@ def test_valid_targets_msr(test_generic_data):
 
 
 @pytest.fixture(
-    params=[(test_echoes_data, PrimeTrilogyTeleporterConfiguration), (test_generic_data, TeleporterConfiguration)]
+    params=[(test_echoes_data, EchoesTeleporterConfiguration), (test_generic_data, TeleporterConfiguration)]
 )
 def test_decode(data, configuration):
     # Run


### PR DESCRIPTION
divides it into separate classes for prime and echoes, rather than checking a game enum