### PR TITLE
Better safeguards if we can't read the inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Waiting changes to be added.
 
-## [10.8.1] - 2026-06-??
+## [10.8.2] - 2026-06-14
+
+### Metroid Prime
+
+- Fixed: Edge case of Randovania sending wrong items to the game when it cannot read the inventory.
+
+### Metroid Prime 2: Echoes
+
+- Fixed: Edge case of Randovania sending wrong items to the game when it cannot read the inventory.
+
+## [10.8.1] - 2026-06-13
 
 - Changed: The seed hash text in the Multiplayer window can now be interacted with.
 - Changed: Nintendont: The time on how long Randovania waits for requests for the Wii before it disconnects has been made consistent and reduced to 5 seconds.

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -407,6 +407,9 @@ class PrimeRemoteConnector(RemoteConnector):
             if region is not None:
                 await self.update_current_inventory()
 
+                if self.last_inventory == Inventory.empty():
+                    return
+
                 if self.at_end_of_game():
                     self.GameHasBeenBeaten.emit()
                     self.logger.debug("The game has been beaten")

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -61,7 +61,7 @@ class PrimeRemoteConnector(RemoteConnector):
     executor: MemoryOperationExecutor
     remote_pickups: tuple[RemotePickup, ...]
     message_cooldown: float = 0.0
-    last_inventory = Inventory.empty()
+    last_inventory: Inventory | None = Inventory.empty()
     _dt: float = 2.5
     _pending_op_offset: int = 0x2
     """Offset compared to CStateManager where we store whether we still have pending write operations going on."""
@@ -199,6 +199,10 @@ class PrimeRemoteConnector(RemoteConnector):
         Queries the game for the multiworld magic item and checks if a new location was collected.
         :return: True, if a new location was found and remote patches were executed. False otherwise.
         """
+
+        if self.last_inventory is None:
+            # If we don't have any valid inventory, just pretend that we cannot keep writnig
+            return True
 
         multiworld_magic_item = self.multiworld_magic_item
         magic_inv = self.last_inventory.get(multiworld_magic_item)
@@ -370,6 +374,8 @@ class PrimeRemoteConnector(RemoteConnector):
 
     def _check_magic_capacity(self) -> None:
         # Safety/debugging check to see what causes magic item randomly increases by 2 instead of 1.
+        if self.last_inventory is None:
+            return
         magic_inv = self.last_inventory.get(self.multiworld_magic_item)
         expected_capacity = self._debug_expected_capacity
         expected_capacity += magic_inv.amount
@@ -407,7 +413,7 @@ class PrimeRemoteConnector(RemoteConnector):
             if region is not None:
                 await self.update_current_inventory()
 
-                if self.last_inventory == Inventory.empty():
+                if self.last_inventory is None:
                     return
 
                 if self.at_end_of_game():
@@ -447,7 +453,10 @@ class PrimeRemoteConnector(RemoteConnector):
         except MemoryOperationException:
             # If player reboots the game while we try to read the inventory, don't disconnect. Just mark
             # that they have an empty inventory
-            new_inventory = Inventory.empty()
+            self.InventoryUpdated.emit(Inventory.empty())
+            self.last_inventory = None
+            return
+
         if new_inventory != self.last_inventory:
             self.InventoryUpdated.emit(new_inventory)
             self.last_inventory = new_inventory
@@ -457,6 +466,10 @@ class PrimeRemoteConnector(RemoteConnector):
         Tries to do the next Multiworld interaction. Priority is checking locations first, and then sending new items.
         Returns true if remote patches were executed.
         """
+        if self.last_inventory is None:
+            # Don't do any MW interactions if we don't have a valid inventory
+            return True
+
         if await self.check_for_collected_location():
             return True
         else:

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -189,7 +189,7 @@ class PrimeRemoteConnector(RemoteConnector):
         for item, memory_op in zip(all_items, memory_ops, strict=True):
             inv = InventoryItem(*struct.unpack(">II", ops_result[memory_op]))
             if (inv.amount > inv.capacity or inv.capacity > item.max_capacity) and (item != self.multiworld_magic_item):
-                raise MemoryOperationException(f"Received {inv} for {item.long_name}, which is an invalid state.")
+                raise ValueError(f"Received {inv} for {item.long_name}, which is an invalid state.")
             inventory[item] = inv
 
         return Inventory(inventory)
@@ -427,7 +427,13 @@ class PrimeRemoteConnector(RemoteConnector):
             # It should automatically disconnect the executor, so fail loudly if that's not the case
             if self.executor.is_connected():
                 self.executor.disconnect()
-                self.logger.debug("Disconnecting due to an exception: %s", str(e))
+                self.logger.debug("Disconnecting due to a memory exception: %s", str(e))
+
+        except Exception as e:
+            # If any other exception occurs, something has gone horribly wrong, so scream.
+            if self.executor.is_connected():
+                self.executor.disconnect()
+                self.logger.warning("Disconnecting due to an exception: %s", str(e))
 
         finally:
             if self.is_disconnected():

--- a/test/game_connection/connector/test_echoes_remote_connector.py
+++ b/test/game_connection/connector/test_echoes_remote_connector.py
@@ -12,7 +12,7 @@ from retro_data_structures.game_check import Game as RDSGame
 
 from randovania.game_connection.connector.echoes_remote_connector import EchoesRemoteConnector
 from randovania.game_connection.connector.prime_remote_connector import DolRemotePatch
-from randovania.game_connection.executor.memory_operation import MemoryOperation, MemoryOperationException
+from randovania.game_connection.executor.memory_operation import MemoryOperation
 from randovania.game_description.pickup.pickup_entry import PickupEntry
 from randovania.game_description.resources.inventory import Inventory, InventoryItem
 from randovania.game_description.resources.pickup_index import PickupIndex
@@ -122,7 +122,7 @@ async def test_get_inventory_invalid_capacity(connector: EchoesRemoteConnector):
 
     # Run
     msg = "Received InventoryItem(amount=0, capacity=50) for Darkburst, which is an invalid state."
-    with pytest.raises(MemoryOperationException, match=re.escape(msg)):
+    with pytest.raises(ValueError, match=re.escape(msg)):
         await connector.get_inventory()
 
 
@@ -141,7 +141,7 @@ async def test_get_inventory_invalid_amount(connector: EchoesRemoteConnector):
 
     # Run
     msg = "Received InventoryItem(amount=1, capacity=0) for Darkburst, which is an invalid state."
-    with pytest.raises(MemoryOperationException, match=re.escape(msg)):
+    with pytest.raises(ValueError, match=re.escape(msg)):
         await connector.get_inventory()
 
 

--- a/test/game_connection/connector/test_prime1_remote_connector.py
+++ b/test/game_connection/connector/test_prime1_remote_connector.py
@@ -191,7 +191,7 @@ async def test_interact_with_game(
         connector._multiworld_interaction.side_effect = MemoryOperationException("error at _check_for_collected_index")
         should_disconnect = depth > 1
 
-    expected_depth = min(depth, failure_at) if (failure_at is not None and failure_at > 1) else depth
+    expected_depth = min(depth, failure_at) if (failure_at is not None) else depth
     if failure_at != 1 and (failure_at or 999) <= depth:
         should_disconnect = True
 
@@ -218,7 +218,7 @@ async def test_interact_with_game(
 
     if 0 < depth:
         assert connector._last_emitted_region is not None
-        if is_at_end_of_game:
+        if is_at_end_of_game and failure_at != 1:
             game_has_been_beaten_mock.assert_called_once_with()
         else:
             game_has_been_beaten_mock.assert_not_called()


### PR DESCRIPTION
A fix because *someone* put in 99 missiles per expansion (see #9286 )
I think under normal circumstances, the worst case is that we fail when reading the inventory during an elevator transition or whatever, and then duplicate some ammo for the player.