### PR TITLE
Primes: Don't disconnect when trying to read inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: Dark Stairwell: Using the hidden connection to/from Central Nexus can now expect Mid-Air Morphs instead of Bombs/Hi-Jump.
 
+### Metroid Prime
+
+- Fixed: When connected to the game via Nintendont, don't disconnect when resetting the game.
+
 ### Metroid Prime 2: Echoes
 
 - Fixed: When having Randovania connected to the game while on the title screen, it will not throw warnings (Dolphin) or repeatedly disconnect (Nintendont) from the game.
+- Fixed: When connected to the game via Nintendont, don't disconnect when resetting the game.
 
 ### Metroid: Samus Returns
 

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -183,7 +183,12 @@ class PrimeRemoteConnector(RemoteConnector):
         resource_db = self.game.get_resource_database_view()
         all_items = [item for item in resource_db.get_all_items() if item.extra["item_id"] < 1000]
         memory_ops = await self._memory_op_for_items(all_items)
-        ops_result = await self.executor.perform_memory_operations(memory_ops)
+        try:
+            ops_result = await self.executor.perform_memory_operations(memory_ops)
+        except MemoryOperationException:
+            # If player returns reboots the game while we try to read the inventory, don't disconnect. Just mark
+            # that they have an empty inventory
+            return Inventory({})
 
         inventory = {}
         for item, memory_op in zip(all_items, memory_ops, strict=True):

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -183,12 +183,7 @@ class PrimeRemoteConnector(RemoteConnector):
         resource_db = self.game.get_resource_database_view()
         all_items = [item for item in resource_db.get_all_items() if item.extra["item_id"] < 1000]
         memory_ops = await self._memory_op_for_items(all_items)
-        try:
-            ops_result = await self.executor.perform_memory_operations(memory_ops)
-        except MemoryOperationException:
-            # If player returns reboots the game while we try to read the inventory, don't disconnect. Just mark
-            # that they have an empty inventory
-            return Inventory.empty()
+        ops_result = await self.executor.perform_memory_operations(memory_ops)
 
         inventory = {}
         for item, memory_op in zip(all_items, memory_ops, strict=True):
@@ -438,7 +433,12 @@ class PrimeRemoteConnector(RemoteConnector):
 
     async def update_current_inventory(self) -> None:
         """Fetches the inventory from the game, saves it and emits the signal if it changed."""
-        new_inventory = await self.get_inventory()
+        try:
+            new_inventory = await self.get_inventory()
+        except MemoryOperationException:
+            # If player reboots the game while we try to read the inventory, don't disconnect. Just mark
+            # that they have an empty inventory
+            new_inventory = Inventory.empty()
         if new_inventory != self.last_inventory:
             self.InventoryUpdated.emit(new_inventory)
             self.last_inventory = new_inventory

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -188,7 +188,7 @@ class PrimeRemoteConnector(RemoteConnector):
         except MemoryOperationException:
             # If player returns reboots the game while we try to read the inventory, don't disconnect. Just mark
             # that they have an empty inventory
-            return Inventory({})
+            return Inventory.empty()
 
         inventory = {}
         for item, memory_op in zip(all_items, memory_ops, strict=True):

--- a/test/game_connection/connector/test_prime1_remote_connector.py
+++ b/test/game_connection/connector/test_prime1_remote_connector.py
@@ -183,7 +183,7 @@ async def test_interact_with_game(
     should_disconnect = False
     if failure_at == 1:
         connector.get_inventory.side_effect = MemoryOperationException("error at _get_inventory")
-        should_disconnect = depth > 0
+        should_disconnect = False
 
     connector._send_next_pending_message = AsyncMock()
     connector._multiworld_interaction = AsyncMock(return_value=depth <= 2)
@@ -191,8 +191,8 @@ async def test_interact_with_game(
         connector._multiworld_interaction.side_effect = MemoryOperationException("error at _check_for_collected_index")
         should_disconnect = depth > 1
 
-    expected_depth = min(depth, failure_at) if failure_at is not None else depth
-    if (failure_at or 999) <= depth:
+    expected_depth = min(depth, failure_at) if (failure_at is not None and failure_at > 1) else depth
+    if failure_at != 1 and (failure_at or 999) <= depth:
         should_disconnect = True
 
     # Run
@@ -218,7 +218,7 @@ async def test_interact_with_game(
 
     if 0 < depth:
         assert connector._last_emitted_region is not None
-        if is_at_end_of_game and (failure_at is None or failure_at > 1):
+        if is_at_end_of_game:
             game_has_been_beaten_mock.assert_called_once_with()
         else:
             game_has_been_beaten_mock.assert_not_called()


### PR DESCRIPTION
As is expected by now, reading the items can return an invalid address because we're reading them based off of a cplayer_state pointer which can be null. If that is the case, handle that gracefully so that we don't need to do the whole dance of reconnecting again.