### PR TITLE
Dolphin Executor: Treat invalid address operation as fatal

### DIFF
--- a/randovania/game_connection/executor/dolphin_executor.py
+++ b/randovania/game_connection/executor/dolphin_executor.py
@@ -123,13 +123,9 @@ class DolphinExecutor(MemoryOperationExecutor):
 
             try:
                 pointers[pointer] = self.dolphin.follow_pointers(pointer, [0])
-            except RuntimeError:
-                pointers[pointer] = None
+            except RuntimeError as e:
                 self.logger.debug(f"Failed to read a valid pointer from {pointer:x}")
-                self._test_still_hooked()
-
-            if not self.dolphin.is_hooked():
-                raise MemoryOperationException("Lost connection do Dolphin")
+                raise MemoryOperationException("Operation tried to read an invalid address") from e
 
         result = {}
         for op in ops:

--- a/randovania/game_connection/executor/dolphin_executor.py
+++ b/randovania/game_connection/executor/dolphin_executor.py
@@ -78,7 +78,7 @@ class DolphinExecutor(MemoryOperationExecutor):
         return self.dolphin.is_hooked()
 
     # Game Backend Stuff
-    def _memory_operation(self, op: MemoryOperation, pointers: dict[int, int | None]) -> bytes | None:
+    def _memory_operation(self, op: MemoryOperation, pointers: dict[int, int]) -> bytes | None:
         op.validate_byte_sizes()
 
         address = op.address
@@ -87,8 +87,6 @@ class DolphinExecutor(MemoryOperationExecutor):
                 raise MemoryOperationException(f"Invalid op: {address:x} is not in pointers")
 
             new_address = pointers[address]
-            if new_address is None:
-                return None
             address = new_address + op.offset
 
         _validate_range(address, op.byte_count)

--- a/test/game_connection/executor/test_dolphin_executor.py
+++ b/test/game_connection/executor/test_dolphin_executor.py
@@ -131,27 +131,6 @@ async def test_perform_memory_operations_success(executor: DolphinExecutor):
 
 async def test_perform_memory_operations_follow_fail(executor: DolphinExecutor):
     executor.dolphin.follow_pointers = MagicMock(side_effect=RuntimeError("can't follow"))
-    executor._test_still_hooked = MagicMock()
-
-    # Run
-    result = await executor.perform_memory_operations(
-        [
-            MemoryOperation(0x80001000, offset=20, read_byte_count=50),
-        ]
-    )
-
-    # Assert
-    assert list(result.values()) == []
-    executor.dolphin.follow_pointers.assert_called_once_with(0x80001000, [0x0])
-    executor.dolphin.read_bytes.assert_not_called()
-    executor.dolphin.write_bytes.assert_not_called()
-    executor._test_still_hooked.assert_called_once_with()
-
-
-async def test_perform_memory_operations_follow_fail_disconnect(executor: DolphinExecutor):
-    executor.dolphin.follow_pointers = MagicMock(side_effect=RuntimeError("can't follow"))
-    executor._test_still_hooked = MagicMock()
-    executor.dolphin.is_hooked.side_effect = [True, False]
 
     # Run
     with pytest.raises(MemoryOperationException):
@@ -165,7 +144,6 @@ async def test_perform_memory_operations_follow_fail_disconnect(executor: Dolphi
     executor.dolphin.follow_pointers.assert_called_once_with(0x80001000, [0x0])
     executor.dolphin.read_bytes.assert_not_called()
     executor.dolphin.write_bytes.assert_not_called()
-    executor._test_still_hooked.assert_called_once_with()
 
 
 def test_test_still_hooked_success(executor: DolphinExecutor):


### PR DESCRIPTION
Gives some parity with the Nintendont executor. Makes it easier to find bugs/wrong behaviour without having them run on nintendont first and should also guarantee that the result dict will always have as many entries as the operations that were requested