### PR TITLE
fix a crash in the data editor

### DIFF
--- a/randovania/gui/widgets/data_editor_canvas.py
+++ b/randovania/gui/widgets/data_editor_canvas.py
@@ -260,6 +260,7 @@ class DataEditorCanvas(QtWidgets.QWidget):
             self.image_bounds = BoundsInt(min_x, min_y, max_x, max_y)
             self.region_bounds = BoundsFloat(min_x, min_y, max_x, max_y)
         else:
+            self._background_image = None
             self.update_region_bounds()
 
         self.area_bounds = BoundsFloat(


### PR DESCRIPTION
would happen when swapping from an area with a map image to one without