### PR TITLE
Primes: Read inventory array in bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Preset option to skip the opening storyboard cutscene (default: off)
 - Fixed: Spazer and Plasma beam projectiles no longer shoot through blocks without Wave
 
+### Metroid Prime
+
+ - Changed: Slightly reworked the way the inventory is read for the sake of a slight speedup. No expected changes in fuctionality.
+
+### Metroid Prime 2: Echoes
+
+ - Changed: Slightly reworked the way the inventory is read for the sake of a significant speedup. No expected changes in fuctionality.
+
 ## [10.8.2] - 2026-06-14
 
 ### Metroid Prime

--- a/randovania/game_connection/connector/echoes_remote_connector.py
+++ b/randovania/game_connection/connector/echoes_remote_connector.py
@@ -51,6 +51,19 @@ class EchoesRemoteConnector(PrimeRemoteConnector):
     def __init__(self, version: EchoesDolVersion, executor: MemoryOperationExecutor):
         super().__init__(version, executor)
 
+    @property
+    def total_item_length(self) -> int:
+        return 109
+
+    @property
+    def powerup_size(self) -> int:
+        return 0xC
+
+    def powerup_offset(self, item_index: int) -> int:
+        powerups_offset = 0x58
+        vector_data_offset = 0x4
+        return (powerups_offset + vector_data_offset) + (item_index * self.powerup_size)
+
     def _asset_id_format(self) -> str:
         return ">I"
 

--- a/randovania/game_connection/connector/echoes_remote_connector.py
+++ b/randovania/game_connection/connector/echoes_remote_connector.py
@@ -45,13 +45,6 @@ def format_received_item(item_name: str, player_name: str) -> str:
     return special.get(item_name, generic).format(item_name=item_name, provider_name=player_name)
 
 
-def _echoes_powerup_offset(item_index: int) -> int:
-    powerups_offset = 0x58
-    vector_data_offset = 0x4
-    powerup_size = 0xC
-    return (powerups_offset + vector_data_offset) + (item_index * powerup_size)
-
-
 class EchoesRemoteConnector(PrimeRemoteConnector):
     _should_read_object_count: bool = False
 
@@ -96,19 +89,10 @@ class EchoesRemoteConnector(PrimeRemoteConnector):
 
         return has_pending_op, self._current_status_world(world_asset_id, cplayer_vtable)
 
-    async def _memory_op_for_items(
-        self,
-        items: list[ItemResourceInfo],
-    ) -> list[MemoryOperation]:
-        player_state_pointer = self.version.cstate_manager_global + 0x150C
-        return [
-            MemoryOperation(
-                address=player_state_pointer,
-                offset=_echoes_powerup_offset(item.extra["item_id"]),
-                read_byte_count=8,
-            )
-            for item in items
-        ]
+    async def _get_cplayer_state_pointer(self) -> int:
+        # CPlayerState is an array / normal pointer within CStateManager:
+        # https://github.com/PrimeDecomp/echoes/blob/main/include/MetroidPrime/CStateManager.hpp#L159
+        return self.version.cstate_manager_global + 0x150C
 
     async def _patches_for_pickup(self, provider_name: str, pickup: PickupEntry, inventory: Inventory) -> PickupPatches:
         item_name, resources_to_give = self._resources_to_give_for_pickup(pickup, inventory)

--- a/randovania/game_connection/connector/prime1_remote_connector.py
+++ b/randovania/game_connection/connector/prime1_remote_connector.py
@@ -45,6 +45,19 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
     def __init__(self, version: Prime1DolVersion, executor: MemoryOperationExecutor):
         super().__init__(version, executor)
 
+    @property
+    def total_item_length(self) -> int:
+        return 40
+
+    @property
+    def powerup_size(self) -> int:
+        return 0x8
+
+    def powerup_offset(self, item_index: int) -> int:
+        powerups_offset = 0x24
+        vector_data_offset = 0x4
+        return (powerups_offset + vector_data_offset) + (item_index * self.powerup_size)
+
     def _asset_id_format(self) -> str:
         return ">I"
 

--- a/randovania/game_connection/connector/prime1_remote_connector.py
+++ b/randovania/game_connection/connector/prime1_remote_connector.py
@@ -12,6 +12,7 @@ from randovania.game_connection.executor.memory_operation import (
     MemoryOperationException,
     MemoryOperationExecutor,
 )
+from randovania.game_description.resources.inventory import Inventory
 from randovania.game_description.resources.item_resource_info import ItemResourceInfo
 from randovania.games.prime1.patcher import prime_items
 
@@ -21,7 +22,6 @@ if TYPE_CHECKING:
     from randovania.game_connection.connector.prime_remote_connector import PatchInstructions, PickupPatches
     from randovania.game_description.db.region import Region
     from randovania.game_description.pickup.pickup_entry import PickupEntry
-    from randovania.game_description.resources.inventory import Inventory
 
 
 def format_received_item(item_name: str, player_name: str) -> str:
@@ -37,13 +37,6 @@ def format_received_item(item_name: str, player_name: str) -> str:
     generic = "Received {item_name} from {provider_name}."
 
     return special.get(item_name, generic).format(item_name=item_name, provider_name=player_name)
-
-
-def _prime1_powerup_offset(item_index: int) -> int:
-    powerups_offset = 0x24
-    vector_data_offset = 0x4
-    powerup_size = 0x8
-    return (powerups_offset + vector_data_offset) + (item_index * powerup_size)
 
 
 class Prime1RemoteConnector(PrimeRemoteConnector):
@@ -90,10 +83,9 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
         current_world = self._current_status_world(world_asset_id, cplayer_vtable)
         return has_pending_op, current_world
 
-    async def _memory_op_for_items(
-        self,
-        items: list[ItemResourceInfo],
-    ) -> list[MemoryOperation]:
+    async def _get_cplayer_state_pointer(self) -> int:
+        # CPlayerState a ref counted pointer within CStatemanager:
+        # https://github.com/PrimeDecomp/prime/blob/main/include/MetroidPrime/CStateManager.hpp#L395
         cplayer_state_offset = 0x8B8
 
         op = await self.executor.perform_single_memory_operation(
@@ -104,15 +96,7 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
         )
         assert op is not None
         player_state_pointer = int.from_bytes(op, "big")
-
-        return [
-            MemoryOperation(
-                address=player_state_pointer,
-                offset=_prime1_powerup_offset(item.extra["item_id"]),
-                read_byte_count=8,
-            )
-            for item in items
-        ]
+        return player_state_pointer
 
     async def _patches_for_pickup(self, provider_name: str, pickup: PickupEntry, inventory: Inventory) -> PickupPatches:
         item_name, resources_to_give = self._resources_to_give_for_pickup(pickup, inventory)

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import itertools
 import logging
 import struct
 import uuid
@@ -184,17 +185,14 @@ class PrimeRemoteConnector(RemoteConnector):
             splits.append(total_bytes)
 
         # Create memory ops to read each chunk.
-        mem_ops = []
-        for index, element in enumerate(splits[:-1]):
-            mem_ops.append(
-                MemoryOperation(
-                    address=player_state_pointer,
-                    offset=self.powerup_offset(0) + element,
-                    read_byte_count=splits[index + 1] - element,
-                )
+        return [
+            MemoryOperation(
+                address=player_state_pointer,
+                offset=self.powerup_offset(0) + element,
+                read_byte_count=next_element - element,
             )
-
-        return mem_ops
+            for element, next_element in itertools.pairwise(splits)
+        ]
 
     @property
     def multiworld_magic_item(self) -> ItemResourceInfo:

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -226,13 +226,20 @@ class PrimeRemoteConnector(RemoteConnector):
         item_responses = [
             joined_result[i : i + self.powerup_size] for i in range(0, len(joined_result), self.powerup_size)
         ]
+        if len(item_responses) != self.total_item_length:
+            raise ValueError(
+                f"Should have read {self.total_item_length} items from the game, instead read {len(item_responses)}"
+            )
 
         inventory = {}
         for item in resource_db.get_all_items():
             if item.extra["item_id"] >= 1000:
                 continue
             item_response = item_responses[item.extra["item_id"]]
-            inv = InventoryItem(*struct.unpack(">II", item_response))
+            struct_format = ">II"
+            if self.powerup_size > 8:
+                struct_format += f"{self.powerup_size - 8}x"
+            inv = InventoryItem(*struct.unpack(struct_format, item_response))
             if (inv.amount > inv.capacity or inv.capacity > item.max_capacity) and (item != self.multiworld_magic_item):
                 raise ValueError(f"Received {inv} for {item.long_name}, which is an invalid state.")
             inventory[item] = inv

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -223,22 +223,19 @@ class PrimeRemoteConnector(RemoteConnector):
         ops_result = await self.executor.perform_memory_operations(memory_ops)
         # Join all results together and then split them up per power up.
         joined_result = b"".join(ops_result.values())
-        item_responses = [
-            joined_result[i : i + self.powerup_size] for i in range(0, len(joined_result), self.powerup_size)
-        ]
-        if len(item_responses) != self.total_item_length:
+        if len(joined_result) != (self.total_item_length * self.powerup_size):
             raise ValueError(
-                f"Should have read {self.total_item_length} items from the game, instead read {len(item_responses)}"
+                f"Should have read {self.total_item_length} items from the game, "
+                f"instead read {len(joined_result) / self.powerup_size}"
             )
 
         inventory = {}
         for item in resource_db.get_all_items():
             if item.extra["item_id"] >= 1000:
                 continue
-            item_response = item_responses[item.extra["item_id"]]
-            # using "unpack_from", because Prime has amount/capacity, while
-            # Echoes has amount/capacity/how-many-seconds-item-stil-has
-            inv = InventoryItem(*struct.unpack_from(">II", item_response, 0))
+            item_id = item.extra["item_id"]
+            # Each element in the powerup array starts with amount/capacity in all Prime games.
+            inv = InventoryItem(*struct.unpack_from(">II", joined_result, item_id * self.powerup_size))
             if (inv.amount > inv.capacity or inv.capacity > item.max_capacity) and (item != self.multiworld_magic_item):
                 raise ValueError(f"Received {inv} for {item.long_name}, which is an invalid state.")
             inventory[item] = inv

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -236,10 +236,9 @@ class PrimeRemoteConnector(RemoteConnector):
             if item.extra["item_id"] >= 1000:
                 continue
             item_response = item_responses[item.extra["item_id"]]
-            struct_format = ">II"
-            if self.powerup_size > 8:
-                struct_format += f"{self.powerup_size - 8}x"
-            inv = InventoryItem(*struct.unpack(struct_format, item_response))
+            # using "unpack_from", because Prime has amount/capacity, while
+            # Echoes has amount/capacity/how-many-seconds-item-stil-has
+            inv = InventoryItem(*struct.unpack_from(">II", item_response, 0))
             if (inv.amount > inv.capacity or inv.capacity > item.max_capacity) and (item != self.multiworld_magic_item):
                 raise ValueError(f"Received {inv} for {item.long_name}, which is an invalid state.")
             inventory[item] = inv

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -82,6 +82,20 @@ class PrimeRemoteConnector(RemoteConnector):
         self._timer = InfiniteTimer(self.update, self._dt)
 
     @property
+    def total_item_length(self) -> int:
+        """Returns the length of the inventory array for this game."""
+        raise NotImplementedError
+
+    @property
+    def powerup_size(self) -> int:
+        """Returns the size of each element in the inventory array for this game."""
+        raise NotImplementedError
+
+    def powerup_offset(self, item_index: int) -> int:
+        """Returns the offset in relation to the player state pointer for a given item index."""
+        raise NotImplementedError
+
+    @property
     def game_enum(self) -> RandovaniaGame:
         return self.game.game
 
@@ -151,12 +165,36 @@ class PrimeRemoteConnector(RemoteConnector):
         # TODO: the prime1 and echoes implementation are very similar to each other. Merge them into one?
         raise NotImplementedError
 
+    async def _get_cplayer_state_pointer(self) -> int:
+        """Returns the address on where the pointer to the CPlayerState class for the game lies in RAM."""
+        raise NotImplementedError
+
     async def _memory_op_for_items(
         self,
-        items: list[ItemResourceInfo],
     ) -> list[MemoryOperation]:
         """Creates a list of memory operations to read the given item resources."""
-        raise NotImplementedError
+        player_state_pointer = await self._get_cplayer_state_pointer()
+
+        # Create a chunked list. Subtracting [N+1] - [N] results in how many bytes one can read at once while still
+        # being aligned to the power ups and not surpassing the executor's max output.
+        total_bytes = self.total_item_length * self.powerup_size
+        chunk_size = self.executor.max_output - (self.executor.max_output % self.powerup_size)
+        splits = [i * chunk_size for i in range((total_bytes // chunk_size) + 1)]
+        if total_bytes % chunk_size:
+            splits.append(total_bytes)
+
+        # Create memory ops to read each chunk.
+        mem_ops = []
+        for index, element in enumerate(splits[:-1]):
+            mem_ops.append(
+                MemoryOperation(
+                    address=player_state_pointer,
+                    offset=self.powerup_offset(0) + element,
+                    read_byte_count=splits[index + 1] - element,
+                )
+            )
+
+        return mem_ops
 
     @property
     def multiworld_magic_item(self) -> ItemResourceInfo:
@@ -181,13 +219,23 @@ class PrimeRemoteConnector(RemoteConnector):
         """Fetches the inventory represented by the given game memory."""
 
         resource_db = self.game.get_resource_database_view()
-        all_items = [item for item in resource_db.get_all_items() if item.extra["item_id"] < 1000]
-        memory_ops = await self._memory_op_for_items(all_items)
+        memory_ops = await self._memory_op_for_items()
         ops_result = await self.executor.perform_memory_operations(memory_ops)
+        # Join all results together and then split them up per power up.
+        joined_result = b"".join(ops_result.values())
+        item_responses = [
+            joined_result[i : i + self.powerup_size] for i in range(0, len(joined_result), self.powerup_size)
+        ]
 
         inventory = {}
-        for item, memory_op in zip(all_items, memory_ops, strict=True):
-            inv = InventoryItem(*struct.unpack(">II", ops_result[memory_op]))
+        items_by_id = {
+            item.extra["item_id"]: item for item in resource_db.get_all_items() if item.extra["item_id"] < 1000
+        }
+        for index, item_response in enumerate(item_responses):
+            if index not in items_by_id:
+                continue
+            item = items_by_id[index]
+            inv = InventoryItem(*struct.unpack(">II", item_response))
             if (inv.amount > inv.capacity or inv.capacity > item.max_capacity) and (item != self.multiworld_magic_item):
                 raise ValueError(f"Received {inv} for {item.long_name}, which is an invalid state.")
             inventory[item] = inv

--- a/randovania/game_connection/connector/prime_remote_connector.py
+++ b/randovania/game_connection/connector/prime_remote_connector.py
@@ -228,13 +228,10 @@ class PrimeRemoteConnector(RemoteConnector):
         ]
 
         inventory = {}
-        items_by_id = {
-            item.extra["item_id"]: item for item in resource_db.get_all_items() if item.extra["item_id"] < 1000
-        }
-        for index, item_response in enumerate(item_responses):
-            if index not in items_by_id:
+        for item in resource_db.get_all_items():
+            if item.extra["item_id"] >= 1000:
                 continue
-            item = items_by_id[index]
+            item_response = item_responses[item.extra["item_id"]]
             inv = InventoryItem(*struct.unpack(">II", item_response))
             if (inv.amount > inv.capacity or inv.capacity > item.max_capacity) and (item != self.multiworld_magic_item):
                 raise ValueError(f"Received {inv} for {item.long_name}, which is an invalid state.")

--- a/test/game_connection/connector/test_echoes_remote_connector.py
+++ b/test/game_connection/connector/test_echoes_remote_connector.py
@@ -98,8 +98,8 @@ async def test_get_inventory_valid(connector: EchoesRemoteConnector):
     for i in range(109):
         if custom_response[i] == b"":
             custom_response[i] = struct.pack(">III", 0, 0, 0)
-    custom_response = b"".join(custom_response)
-    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response}
+    custom_response_mock = b"".join(custom_response)
+    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response_mock}
 
     # Run
     inventory = await connector.get_inventory()
@@ -128,8 +128,8 @@ async def test_invalid_read_invalid_inventory_length(connector: EchoesRemoteConn
         )
         break
 
-    custom_response = b"".join(custom_response)
-    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response}
+    custom_response_mock = b"".join(custom_response)
+    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response_mock}
 
     # Run
     msg = "Should have read 109 items from the game, instead read 1"
@@ -153,8 +153,8 @@ async def test_get_inventory_invalid_capacity(connector: EchoesRemoteConnector):
     for i in range(109):
         if custom_response[i] == b"":
             custom_response[i] = struct.pack(">III", 0, 0, 0)
-    custom_response = b"".join(custom_response)
-    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response}
+    custom_response_mock = b"".join(custom_response)
+    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response_mock}
 
     # Run
     msg = "Received InventoryItem(amount=0, capacity=50) for Darkburst, which is an invalid state."
@@ -178,8 +178,8 @@ async def test_get_inventory_invalid_amount(connector: EchoesRemoteConnector):
     for i in range(109):
         if custom_response[i] == b"":
             custom_response[i] = struct.pack(">III", 0, 0, 0)
-    custom_response = b"".join(custom_response)
-    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response}
+    custom_response_mock = b"".join(custom_response)
+    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response_mock}
 
     # Run
     msg = "Received InventoryItem(amount=1, capacity=0) for Darkburst, which is an invalid state."

--- a/test/game_connection/connector/test_echoes_remote_connector.py
+++ b/test/game_connection/connector/test_echoes_remote_connector.py
@@ -88,10 +88,18 @@ async def test_get_inventory_valid(connector: EchoesRemoteConnector):
     # Setup
     assert isinstance(connector.executor, AsyncMock)
 
-    connector.executor.perform_memory_operations.side_effect = lambda ops: {
-        op: struct.pack(">II", item.max_capacity, item.max_capacity)
-        for op, item in zip(ops, connector.game.resource_database.item)
-    }
+    custom_response = [b"" for _ in range(109)]
+    for item in connector.game.resource_database.item:
+        if item.extra["item_id"] >= 1000:
+            continue
+        custom_response[item.extra["item_id"]] = struct.pack(
+            ">III", *InventoryItem(item.max_capacity, item.max_capacity), 0
+        )
+    for i in range(109):
+        if custom_response[i] == b"":
+            custom_response[i] = struct.pack(">III", 0, 0, 0)
+    custom_response = b"".join(custom_response)
+    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response}
 
     # Run
     inventory = await connector.get_inventory()
@@ -107,18 +115,46 @@ async def test_get_inventory_valid(connector: EchoesRemoteConnector):
     )
 
 
+async def test_invalid_read_invalid_inventory_length(connector: EchoesRemoteConnector):
+    # Setup
+    assert isinstance(connector.executor, AsyncMock)
+
+    custom_response = [b"" for _ in range(109)]
+    for item in connector.game.resource_database.item:
+        if item.extra["item_id"] >= 1000:
+            continue
+        custom_response[item.extra["item_id"]] = struct.pack(
+            ">III", *InventoryItem(item.max_capacity, item.max_capacity), 0
+        )
+        break
+
+    custom_response = b"".join(custom_response)
+    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response}
+
+    # Run
+    msg = "Should have read 109 items from the game, instead read 1"
+    with pytest.raises(ValueError, match=re.escape(msg)):
+        await connector.get_inventory()
+
+
 async def test_get_inventory_invalid_capacity(connector: EchoesRemoteConnector):
     # Setup
     assert isinstance(connector.executor, AsyncMock)
 
     custom_inventory = {"Darkburst": InventoryItem(0, 50)}
 
-    connector.executor.perform_memory_operations.side_effect = lambda ops: {
-        op: struct.pack(
-            ">II", *custom_inventory.get(item.short_name, InventoryItem(item.max_capacity, item.max_capacity))
+    custom_response = [b"" for _ in range(109)]
+    for item in connector.game.resource_database.item:
+        if item.extra["item_id"] >= 1000:
+            continue
+        custom_response[item.extra["item_id"]] = struct.pack(
+            ">III", *custom_inventory.get(item.short_name, InventoryItem(item.max_capacity, item.max_capacity)), 0
         )
-        for op, item in zip(ops, connector.game.resource_database.item)
-    }
+    for i in range(109):
+        if custom_response[i] == b"":
+            custom_response[i] = struct.pack(">III", 0, 0, 0)
+    custom_response = b"".join(custom_response)
+    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response}
 
     # Run
     msg = "Received InventoryItem(amount=0, capacity=50) for Darkburst, which is an invalid state."
@@ -132,12 +168,18 @@ async def test_get_inventory_invalid_amount(connector: EchoesRemoteConnector):
 
     custom_inventory = {"Darkburst": InventoryItem(1, 0)}
 
-    connector.executor.perform_memory_operations.side_effect = lambda ops: {
-        op: struct.pack(
-            ">II", *custom_inventory.get(item.short_name, InventoryItem(item.max_capacity, item.max_capacity))
+    custom_response = [b"" for _ in range(109)]
+    for item in connector.game.resource_database.item:
+        if item.extra["item_id"] >= 1000:
+            continue
+        custom_response[item.extra["item_id"]] = struct.pack(
+            ">III", *custom_inventory.get(item.short_name, InventoryItem(item.max_capacity, item.max_capacity)), 0
         )
-        for op, item in zip(ops, connector.game.resource_database.item)
-    }
+    for i in range(109):
+        if custom_response[i] == b"":
+            custom_response[i] = struct.pack(">III", 0, 0, 0)
+    custom_response = b"".join(custom_response)
+    connector.executor.perform_memory_operations.side_effect = lambda op: {op[0]: custom_response}
 
     # Run
     msg = "Received InventoryItem(amount=1, capacity=0) for Darkburst, which is an invalid state."


### PR DESCRIPTION
Havent checked yet if tests fail (they probably do), just wanted to have this opened so it can get a look already.
Have not tested yet whether this fatally crashes somewhere in the current state as ive rewritten it a bit, but the general gist was that it was ~2ms faster for prime1 and ~2x as fast for echoes (my tests in debug went from 6.5 seconds to 3 seconds)