### PR TITLE
Add a test to ensure that Bootstrap is serializable

### DIFF
--- a/test/resolver/test_bootstrap.py
+++ b/test/resolver/test_bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pickle
 from random import Random
 
 import pytest
@@ -112,3 +113,12 @@ def test_victory_condition_for_pickup_placement(
     # Assert
     # print(victory_str)
     assert victory_str == expected
+
+
+# ensure that Bootstrap class is serializable with pickle to use it in a ProcessPoolExecutor
+def test_pickle_roundtrip():
+    bootstrap_obj = bootstrap.Bootstrap()
+    serialised = pickle.dumps(bootstrap_obj)
+    loaded = pickle.loads(serialised)
+
+    assert serialised == pickle.dumps(loaded)


### PR DESCRIPTION
I thought about adding a good test to prevent regressions, but this is the only thing I could come up with.

It fails for me with the PEP-695 syntax and the following error, so it should be sufficient as a safeguard.
```
================================== FAILURES ===================================
____________________________ test_pickle_roundtrip ____________________________

    def test_pickle_roundtrip():
        bootstrap_obj = bootstrap.Bootstrap()
>       serialised = pickle.dumps(bootstrap_obj)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       _pickle.PicklingError: Can't pickle Configuration: attribute lookup Configuration on typing failed
```