### PR TITLE
Add node coordinates to ~75% of nodes in OPR

### DIFF
--- a/randovania/games/prime2_opr/logic_database/Agon Wastes.json
+++ b/randovania/games/prime2_opr/logic_database/Agon Wastes.json
@@ -15,7 +15,11 @@
                 "Door to Plaza Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -525.0286865234375,
+                        "y": -8.067428588867188,
+                        "z": -26.801864624023438
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -51,7 +55,11 @@
                 "Elevator to Temple Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -553.5216674804688,
+                        "y": -10.500246047973633,
+                        "z": -28.807239532470703
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -96,7 +104,11 @@
                 "Door to Transport to Temple Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -525.0286865234375,
+                        "y": -8.06743049621582,
+                        "z": -26.801864624023438
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -130,7 +142,11 @@
                 "Door to Mining Plaza": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -438.5470886230469,
+                        "y": -34.67979431152344,
+                        "z": -26.801868438720703
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -177,7 +193,11 @@
                 "Door to Transit Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -330.4879150390625,
+                        "y": 17.276336669921875,
+                        "z": -11.80185317993164
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -203,7 +223,11 @@
                 "Portal from Duelling Range": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -300.86004638671875,
+                        "y": 1.6655998229980469,
+                        "z": -8.418006896972656
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -237,7 +261,11 @@
                 "Morph Ball Door to Agon Map Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -340.8734130859375,
+                        "y": 11.728996276855469,
+                        "z": -26.958524703979492
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -341,7 +369,11 @@
                 "Door to Save Station A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -331.52801513671875,
+                        "y": -103.62609100341797,
+                        "z": -29.3018798828125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -375,7 +407,11 @@
                 "Door to Mining Station Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -267.176513671875,
+                        "y": -85.33049774169922,
+                        "z": -11.763887405395508
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -489,7 +525,11 @@
                 "Door to Plaza Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -438.5470886230469,
+                        "y": -34.67979431152344,
+                        "z": -26.801868438720703
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -799,7 +839,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -347.95416259765625,
+                        "y": -44.35987854003906,
+                        "z": -18.086029052734375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -858,7 +902,11 @@
                 "Morph Ball Door to Mining Plaza": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -340.8734130859375,
+                        "y": 11.728996276855469,
+                        "z": -26.958524703979492
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -925,7 +973,11 @@
                 "Door to Mining Plaza": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -330.4879150390625,
+                        "y": 17.276336669921875,
+                        "z": -11.80185317993164
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1021,7 +1073,11 @@
                 "Door to Mining Station B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -318.72784423828125,
+                        "y": 125.96136474609375,
+                        "z": -6.801844596862793
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1156,7 +1212,11 @@
                 "Door to Transport Center": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -235.50665283203125,
+                        "y": -211.6622772216797,
+                        "z": -22.30190086364746
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1192,7 +1252,11 @@
                 "Door to Mining Plaza": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -331.528076171875,
+                        "y": -103.6260986328125,
+                        "z": -29.301881790161133
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1238,7 +1302,11 @@
                 "Door to Mining Station A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -145.17652893066406,
+                        "y": -85.35029602050781,
+                        "z": -7.839852333068848
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1274,7 +1342,11 @@
                 "Door to Mining Plaza": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -267.1765441894531,
+                        "y": -85.33069610595703,
+                        "z": -11.76388168334961
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1421,7 +1493,11 @@
                 "Door to Storage A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -263.5005798339844,
+                        "y": 99.45597076416016,
+                        "z": -26.801849365234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1474,7 +1550,11 @@
                 "Door to Transit Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -318.72784423828125,
+                        "y": 125.96136474609375,
+                        "z": -6.801843643188477
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1568,7 +1648,11 @@
                 "Door to Mine Shaft": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -216.6754150390625,
+                        "y": 112.16871643066406,
+                        "z": -6.801846027374268
+                    },
                     "description": "<https://youtu.be/Myr8MRM5ZDc&t=88>",
                     "layers": [
                         "default"
@@ -1643,7 +1727,11 @@
                 "Portal to Trial Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -266.34576416015625,
+                        "y": 107.56108093261719,
+                        "z": 38.975608825683594
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2706,7 +2794,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -271.2403564453125,
+                        "y": 187.65615844726562,
+                        "z": -7.733524799346924
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2769,7 +2861,11 @@
                 "Portal to Crossroads": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -173.8229217529297,
+                        "y": -205.46498107910156,
+                        "z": 27.496919631958008
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2867,7 +2963,11 @@
                 "Door to Save Station A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -235.50665283203125,
+                        "y": -211.6622772216797,
+                        "z": -22.301898956298828
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2903,7 +3003,11 @@
                 "Door to Transport to Torvus Bog": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -216.15292358398438,
+                        "y": -256.9056701660156,
+                        "z": -5.878824234008789
+                    },
                     "description": "<https://www.youtube.com/watch?v=yZIy4aLaKNU>",
                     "layers": [
                         "default"
@@ -3050,7 +3154,11 @@
                 "Door to Portal Terminal": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -148.98585510253906,
+                        "y": -245.2932891845703,
+                        "z": -15.878767013549805
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3422,7 +3530,11 @@
                 "Door to Temple Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -80.0225830078125,
+                        "y": -62.25899124145508,
+                        "z": 7.1981306076049805
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3456,7 +3568,11 @@
                 "Door to Sand Cache": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -63.85751724243164,
+                        "y": -154.99217224121094,
+                        "z": 7.198115348815918
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3490,7 +3606,11 @@
                 "Door to Central Station Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -2.018585205078125,
+                        "y": -105.39482116699219,
+                        "z": 14.69812297821045
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3620,7 +3740,11 @@
                 "Door to Mining Station Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -145.17652893066406,
+                        "y": -85.35029602050781,
+                        "z": -7.8398518562316895
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3654,7 +3778,11 @@
                 "Door to Portal Access A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -79.84837341308594,
+                        "y": -155.95767211914062,
+                        "z": -0.30188465118408203
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4375,7 +4503,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -41.176185607910156,
+                        "y": -112.4239730834961,
+                        "z": 16.928329467773438
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4434,7 +4566,11 @@
                 "Door to Mining Station B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -263.5005798339844,
+                        "y": 99.45597076416016,
+                        "z": -26.801847457885742
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4529,7 +4665,11 @@
                 "Door to Agon Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -150.40353393554688,
+                        "y": 112.14213562011719,
+                        "z": 9.698163986206055
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4591,7 +4731,11 @@
                 "Door to Mining Station B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -216.6754150390625,
+                        "y": 112.16871643066406,
+                        "z": -6.801845550537109
+                    },
                     "description": "<https://youtu.be/Myr8MRM5ZDc&t=76>",
                     "layers": [
                         "default"
@@ -4780,7 +4924,11 @@
                 "Door to Portal Access A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -139.84837341308594,
+                        "y": -197.95767211914062,
+                        "z": -0.30189037322998047
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4814,7 +4962,11 @@
                 "Door to Transport Center": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -148.98585510253906,
+                        "y": -245.2932891845703,
+                        "z": -15.878767013549805
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4943,7 +5095,11 @@
                 "Portal to Portal Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -70.7958755493164,
+                        "y": -307.1782531738281,
+                        "z": 29.249347686767578
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5151,7 +5307,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 2.4342498779296875,
+                        "y": -266.56085205078125,
+                        "z": -15.8095703125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5210,7 +5370,11 @@
                 "Door to Transport Center": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -216.15292358398438,
+                        "y": -256.9056701660156,
+                        "z": -5.878824234008789
+                    },
                     "description": "<https://youtu.be/Myr8MRM5ZDc&t=115>",
                     "layers": [
                         "default"
@@ -5287,7 +5451,11 @@
                 "Elevator to Torvus Bog": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -215.04356384277344,
+                        "y": -272.80767822265625,
+                        "z": -7.884247779846191
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5332,7 +5500,11 @@
                 "Door to Agon Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -65.00241088867188,
+                        "y": 26.741012573242188,
+                        "z": 7.198144912719727
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5366,7 +5538,11 @@
                 "Door to Mining Station A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -80.0225830078125,
+                        "y": -62.25899124145508,
+                        "z": 7.1981306076049805
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5409,7 +5585,11 @@
                 "Door to Mining Station A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -2.018585205078125,
+                        "y": -105.39482116699219,
+                        "z": 14.698123931884766
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5443,7 +5623,11 @@
                 "Door to Central Mining Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 106.98141479492188,
+                        "y": -88.39482116699219,
+                        "z": 11.698125839233398
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5616,7 +5800,11 @@
                 "Door to Mining Station A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -63.857513427734375,
+                        "y": -154.99217224121094,
+                        "z": 7.198115348815918
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5713,7 +5901,11 @@
                 "Door to Portal Terminal": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -139.84837341308594,
+                        "y": -197.95767211914062,
+                        "z": -0.30188989639282227
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5758,7 +5950,11 @@
                 "Door to Mining Station A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -79.84837341308594,
+                        "y": -155.95767211914062,
+                        "z": -0.30188488960266113
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5858,7 +6054,11 @@
                 "Door to Mine Shaft": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -150.40353393554688,
+                        "y": 112.14214324951172,
+                        "z": 9.698163986206055
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5952,7 +6152,11 @@
                 "Door to Temple Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -65.00240325927734,
+                        "y": 26.741004943847656,
+                        "z": 7.198149681091309
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6195,7 +6399,11 @@
                 "Door to Controller Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -65.00240325927734,
+                        "y": 197.54327392578125,
+                        "z": 9.698177337646484
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6446,7 +6654,11 @@
                 "Door to Sandcanyon": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 20.39873504638672,
+                        "y": 112.14214324951172,
+                        "z": 9.698163986206055
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7164,7 +7376,11 @@
                 "Door to Command Center Access (Top)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 219.9814453125,
+                        "y": -88.39482116699219,
+                        "z": 21.69812774658203
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7388,7 +7604,11 @@
                 "Door to Central Station Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 106.98141479492188,
+                        "y": -88.39482116699219,
+                        "z": 11.698127746582031
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7616,7 +7836,11 @@
                 "Door to Command Center Access (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 224.9814453125,
+                        "y": -88.39482116699219,
+                        "z": 9.698127746582031
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7790,7 +8014,11 @@
                 "Keybearer Corpse (J-Stl)": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 96.66109466552734,
+                        "y": -86.40156555175781,
+                        "z": 27.36712646484375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7994,7 +8222,11 @@
                 "Door to Agon Energy Controller": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -64.99284362792969,
+                        "y": 270.00115966796875,
+                        "z": 9.698189735412598
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8076,7 +8308,11 @@
                 "Door to Agon Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -65.00240325927734,
+                        "y": 197.54327392578125,
+                        "z": 9.698177337646484
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8170,7 +8406,11 @@
                 "Door to Ventilation Area A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 233.25729370117188,
+                        "y": 107.48896789550781,
+                        "z": 25.598655700683594
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8293,7 +8533,11 @@
                 "Door to Agon Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 20.39874267578125,
+                        "y": 112.14214324951172,
+                        "z": 9.698163986206055
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8569,7 +8813,11 @@
                 "Door to Command Center (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 296.975830078125,
+                        "y": -88.41329193115234,
+                        "z": 13.792535781860352
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8603,7 +8851,11 @@
                 "Door to Central Mining Station (Top)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 219.9814453125,
+                        "y": -88.39482116699219,
+                        "z": 21.6981258392334
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8637,7 +8889,11 @@
                 "Morph Ball Door to Command Center": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 296.975830078125,
+                        "y": -94.34146881103516,
+                        "z": 6.065685272216797
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8877,7 +9133,11 @@
                 "Door to Central Mining Station (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 224.9814453125,
+                        "y": -88.39481353759766,
+                        "z": 9.698127746582031
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9035,7 +9295,11 @@
                 "Door to Command Center (Top)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 296.975830078125,
+                        "y": -88.41329193115234,
+                        "z": 21.65185546875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9232,7 +9496,11 @@
                 "Door to Controller Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -64.99284362792969,
+                        "y": 270.00115966796875,
+                        "z": 9.698189735412598
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9387,7 +9655,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -84.86548614501953,
+                        "y": 321.2275085449219,
+                        "z": 14.201351165771484
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9485,7 +9757,11 @@
                 "Door to Transport to Sanctuary Fortress": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 294.2286376953125,
+                        "y": 186.5240478515625,
+                        "z": 31.59866714477539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9521,7 +9797,11 @@
                 "Door to Sandcanyon": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 233.25729370117188,
+                        "y": 107.48896789550781,
+                        "z": 25.598655700683594
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9557,7 +9837,11 @@
                 "Door to Main Reactor": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 355.25201416015625,
+                        "y": 107.45858764648438,
+                        "z": 21.598655700683594
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9708,7 +9992,11 @@
                 "Door to Command Center Access (Top)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 296.975830078125,
+                        "y": -88.41329193115234,
+                        "z": 21.65185546875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9749,7 +10037,11 @@
                 "Morph Ball Door to Command Center Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 296.975830078125,
+                        "y": -94.34146118164062,
+                        "z": 6.065683841705322
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9828,7 +10120,11 @@
                 "Door to Security Station B (First)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 348.10247802734375,
+                        "y": -37.46430587768555,
+                        "z": 21.59866714477539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9862,7 +10158,11 @@
                 "Door to Biostorage Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 350.0319519042969,
+                        "y": -150.313232421875,
+                        "z": 11.287775039672852
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9915,7 +10215,11 @@
                 "Door to Command Center Access (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 296.975830078125,
+                        "y": -88.41329193115234,
+                        "z": 13.792534828186035
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10081,7 +10385,11 @@
                 "Portal to Doomed Entry": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 388.0945739746094,
+                        "y": -88.24955749511719,
+                        "z": 58.19388961791992
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10115,7 +10423,11 @@
                 "Door to Security Station B (Second)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 371.00140380859375,
+                        "y": -37.46430969238281,
+                        "z": 21.59866714477539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10254,7 +10566,11 @@
                 "Door to Ventilation Area A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 294.2286376953125,
+                        "y": 186.5240478515625,
+                        "z": 31.59866714477539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10290,7 +10606,11 @@
                 "Elevator to Sanctuary Fortress": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 295.35919189453125,
+                        "y": 202.05105590820312,
+                        "z": 29.59329605102539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10342,7 +10662,11 @@
                 "Portal from Dark Oasis": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 443.1557922363281,
+                        "y": 94.3379898071289,
+                        "z": 36.77452087402344
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10376,7 +10700,11 @@
                 "Door to Ventilation Area A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 355.25201416015625,
+                        "y": 107.45858001708984,
+                        "z": 21.598655700683594
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10488,7 +10816,11 @@
                 "Door to Sand Processing": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 427.25201416015625,
+                        "y": 77.45858001708984,
+                        "z": 21.598651885986328
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10522,7 +10854,11 @@
                 "Door to Storage D": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 355.25201416015625,
+                        "y": 77.45857238769531,
+                        "z": 21.598651885986328
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10629,7 +10965,11 @@
                 "Door to Security Station B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 391.25201416015625,
+                        "y": 41.45857620239258,
+                        "z": 21.598644256591797
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10943,7 +11283,11 @@
                 "Keybearer Corpse (B-Stl)": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 363.2920837402344,
+                        "y": 104.14478302001953,
+                        "z": 19.127283096313477
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11514,7 +11858,11 @@
                 "Door to Command Center": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 350.0319519042969,
+                        "y": -150.313232421875,
+                        "z": 11.287775039672852
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11548,7 +11896,11 @@
                 "Door to Biostorage Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 355.5319519042969,
+                        "y": -232.313232421875,
+                        "z": 6.2877607345581055
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11591,7 +11943,11 @@
                 "Door to Command Center (Second)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 371.0014343261719,
+                        "y": -37.46431350708008,
+                        "z": 21.59866714477539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11625,7 +11981,11 @@
                 "Door to Main Reactor": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 391.25201416015625,
+                        "y": 41.45858383178711,
+                        "z": 21.59864044189453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11664,7 +12024,11 @@
                 "Door to Command Center (First)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 348.10247802734375,
+                        "y": -37.46430587768555,
+                        "z": 21.59866714477539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11722,7 +12086,11 @@
                 "Door to Main Reactor": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 427.25201416015625,
+                        "y": 77.45858001708984,
+                        "z": 21.598651885986328
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11787,7 +12155,11 @@
                 "Door to Save Station C": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 524.4063110351562,
+                        "y": 51.295654296875,
+                        "z": 36.598670959472656
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12477,7 +12849,11 @@
                 "Door to Main Reactor": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 355.25201416015625,
+                        "y": 77.45857238769531,
+                        "z": 21.598651885986328
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12608,7 +12984,11 @@
                 "Door to Security Station A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 411.5266418457031,
+                        "y": -268.813232421875,
+                        "z": 13.287755966186523
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12642,7 +13022,11 @@
                 "Door to Biostorage Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 355.5319519042969,
+                        "y": -232.313232421875,
+                        "z": 6.287761688232422
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12747,7 +13131,11 @@
                 "Door to Storage B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 319.5266418457031,
+                        "y": -298.81817626953125,
+                        "z": 14.287750244140625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12852,7 +13240,11 @@
                 "Door to Sand Processing": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 524.4063110351562,
+                        "y": 51.295654296875,
+                        "z": 36.598670959472656
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12886,7 +13278,11 @@
                 "Door to Ventilation Area B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 542.9063110351562,
+                        "y": 33.795654296875,
+                        "z": 36.59866714477539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12929,7 +13325,11 @@
                 "Door to Biostorage Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 411.5266418457031,
+                        "y": -268.813232421875,
+                        "z": 13.28775691986084
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13011,7 +13411,11 @@
                 "Door to Bioenergy Production": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 465.5266418457031,
+                        "y": -199.313232421875,
+                        "z": 13.28776741027832
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13102,7 +13506,11 @@
                 "Door to Biostorage Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 319.5266418457031,
+                        "y": -298.81817626953125,
+                        "z": 14.287750244140625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13195,7 +13603,11 @@
                 "Door to Save Station C": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 542.9063110351562,
+                        "y": 33.795654296875,
+                        "z": 36.59866714477539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13248,7 +13660,11 @@
                 "Door to Bioenergy Production": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 490.5266418457031,
+                        "y": -82.313232421875,
+                        "z": 35.787784576416016
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13367,7 +13783,11 @@
                 "Door to Storage C": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 532.2556762695312,
+                        "y": -143.313232421875,
+                        "z": 35.787776947021484
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13409,7 +13829,11 @@
                 "Door to Security Station A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 465.5266418457031,
+                        "y": -199.313232421875,
+                        "z": 13.28776741027832
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14062,7 +14486,11 @@
                 "Door to Ventilation Area B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 490.5266418457031,
+                        "y": -82.313232421875,
+                        "z": 35.787784576416016
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14167,7 +14595,11 @@
                 "Door to Bioenergy Production": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 532.2556762695312,
+                        "y": -143.313232421875,
+                        "z": 35.78777313232422
+                    },
                     "description": "",
                     "layers": [
                         "default"

--- a/randovania/games/prime2_opr/logic_database/Dark Agon Wastes.json
+++ b/randovania/games/prime2_opr/logic_database/Dark Agon Wastes.json
@@ -14,7 +14,11 @@
                 "Door to Junction Site": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -267.1276550292969,
+                        "y": -85.32030487060547,
+                        "z": -11.763895034790039
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -177,7 +181,11 @@
                 "Door to Dark Transit Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -330.43902587890625,
+                        "y": 17.286529541015625,
+                        "z": -11.801860809326172
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -213,7 +221,11 @@
                 "Door to Save Station 2": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -331.4791564941406,
+                        "y": -103.61589813232422,
+                        "z": -29.30188751220703
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -312,7 +324,11 @@
                 "Door to Ing Cache 4": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -438.49822998046875,
+                        "y": -34.66960144042969,
+                        "z": -26.801876068115234
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -420,7 +436,11 @@
                 "Portal to Mining Plaza": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -300.8111877441406,
+                        "y": 1.6757926940917969,
+                        "z": -8.418014526367188
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -625,7 +645,11 @@
                 "Door to Duelling Range": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -330.43902587890625,
+                        "y": 17.286529541015625,
+                        "z": -11.801857948303223
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -661,7 +685,11 @@
                 "Door to Trial Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -318.678955078125,
+                        "y": 125.9715576171875,
+                        "z": -6.801849365234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1015,7 +1043,11 @@
                 "Door to Duelling Range": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -331.4791564941406,
+                        "y": -103.61590576171875,
+                        "z": -29.301889419555664
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1051,7 +1083,11 @@
                 "Door to Crossroads": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -235.45773315429688,
+                        "y": -211.65208435058594,
+                        "z": -22.301908493041992
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1184,7 +1220,11 @@
                 "Door to Duelling Range": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -438.49822998046875,
+                        "y": -34.66960144042969,
+                        "z": -26.801876068115234
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1302,7 +1342,11 @@
                 "Door to Duelling Range": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -267.1276550292969,
+                        "y": -85.32029724121094,
+                        "z": -11.763895034790039
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1355,7 +1399,11 @@
                 "Door to Judgment Pit": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -145.1276397705078,
+                        "y": -85.33989715576172,
+                        "z": -7.839865684509277
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1595,7 +1643,11 @@
                 "Door to Dark Transit Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -318.678955078125,
+                        "y": 125.9715576171875,
+                        "z": -6.801850318908691
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1720,7 +1772,11 @@
                 "Portal to Mining Station B": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -266.296875,
+                        "y": 107.57127380371094,
+                        "z": 38.97560501098633
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2344,7 +2400,11 @@
                 "Portal from Transport Center": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -173.7740020751953,
+                        "y": -205.4547882080078,
+                        "z": 27.496910095214844
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2387,7 +2447,11 @@
                 "Door to Portal Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -148.9369354248047,
+                        "y": -245.28309631347656,
+                        "z": -15.878776550292969
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2478,7 +2542,11 @@
                 "Door to Save Station 2": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -235.45773315429688,
+                        "y": -211.65208435058594,
+                        "z": -22.301908493041992
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3073,7 +3141,11 @@
                 "Door to Dark Agon Temple Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -79.97367858886719,
+                        "y": -62.24879837036133,
+                        "z": 7.198128700256348
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3296,7 +3368,11 @@
                 "Door to Save Station 1": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -63.80861282348633,
+                        "y": -154.9819793701172,
+                        "z": 7.198113441467285
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3746,7 +3822,11 @@
                 "Door to Warrior's Walk": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -1.9696807861328125,
+                        "y": -105.38462829589844,
+                        "z": 14.698121070861816
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4041,7 +4121,11 @@
                 "Door to Portal Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -79.79946899414062,
+                        "y": -155.94747924804688,
+                        "z": -0.30188655853271484
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4328,7 +4412,11 @@
                 "Door to Junction Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -145.12762451171875,
+                        "y": -85.34010314941406,
+                        "z": -7.839853763580322
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4714,7 +4802,11 @@
                 "Door to Dark Agon Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -150.35464477539062,
+                        "y": 112.15233612060547,
+                        "z": 9.698158264160156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4808,7 +4900,11 @@
                 "Door to Crossroads": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -148.9369354248047,
+                        "y": -245.28309631347656,
+                        "z": -15.878776550292969
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4998,7 +5094,11 @@
                 "Door to Portal Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -139.79946899414062,
+                        "y": -197.94747924804688,
+                        "z": -0.30189990997314453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5051,7 +5151,11 @@
                 "Portal to Portal Terminal": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -70.74696350097656,
+                        "y": -307.1680603027344,
+                        "z": 29.249338150024414
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5746,7 +5850,11 @@
                 "Door to Judgment Pit": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -79.97367858886719,
+                        "y": -62.24879837036133,
+                        "z": 7.198128700256348
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5837,7 +5945,11 @@
                 "Door to Dark Agon Temple": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -64.95350646972656,
+                        "y": 26.751205444335938,
+                        "z": 7.198143005371094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5913,7 +6025,11 @@
                 "Door to Judgment Pit": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -1.9696807861328125,
+                        "y": -105.38462829589844,
+                        "z": 14.698122024536133
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6012,7 +6128,11 @@
                 "Door to Battleground": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 107.03031921386719,
+                        "y": -88.38462829589844,
+                        "z": 11.698123931884766
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6598,7 +6718,11 @@
                 "Door to Judgment Pit": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -63.808616638183594,
+                        "y": -154.9819793701172,
+                        "z": 7.198113441467285
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6643,7 +6767,11 @@
                 "Door to Judgment Pit": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -79.79947662353516,
+                        "y": -155.94747924804688,
+                        "z": -0.3018949031829834
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6768,7 +6896,11 @@
                 "Door to Portal Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -139.79946899414062,
+                        "y": -197.94747924804688,
+                        "z": -0.30189990997314453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6926,7 +7058,11 @@
                 "Door to Dark Agon Temple Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -64.95350646972656,
+                        "y": 26.751205444335938,
+                        "z": 7.198143005371094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7268,7 +7404,11 @@
                 "Door to Dark Controller Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -64.95350646972656,
+                        "y": 197.553466796875,
+                        "z": 9.69817066192627
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7333,7 +7473,11 @@
                 "Door to Trial Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -150.35464477539062,
+                        "y": 112.15234375,
+                        "z": 9.69815731048584
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8731,7 +8875,11 @@
                 "Door to Double Path (Top)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 220.03033447265625,
+                        "y": -88.38462829589844,
+                        "z": 21.698123931884766
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9008,7 +9156,11 @@
                 "Door to Double Path (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 225.03033447265625,
+                        "y": -88.38462829589844,
+                        "z": 9.698123931884766
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9099,7 +9251,11 @@
                 "Door to Warrior's Walk": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 107.03031921386719,
+                        "y": -88.38462829589844,
+                        "z": 11.698123931884766
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9883,7 +10039,11 @@
                 "Door to Dark Agon Temple": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -64.95350646972656,
+                        "y": 197.553466796875,
+                        "z": 9.69817066192627
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9982,7 +10142,11 @@
                 "Door to Dark Agon Energy Controller": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -64.9439468383789,
+                        "y": 270.0113525390625,
+                        "z": 9.6981840133667
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10090,7 +10254,11 @@
                 "Door to Battleground (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 225.03033447265625,
+                        "y": -88.38462829589844,
+                        "z": 9.698123931884766
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10250,7 +10418,11 @@
                 "Door to Battleground (Top)": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 220.03033447265625,
+                        "y": -88.38463592529297,
+                        "z": 21.698122024536133
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10315,7 +10487,11 @@
                 "Door to Doomed Entry (Top)": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 297.02471923828125,
+                        "y": -88.40310668945312,
+                        "z": 21.651851654052734
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10380,7 +10556,11 @@
                 "Door to Doomed Entry (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 297.02471923828125,
+                        "y": -88.40310668945312,
+                        "z": 13.792531967163086
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10532,7 +10712,11 @@
                 "Door to Dark Controller Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -64.9439468383789,
+                        "y": 270.0113525390625,
+                        "z": 9.6981840133667
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10644,7 +10828,11 @@
                 "Door to Double Path (Bottom)": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 297.02471923828125,
+                        "y": -88.40310668945312,
+                        "z": 13.792531967163086
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10884,7 +11072,11 @@
                 "Portal from Command Center": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 388.1434631347656,
+                        "y": -88.23937225341797,
+                        "z": 58.193885803222656
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11026,7 +11218,11 @@
                 "Door to Double Path (Top)": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 297.02471923828125,
+                        "y": -88.40310668945312,
+                        "z": 21.651851654052734
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11091,7 +11287,11 @@
                 "Door to Oasis Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 371.05029296875,
+                        "y": -37.454124450683594,
+                        "z": 21.598663330078125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11220,7 +11420,11 @@
                 "Door to Feeding Pit Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 350.0808410644531,
+                        "y": -150.30303955078125,
+                        "z": 11.287772178649902
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11934,7 +12138,11 @@
                 "Portal to Main Reactor": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 443.20465087890625,
+                        "y": 94.34819030761719,
+                        "z": 36.77451705932617
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12011,7 +12219,11 @@
                 "Door to Hall of Stairs": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 427.3008728027344,
+                        "y": 77.46878051757812,
+                        "z": 21.598648071289062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12047,7 +12259,11 @@
                 "Door to Oasis Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 391.3008728027344,
+                        "y": 41.46877670288086,
+                        "z": 21.59864044189453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12277,7 +12493,11 @@
                 "Door to Ing Cache 3": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 355.3008728027344,
+                        "y": 77.4687728881836,
+                        "z": 21.598648071289062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12563,7 +12783,11 @@
                 "Door to Feeding Pit": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 355.5808410644531,
+                        "y": -232.30303955078125,
+                        "z": 6.287757873535156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12686,7 +12910,11 @@
                 "Door to Doomed Entry": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 350.0808410644531,
+                        "y": -150.30303955078125,
+                        "z": 11.287771224975586
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12934,7 +13162,11 @@
                 "Door to Dark Oasis": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 391.3008728027344,
+                        "y": 41.46877670288086,
+                        "z": 21.59864044189453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13012,7 +13244,11 @@
                 "Door to Doomed Entry": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 371.05029296875,
+                        "y": -37.45412063598633,
+                        "z": 21.59866714477539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13130,7 +13366,11 @@
                 "Door to Save Station 3": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 524.4552001953125,
+                        "y": 51.30585479736328,
+                        "z": 36.59866714477539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13195,7 +13435,11 @@
                 "Door to Dark Oasis": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 427.3008728027344,
+                        "y": 77.46878051757812,
+                        "z": 21.598648071289062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13689,7 +13933,11 @@
                 "Door to Dark Oasis": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 355.3008728027344,
+                        "y": 77.4687728881836,
+                        "z": 21.598648071289062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13757,7 +14005,11 @@
                 "Door to Feeding Pit Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 355.5808410644531,
+                        "y": -232.30303955078125,
+                        "z": 6.287757396697998
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14285,7 +14537,11 @@
                 "Door to Ing Cache 1": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 319.5755310058594,
+                        "y": -298.8079833984375,
+                        "z": 14.28774642944336
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14350,7 +14606,11 @@
                 "Door to Watering Hole": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 411.5755310058594,
+                        "y": -268.80303955078125,
+                        "z": 13.287752151489258
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14661,7 +14921,11 @@
                 "Door to Bitter Well": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 542.9552001953125,
+                        "y": 33.80585479736328,
+                        "z": 36.598663330078125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14697,7 +14961,11 @@
                 "Door to Hall of Stairs": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 524.4552001953125,
+                        "y": 51.30585479736328,
+                        "z": 36.59866714477539
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14742,7 +15010,11 @@
                 "Door to Phazon Site": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 465.5755310058594,
+                        "y": -199.30303955078125,
+                        "z": 13.287763595581055
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14851,7 +15123,11 @@
                 "Door to Feeding Pit": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 411.5755310058594,
+                        "y": -268.80303955078125,
+                        "z": 13.287753105163574
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14971,7 +15247,11 @@
                 "Door to Feeding Pit": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 319.5755310058594,
+                        "y": -298.8079833984375,
+                        "z": 14.28774642944336
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15138,7 +15418,11 @@
                 "Door to Phazon Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 490.5755310058594,
+                        "y": -82.30303955078125,
+                        "z": 35.78778076171875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15200,7 +15484,11 @@
                 "Door to Save Station 3": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 542.9552001953125,
+                        "y": 33.80585479736328,
+                        "z": 36.598663330078125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15322,7 +15610,11 @@
                 "Door to Watering Hole": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 465.5755310058594,
+                        "y": -199.30303955078125,
+                        "z": 13.287763595581055
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15375,7 +15667,11 @@
                 "Door to Bitter Well": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 490.5755310058594,
+                        "y": -82.30303955078125,
+                        "z": 35.78778076171875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15411,7 +15707,11 @@
                 "Door to Ing Cache 2": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 532.3045654296875,
+                        "y": -143.30303955078125,
+                        "z": 35.78777313232422
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16210,7 +16510,11 @@
                 "Door to Phazon Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 532.3045654296875,
+                        "y": -143.30303955078125,
+                        "z": 35.78777313232422
+                    },
                     "description": "",
                     "layers": [
                         "default"

--- a/randovania/games/prime2_opr/logic_database/Dark Torvus Bog.json
+++ b/randovania/games/prime2_opr/logic_database/Dark Torvus Bog.json
@@ -14,7 +14,11 @@
                 "Door to Venomous Pond": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 53.1624755859375,
+                        "y": -106.2174072265625,
+                        "z": 35.630218505859375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -127,7 +131,11 @@
                 "Portal to Portal Chamber (Light)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 89.77946472167969,
+                        "y": -124.24705505371094,
+                        "z": 56.535560607910156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -180,7 +188,11 @@
                 "Door to Poisoned Bog": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 118.6470947265625,
+                        "y": -77.23229217529297,
+                        "z": 40.62177276611328
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -431,7 +443,11 @@
                 "Door to Poisoned Bog": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 160.6470947265625,
+                        "y": -109.23229217529297,
+                        "z": 40.62177276611328
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -529,7 +545,11 @@
                 "Door to Brooding Ground": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 30.270751953125,
+                        "y": -30.03115463256836,
+                        "z": 55.63031768798828
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -683,7 +703,11 @@
                 "Door to Dark Falls": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -23.958534240722656,
+                        "y": 45.37107849121094,
+                        "z": 65.63032531738281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1028,7 +1052,11 @@
                 "Door to Putrid Alcove": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 80.36318969726562,
+                        "y": -13.625677108764648,
+                        "z": 40.621788024902344
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1467,7 +1495,11 @@
                 "Door to Dark Arena Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 27.770748138427734,
+                        "y": 91.96886444091797,
+                        "z": 65.63034057617188
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1641,7 +1673,11 @@
                 "Portal to Forgotten Bridge": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -13.4588623046875,
+                        "y": -6.524425506591797,
+                        "z": 94.84652709960938
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2608,7 +2644,11 @@
                 "Door to Putrid Alcove": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 150.6470947265625,
+                        "y": -45.23228073120117,
+                        "z": 40.62178039550781
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2653,7 +2693,11 @@
                 "Door to Cache A": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 160.6470947265625,
+                        "y": -109.23228454589844,
+                        "z": 40.621768951416016
+                    },
                     "description": "https://youtu.be/Myr8MRM5ZDc&t=182",
                     "layers": [
                         "default"
@@ -2768,7 +2812,11 @@
                 "Door to Portal Chamber (Dark)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 118.6470947265625,
+                        "y": -77.23229217529297,
+                        "z": 40.62177276611328
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3564,7 +3612,11 @@
                 "Door to Save Station 1": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 14.453137397766113,
+                        "y": -187.07797241210938,
+                        "z": 41.460838317871094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3830,7 +3882,11 @@
                 "Door to Brooding Ground": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 29.662479400634766,
+                        "y": -80.21746826171875,
+                        "z": 45.629844665527344
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4115,7 +4171,11 @@
                 "Door to Dark Torvus Temple Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.1624794006347656,
+                        "y": -123.71746826171875,
+                        "z": 35.62983322143555
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4514,7 +4574,11 @@
                 "Door to Portal Chamber (Dark)": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 53.162479400634766,
+                        "y": -106.21746826171875,
+                        "z": 35.62983703613281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5655,7 +5719,11 @@
                 "Door to Dark Forgotten Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 27.770748138427734,
+                        "y": 91.9688720703125,
+                        "z": 65.63034057617188
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5835,7 +5903,11 @@
                 "Door to Dark Torvus Arena": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 14.770748138427734,
+                        "y": 196.9688720703125,
+                        "z": 65.63035583496094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6041,7 +6113,11 @@
                 "Door to Poisoned Bog": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 150.6470947265625,
+                        "y": -45.23228073120117,
+                        "z": 40.62178039550781
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6311,7 +6387,11 @@
                 "Door to Dark Forgotten Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 80.36318969726562,
+                        "y": -13.625677108764648,
+                        "z": 40.621788024902344
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6945,7 +7025,11 @@
                 "Door to Dark Forgotten Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 30.270751953125,
+                        "y": -30.031152725219727,
+                        "z": 55.63031768798828
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7147,7 +7231,11 @@
                 "Door to Venomous Pond": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 29.662477493286133,
+                        "y": -80.21746826171875,
+                        "z": 45.629844665527344
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7562,7 +7650,11 @@
                 "Door to Polluted Mire": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -111.35293579101562,
+                        "y": 53.28253173828125,
+                        "z": 55.78138732910156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7653,7 +7745,11 @@
                 "Door to Dark Forgotten Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -23.95853042602539,
+                        "y": 45.37107849121094,
+                        "z": 65.63032531738281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7753,7 +7849,11 @@
                 "Door to Venomous Pond": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.1624832153320312,
+                        "y": -123.71746826171875,
+                        "z": 35.62983322143555
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7866,7 +7966,11 @@
                 "Door to Dark Torvus Temple": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -110.42527770996094,
+                        "y": -123.71747589111328,
+                        "z": 35.6297492980957
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8011,7 +8115,11 @@
                 "Door to Venomous Pond": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 14.453137397766113,
+                        "y": -187.07797241210938,
+                        "z": 41.460838317871094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8059,7 +8167,11 @@
                 "Door to Dark Arena Tunnel": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 14.770748138427734,
+                        "y": 196.9688720703125,
+                        "z": 65.63035583496094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9032,7 +9144,11 @@
                 "Door to Dark Falls": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -111.35294342041016,
+                        "y": 53.28253173828125,
+                        "z": 55.78138732910156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9097,7 +9213,11 @@
                 "Door to Gloom Vista": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.07421875,
+                        "y": 104.89163208007812,
+                        "z": 31.781465530395508
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9327,7 +9447,11 @@
                 "Door to Ammo Station": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -186.07424926757812,
+                        "y": -166.0240478515625,
+                        "z": 38.12989807128906
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9409,7 +9533,11 @@
                 "Door to Dark Torvus Temple Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -110.42527770996094,
+                        "y": -123.71747589111328,
+                        "z": 35.6297492980957
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9445,7 +9573,11 @@
                 "Door to Dark Controller Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -246.1370849609375,
+                        "y": -123.71476745605469,
+                        "z": 98.12983703613281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9498,7 +9630,11 @@
                 "Door to Cache B": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -224.86497497558594,
+                        "y": -123.79228973388672,
+                        "z": 33.83242416381836
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10513,7 +10649,11 @@
                 "Portal to Meditation Vista": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.05938720703125,
+                        "y": 136.87025451660156,
+                        "z": 100.84937286376953
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10549,7 +10689,11 @@
                 "Door to Polluted Mire": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.07421875,
+                        "y": 104.8916244506836,
+                        "z": 31.781465530395508
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10636,7 +10780,11 @@
                 "Door to Dark Torvus Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -186.07424926757812,
+                        "y": -166.0240478515625,
+                        "z": 38.12989807128906
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10703,7 +10851,11 @@
                 "Door to Dark Torvus Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -224.86497497558594,
+                        "y": -123.79228973388672,
+                        "z": 33.83242416381836
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10842,7 +10994,11 @@
                 "Door to Dark Torvus Energy Controller": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -318.594970703125,
+                        "y": -123.70521545410156,
+                        "z": 98.12983703613281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10941,7 +11097,11 @@
                 "Door to Dark Torvus Temple": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -246.1370849609375,
+                        "y": -123.71477508544922,
+                        "z": 98.12983703613281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11049,7 +11209,11 @@
                 "Door to Crypt Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -193.7645721435547,
+                        "y": -139.58807373046875,
+                        "z": -32.72386932373047
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11261,7 +11425,11 @@
                 "Door to Undertemple Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -151.1370391845703,
+                        "y": -123.85021209716797,
+                        "z": -68.77202606201172
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11480,7 +11648,11 @@
                 "Door to Save Station 2": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -130.9410400390625,
+                        "y": -123.79228210449219,
+                        "z": -2.7238616943359375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11528,7 +11700,11 @@
                 "Door to Sacrificial Chamber Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -166.36459350585938,
+                        "y": -93.36873626708984,
+                        "z": -32.72386169433594
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12332,7 +12508,11 @@
                 "Door to Dark Controller Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -318.594970703125,
+                        "y": -123.70521545410156,
+                        "z": 98.12983703613281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12484,7 +12664,11 @@
                 "Door to Undertemple Shaft": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -193.7645721435547,
+                        "y": -139.58807373046875,
+                        "z": -32.72386932373047
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12562,7 +12746,11 @@
                 "Door to Crypt": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -269.28765869140625,
+                        "y": -186.29217529296875,
+                        "z": -22.723876953125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12649,7 +12837,11 @@
                 "Door to Sacrificial Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -166.36463928222656,
+                        "y": -5.504188537597656,
+                        "z": -22.797637939453125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12753,7 +12945,11 @@
                 "Door to Undertemple Shaft": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -166.36463928222656,
+                        "y": -93.36856079101562,
+                        "z": -32.72385787963867
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12889,7 +13085,11 @@
                 "Door to Undertemple Shaft": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -130.9410400390625,
+                        "y": -123.79228210449219,
+                        "z": -2.7238621711730957
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12936,7 +13136,11 @@
                 "Portal to Hydrodynamo Shaft": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -159.20013427734375,
+                        "y": -157.39212036132812,
+                        "z": -73.12724304199219
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13059,7 +13263,11 @@
                 "Door to Undertemple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -159.26065063476562,
+                        "y": -162.82980346679688,
+                        "z": -103.13609313964844
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13281,7 +13489,11 @@
                 "Door to Undertemple Shaft": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -151.1370391845703,
+                        "y": -123.85021209716797,
+                        "z": -68.77202606201172
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13496,7 +13708,11 @@
                 "Door to Undertransit One": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -323.6308288574219,
+                        "y": -158.271728515625,
+                        "z": -36.729164123535156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13662,7 +13878,11 @@
                 "Door to Crypt Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -269.28765869140625,
+                        "y": -186.29217529296875,
+                        "z": -22.723880767822266
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13769,7 +13989,11 @@
                 "Portal to Gathering Hall": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -257.81829833984375,
+                        "y": -189.21453857421875,
+                        "z": -46.723899841308594
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14555,7 +14779,11 @@
                 "Door to Undertransit Two": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -120.42575073242188,
+                        "y": 27.94945526123047,
+                        "z": -37.72385025024414
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14651,7 +14879,11 @@
                 "Door to Sacrificial Chamber Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -166.36463928222656,
+                        "y": -5.504188537597656,
+                        "z": -22.797637939453125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14730,7 +14962,11 @@
                 "Door to Undertransit One": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -212.10543823242188,
+                        "y": 27.949447631835938,
+                        "z": -37.723846435546875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15588,7 +15824,11 @@
                 "Door to Undertemple Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -159.26065063476562,
+                        "y": -162.82980346679688,
+                        "z": -103.13609313964844
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15692,7 +15932,11 @@
                 "Portal to Main Hydrochamber": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -210.0290985107422,
+                        "y": -106.266845703125,
+                        "z": -113.12721252441406
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16355,7 +16599,11 @@
                 "Portal to Catacombs": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -0.6943988800048828,
+                        "y": -152.26150512695312,
+                        "z": -45.223873138427734
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16391,7 +16639,11 @@
                 "Door to Undertransit Two": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -9.259063720703125,
+                        "y": -158.07102966308594,
+                        "z": -27.723876953125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16851,7 +17103,11 @@
                 "Door to Crypt": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -323.6308288574219,
+                        "y": -158.271728515625,
+                        "z": -36.729164123535156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16913,7 +17169,11 @@
                 "Door to Sacrificial Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -212.10543823242188,
+                        "y": 27.949447631835938,
+                        "z": -37.723846435546875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -17203,7 +17463,11 @@
                 "Door to Sacrificial Chamber": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -120.42575073242188,
+                        "y": 27.94945526123047,
+                        "z": -37.72385025024414
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -17333,7 +17597,11 @@
                 "Door to Dungeon": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -9.259063720703125,
+                        "y": -158.07102966308594,
+                        "z": -27.723876953125
+                    },
                     "description": "",
                     "layers": [
                         "default"

--- a/randovania/games/prime2_opr/logic_database/Great Temple.json
+++ b/randovania/games/prime2_opr/logic_database/Great Temple.json
@@ -15,7 +15,11 @@
                 "Door to Transport A Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.3206959962844849,
+                        "y": 89.10395812988281,
+                        "z": -12.700155258178711
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -51,7 +55,11 @@
                 "Elevator to Temple Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 2.1175179481506348,
+                        "y": 98.60032653808594,
+                        "z": -14.75407600402832
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -285,7 +293,11 @@
                 "Door to Temple Sanctuary": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.3313040733337402,
+                        "y": 17.99344825744629,
+                        "z": -17.700166702270508
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -453,7 +465,11 @@
                 "Door to Temple Transport A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.3206959962844849,
+                        "y": 89.10395050048828,
+                        "z": -12.700155258178711
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -550,7 +566,11 @@
                 "Door to Transport B Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 62.23332595825195,
+                        "y": -42.896549224853516,
+                        "z": -17.68570899963379
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -584,7 +604,11 @@
                 "Door to Transport A Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.3313040733337402,
+                        "y": 17.993450164794922,
+                        "z": -17.700166702270508
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -618,7 +642,11 @@
                 "Door to Controller Transport": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.3313040733337402,
+                        "y": -103.78829956054688,
+                        "z": -17.700185775756836
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -652,7 +680,11 @@
                 "Door to Transport C Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -59.548423767089844,
+                        "y": -42.896549224853516,
+                        "z": -17.68570899963379
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1239,7 +1271,11 @@
                 "Door to Temple Transport C": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -135.10980224609375,
+                        "y": -79.06395721435547,
+                        "z": -17.685718536376953
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1279,7 +1315,11 @@
                 "Door to Temple Sanctuary": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -59.548423767089844,
+                        "y": -42.896549224853516,
+                        "z": -17.68570899963379
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1356,7 +1396,11 @@
                 "Door to Temple Sanctuary": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.3313039541244507,
+                        "y": -103.78829956054688,
+                        "z": -17.700185775756836
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1392,7 +1436,11 @@
                 "Door to Main Energy Controller": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.3312890529632568,
+                        "y": -113.53443145751953,
+                        "z": 12.299812316894531
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1439,7 +1487,11 @@
                 "Door to Temple Sanctuary": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 62.23332977294922,
+                        "y": -42.896549224853516,
+                        "z": -17.68570899963379
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1575,7 +1627,11 @@
                 "Door to Temple Transport B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 135.3751220703125,
+                        "y": -76.1244888305664,
+                        "z": -17.685718536376953
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1668,7 +1724,11 @@
                 "Door to Transport C Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -135.10980224609375,
+                        "y": -79.06395721435547,
+                        "z": -17.685718536376953
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1704,7 +1764,11 @@
                 "Elevator to Temple Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -162.4551239013672,
+                        "y": -93.19361114501953,
+                        "z": -19.683338165283203
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1753,7 +1817,11 @@
                 "Door to Controller Transport": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.3312889337539673,
+                        "y": -113.53443145751953,
+                        "z": 12.299812316894531
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1958,7 +2026,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 6.734829902648926,
+                        "y": -79.36587524414062,
+                        "z": 16.79358673095703
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2054,7 +2126,11 @@
                 "Door to Transport B Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 135.3751220703125,
+                        "y": -76.12448120117188,
+                        "z": -17.685718536376953
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2090,7 +2166,11 @@
                 "Elevator to Temple Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 164.33387756347656,
+                        "y": -90.2776107788086,
+                        "z": -19.685766220092773
+                    },
                     "description": "",
                     "layers": [
                         "default"

--- a/randovania/games/prime2_opr/logic_database/Ing Hive.json
+++ b/randovania/games/prime2_opr/logic_database/Ing Hive.json
@@ -14,7 +14,11 @@
                 "Portal from Transit Station (Second)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 5.959724426269531,
+                        "y": 215.75547790527344,
+                        "z": -95.7335205078125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -191,7 +195,11 @@
                 "Portal to Transit Station (Second)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -13.040275573730469,
+                        "y": 215.61895751953125,
+                        "z": -84.61164093017578
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -217,7 +225,11 @@
                 "Portal from Transit Station (First)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -13.040275573730469,
+                        "y": 156.75547790527344,
+                        "z": -84.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -365,7 +377,11 @@
                 "Portal to Transit Station (First)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -33.04027557373047,
+                        "y": 211.75547790527344,
+                        "z": -92.7335205078125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -436,7 +452,11 @@
                 "Door to Hazing Cliff": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 328.9870910644531,
+                        "y": 138.58560180664062,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -472,7 +492,11 @@
                 "Door to Unseen Way": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 197.9871063232422,
+                        "y": 144.53489685058594,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -520,7 +544,11 @@
                 "Door to Central Hive East Transport": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 287.93927001953125,
+                        "y": 228.93675231933594,
+                        "z": -109.72550964355469
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -908,7 +936,11 @@
                 "Portal to Hall of Combat Mastery": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 319.41351318359375,
+                        "y": 117.10848999023438,
+                        "z": -80.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1419,7 +1451,11 @@
                 "Portal to Main Research (Lower)": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -171.24716186523438,
+                        "y": 120.0107650756836,
+                        "z": -104.2799072265625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1550,7 +1586,11 @@
                 "Door to Central Hive West Transport": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -143.54026794433594,
+                        "y": 144.75547790527344,
+                        "z": -104.73356628417969
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1649,7 +1689,11 @@
                 "Portal to Main Research (Upper)": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -170.76614379882812,
+                        "y": 145.12298583984375,
+                        "z": -104.2063217163086
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1987,7 +2031,11 @@
                 "Door to Culling Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 328.9870910644531,
+                        "y": 138.58560180664062,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2235,7 +2283,11 @@
                 "Door to Culling Chamber": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 287.93927001953125,
+                        "y": 228.93675231933594,
+                        "z": -109.72550964355469
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2322,7 +2374,11 @@
                 "Door to Hive Dynamo Works": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 287.9597473144531,
+                        "y": 228.92539978027344,
+                        "z": 1.2664794921875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2418,7 +2474,11 @@
                 "Door to Hive Reactor": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 108.43927001953125,
+                        "y": 144.80233764648438,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2664,7 +2724,11 @@
                 "Door to Culling Chamber": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 197.9871063232422,
+                        "y": 144.53489685058594,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2919,7 +2983,11 @@
                 "Door to Aerial Training Site": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -143.54026794433594,
+                        "y": 144.75546264648438,
+                        "z": -8.733570098876953
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2989,7 +3057,11 @@
                 "Door to Staging Area": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -143.54026794433594,
+                        "y": 144.75547790527344,
+                        "z": -104.73356628417969
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3079,7 +3151,11 @@
                 "Door to Hive Dynamo Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 188.45974731445312,
+                        "y": 228.92539978027344,
+                        "z": -8.733522415161133
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3636,7 +3712,11 @@
                 "Portal to Dynamo Works": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 248.4168701171875,
+                        "y": 312.2320556640625,
+                        "z": -19.321802139282227
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3689,7 +3769,11 @@
                 "Door to Central Hive East Transport": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 287.9597473144531,
+                        "y": 228.92539978027344,
+                        "z": 1.2664794921875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3737,7 +3821,11 @@
                 "Door to Hive Cache 3": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 318.51080322265625,
+                        "y": 184.56178283691406,
+                        "z": -17.978469848632812
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4769,7 +4857,11 @@
                 "Door to Hive Save Station 1": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 105.41883850097656,
+                        "y": 156.75546264648438,
+                        "z": -139.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4805,7 +4897,11 @@
                 "Door to Hive Reactor Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.41883850097656,
+                        "y": 75.75546264648438,
+                        "z": -139.73355102539062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4883,7 +4979,11 @@
                 "Door to Unseen Way": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 108.43927001953125,
+                        "y": 144.80233764648438,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4931,7 +5031,11 @@
                 "Door to Hive Cache 1": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 29.421104431152344,
+                        "y": 156.75546264648438,
+                        "z": -139.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5203,7 +5307,11 @@
                 "Door to Judgment Drop": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.540283203125,
+                        "y": 197.25546264648438,
+                        "z": -3.7335662841796875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5428,7 +5536,11 @@
                 "Portal to Watch Station": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -103.04029083251953,
+                        "y": 262.8120422363281,
+                        "z": -5.380134582519531
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5805,7 +5917,11 @@
                 "Door to Temple Security Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -76.45494079589844,
+                        "y": 132.26986694335938,
+                        "z": -1.233572006225586
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6455,7 +6571,11 @@
                 "Door to Central Hive West Transport": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -143.54026794433594,
+                        "y": 144.75546264648438,
+                        "z": -8.733570098876953
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7388,7 +7508,11 @@
                 "Portal to Dynamo Storage": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 372.1052551269531,
+                        "y": 187.06178283691406,
+                        "z": -20.478469848632812
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7466,7 +7590,11 @@
                 "Door to Hive Dynamo Works": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 318.51080322265625,
+                        "y": 184.56178283691406,
+                        "z": -17.978469848632812
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7511,7 +7639,11 @@
                 "Door to Hive Gyro Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 98.45974731445312,
+                        "y": 228.92539978027344,
+                        "z": -8.73352336883545
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7644,7 +7776,11 @@
                 "Door to Hive Dynamo Works": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 188.45974731445312,
+                        "y": 228.92539978027344,
+                        "z": -8.73352336883545
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7917,7 +8053,11 @@
                 "Door to Hive Reactor": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 105.41883850097656,
+                        "y": 156.75546264648438,
+                        "z": -139.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7996,7 +8136,11 @@
                 "Door to Entrance Defense Hall": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.41883850097656,
+                        "y": -6.244525909423828,
+                        "z": -149.7335662841797
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8092,7 +8236,11 @@
                 "Door to Hive Reactor": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.41883850097656,
+                        "y": 75.75546264648438,
+                        "z": -139.73355102539062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8257,7 +8405,11 @@
                 "Door to Hive Reactor": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 29.421104431152344,
+                        "y": 156.75546264648438,
+                        "z": -139.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8366,7 +8518,11 @@
                 "Portal to Grand Abyss": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -267.2837829589844,
+                        "y": 310.2554626464844,
+                        "z": 22.266450881958008
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8392,7 +8548,11 @@
                 "Door to Aerial Training Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.540283203125,
+                        "y": 197.25546264648438,
+                        "z": -3.7335662841796875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8681,7 +8841,11 @@
                 "Door to Aerial Training Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -76.45494079589844,
+                        "y": 132.26986694335938,
+                        "z": -1.23357093334198
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9077,7 +9241,11 @@
                 "Door to Hive Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -0.387420654296875,
+                        "y": 30.37749481201172,
+                        "z": -4.2393388748168945
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10456,7 +10624,11 @@
                 "Door to Hive Dynamo Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 98.45974731445312,
+                        "y": 228.92539978027344,
+                        "z": -8.733522415161133
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10724,7 +10896,11 @@
                 "Door to Hive Temple Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.4597396850586,
+                        "y": 221.42539978027344,
+                        "z": 5.746088981628418
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10911,7 +11087,11 @@
                 "Door to Hive Save Station 2": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 38.70430374145508,
+                        "y": 320.67498779296875,
+                        "z": -8.733505249023438
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11172,7 +11352,11 @@
                 "Door to Hive Gyro Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.45976257324219,
+                        "y": 324.17218017578125,
+                        "z": 8.03703784942627
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11894,7 +12078,11 @@
                 "Door to Hive Reactor Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.41883850097656,
+                        "y": -6.244525909423828,
+                        "z": -149.7335662841797
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11972,7 +12160,11 @@
                 "Door to Hive Entrance": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.41883850097656,
+                        "y": -114.49507904052734,
+                        "z": -149.73358154296875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12174,7 +12366,11 @@
                 "Portal to Vault (Light)": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -314.6307373046875,
+                        "y": 230.24459838867188,
+                        "z": 1.7584309577941895
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12330,7 +12526,11 @@
                 "Portal to Vault (Scan)": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -431.4617919921875,
+                        "y": 236.17901611328125,
+                        "z": 1.7584320306777954
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12482,7 +12682,11 @@
                 "Door to Hive Temple Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.4597396850586,
+                        "y": 115.22457885742188,
+                        "z": -4.239326477050781
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12613,7 +12817,11 @@
                 "Door to Hive Controller Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45967102050781,
+                        "y": -54.4696044921875,
+                        "z": -4.239339828491211
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12726,7 +12934,11 @@
                 "Door to Temple Security Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -0.387420654296875,
+                        "y": 30.37749481201172,
+                        "z": -4.239339828491211
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13850,7 +14062,11 @@
                 "Door to Hive Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.4597396850586,
+                        "y": 115.22457885742188,
+                        "z": -4.239326000213623
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14124,7 +14340,11 @@
                 "Door to Hive Gyro Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.4597396850586,
+                        "y": 221.42538452148438,
+                        "z": 5.746088981628418
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14596,7 +14816,11 @@
                 "Door to Hive Ammo Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.45977020263672,
+                        "y": 390.30389404296875,
+                        "z": 6.787056922912598
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14632,7 +14856,11 @@
                 "Door to Hive Gyro Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.45976257324219,
+                        "y": 324.17218017578125,
+                        "z": 8.03703784942627
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14734,7 +14962,11 @@
                 "Door to Hive Gyro Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 38.70430374145508,
+                        "y": 320.67498779296875,
+                        "z": -8.733505249023438
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14817,7 +15049,11 @@
                 "Door to Entrance Defense Hall": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.41883850097656,
+                        "y": -114.49507141113281,
+                        "z": -149.73358154296875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15153,7 +15389,11 @@
                 "Door to Hive Temple": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45967102050781,
+                        "y": -54.469600677490234,
+                        "z": -4.239339828491211
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15300,7 +15540,11 @@
                 "Door to Hive Energy Controller": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45967102050781,
+                        "y": -126.92748260498047,
+                        "z": -4.239352226257324
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15456,7 +15700,11 @@
                 "Door to Hive Gyro Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.45977020263672,
+                        "y": 390.30389404296875,
+                        "z": 6.787056922912598
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15587,7 +15835,11 @@
                 "Door to Hive Controller Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45967102050781,
+                        "y": -126.92747497558594,
+                        "z": -4.239352226257324
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15689,7 +15941,11 @@
                 "Portal to Aerie": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 18.09156036376953,
+                        "y": 431.25714111328125,
+                        "z": 228.57675170898438
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15715,7 +15971,11 @@
                 "Portal from Aerie": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 139.802978515625,
+                        "y": 431.25714111328125,
+                        "z": 218.54974365234375
+                    },
                     "description": "",
                     "layers": [
                         "default"

--- a/randovania/games/prime2_opr/logic_database/Sanctuary Fortress.json
+++ b/randovania/games/prime2_opr/logic_database/Sanctuary Fortress.json
@@ -15,7 +15,11 @@
                 "Door to Temple Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 31.808073043823242,
+                        "y": -407.0701904296875,
+                        "z": -151.89878845214844
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -51,7 +55,11 @@
                 "Elevator to Temple Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 32.918243408203125,
+                        "y": -433.2576904296875,
+                        "z": -154.89878845214844
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -96,7 +104,11 @@
                 "Door to Transport to Temple Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 31.808073043823242,
+                        "y": -407.0701904296875,
+                        "z": -151.89878845214844
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -176,7 +188,11 @@
                 "Door to Sanctuary Entrance": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.16674041748047,
+                        "y": -276.45269775390625,
+                        "z": -149.96127319335938
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -278,7 +294,11 @@
                 "Door to Power Junction": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.4189224243164,
+                        "y": -114.49508666992188,
+                        "z": -149.73358154296875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -810,7 +830,11 @@
                 "Door to Temple Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.16674041748047,
+                        "y": -276.45269775390625,
+                        "z": -149.96127319335938
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -939,7 +963,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 97.00480651855469,
+                        "y": -87.66755676269531,
+                        "z": -139.78111267089844
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1027,7 +1055,11 @@
                 "Keybearer Corpse (S-Jrs)": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 60.08767318725586,
+                        "y": -142.98133850097656,
+                        "z": -112.23397827148438
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1176,7 +1208,11 @@
                 "Door to Reactor Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.4189224243164,
+                        "y": -6.244533538818359,
+                        "z": -149.7335662841797
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1219,7 +1255,11 @@
                 "Door to Sanctuary Entrance": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.4189224243164,
+                        "y": -114.49508666992188,
+                        "z": -149.73358154296875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1283,7 +1323,11 @@
                 "Door to Power Junction": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.4189224243164,
+                        "y": -6.244532585144043,
+                        "z": -149.7335662841797
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1431,7 +1475,11 @@
                 "Door to Reactor Core": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.4189224243164,
+                        "y": 75.75546264648438,
+                        "z": -139.73355102539062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1501,7 +1549,11 @@
                 "Door to Minigyro Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 108.4393539428711,
+                        "y": 144.80233764648438,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1535,7 +1587,11 @@
                 "Door to Save Station A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 105.4189224243164,
+                        "y": 156.75546264648438,
+                        "z": -139.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1569,7 +1625,11 @@
                 "Door to Sanctuary Map Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 29.421188354492188,
+                        "y": 156.75546264648438,
+                        "z": -139.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1603,7 +1663,11 @@
                 "Door to Reactor Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 67.4189224243164,
+                        "y": 75.75546264648438,
+                        "z": -139.73355102539062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1637,7 +1701,11 @@
                 "Door to Transit Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 20.418922424316406,
+                        "y": 144.75546264648438,
+                        "z": -109.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2370,7 +2438,11 @@
                 "Door to Reactor Core": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 105.4189224243164,
+                        "y": 156.75546264648438,
+                        "z": -139.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2413,7 +2485,11 @@
                 "Door to Hall of Combat Mastery": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 197.98719787597656,
+                        "y": 144.53489685058594,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2466,7 +2542,11 @@
                 "Door to Reactor Core": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 108.43936157226562,
+                        "y": 144.80233764648438,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2585,7 +2665,11 @@
                 "Door to Reactor Core": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 20.418914794921875,
+                        "y": 144.75547790527344,
+                        "z": -109.731201171875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2619,7 +2703,11 @@
                 "Portal to Hive Portal Chamber (Second)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 5.959800720214844,
+                        "y": 215.75547790527344,
+                        "z": -95.7335205078125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2645,7 +2733,11 @@
                 "Portal from Hive Portal Chamber (Second)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -13.040199279785156,
+                        "y": 215.61895751953125,
+                        "z": -84.61164093017578
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2734,7 +2826,11 @@
                 "Door to Main Research": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -51.540199279785156,
+                        "y": 144.75547790527344,
+                        "z": -109.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2768,7 +2864,11 @@
                 "Portal from Hive Portal Chamber (First)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -33.040199279785156,
+                        "y": 211.75547790527344,
+                        "z": -92.7335205078125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2804,7 +2904,11 @@
                 "Portal to Hive Portal Chamber (First)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -13.040199279785156,
+                        "y": 156.75547790527344,
+                        "z": -84.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3087,7 +3191,11 @@
                 "Door to Reactor Core": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 29.421188354492188,
+                        "y": 156.75546264648438,
+                        "z": -139.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3191,7 +3299,11 @@
                 "Door to Central Area Transport East": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 287.9393615722656,
+                        "y": 228.93675231933594,
+                        "z": -109.72550964355469
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3390,7 +3502,11 @@
                 "Door to Agon Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 328.9871826171875,
+                        "y": 138.58560180664062,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3452,7 +3568,11 @@
                 "Portal to Culling Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 319.4136047363281,
+                        "y": 117.10848999023438,
+                        "z": -80.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3622,7 +3742,11 @@
                 "Door to Minigyro Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 197.98719787597656,
+                        "y": 144.53489685058594,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4099,7 +4223,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 269.6321105957031,
+                        "y": 237.4957275390625,
+                        "z": -108.6769790649414
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4254,7 +4382,11 @@
                 "Portal from Staging Area": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -171.24708557128906,
+                        "y": 120.0107650756836,
+                        "z": -104.2799072265625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4368,7 +4500,11 @@
                 "Door to Central Area Transport West": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -143.54019165039062,
+                        "y": 144.75547790527344,
+                        "z": -104.73356628417969
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4402,7 +4538,11 @@
                 "Door to Transit Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -51.540199279785156,
+                        "y": 144.75547790527344,
+                        "z": -109.73353576660156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4468,7 +4608,11 @@
                 "Portal to Staging Area": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -170.7660675048828,
+                        "y": 145.12298583984375,
+                        "z": -104.2063217163086
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4502,7 +4646,11 @@
                 "Door to Torvus Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -143.54019165039062,
+                        "y": 144.75547790527344,
+                        "z": -124.73352813720703
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4785,7 +4933,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -127.27115631103516,
+                        "y": 155.34857177734375,
+                        "z": -121.51915740966797
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4898,7 +5050,11 @@
                 "Door to Hall of Combat Mastery": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 328.9871826171875,
+                        "y": 138.58560180664062,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4932,7 +5088,11 @@
                 "Door to Transport to Agon Wastes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 418.9871826171875,
+                        "y": 138.58560180664062,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4975,7 +5135,11 @@
                 "Door to Dynamo Works": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 287.9598388671875,
+                        "y": 228.92539978027344,
+                        "z": 1.2664794921875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5011,7 +5175,11 @@
                 "Door to Hall of Combat Mastery": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 287.9393615722656,
+                        "y": 228.93675231933594,
+                        "z": -109.72550964355469
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5059,7 +5227,11 @@
                 "Door to Main Research": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -143.54019165039062,
+                        "y": 144.75547790527344,
+                        "z": -104.73356628417969
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5112,7 +5284,11 @@
                 "Door to Watch Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -143.54019165039062,
+                        "y": 144.75546264648438,
+                        "z": -8.733570098876953
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5227,7 +5403,11 @@
                 "Door to Transport to Torvus Bog": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -251.79074096679688,
+                        "y": 144.75547790527344,
+                        "z": -124.73352813720703
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5261,7 +5441,11 @@
                 "Door to Main Research": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -143.54019165039062,
+                        "y": 144.75547790527344,
+                        "z": -124.73352813720703
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5304,7 +5488,11 @@
                 "Door to Agon Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 418.9871826171875,
+                        "y": 138.58560180664062,
+                        "z": -109.72552490234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5340,7 +5528,11 @@
                 "Elevator to Agon Wastes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 450.68560791015625,
+                        "y": 144.7085418701172,
+                        "z": -112.03022003173828
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5393,7 +5585,11 @@
                 "Door to Workers Path": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 200.45314025878906,
+                        "y": 151.47198486328125,
+                        "z": -7.7335357666015625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5542,7 +5738,11 @@
                 "Portal to Hive Dynamo Works": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 248.41696166992188,
+                        "y": 312.2320556640625,
+                        "z": -19.321802139282227
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5576,7 +5776,11 @@
                 "Door to Dynamo Storage": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 318.5108947753906,
+                        "y": 184.56178283691406,
+                        "z": -17.978469848632812
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5691,7 +5895,11 @@
                 "Door to Central Area Transport East": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 287.9598388671875,
+                        "y": 228.92539978027344,
+                        "z": 1.2664794921875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5776,7 +5984,11 @@
                 "Door to Dynamo Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 188.4598388671875,
+                        "y": 228.92539978027344,
+                        "z": -8.733522415161133
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6274,7 +6486,11 @@
                 "Keybearer Corpse (C-Rch)": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 283.227783203125,
+                        "y": 216.58580017089844,
+                        "z": -1.1960678100585938
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6332,7 +6548,11 @@
                 "Door to Watch Station Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -44.54020690917969,
+                        "y": 197.25546264648438,
+                        "z": -3.733562469482422
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6590,7 +6810,11 @@
                 "Door to Central Area Transport West": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -143.54019165039062,
+                        "y": 144.75546264648438,
+                        "z": -8.733570098876953
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6784,7 +7008,11 @@
                 "Portal to Aerial Training Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -103.04020690917969,
+                        "y": 262.8120422363281,
+                        "z": -5.380134582519531
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6820,7 +7048,11 @@
                 "Door to Grand Abyss": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.54019165039062,
+                        "y": 197.25546264648438,
+                        "z": -3.7335662841796875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7030,7 +7262,11 @@
                 "Door to Sentinel's Path": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -76.45484924316406,
+                        "y": 132.26986694335938,
+                        "z": -1.233572006225586
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7346,7 +7582,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -66.81385040283203,
+                        "y": 218.89004516601562,
+                        "z": -8.295648574829102
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7405,7 +7645,11 @@
                 "Door to Torvus Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -251.79074096679688,
+                        "y": 144.75546264648438,
+                        "z": -124.73352813720703
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7441,7 +7685,11 @@
                 "Elevator to Torvus Bog": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -266.3802795410156,
+                        "y": 144.57351684570312,
+                        "z": -126.74755859375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7486,7 +7734,11 @@
                 "Door to Dynamo Works": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 188.4598388671875,
+                        "y": 228.92539978027344,
+                        "z": -8.73352336883545
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7573,7 +7825,11 @@
                 "Door to Main Gyro Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 98.4598388671875,
+                        "y": 228.92539978027344,
+                        "z": -8.73352336883545
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7669,7 +7925,11 @@
                 "Door to Dynamo Works": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 200.45314025878906,
+                        "y": 151.47198486328125,
+                        "z": -7.733541011810303
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7842,7 +8102,11 @@
                 "Door to Sanctuary Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 149.3069305419922,
+                        "y": 30.377479553222656,
+                        "z": -4.239342212677002
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8050,7 +8314,11 @@
                 "Door to Dynamo Works": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 318.5108947753906,
+                        "y": 184.56178283691406,
+                        "z": -17.978469848632812
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8084,7 +8352,11 @@
                 "Portal to Hive Cache 3": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 372.1053466796875,
+                        "y": 187.06178283691406,
+                        "z": -20.478469848632812
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8129,7 +8401,11 @@
                 "Door to Watch Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -76.45484924316406,
+                        "y": 132.26986694335938,
+                        "z": -1.23357093334198
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8163,7 +8439,11 @@
                 "Door to Sanctuary Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -0.3873291015625,
+                        "y": 30.37749481201172,
+                        "z": -4.2393388748168945
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8363,7 +8643,11 @@
                 "Door to Watch Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -44.54020690917969,
+                        "y": 197.25546264648438,
+                        "z": -3.733562469482422
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8427,7 +8711,11 @@
                 "Door to Main Gyro Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 38.45979309082031,
+                        "y": 228.92538452148438,
+                        "z": -8.73355770111084
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9315,7 +9603,11 @@
                 "Door to Vault": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -306.2544860839844,
+                        "y": 300.12359619140625,
+                        "z": -3.664055109024048
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9349,7 +9641,11 @@
                 "Door to Watch Station": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.54019165039062,
+                        "y": 197.25546264648438,
+                        "z": -3.7335662841796875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9530,7 +9826,11 @@
                 "Portal from Judgment Drop": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -267.28369140625,
+                        "y": 310.2554626464844,
+                        "z": 22.266450881958008
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10011,7 +10311,11 @@
                 "Door to Dynamo Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 98.4598388671875,
+                        "y": 228.92539978027344,
+                        "z": -8.733522415161133
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10145,7 +10449,11 @@
                 "Door to Save Station B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 38.70439529418945,
+                        "y": 320.67498779296875,
+                        "z": -8.733505249023438
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10464,7 +10772,11 @@
                 "Door to Watch Station Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 38.4598388671875,
+                        "y": 228.92539978027344,
+                        "z": -8.733522415161133
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10654,7 +10966,11 @@
                 "Door to Temple Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45983123779297,
+                        "y": 221.42539978027344,
+                        "z": 5.746088981628418
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10750,7 +11066,11 @@
                 "Door to Checkpoint Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.45985412597656,
+                        "y": 324.17218017578125,
+                        "z": 8.03703784942627
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11750,7 +12070,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 75.5928726196289,
+                        "y": 241.0950469970703,
+                        "z": -30.82831573486328
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11813,7 +12137,11 @@
                 "Door to Controller Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45976257324219,
+                        "y": -54.4696044921875,
+                        "z": -4.239339828491211
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11906,7 +12234,11 @@
                 "Door to Workers Path": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 149.3069305419922,
+                        "y": 30.377479553222656,
+                        "z": -4.239341735839844
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11940,7 +12272,11 @@
                 "Door to Temple Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45983123779297,
+                        "y": 115.22457885742188,
+                        "z": -4.239326477050781
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -12051,7 +12387,11 @@
                 "Door to Sentinel's Path": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -0.3873291015625,
+                        "y": 30.37749481201172,
+                        "z": -4.239339828491211
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13109,7 +13449,11 @@
                 "Door to Grand Abyss": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -306.2544860839844,
+                        "y": 300.12359619140625,
+                        "z": -3.6640539169311523
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13317,7 +13661,11 @@
                 "Portal to Vault Attack Portal (Dark)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -329.0085144042969,
+                        "y": 230.15951538085938,
+                        "z": -6.164051055908203
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13589,7 +13937,11 @@
                 "Portal to Vault Attack Portal (Scan)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -445.839599609375,
+                        "y": 236.09393310546875,
+                        "z": -6.164050102233887
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14528,7 +14880,11 @@
                 "Door to Main Gyro Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45983123779297,
+                        "y": 221.42538452148438,
+                        "z": 5.746088981628418
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -14682,7 +15038,11 @@
                 "Door to Sanctuary Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45983123779297,
+                        "y": 115.22457885742188,
+                        "z": -4.239326000213623
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15219,7 +15579,11 @@
                 "Door to Main Gyro Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.45985412597656,
+                        "y": 324.17218017578125,
+                        "z": 8.03703784942627
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15253,7 +15617,11 @@
                 "Door to Aerie Transport Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.4598617553711,
+                        "y": 390.30389404296875,
+                        "z": 6.787056922912598
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15317,7 +15685,11 @@
                 "Door to Main Gyro Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 38.70439529418945,
+                        "y": 320.67498779296875,
+                        "z": -8.733505249023438
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15360,7 +15732,11 @@
                 "Door to Sanctuary Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45976257324219,
+                        "y": -54.469600677490234,
+                        "z": -4.239339828491211
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15490,7 +15866,11 @@
                 "Door to Sanctuary Energy Controller": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45976257324219,
+                        "y": -126.92748260498047,
+                        "z": -4.239352226257324
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15629,7 +16009,11 @@
                 "Door to Checkpoint Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.4598617553711,
+                        "y": 390.30389404296875,
+                        "z": 6.787056922912598
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15674,7 +16058,11 @@
                 "Dock to Aerie Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.4598617553711,
+                        "y": 431.30389404296875,
+                        "z": 54.28706359863281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15700,7 +16088,11 @@
                 "Elevator to Aerie": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 69.5848617553711,
+                        "y": 431.11639404296875,
+                        "z": 4.787064075469971
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15751,7 +16143,11 @@
                 "Door to Controller Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 74.45976257324219,
+                        "y": -126.92747497558594,
+                        "z": -4.239352226257324
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15879,7 +16275,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 107.18936920166016,
+                        "y": -155.6034393310547,
+                        "z": -3.237812042236328
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15976,7 +16376,11 @@
                 "Dock to Aerie Transport Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.4598617553711,
+                        "y": 431.30389404296875,
+                        "z": 54.28706359863281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16010,7 +16414,11 @@
                 "Dock to Aerie": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.4598617553711,
+                        "y": 431.30389404296875,
+                        "z": 134.2870635986328
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16060,7 +16468,11 @@
                 "Portal to Hive Summit": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 139.82342529296875,
+                        "y": 431.30389404296875,
+                        "z": 218.55776977539062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16086,7 +16498,11 @@
                 "Portal from Hive Summit": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 18.11200714111328,
+                        "y": 431.30389404296875,
+                        "z": 228.5847625732422
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16227,7 +16643,11 @@
                 "Dock to Aerie Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.4598617553711,
+                        "y": 431.30389404296875,
+                        "z": 134.2870635986328
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16417,7 +16837,11 @@
                 "Elevator to Aerie Transport Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 69.58484649658203,
+                        "y": 431.11639404296875,
+                        "z": 152.4156036376953
+                    },
                     "description": "",
                     "layers": [
                         "default"

--- a/randovania/games/prime2_opr/logic_database/Sky Temple Grounds.json
+++ b/randovania/games/prime2_opr/logic_database/Sky Temple Grounds.json
@@ -14,7 +14,11 @@
                 "Door to War Ritual Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -206.99278259277344,
+                        "y": 2.3191146850585938,
+                        "z": -43.09780502319336
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -174,7 +178,11 @@
                 "Door to Abandoned Base": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -275.4927978515625,
+                        "y": 56.819114685058594,
+                        "z": -34.59779357910156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -210,7 +218,11 @@
                 "Portal to Hall of Eyes": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -260.2784423828125,
+                        "y": 20.72380828857422,
+                        "z": -1.5979423522949219
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -296,7 +308,11 @@
                 "Door to Shrine Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -126.2698974609375,
+                        "y": -84.15702056884766,
+                        "z": -36.09782028198242
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -366,7 +382,11 @@
                 "Door to Base Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -206.99278259277344,
+                        "y": 2.3191146850585938,
+                        "z": -43.09780502319336
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -796,7 +816,11 @@
                 "Portal to Path of Eyes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -218.3673095703125,
+                        "y": 129.19651794433594,
+                        "z": -38.127681732177734
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -832,7 +856,11 @@
                 "Door to Base Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -275.4927978515625,
+                        "y": 56.819114685058594,
+                        "z": -34.59779357910156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1210,7 +1238,11 @@
                 "Door to War Ritual Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -126.2698974609375,
+                        "y": -84.15702056884766,
+                        "z": -36.09782409667969
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1360,7 +1392,11 @@
                 "Door to Defiled Shrine": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -75.03659057617188,
+                        "y": -130.78701782226562,
+                        "z": -35.658668518066406
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1396,7 +1432,11 @@
                 "Door to Gateway Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -16.036605834960938,
+                        "y": -103.78702545166016,
+                        "z": -33.158660888671875
+                    },
                     "description": "<https://www.youtube.com/watch?v=6Ks1mKF1Jgw>",
                     "layers": [
                         "default"
@@ -1743,7 +1783,11 @@
                 "Door to Lake Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 262.7097473144531,
+                        "y": -59.47412872314453,
+                        "z": -37.97524642944336
+                    },
                     "description": "<https://youtu.be/_mSQ-ckqaA8>",
                     "layers": [
                         "default"
@@ -1837,7 +1881,11 @@
                 "Portal to Temple Assembly Site": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 281.80889892578125,
+                        "y": -7.767488479614258,
+                        "z": -29.613765716552734
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2327,7 +2375,11 @@
                 "Door to Shrine Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -75.03659057617188,
+                        "y": -130.78701782226562,
+                        "z": -35.658668518066406
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2689,7 +2741,11 @@
                 "Door to Sky Temple Gateway": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 3.4632091522216797,
+                        "y": -10.28704833984375,
+                        "z": -33.15864944458008
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2725,7 +2781,11 @@
                 "Door to Shrine Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -16.036605834960938,
+                        "y": -103.78702545166016,
+                        "z": -33.158660888671875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2974,7 +3034,11 @@
                 "Portal to Grand Windchamber": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -195.03070068359375,
+                        "y": 286.56903076171875,
+                        "z": -107.74087524414062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3226,7 +3290,11 @@
                 "Door to Accursed Lake": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 220.6387481689453,
+                        "y": -123.11283874511719,
+                        "z": -37.975257873535156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3299,7 +3367,11 @@
                 "Door to Plain of Dark Worship": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 262.7097473144531,
+                        "y": -59.47412872314453,
+                        "z": -37.97524642944336
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3381,7 +3453,11 @@
                 "Door to Gateway Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 3.4632091522216797,
+                        "y": -10.28704833984375,
+                        "z": -33.15864944458008
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3480,7 +3556,11 @@
                 "Elevator to Sky Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 8.28526496887207,
+                        "y": 77.50634002685547,
+                        "z": -30.777488708496094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3966,7 +4046,11 @@
                 "Door to Lake Access": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 220.6387481689453,
+                        "y": -123.11283874511719,
+                        "z": -37.975257873535156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4768,7 +4852,11 @@
                 "Door to Phazon Pit": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -7.801814556121826,
+                        "y": 289.94061279296875,
+                        "z": -35.988525390625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5005,7 +5093,11 @@
                 "Portal to Sacred Path": {
                     "node_type": "dock",
                     "heal": true,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -31.632530212402344,
+                        "y": 282.28204345703125,
+                        "z": -19.019365310668945
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5453,7 +5545,11 @@
                 "Door to Profane Path": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -7.801815032958984,
+                        "y": 289.94061279296875,
+                        "z": -35.988525390625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5759,7 +5855,11 @@
                 "Door to Phazon Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 35.482460021972656,
+                        "y": 333.2248840332031,
+                        "z": -36.113525390625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5954,7 +6054,11 @@
                 "Door to Phazon Pit": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 35.482460021972656,
+                        "y": 333.224853515625,
+                        "z": -36.113525390625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6266,7 +6370,11 @@
                 "Door to Reliquary Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 92.4237060546875,
+                        "y": 289.931884765625,
+                        "z": -41.0977897644043
+                    },
                     "description": "<https://youtu.be/_ZB9NSBnIrs>",
                     "layers": [
                         "default"
@@ -6794,7 +6902,11 @@
                 "Door to Phazon Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 92.42369842529297,
+                        "y": 289.931884765625,
+                        "z": -41.0977897644043
+                    },
                     "description": "<https://www.youtube.com/watch?v=L0ULmh5YmFg>",
                     "layers": [
                         "default"
@@ -7063,7 +7175,11 @@
                 "Door to Reliquary Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 162.29856872558594,
+                        "y": 217.43186950683594,
+                        "z": -38.597801208496094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7300,7 +7416,11 @@
                 "Door to Reliquary Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 162.29856872558594,
+                        "y": 217.43186950683594,
+                        "z": -38.597801208496094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7598,7 +7718,11 @@
                 "Door to Ing Reliquary": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 157.97232055664062,
+                        "y": 112.62187957763672,
+                        "z": -21.097816467285156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7790,7 +7914,11 @@
                 "Door to Reliquary Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 157.97232055664062,
+                        "y": 112.62187957763672,
+                        "z": -21.097816467285156
+                    },
                     "description": "",
                     "layers": [
                         "default"

--- a/randovania/games/prime2_opr/logic_database/Sky Temple.json
+++ b/randovania/games/prime2_opr/logic_database/Sky Temple.json
@@ -117,7 +117,11 @@
                 "Door to Sanctum Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.331292986869812,
+                        "y": -113.5344467163086,
+                        "z": 83.23806762695312
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -211,7 +215,11 @@
                 "Elevator to Sky Temple Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 6.1659979820251465,
+                        "y": -41.10333251953125,
+                        "z": 55.64638137817383
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -468,7 +476,11 @@
                 "Door to Sky Temple Energy Controller": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.3312931060791016,
+                        "y": -113.5344467163086,
+                        "z": 83.23806762695312
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -574,7 +586,11 @@
                 "Door to Sanctum": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.3312797546386719,
+                        "y": -103.78831481933594,
+                        "z": 113.23806762695312
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -622,7 +638,11 @@
                 "Door to Sanctum Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.331279993057251,
+                        "y": -103.78831481933594,
+                        "z": 113.23806762695312
+                    },
                     "description": "",
                     "layers": [
                         "default"

--- a/randovania/games/prime2_opr/logic_database/Temple Grounds.json
+++ b/randovania/games/prime2_opr/logic_database/Temple Grounds.json
@@ -326,7 +326,11 @@
                 "Door to Service Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -75.03620910644531,
+                        "y": -130.7867431640625,
+                        "z": -35.65867614746094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -360,7 +364,11 @@
                 "Door to Hive Access Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -22.834457397460938,
+                        "y": -194.4658660888672,
+                        "z": -43.15507125854492
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -487,7 +495,11 @@
                 "Keybearer Corpse (M-Dhe)": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -88.98485565185547,
+                        "y": -150.21063232421875,
+                        "z": -38.18117904663086
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -537,7 +549,11 @@
                 "Door to Landing Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -75.03620910644531,
+                        "y": -130.7867431640625,
+                        "z": -35.65867614746094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -639,7 +655,11 @@
                 "Door to Path of Honor": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -16.036224365234375,
+                        "y": -103.78675079345703,
+                        "z": -33.158668518066406
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -673,7 +693,11 @@
                 "Morph Ball Door to Meeting Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -126.26951599121094,
+                        "y": -84.15674591064453,
+                        "z": -29.45114517211914
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -984,7 +1008,11 @@
                 "Morph Ball Door to Path of Honor": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -16.03622055053711,
+                        "y": -103.7867660522461,
+                        "z": -20.65867042541504
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1198,7 +1226,11 @@
                 "Door to Meeting Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -126.26951599121094,
+                        "y": -84.15674591064453,
+                        "z": -36.09783172607422
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1302,7 +1334,11 @@
                 "Door to Landing Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -22.83445930480957,
+                        "y": -194.4658660888672,
+                        "z": -43.15507125854492
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1343,7 +1379,11 @@
                 "Door to Hive Transport Area": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.04546356201172,
+                        "y": -194.4658660888672,
+                        "z": -43.15507125854492
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1377,7 +1417,11 @@
                 "Dock to Hive Chamber A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 37.113372802734375,
+                        "y": -224.36752319335938,
+                        "z": -59.65507507324219
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1451,7 +1495,11 @@
                 "Morph Ball Door to Hall of Honored Dead": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 3.4635887145996094,
+                        "y": -10.28680419921875,
+                        "z": -22.908662796020508
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1487,7 +1535,11 @@
                 "Door to Service Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -16.036224365234375,
+                        "y": -103.78675079345703,
+                        "z": -33.158668518066406
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1566,7 +1618,11 @@
                 "Door to Hall of Honored Dead": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 3.463592529296875,
+                        "y": -10.286773681640625,
+                        "z": -33.15865707397461
+                    },
                     "description": "<https://youtu.be/Myr8MRM5ZDc&t=24>",
                     "layers": [
                         "default"
@@ -1641,7 +1697,11 @@
                 "Morph Ball Door to Service Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -16.036224365234375,
+                        "y": -103.78675842285156,
+                        "z": -20.658672332763672
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1686,7 +1746,11 @@
                 "Morph Ball Door to Service Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -126.26951599121094,
+                        "y": -84.15674591064453,
+                        "z": -29.451141357421875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1722,7 +1786,11 @@
                 "Door to Hall of Eyes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -206.99240112304688,
+                        "y": 2.3193893432617188,
+                        "z": -43.09781265258789
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1756,7 +1824,11 @@
                 "Door to Service Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -126.26951599121094,
+                        "y": -84.15674591064453,
+                        "z": -36.09782791137695
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1790,7 +1862,11 @@
                 "Door to Temple Transport C": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -135.7259521484375,
+                        "y": -18.278966903686523,
+                        "z": -36.09781265258789
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2067,7 +2143,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -189.98526000976562,
+                        "y": -61.74858093261719,
+                        "z": -18.700931549072266
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2126,7 +2206,11 @@
                 "Door to Industrial Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 148.42547607421875,
+                        "y": -148.2116241455078,
+                        "z": -42.78467559814453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2160,7 +2244,11 @@
                 "Door to Hive Access Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.0450668334961,
+                        "y": -194.46617126464844,
+                        "z": -43.15507888793945
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2194,7 +2282,11 @@
                 "Door to Hive Chamber C": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 123.05333709716797,
+                        "y": -150.71151733398438,
+                        "z": -103.28494262695312
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2308,7 +2400,11 @@
                 "Dock to Hive Access Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 37.113372802734375,
+                        "y": -224.36752319335938,
+                        "z": -59.65507507324219
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2382,7 +2478,11 @@
                 "Door to Hive Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 66.62074279785156,
+                        "y": -351.97723388671875,
+                        "z": -103.65872955322266
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2537,7 +2637,11 @@
                 "Door to Path of Honor": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 3.4635891914367676,
+                        "y": -10.28680419921875,
+                        "z": -33.15865707397461
+                    },
                     "description": "https://www.youtube.com/watch?v=Tb0XJ6Y5WH4",
                     "layers": [
                         "default"
@@ -2832,7 +2936,11 @@
                 "Morph Ball Door to Path of Honor": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 3.4635891914367676,
+                        "y": -10.28680419921875,
+                        "z": -22.90866470336914
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2936,7 +3044,11 @@
                 "Door to Path of Eyes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -275.4924011230469,
+                        "y": 56.81938934326172,
+                        "z": -34.597801208496094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2970,7 +3082,11 @@
                 "Door to Meeting Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -206.99240112304688,
+                        "y": 2.3193893432617188,
+                        "z": -43.09781265258789
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3049,7 +3165,11 @@
                 "Portal to Base Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -260.278076171875,
+                        "y": 20.724082946777344,
+                        "z": -1.5979499816894531
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3099,7 +3219,11 @@
                 "Door to Meeting Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -135.7259521484375,
+                        "y": -18.278966903686523,
+                        "z": -36.09781265258789
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3135,7 +3259,11 @@
                 "Elevator to Great Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -116.42996215820312,
+                        "y": -10.210992813110352,
+                        "z": -38.09782028198242
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3180,7 +3308,11 @@
                 "Door to Agon Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 247.18801879882812,
+                        "y": -194.77964782714844,
+                        "z": -47.975284576416016
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3221,7 +3353,11 @@
                 "Door to Collapsed Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 220.6387176513672,
+                        "y": -123.11286926269531,
+                        "z": -37.97527313232422
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3264,7 +3400,11 @@
                 "Door to Hive Transport Area": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 148.42547607421875,
+                        "y": -148.2116241455078,
+                        "z": -42.78467559814453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4378,7 +4518,11 @@
                 "Keybearer Corpse (J-Fme)": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 238.48361206054688,
+                        "y": -193.24290466308594,
+                        "z": -50.635986328125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4449,7 +4593,11 @@
                 "Door to Hive Save Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 149.8908233642578,
+                        "y": -135.04840087890625,
+                        "z": -107.07335662841797
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4492,7 +4640,11 @@
                 "Door to Hive Transport Area": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 123.05333709716797,
+                        "y": -150.71151733398438,
+                        "z": -103.28494262695312
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4535,7 +4687,11 @@
                 "Morph Ball Door to Hive Chamber B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 167.1214599609375,
+                        "y": -183.84494018554688,
+                        "z": -105.54428100585938
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4589,7 +4745,11 @@
                 "Door to Command Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 117.9609375,
+                        "y": -351.90216064453125,
+                        "z": -105.82219696044922
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4658,7 +4818,11 @@
                 "Door to Hive Chamber A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 66.62074279785156,
+                        "y": -351.97723388671875,
+                        "z": -103.65872955322266
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4738,7 +4902,11 @@
                 "Door to Windchamber Gateway": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -279.2556457519531,
+                        "y": 187.88619995117188,
+                        "z": -34.734588623046875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4774,7 +4942,11 @@
                 "Portal from Abandoned Base": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -218.36691284179688,
+                        "y": 129.19679260253906,
+                        "z": -38.127689361572266
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4808,7 +4980,11 @@
                 "Door to Hall of Eyes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -275.4924011230469,
+                        "y": 56.81938934326172,
+                        "z": -34.597801208496094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5003,7 +5179,11 @@
                 "Door to Torvus Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -333.9935607910156,
+                        "y": 41.448158264160156,
+                        "z": -29.734619140625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5314,7 +5494,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -309.6939697265625,
+                        "y": 81.97710418701172,
+                        "z": -30.57790756225586
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5551,7 +5735,11 @@
                 "Door to Transport to Agon Wastes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 303.2127685546875,
+                        "y": -270.9495849609375,
+                        "z": -47.97530746459961
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5585,7 +5773,11 @@
                 "Door to Industrial Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 247.18800354003906,
+                        "y": -194.77964782714844,
+                        "z": -47.975284576416016
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5628,7 +5820,11 @@
                 "Door to Temple Assembly Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 262.709716796875,
+                        "y": -59.474159240722656,
+                        "z": -37.97526168823242
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5664,7 +5860,11 @@
                 "Door to Industrial Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 220.6387176513672,
+                        "y": -123.11286926269531,
+                        "z": -37.97527313232422
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5711,7 +5911,11 @@
                 "Morph Ball Door to Hive Chamber C": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 167.1214599609375,
+                        "y": -183.84494018554688,
+                        "z": -105.54428100585938
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5790,7 +5994,11 @@
                 "Door to Hive Storage": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 142.91024780273438,
+                        "y": -276.91571044921875,
+                        "z": -105.82218933105469
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5908,7 +6116,11 @@
                 "Door to Hive Chamber C": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 149.8908233642578,
+                        "y": -135.04840087890625,
+                        "z": -107.07335662841797
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5951,7 +6163,11 @@
                 "Door to Hive Storage": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 159.4927215576172,
+                        "y": -304.8999328613281,
+                        "z": -105.82167053222656
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5987,7 +6203,11 @@
                 "Door to Hive Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 117.9609375,
+                        "y": -351.90216064453125,
+                        "z": -105.82219696044922
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6099,7 +6319,11 @@
                 "Door to Path of Eyes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -279.2556457519531,
+                        "y": 187.88619995117188,
+                        "z": -34.734588623046875
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6147,7 +6371,11 @@
                 "Door to Grand Windchamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -174.25564575195312,
+                        "y": 242.88616943359375,
+                        "z": -34.734580993652344
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6598,7 +6826,11 @@
                 "Door to Path of Eyes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -333.9935607910156,
+                        "y": 41.448158264160156,
+                        "z": -29.734619140625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6632,7 +6864,11 @@
                 "Door to Transport to Torvus Bog": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -292.9937744140625,
+                        "y": -32.221858978271484,
+                        "z": -29.73462677001953
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6679,7 +6915,11 @@
                 "Door to Agon Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 303.2127685546875,
+                        "y": -270.9495849609375,
+                        "z": -47.97530746459961
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6781,7 +7021,11 @@
                 "Elevator to Agon Wastes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 304.3321838378906,
+                        "y": -286.8515930175781,
+                        "z": -51.23129653930664
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6817,7 +7061,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 303.56182861328125,
+                        "y": -326.91705322265625,
+                        "z": -51.1168212890625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6880,7 +7128,11 @@
                 "Door to Storage Cavern B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 219.05532836914062,
+                        "y": -52.434974670410156,
+                        "z": -40.90407180786133
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6914,7 +7166,11 @@
                 "Portal to Plain of Dark Worship": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 281.80889892578125,
+                        "y": -7.767522811889648,
+                        "z": -29.613780975341797
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6979,7 +7235,11 @@
                 "Door to Temple Transport B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 144.0738525390625,
+                        "y": -15.050545692443848,
+                        "z": -35.904327392578125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7013,7 +7273,11 @@
                 "Door to Dynamo Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 196.77630615234375,
+                        "y": 39.79792022705078,
+                        "z": -33.40431594848633
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7047,7 +7311,11 @@
                 "Door to Collapsed Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 262.709716796875,
+                        "y": -59.47416305541992,
+                        "z": -37.97526168823242
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7591,7 +7859,11 @@
                 "Door to Hive Chamber B": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 142.91024780273438,
+                        "y": -276.91571044921875,
+                        "z": -105.82218933105469
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7625,7 +7897,11 @@
                 "Door to Command Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 159.4927215576172,
+                        "y": -304.8999328613281,
+                        "z": -105.82167053222656
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7674,7 +7950,11 @@
                 "Door to Windchamber Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -55.10457992553711,
+                        "y": 304.09619140625,
+                        "z": -33.613525390625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8097,7 +8377,11 @@
                 "Portal to Ing Windchamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -195.03070068359375,
+                        "y": 286.569091796875,
+                        "z": -107.7408676147461
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8131,7 +8415,11 @@
                 "Door to Windchamber Gateway": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -174.25564575195312,
+                        "y": 242.8861846923828,
+                        "z": -34.734580993652344
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8610,7 +8898,11 @@
                 "Door to Torvus Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -292.9937744140625,
+                        "y": -32.221858978271484,
+                        "z": -29.73462677001953
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8646,7 +8938,11 @@
                 "Elevator to Torvus Bog": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -285.53045654296875,
+                        "y": -39.2679443359375,
+                        "z": -32.99061584472656
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8691,7 +8987,11 @@
                 "Door to Communication Area": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 236.8562469482422,
+                        "y": 114.80029296875,
+                        "z": -36.097808837890625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8761,7 +9061,11 @@
                 "Door to Temple Assembly Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 196.77630615234375,
+                        "y": 39.79792022705078,
+                        "z": -33.40430450439453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8980,7 +9284,11 @@
                 "Door to Temple Assembly Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 144.0738525390625,
+                        "y": -15.050546646118164,
+                        "z": -35.904327392578125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9016,7 +9324,11 @@
                 "Elevator to Great Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 128.2506561279297,
+                        "y": -6.912927150726318,
+                        "z": -37.904327392578125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9061,7 +9373,11 @@
                 "Door to Temple Assembly Site": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 219.05532836914062,
+                        "y": -52.434974670410156,
+                        "z": -40.90407180786133
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9154,7 +9470,11 @@
                 "Door to GFMC Compound": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 0.037555694580078125,
+                        "y": 359.23834228515625,
+                        "z": -33.6135139465332
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9190,7 +9510,11 @@
                 "Door to Grand Windchamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -55.104583740234375,
+                        "y": 304.09619140625,
+                        "z": -33.613525390625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9235,7 +9559,11 @@
                 "Door to Dynamo Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 236.8562469482422,
+                        "y": 114.80029296875,
+                        "z": -36.097808837890625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9389,7 +9717,11 @@
                 "Door to Storage Cavern A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 157.97235107421875,
+                        "y": 112.62194061279297,
+                        "z": -21.097808837890625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9423,7 +9755,11 @@
                 "Door to Trooper Security Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 162.29859924316406,
+                        "y": 217.4319305419922,
+                        "z": -38.59779357910156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9672,7 +10008,11 @@
                 "Door to Windchamber Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 0.037555694580078125,
+                        "y": 359.23834228515625,
+                        "z": -33.61351013183594
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9715,7 +10055,11 @@
                 "Door to Sacred Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 35.48247146606445,
+                        "y": 333.22491455078125,
+                        "z": -36.11351776123047
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9758,7 +10102,11 @@
                 "Door to Trooper Security Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 92.42372131347656,
+                        "y": 289.93194580078125,
+                        "z": -41.097782135009766
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -9826,7 +10174,11 @@
                 "Door to Fortress Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 19.576583862304688,
+                        "y": 412.50238037109375,
+                        "z": -46.113502502441406
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10312,7 +10664,11 @@
                 "Door to Communication Area": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 157.97235107421875,
+                        "y": 112.62194061279297,
+                        "z": -21.097808837890625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10346,7 +10702,11 @@
                 "Keybearer Corpse (D-Isl)": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 147.10678100585938,
+                        "y": 77.09263610839844,
+                        "z": -35.06542205810547
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10396,7 +10756,11 @@
                 "Door to GFMC Compound": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 92.4237289428711,
+                        "y": 289.93194580078125,
+                        "z": -41.097782135009766
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10495,7 +10859,11 @@
                 "Door to Communication Area": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 162.29859924316406,
+                        "y": 217.4319305419922,
+                        "z": -38.59779357910156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10625,7 +10993,11 @@
                 "Door to Transport to Sanctuary Fortress": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -68.9321060180664,
+                        "y": 463.00238037109375,
+                        "z": -49.51326370239258
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10666,7 +11038,11 @@
                 "Door to GFMC Compound": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 19.576583862304688,
+                        "y": 412.50238037109375,
+                        "z": -46.113502502441406
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10759,7 +11135,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -52.017337799072266,
+                        "y": 456.2418212890625,
+                        "z": -48.69470977783203
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10818,7 +11198,11 @@
                 "Door to GFMC Compound": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 35.48247146606445,
+                        "y": 333.22491455078125,
+                        "z": -36.11351776123047
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10948,7 +11332,11 @@
                 "Door to Sacred Path": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -7.80180549621582,
+                        "y": 289.9406433105469,
+                        "z": -35.98851776123047
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11108,7 +11496,11 @@
                 "Door to Fortress Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -68.9321060180664,
+                        "y": 463.00238037109375,
+                        "z": -49.51326370239258
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11144,7 +11536,11 @@
                 "Elevator to Sanctuary Fortress": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -93.80712127685547,
+                        "y": 462.800048828125,
+                        "z": -51.513309478759766
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11189,7 +11585,11 @@
                 "Portal to Profane Path": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -31.632522583007812,
+                        "y": 282.2821044921875,
+                        "z": -19.019357681274414
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11230,7 +11630,11 @@
                 "Door to Sacred Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -7.80180549621582,
+                        "y": 289.9406433105469,
+                        "z": -35.98851776123047
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11433,7 +11837,11 @@
                 "Door to Temple Transport A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 3.4936909675598145,
+                        "y": 195.02255249023438,
+                        "z": -33.49665832519531
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11623,7 +12031,11 @@
                 "Door to Sacred Path": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 3.4936909675598145,
+                        "y": 195.02255249023438,
+                        "z": -33.49665832519531
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11659,7 +12071,11 @@
                 "Elevator to Great Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 5.1186909675598145,
+                        "y": 194.83505249023438,
+                        "z": -35.49665832519531
+                    },
                     "description": "",
                     "layers": [
                         "default"

--- a/randovania/games/prime2_opr/logic_database/Torvus Bog.json
+++ b/randovania/games/prime2_opr/logic_database/Torvus Bog.json
@@ -15,7 +15,11 @@
                 "Door to Temple Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 277.6470947265625,
+                        "y": -50.2322998046875,
+                        "z": 35.621395111083984
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -51,7 +55,11 @@
                 "Elevator to Temple Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 304.7720947265625,
+                        "y": -50.434627532958984,
+                        "z": 32.621395111083984
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -96,7 +104,11 @@
                 "Door to Transport to Temple Grounds": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 277.6470947265625,
+                        "y": -50.2322998046875,
+                        "z": 35.621395111083984
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -130,7 +142,11 @@
                 "Door to Torvus Lagoon": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 212.64707946777344,
+                        "y": -89.7322998046875,
+                        "z": 35.62138748168945
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -177,7 +193,11 @@
                 "Door to Temple Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 212.64707946777344,
+                        "y": -89.7322998046875,
+                        "z": 35.62138748168945
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -358,7 +378,11 @@
                 "Door to Save Station A": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 160.6470947265625,
+                        "y": -109.2322998046875,
+                        "z": 40.62138366699219
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -392,7 +416,11 @@
                 "Door to Portal Chamber (Light)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 118.6470947265625,
+                        "y": -77.23230743408203,
+                        "z": 40.62138748168945
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -475,7 +503,11 @@
                 "Door to Path of Roots": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 130.6470947265625,
+                        "y": -108.23229217529297,
+                        "z": 25.621387481689453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -511,7 +543,11 @@
                 "Door to Ruined Alcove": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 150.6470947265625,
+                        "y": -45.232295989990234,
+                        "z": 40.62139892578125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -618,7 +654,11 @@
                 "Keybearer Corpse (S-Dly)": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 182.39144897460938,
+                        "y": -93.10602569580078,
+                        "z": 33.018287658691406
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -668,7 +708,11 @@
                 "Door to Torvus Lagoon": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 150.6470947265625,
+                        "y": -45.232295989990234,
+                        "z": 40.62139892578125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -702,7 +746,11 @@
                 "Door to Forgotten Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 80.36318969726562,
+                        "y": -13.625692367553711,
+                        "z": 40.62140655517578
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -747,7 +795,11 @@
                 "Portal to Portal Chamber (Dark)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 89.77946472167969,
+                        "y": -124.2470703125,
+                        "z": 56.53517150878906
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -781,7 +833,11 @@
                 "Door to Torvus Lagoon": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 118.6470947265625,
+                        "y": -77.23230743408203,
+                        "z": 40.62138366699219
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -898,7 +954,11 @@
                 "Door to Great Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 53.1624755859375,
+                        "y": -106.21742248535156,
+                        "z": 35.62982940673828
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1047,7 +1107,11 @@
                 "Door to Torvus Lagoon": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 130.6470947265625,
+                        "y": -108.23229217529297,
+                        "z": 25.621387481689453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1120,7 +1184,11 @@
                 "Door to Great Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.1624755859375,
+                        "y": -146.21746826171875,
+                        "z": 35.62982940673828
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1630,7 +1698,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 99.50190734863281,
+                        "y": -158.29562377929688,
+                        "z": 33.96636962890625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1710,7 +1782,11 @@
                 "Door to Torvus Lagoon": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 160.6470947265625,
+                        "y": -109.23229217529297,
+                        "z": 40.62138366699219
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1757,7 +1833,11 @@
                 "Door to Plaza Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 27.770736694335938,
+                        "y": 91.9688491821289,
+                        "z": 65.62995910644531
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1791,7 +1871,11 @@
                 "Portal to Dark Forgotten Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -13.458873748779297,
+                        "y": -6.524440765380859,
+                        "z": 94.84615325927734
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -1949,7 +2033,11 @@
                 "Door to Ruined Alcove": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 80.3631820678711,
+                        "y": -13.625692367553711,
+                        "z": 40.62140655517578
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2134,7 +2222,11 @@
                 "Door to Grove Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -23.958545684814453,
+                        "y": 45.371063232421875,
+                        "z": 65.62995147705078
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2290,7 +2382,11 @@
                 "Door to Abandoned Worksite": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 30.270740509033203,
+                        "y": -30.031169891357422,
+                        "z": 55.62993621826172
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2761,7 +2857,11 @@
                 "Door to Torvus Map Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 14.453133583068848,
+                        "y": -187.07797241210938,
+                        "z": 41.460838317871094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -2830,7 +2930,11 @@
                 "Door to Temple Access (Top)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.1624755859375,
+                        "y": -123.71748352050781,
+                        "z": 50.62983322143555
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3171,7 +3275,11 @@
                 "Door to Abandoned Worksite": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 29.6624755859375,
+                        "y": -80.21747589111328,
+                        "z": 45.629844665527344
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3287,7 +3395,11 @@
                 "Door to Path of Roots": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 68.1624755859375,
+                        "y": -146.21746826171875,
+                        "z": 35.62982940673828
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3438,7 +3550,11 @@
                 "Door to Portal Chamber (Light)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 53.1624755859375,
+                        "y": -106.21747589111328,
+                        "z": 35.62983703613281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -3472,7 +3588,11 @@
                 "Door to Temple Access (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.1624755859375,
+                        "y": -123.71747589111328,
+                        "z": 35.62983322143555
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4160,7 +4280,11 @@
                 "Door to Torvus Plaza": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 14.770736694335938,
+                        "y": 196.96884155273438,
+                        "z": 65.62997436523438
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4243,7 +4367,11 @@
                 "Door to Forgotten Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 27.770736694335938,
+                        "y": 91.96884155273438,
+                        "z": 65.62995910644531
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -4692,7 +4820,11 @@
                 "Door to Great Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 29.662466049194336,
+                        "y": -80.21748352050781,
+                        "z": 45.62946319580078
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5002,7 +5134,11 @@
                 "Door to Forgotten Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 30.270740509033203,
+                        "y": -30.03116798400879,
+                        "z": 55.62993621826172
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5454,7 +5590,11 @@
                 "Door to Torvus Grove": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -111.35295104980469,
+                        "y": 53.28251647949219,
+                        "z": 55.7810173034668
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5488,7 +5628,11 @@
                 "Door to Forgotten Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -23.958545684814453,
+                        "y": 45.371063232421875,
+                        "z": 65.62995147705078
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5533,7 +5677,11 @@
                 "Door to Great Bridge (Top)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.1624755859375,
+                        "y": -123.71748352050781,
+                        "z": 50.62983322143555
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5567,7 +5715,11 @@
                 "Door to Great Bridge (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 1.1624794006347656,
+                        "y": -123.71747589111328,
+                        "z": 35.62983322143555
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5603,7 +5755,11 @@
                 "Door to Torvus Temple (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -110.42527770996094,
+                        "y": -123.71748352050781,
+                        "z": 35.6297492980957
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5639,7 +5795,11 @@
                 "Door to Torvus Temple (Top)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -102.83753967285156,
+                        "y": -123.71748352050781,
+                        "z": 48.12983322143555
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -5969,7 +6129,11 @@
                 "Door to Great Bridge": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 14.453133583068848,
+                        "y": -187.07797241210938,
+                        "z": 41.460838317871094
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6036,7 +6200,11 @@
                 "Door to Plaza Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": 14.770736694335938,
+                        "y": 196.96884155273438,
+                        "z": 65.62997436523438
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6440,7 +6608,11 @@
                 "Door to Grove Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -111.35294342041016,
+                        "y": 53.28252029418945,
+                        "z": 55.7810173034668
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6474,7 +6646,11 @@
                 "Door to Underground Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.07421875,
+                        "y": -1.4109039306640625,
+                        "z": 33.28107833862305
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6730,7 +6906,11 @@
                 "Door to Meditation Vista": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.07421875,
+                        "y": 104.8916244506836,
+                        "z": 31.781095504760742
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6888,7 +7068,11 @@
                 "Door to Controller Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -246.1370849609375,
+                        "y": -123.71477508544922,
+                        "z": 98.12983703613281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6931,7 +7115,11 @@
                 "Door to Underground Tunnel": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -186.07421875,
+                        "y": -76.41090393066406,
+                        "z": 35.629913330078125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -6965,7 +7153,11 @@
                 "Door to Temple Access (Top)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -102.83753967285156,
+                        "y": -123.71747589111328,
+                        "z": 48.12983322143555
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7034,7 +7226,11 @@
                 "Door to Transport to Agon Wastes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -186.07424926757812,
+                        "y": -166.0240478515625,
+                        "z": 38.12989807128906
+                    },
                     "description": "<https://youtu.be/WNMbKEZjDz0>",
                     "layers": [
                         "default"
@@ -7111,7 +7307,11 @@
                 "Door to Temple Access (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -110.42527770996094,
+                        "y": -123.71748352050781,
+                        "z": 35.6297492980957
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7145,7 +7345,11 @@
                 "Door to Underground Transport": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -224.86497497558594,
+                        "y": -123.79229736328125,
+                        "z": 33.83242416381836
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7472,7 +7676,11 @@
                 "Door to Torvus Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -186.07421875,
+                        "y": -76.41090393066406,
+                        "z": 35.629913330078125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7517,7 +7725,11 @@
                 "Door to Torvus Grove": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.07421875,
+                        "y": -1.4109039306640625,
+                        "z": 33.28107833862305
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7701,7 +7913,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -159.87496948242188,
+                        "y": -25.119848251342773,
+                        "z": 36.701568603515625
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7763,7 +7979,11 @@
                 "Portal to Gloom Vista": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.05938720703125,
+                        "y": 136.87025451660156,
+                        "z": 100.8489990234375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -7797,7 +8017,11 @@
                 "Door to Torvus Grove": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -161.07421875,
+                        "y": 104.8916244506836,
+                        "z": 31.781095504760742
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8044,7 +8268,11 @@
                 "Door to Torvus Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -186.07424926757812,
+                        "y": -166.0240478515625,
+                        "z": 38.12989807128906
+                    },
                     "description": "<https://youtu.be/Myr8MRM5ZDc&t=153>",
                     "layers": [
                         "default"
@@ -8121,7 +8349,11 @@
                 "Elevator to Agon Wastes": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -184.96408081054688,
+                        "y": -212.71353149414062,
+                        "z": 35.12989044189453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8166,7 +8398,11 @@
                 "Door to Torvus Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -224.86497497558594,
+                        "y": -123.79229736328125,
+                        "z": 33.83242416381836
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8202,7 +8438,11 @@
                 "Door to Hydrodynamo Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -214.86459350585938,
+                        "y": -123.79228973388672,
+                        "z": -17.723861694335938
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8264,7 +8504,11 @@
                 "Door to Torvus Temple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -246.1370849609375,
+                        "y": -123.71478271484375,
+                        "z": 98.12983703613281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8346,7 +8590,11 @@
                 "Door to Torvus Energy Controller": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -318.594970703125,
+                        "y": -123.7052230834961,
+                        "z": 98.12983703613281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -8495,9 +8743,9 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -214.86,
-                        "y": -123.79,
-                        "z": -20.22
+                        "x": -214.86459350585938,
+                        "y": -123.79228973388672,
+                        "z": -17.723861694335938
                     },
                     "description": "",
                     "layers": [
@@ -8774,9 +9022,9 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -130.94,
-                        "y": -123.79,
-                        "z": -5.22
+                        "x": -130.9410400390625,
+                        "y": -123.79228973388672,
+                        "z": -2.7238616943359375
                     },
                     "description": "",
                     "layers": [
@@ -8812,9 +9060,9 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -193.76,
-                        "y": -139.58,
-                        "z": -35.22
+                        "x": -193.7645721435547,
+                        "y": -139.5880889892578,
+                        "z": -32.72386932373047
                     },
                     "description": "",
                     "layers": [
@@ -8930,9 +9178,9 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -151.13,
-                        "y": -123.85,
-                        "z": -71.27
+                        "x": -151.1370391845703,
+                        "y": -123.8502197265625,
+                        "z": -68.77202606201172
                     },
                     "description": "",
                     "layers": [
@@ -9064,9 +9312,9 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -138.96,
-                        "y": -139.58,
-                        "z": -35.22
+                        "x": -138.964599609375,
+                        "y": -139.5880889892578,
+                        "z": -32.7238655090332
                     },
                     "description": "",
                     "layers": [
@@ -9182,9 +9430,9 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -166.36,
-                        "y": -93.36,
-                        "z": -35.22
+                        "x": -166.36459350585938,
+                        "y": -93.36874389648438,
+                        "z": -32.72386169433594
                     },
                     "description": "[https://youtu.be/Myr8MRM5ZDc\\&t=134](https://youtu.be/Myr8MRM5ZDc&t=134)",
                     "layers": [
@@ -10168,7 +10416,11 @@
                 "Door to Controller Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -318.594970703125,
+                        "y": -123.7052230834961,
+                        "z": 98.12983703613281
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10326,7 +10578,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -363.3290710449219,
+                        "y": -149.85902404785156,
+                        "z": 103.11968231201172
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10422,7 +10678,11 @@
                 "Door to Hydrodynamo Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -193.7645721435547,
+                        "y": -139.5880889892578,
+                        "z": -32.72386932373047
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10458,7 +10718,11 @@
                 "Door to Gathering Hall": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -269.28765869140625,
+                        "y": -186.2921905517578,
+                        "z": -22.723876953125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10501,7 +10765,11 @@
                 "Door to Training Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -166.36465454101562,
+                        "y": -5.504203796386719,
+                        "z": -22.79764175415039
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10535,7 +10803,11 @@
                 "Door to Hydrodynamo Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -166.36465454101562,
+                        "y": -93.36857604980469,
+                        "z": -32.72386169433594
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10580,7 +10852,11 @@
                 "Door to Hydrodynamo Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -138.964599609375,
+                        "y": -139.5885772705078,
+                        "z": -32.7238655090332
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10616,7 +10892,11 @@
                 "Door to Catacombs": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -63.53239822387695,
+                        "y": -185.9745330810547,
+                        "z": -32.7853889465332
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10751,7 +11031,11 @@
                 "Door to Hydrodynamo Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -130.9410400390625,
+                        "y": -123.79228973388672,
+                        "z": -2.7238621711730957
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10794,7 +11078,11 @@
                 "Portal to Undertemple Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -159.20013427734375,
+                        "y": -157.3921356201172,
+                        "z": -73.12724304199219
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10828,7 +11116,11 @@
                 "Door to Hydrodynamo Station": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -151.1370391845703,
+                        "y": -123.8502197265625,
+                        "z": -68.77202606201172
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -10938,7 +11230,11 @@
                 "Door to Main Hydrochamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -159.26065063476562,
+                        "y": -162.82981872558594,
+                        "z": -103.13609313964844
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11055,7 +11351,11 @@
                 "Door to Transit Tunnel West": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -323.6308288574219,
+                        "y": -158.271728515625,
+                        "z": -36.729164123535156
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11223,7 +11523,11 @@
                 "Portal to Crypt": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -257.81829833984375,
+                        "y": -189.21453857421875,
+                        "z": -46.723899841308594
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11259,7 +11563,11 @@
                 "Door to Transit Tunnel South": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -274.3646240234375,
+                        "y": -247.2921905517578,
+                        "z": -36.7238883972168
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -11429,7 +11737,11 @@
                 "Door to Gathering Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -269.28765869140625,
+                        "y": -186.2921905517578,
+                        "z": -22.723880767822266
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13178,7 +13490,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -291.71160888671875,
+                        "y": -239.9214324951172,
+                        "z": -46.172142028808594
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13264,7 +13580,11 @@
                 "Door to Transit Tunnel East": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -120.42576599121094,
+                        "y": 27.949440002441406,
+                        "z": -37.723854064941406
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13356,7 +13676,11 @@
                 "Door to Training Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -166.36465454101562,
+                        "y": -5.504205703735352,
+                        "z": -22.79764175415039
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13698,7 +14022,11 @@
                 "Door to Fortress Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -166.27015686035156,
+                        "y": 81.13043212890625,
+                        "z": -22.79762840270996
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -13851,7 +14179,11 @@
                 "Door to Transit Tunnel West": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -212.10543823242188,
+                        "y": 27.949430465698242,
+                        "z": -37.72385025024414
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15015,7 +15347,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -144.41305541992188,
+                        "y": 10.208112716674805,
+                        "z": -35.8223991394043
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15074,7 +15410,11 @@
                 "Door to Transit Tunnel East": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -9.259084701538086,
+                        "y": -158.071044921875,
+                        "z": -27.723880767822266
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15108,7 +15448,11 @@
                 "Portal to Dungeon": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -0.6944198608398438,
+                        "y": -152.26153564453125,
+                        "z": -45.223876953125
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15169,7 +15513,11 @@
                 "Door to Transit Tunnel South": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -58.45622253417969,
+                        "y": -246.9745330810547,
+                        "z": -27.723892211914062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15203,7 +15551,11 @@
                 "Door to Catacombs Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -63.53239440917969,
+                        "y": -185.9745330810547,
+                        "z": -32.7853889465332
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15857,7 +16209,11 @@
                 "Lore Scan": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -14.646852493286133,
+                        "y": -211.38780212402344,
+                        "z": -21.871875762939453
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15907,7 +16263,11 @@
                 "Keybearer Corpse (G-Sch)": {
                     "node_type": "hint",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -59.37604522705078,
+                        "y": -205.99827575683594,
+                        "z": -35.182464599609375
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -15957,7 +16317,11 @@
                 "Door to Hydrochamber Storage": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -159.2124481201172,
+                        "y": -168.76739501953125,
+                        "z": -138.1272430419922
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16829,7 +17193,11 @@
                 "Portal to Undertemple": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -210.0290985107422,
+                        "y": -106.26685333251953,
+                        "z": -113.12721252441406
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16882,7 +17250,11 @@
                 "Door to Hydrodynamo Shaft": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -159.26065063476562,
+                        "y": -162.82981872558594,
+                        "z": -103.13609313964844
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -16971,7 +17343,11 @@
                 "Door to Catacombs": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -58.45622253417969,
+                        "y": -246.9745330810547,
+                        "z": -27.723892211914062
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -17102,7 +17478,11 @@
                 "Door to Gathering Hall": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -274.3646240234375,
+                        "y": -247.2921905517578,
+                        "z": -36.7238883972168
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -17233,7 +17613,11 @@
                 "Door to Training Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -212.10543823242188,
+                        "y": 27.949432373046875,
+                        "z": -37.72385025024414
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -17288,7 +17672,11 @@
                 "Door to Gathering Hall": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -323.6308288574219,
+                        "y": -158.271728515625,
+                        "z": -36.72916793823242
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -17354,7 +17742,11 @@
                 "Door to Training Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -120.42576599121094,
+                        "y": 27.949440002441406,
+                        "z": -37.723854064941406
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -17487,7 +17879,11 @@
                 "Door to Catacombs": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -9.259078979492188,
+                        "y": -158.071044921875,
+                        "z": -27.723880767822266
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -17651,7 +18047,11 @@
                 "Door to Training Chamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -166.27015686035156,
+                        "y": 81.13043212890625,
+                        "z": -22.79762840270996
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -17782,7 +18182,11 @@
                 "Door to Transport to Sanctuary Fortress": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -176.27015686035156,
+                        "y": 174.13043212890625,
+                        "z": -10.797613143920898
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -17828,7 +18232,11 @@
                 "Door to Main Hydrochamber": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -159.2124481201172,
+                        "y": -168.76739501953125,
+                        "z": -138.1272430419922
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -17973,7 +18381,11 @@
                 "Door to Fortress Transport Access": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -176.27015686035156,
+                        "y": 174.13043212890625,
+                        "z": -10.797613143920898
+                    },
                     "description": "",
                     "layers": [
                         "default"
@@ -18009,7 +18421,11 @@
                 "Elevator to Sanctuary Fortress": {
                     "node_type": "dock",
                     "heal": false,
-                    "coordinates": null,
+                    "coordinates": {
+                        "x": -175.14515686035156,
+                        "y": 199.94293212890625,
+                        "z": -13.797609329223633
+                    },
                     "description": "",
                     "layers": [
                         "default"

--- a/tools/automate_echoes_node_coords.py
+++ b/tools/automate_echoes_node_coords.py
@@ -1,0 +1,145 @@
+import dataclasses
+import os
+from collections import Counter
+from pathlib import Path
+
+from open_prime_rando.echoes.dock_lock_rando.dock_type_database import DOCK_TYPES
+from open_prime_rando.patcher_editor import IsoFileProvider, PatcherEditor
+from retro_data_structures.enums.echoes import Message, State
+from retro_data_structures.formats.scan import Scan
+from retro_data_structures.formats.script_object import Connection, ScriptInstance
+from retro_data_structures.game_check import Game
+from retro_data_structures.properties.echoes.objects import Actor, Dock, PointOfInterest, ScannableObjectInfo
+
+from randovania.game.game_enum import RandovaniaGame
+from randovania.game_description import data_writer, default_database, pretty_print
+from randovania.game_description.db.dock_node import DockNode
+from randovania.game_description.db.hint_node import HintNode
+from randovania.game_description.db.node import NodeLocation
+from randovania.game_description.db.node_identifier import NodeIdentifier
+from randovania.game_description.db.pickup_node import PickupNode
+from randovania.game_description.editor import Editor
+from randovania.games.prime2.exporter.patch_data_factory import _asset_id_for_region
+
+patcher_editor = PatcherEditor(IsoFileProvider(Path(os.environ["PRIME2_ISO"])), Game.ECHOES)
+
+
+game = default_database.game_description_for(RandovaniaGame.METROID_PRIME_ECHOES_OPR)
+db_editor = Editor(game)
+
+results: dict[NodeIdentifier, NodeLocation] = {}
+
+door_type = DOCK_TYPES["Normal"]
+
+
+def get_location(instance: ScriptInstance) -> NodeLocation:
+    x, y, z = instance.editor_properties.transform.position
+    return NodeLocation(x, y, z)
+
+
+for region, area, node in game.iterate_nodes_of_type(DockNode, PickupNode, HintNode):
+    print(node.identifier)
+
+    mlvl_id = _asset_id_for_region(game.region_list, region)
+    mrea_id = area.extra["asset_id"]
+
+    rds_area = patcher_editor.get_area(mlvl_id, mrea_id)
+
+    if isinstance(node, DockNode):
+        if "dock_name" in node.extra:
+            dock_name = node.extra["dock_name"]
+            dock = next(inst for inst in rds_area.all_instances if inst.script_type == Dock and inst.name == dock_name)
+            results[node.identifier] = get_location(dock)
+        elif "teleporter_instance_id" in node.extra:
+            teleporter = rds_area.get_instance(node.extra["teleporter_instance_id"])
+            results[node.identifier] = get_location(teleporter)
+
+    elif isinstance(node, PickupNode):
+        if node.location is not None:
+            continue
+        try:
+            pickup_id = node.extra["location_data"]["instances"]["pickup"]
+        except KeyError:
+            continue
+        pickup = rds_area.get_instance(pickup_id)
+        results[node.identifier] = get_location(pickup)
+
+    elif isinstance(node, HintNode):
+        if "string_asset_id" not in node.extra:
+            continue
+        strg_id = node.extra["string_asset_id"]
+        for instance in rds_area.all_instances:
+            position_instance: ScriptInstance
+
+            if instance.script_type == Actor:
+                actor = instance.get_properties_as(Actor)
+                position_instance = instance
+                scan_asset = actor.actor_information.scannable.scannable_info0
+
+            elif instance.script_type == PointOfInterest:
+                poi = instance.get_properties_as(PointOfInterest)
+                position_instance = instance
+                scan_asset = poi.scan_info.scannable_info0
+                actor_inst = next(
+                    (
+                        inst
+                        for inst in rds_area.all_instances
+                        if Connection(State.ScanSource, Message.Attach, instance.id) in inst.connections
+                    ),
+                    None,
+                )
+                if actor_inst is None:
+                    position_instance = actor_inst
+            else:
+                continue
+
+            if scan_asset == 0xFFFFFFFF:
+                continue
+
+            scan = patcher_editor.get_file(scan_asset, Scan)
+            scan_info = scan.scannable_object_info.get_properties_as(ScannableObjectInfo)
+            if scan_info.string == strg_id:
+                results[node.identifier] = get_location(position_instance)
+                break
+
+
+for identifier, location in results.items():
+    node = game.node_by_identifier(identifier)
+    area = game.area_from_node(node)
+
+    db_editor.replace_node(
+        area,
+        node,
+        dataclasses.replace(
+            node,
+            location=location,
+        ),
+    )
+
+
+data = data_writer.write_game_description(game)
+data_path = RandovaniaGame.METROID_PRIME_ECHOES_OPR.data_path.joinpath("logic_database")
+
+data_path.with_suffix("").mkdir(exist_ok=True)
+data_writer.write_as_split_files(data, data_path.with_suffix(""))
+
+pretty_print.write_human_readable_game(game, data_path.with_suffix(""))
+default_database.game_description_for.cache_clear()
+
+nodes_with_location: Counter[str] = Counter()
+nodes_without_location: Counter[str] = Counter()
+
+for _, _, node in game.node_iterator():
+    if node.location is None:
+        nodes_without_location[node.__class__.__name__] += 1
+    else:
+        nodes_with_location[node.__class__.__name__] += 1
+
+
+print("Nodes without location:", nodes_without_location)
+print("Nodes with location:", nodes_with_location)
+
+coverage = sum(nodes_with_location.values()) / (
+    sum(nodes_with_location.values()) + sum(nodes_without_location.values())
+)
+print(f"Location coverage: {coverage:.2%}")


### PR DESCRIPTION
```
Nodes without location: Counter({
    'GenericNode': 149,
    'EventNode': 112,
    'ConfigurableNode': 17,
    'SpecificPickupHintNode': 4,
    'TeleporterNetworkNode': 4
})
Nodes with location: Counter({
    'DockNode': 662,
    'PickupNode': 119,
    'GenericHintNode': 22,
    'EventPickupNode': 13, =
    'SpecificLocationHintNode': 9,
    'EventNode': 3,
    'GenericNode': 3
})
Location coverage: 74.40%
```