### PR TITLE
Add better logging for nintendont

### DIFF
--- a/randovania/game_connection/executor/nintendont_executor.py
+++ b/randovania/game_connection/executor/nintendont_executor.py
@@ -241,6 +241,20 @@ class NintendontExecutor(MemoryOperationExecutor):
             raise MemoryOperationException("Not connected")
 
         requests = self._prepare_requests_for(ops)
+
+        # Debug logging
+        log_message = "Sending requests out:\n"
+        for req_index, request in enumerate(requests):
+            log_message += f"Request {req_index}\n"
+            for op_index, op in enumerate(request.ops):
+                read_write_part = ""
+                if op.write_bytes:
+                    read_write_part = f"write {('(and read) ' if op.read_byte_count else '')} '{op.write_bytes.hex()}'"
+                elif op.read_byte_count:
+                    read_write_part = f"read {op.read_byte_count} bytes"
+                log_message += f"  Operation {op_index}: {read_write_part} at 0x{op.address:0x}\n"
+        self.logger.debug(log_message)
+
         all_responses = await self._send_requests_to_socket(requests)
 
         result = {}

--- a/randovania/game_connection/executor/nintendont_executor.py
+++ b/randovania/game_connection/executor/nintendont_executor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import logging
 import struct
 from typing import TypeGuard
 
@@ -243,17 +244,20 @@ class NintendontExecutor(MemoryOperationExecutor):
         requests = self._prepare_requests_for(ops)
 
         # Debug logging
-        log_message = "Sending requests out:\n"
-        for req_index, request in enumerate(requests):
-            log_message += f"Request {req_index}\n"
-            for op_index, op in enumerate(request.ops):
-                read_write_part = ""
-                if op.write_bytes:
-                    read_write_part = f"write {('(and read) ' if op.read_byte_count else '')} '{op.write_bytes.hex()}'"
-                elif op.read_byte_count:
-                    read_write_part = f"read {op.read_byte_count} bytes"
-                log_message += f"  Operation {op_index}: {read_write_part} at 0x{op.address:0x}\n"
-        self.logger.debug(log_message)
+        if self.logger.isEnabledFor(logging.DEBUG):
+            log_message = "Sending requests out:\n"
+            for req_index, request in enumerate(requests):
+                log_message += f"Request {req_index}\n"
+                for op_index, op in enumerate(request.ops):
+                    read_write_part = ""
+                    if op.write_bytes:
+                        read_write_part = (
+                            f"write {('(and read) ' if op.read_byte_count else '')} '{op.write_bytes.hex()}'"
+                        )
+                    elif op.read_byte_count:
+                        read_write_part = f"read {op.read_byte_count} bytes"
+                    log_message += f"  Operation {op_index}: {read_write_part} at 0x{op.address:0x}\n"
+            self.logger.debug(log_message)
 
         all_responses = await self._send_requests_to_socket(requests)
 


### PR DESCRIPTION
I would like to have this for the CGC tournament.

One of the really annoying things right now about nintendont debugging on past events is that there is no way to decipher on *what* caused things to go out of whack somewhere. A timeout/disconnect for example could happen because we accidentally crashed the wii or sent an otherwise invalid request, and our wrong magic number could maybe us doing something in the wrong order. And since literally no one plays with wireshark and is logging their packets back n forth, they're all more or less undebuggable.

I am unsure whether I should also log the responses. All of our requests are unique enough where its fairly easy to figure out what part of the codebase called it (e.g. 7 read operations a la 4 bytes is us trying to figure out the game), so if we have a logged request followed by an error it *shouldnt* be that much different from trying to figure out the cause while avoiding even more log "spam".

I don't know though whether this amount of "spam" is something that rdv handles nicely on windows. Here's a screenshot on how it looks 
<img width="1310" height="597" alt="grafik" src="https://github.com/user-attachments/assets/40d6e833-042d-4152-bbce-ddb63480638f" />
