### PR TITLE
Planets (Zebeth) DB: Allow Downward Shots are now in logic

### DIFF
--- a/randovania/games/planets_zebeth/generator/bootstrap.py
+++ b/randovania/games/planets_zebeth/generator/bootstrap.py
@@ -31,6 +31,7 @@ class PlanetsZebethBootstrap(Bootstrap[PlanetsZebethConfiguration]):
 
         logical_patches = {
             "open_missile_doors_with_one_missile": "OpenMissileDoorWithOneMissile",
+            "allow_downward_shots": "AllowDownwardShots",
         }
 
         for name, index in logical_patches.items():

--- a/randovania/games/planets_zebeth/logic_database/Brinstar.json
+++ b/randovania/games/planets_zebeth/logic_database/Brinstar.json
@@ -198,6 +198,15 @@
                                     {
                                         "type": "template",
                                         "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -1755,8 +1764,25 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Green Sanctuary W": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -3330,6 +3356,15 @@
                                     {
                                         "type": "template",
                                         "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/planets_zebeth/logic_database/Brinstar.json
+++ b/randovania/games/planets_zebeth/logic_database/Brinstar.json
@@ -191,25 +191,8 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Kraid Prelude": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         },
                         "Door to The Overhang": {
                             "type": "and",
@@ -1764,25 +1747,8 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Green Sanctuary W": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         }
                     }
                 },
@@ -3349,25 +3315,8 @@
                             }
                         },
                         "Door to Item Corridor (Ice Beam)": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         }
                     }
                 },

--- a/randovania/games/planets_zebeth/logic_database/Brinstar.txt
+++ b/randovania/games/planets_zebeth/logic_database/Brinstar.txt
@@ -33,7 +33,7 @@ Extra - map_name: Brinstar/x88_y233
   * Layers: default
   * Normal Door to Maru Mari Hall/Door to Early Construction
   > Door to Kraid Prelude
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
   > Door to The Overhang
       Trivial
 
@@ -305,7 +305,7 @@ Extra - map_name: Brinstar/x312_y30
   * Layers: default
   * Normal Door to Item Corridor (Varia)/Door to Green Hall
   > Door to Green Sanctuary W
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
 
 > Door to Green Sanctuary E; Heals? False
   * Layers: default
@@ -609,7 +609,7 @@ Extra - map_name: Brinstar/x344_y113
   > Door to Blue Rocks East
       Trivial
   > Door to Item Corridor (Ice Beam)
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
 
 > Door to Item Corridor (Ice Beam); Heals? False
   * Layers: default

--- a/randovania/games/planets_zebeth/logic_database/Brinstar.txt
+++ b/randovania/games/planets_zebeth/logic_database/Brinstar.txt
@@ -33,7 +33,7 @@ Extra - map_name: Brinstar/x88_y233
   * Layers: default
   * Normal Door to Maru Mari Hall/Door to Early Construction
   > Door to Kraid Prelude
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
   > Door to The Overhang
       Trivial
 
@@ -305,7 +305,7 @@ Extra - map_name: Brinstar/x312_y30
   * Layers: default
   * Normal Door to Item Corridor (Varia)/Door to Green Hall
   > Door to Green Sanctuary W
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
 
 > Door to Green Sanctuary E; Heals? False
   * Layers: default
@@ -609,7 +609,7 @@ Extra - map_name: Brinstar/x344_y113
   > Door to Blue Rocks East
       Trivial
   > Door to Item Corridor (Ice Beam)
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
 
 > Door to Item Corridor (Ice Beam); Heals? False
   * Layers: default

--- a/randovania/games/planets_zebeth/logic_database/Kraid.json
+++ b/randovania/games/planets_zebeth/logic_database/Kraid.json
@@ -1581,8 +1581,25 @@
                             }
                         },
                         "Door to Hall of Illusion": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -1768,8 +1785,25 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Dock to Kraid Arena Access": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Door to Lower Side Room Access": {
                             "type": "and",

--- a/randovania/games/planets_zebeth/logic_database/Kraid.json
+++ b/randovania/games/planets_zebeth/logic_database/Kraid.json
@@ -1581,25 +1581,8 @@
                             }
                         },
                         "Door to Hall of Illusion": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         }
                     }
                 },
@@ -1785,25 +1768,8 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Dock to Kraid Arena Access": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         },
                         "Door to Lower Side Room Access": {
                             "type": "and",

--- a/randovania/games/planets_zebeth/logic_database/Kraid.txt
+++ b/randovania/games/planets_zebeth/logic_database/Kraid.txt
@@ -284,7 +284,7 @@ Extra - map_name: Kraid/x40_y405
   > Door to Back Storage
       Trivial
   > Door to Hall of Illusion
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
 
 > Door to Back Storage; Heals? False
   * Layers: default
@@ -318,7 +318,7 @@ Extra - map_name: Kraid/x136_y412
   * Layers: default
   * Normal Door to Hall of Illusion/Door to Green Parlor
   > Dock to Kraid Arena Access
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
   > Door to Lower Side Room Access
       Trivial
 

--- a/randovania/games/planets_zebeth/logic_database/Kraid.txt
+++ b/randovania/games/planets_zebeth/logic_database/Kraid.txt
@@ -284,7 +284,7 @@ Extra - map_name: Kraid/x40_y405
   > Door to Back Storage
       Trivial
   > Door to Hall of Illusion
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
 
 > Door to Back Storage; Heals? False
   * Layers: default
@@ -318,7 +318,7 @@ Extra - map_name: Kraid/x136_y412
   * Layers: default
   * Normal Door to Hall of Illusion/Door to Green Parlor
   > Dock to Kraid Arena Access
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
   > Door to Lower Side Room Access
       Trivial
 

--- a/randovania/games/planets_zebeth/logic_database/Norfair.json
+++ b/randovania/games/planets_zebeth/logic_database/Norfair.json
@@ -745,8 +745,25 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Weapons Cache": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -785,8 +802,25 @@
                             }
                         },
                         "Door to Item Trial (High Jump)": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -2381,8 +2415,25 @@
                             }
                         },
                         "Door to Gumdrop Hall": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -2414,8 +2465,25 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Lava Entryway": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -2614,8 +2682,25 @@
                             }
                         },
                         "Door to Bubble Cache": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -3147,8 +3232,25 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Fire Sea": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -3355,13 +3457,22 @@
                             }
                         },
                         "Door to Destroyed Highway": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
                                         "type": "template",
                                         "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -3737,8 +3848,25 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Item Trial (Wave Beam)": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Door to Path of Destruction": {
                             "type": "and",

--- a/randovania/games/planets_zebeth/logic_database/Norfair.json
+++ b/randovania/games/planets_zebeth/logic_database/Norfair.json
@@ -745,25 +745,8 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Weapons Cache": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         }
                     }
                 },
@@ -802,25 +785,8 @@
                             }
                         },
                         "Door to Item Trial (High Jump)": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         }
                     }
                 },
@@ -2415,25 +2381,8 @@
                             }
                         },
                         "Door to Gumdrop Hall": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         }
                     }
                 },
@@ -2465,25 +2414,8 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Lava Entryway": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         }
                     }
                 },
@@ -2682,25 +2614,8 @@
                             }
                         },
                         "Door to Bubble Cache": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         }
                     }
                 },
@@ -3232,25 +3147,8 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Fire Sea": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         }
                     }
                 },
@@ -3457,25 +3355,8 @@
                             }
                         },
                         "Door to Destroyed Highway": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         }
                     }
                 },
@@ -3848,25 +3729,8 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Item Trial (Wave Beam)": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         },
                         "Door to Path of Destruction": {
                             "type": "and",

--- a/randovania/games/planets_zebeth/logic_database/Norfair.txt
+++ b/randovania/games/planets_zebeth/logic_database/Norfair.txt
@@ -139,7 +139,7 @@ Extra - map_name: Norfair/x472_y225
   * Layers: default
   * Normal Door to Hidden Cache/Door to Bubble Tower
   > Door to Weapons Cache
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
 
 > Door to Gauntlet; Heals? False
   * Layers: default
@@ -147,7 +147,7 @@ Extra - map_name: Norfair/x472_y225
   > Door to Ember Hall
       Trivial
   > Door to Item Trial (High Jump)
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
 
 > Door to Item Trial (High Jump); Heals? False
   * Layers: default
@@ -471,13 +471,13 @@ Extra - map_name: Norfair/x280_y247
   > Door to Upper Lava Highway
       Trivial
   > Door to Gumdrop Hall
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
 
 > Door to Item Trial (Screw Attack); Heals? False
   * Layers: default
   * Normal Door to Item Trial (Screw Attack)/Door to Bubble Atrium
   > Door to Lava Entryway
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
 
 > Door to Upper Lava Highway; Heals? False
   * Layers: default
@@ -514,7 +514,7 @@ Extra - map_name: Norfair/x264_y307
   > Door to Destroyed Highway
       Trivial
   > Door to Bubble Cache
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
 
 > Door to Bubble Cache; Heals? False
   * Layers: default
@@ -621,7 +621,7 @@ Extra - map_name: Norfair/x456_y270
   * Layers: default
   * Normal Door to Gumdrop Hall/Door to Lava Pier
   > Door to Fire Sea
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
 
 > Door to Fire Sea; Heals? False
   * Layers: default
@@ -660,7 +660,7 @@ Extra - map_name: Norfair/x200_y269
   > Door to Upper Lava Highway
       Trivial
   > Door to Destroyed Highway
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
 
 > Door to Destroyed Highway; Heals? False
   * Layers: default
@@ -733,7 +733,7 @@ Extra - map_name: Norfair/x328_y300
   * Layers: default
   * Normal Door to Bubble Pillars/Door to Bubble Corridor East
   > Door to Item Trial (Wave Beam)
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
   > Door to Path of Destruction
       Trivial
 

--- a/randovania/games/planets_zebeth/logic_database/Norfair.txt
+++ b/randovania/games/planets_zebeth/logic_database/Norfair.txt
@@ -139,7 +139,7 @@ Extra - map_name: Norfair/x472_y225
   * Layers: default
   * Normal Door to Hidden Cache/Door to Bubble Tower
   > Door to Weapons Cache
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
 
 > Door to Gauntlet; Heals? False
   * Layers: default
@@ -147,7 +147,7 @@ Extra - map_name: Norfair/x472_y225
   > Door to Ember Hall
       Trivial
   > Door to Item Trial (High Jump)
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
 
 > Door to Item Trial (High Jump); Heals? False
   * Layers: default
@@ -471,13 +471,13 @@ Extra - map_name: Norfair/x280_y247
   > Door to Upper Lava Highway
       Trivial
   > Door to Gumdrop Hall
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
 
 > Door to Item Trial (Screw Attack); Heals? False
   * Layers: default
   * Normal Door to Item Trial (Screw Attack)/Door to Bubble Atrium
   > Door to Lava Entryway
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
 
 > Door to Upper Lava Highway; Heals? False
   * Layers: default
@@ -514,7 +514,7 @@ Extra - map_name: Norfair/x264_y307
   > Door to Destroyed Highway
       Trivial
   > Door to Bubble Cache
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
 
 > Door to Bubble Cache; Heals? False
   * Layers: default
@@ -621,7 +621,7 @@ Extra - map_name: Norfair/x456_y270
   * Layers: default
   * Normal Door to Gumdrop Hall/Door to Lava Pier
   > Door to Fire Sea
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
 
 > Door to Fire Sea; Heals? False
   * Layers: default
@@ -660,7 +660,7 @@ Extra - map_name: Norfair/x200_y269
   > Door to Upper Lava Highway
       Trivial
   > Door to Destroyed Highway
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
 
 > Door to Destroyed Highway; Heals? False
   * Layers: default
@@ -733,7 +733,7 @@ Extra - map_name: Norfair/x328_y300
   * Layers: default
   * Normal Door to Bubble Pillars/Door to Bubble Corridor East
   > Door to Item Trial (Wave Beam)
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
   > Door to Path of Destruction
       Trivial
 

--- a/randovania/games/planets_zebeth/logic_database/Ridley.json
+++ b/randovania/games/planets_zebeth/logic_database/Ridley.json
@@ -311,8 +311,25 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Block Room E": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "AllowDownwardShots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },

--- a/randovania/games/planets_zebeth/logic_database/Ridley.json
+++ b/randovania/games/planets_zebeth/logic_database/Ridley.json
@@ -311,25 +311,8 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Block Room E": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "AllowDownwardShots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Floor Blocks"
                         }
                     }
                 },

--- a/randovania/games/planets_zebeth/logic_database/Ridley.txt
+++ b/randovania/games/planets_zebeth/logic_database/Ridley.txt
@@ -57,7 +57,7 @@ Extra - map_name: Ridley/x360_y359
   * Layers: default
   * Normal Door to Purple Gauntlet/Door to Block Room W
   > Door to Block Room E
-      Can Use Bombs
+      Enabled Allow Downward Shots or Can Use Bombs
 
 > Door to Hall of Pillars; Heals? False
   * Layers: default

--- a/randovania/games/planets_zebeth/logic_database/Ridley.txt
+++ b/randovania/games/planets_zebeth/logic_database/Ridley.txt
@@ -57,7 +57,7 @@ Extra - map_name: Ridley/x360_y359
   * Layers: default
   * Normal Door to Purple Gauntlet/Door to Block Room W
   > Door to Block Room E
-      Enabled Allow Downward Shots or Can Use Bombs
+      Can Break Floor Blocks
 
 > Door to Hall of Pillars; Heals? False
   * Layers: default

--- a/randovania/games/planets_zebeth/logic_database/header.json
+++ b/randovania/games/planets_zebeth/logic_database/header.json
@@ -202,6 +202,10 @@
             "OpenMissileDoorWithOneMissile": {
                 "long_name": "Open Missile Door With One Missile",
                 "extra": {}
+            },
+            "AllowDownwardShots": {
+                "long_name": "Allow Downward Shots",
+                "extra": {}
             }
         },
         "requirement_template": {

--- a/randovania/games/planets_zebeth/logic_database/header.json
+++ b/randovania/games/planets_zebeth/logic_database/header.json
@@ -383,6 +383,30 @@
                         ]
                     }
                 }
+            },
+            "Can Break Floor Blocks": {
+                "display_name": "Can Break Floor Blocks",
+                "requirement": {
+                    "type": "or",
+                    "data": {
+                        "comment": null,
+                        "items": [
+                            {
+                                "type": "template",
+                                "data": "Can Use Bombs"
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "misc",
+                                    "name": "AllowDownwardShots",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            }
+                        ]
+                    }
+                }
             }
         },
         "damage_reductions": [],

--- a/randovania/games/planets_zebeth/logic_database/header.txt
+++ b/randovania/games/planets_zebeth/logic_database/header.txt
@@ -21,6 +21,9 @@ Templates
           Unmorph Jump (Beginner) and Can Use Bombs
           IBJ (Beginner) and Can Use Bombs
 
+* Can Break Floor Blocks:
+      Enabled Allow Downward Shots or Can Use Bombs
+
 ====================
 Dock Weaknesses
 


### PR DESCRIPTION
Makes the option `Allow Downward Shots` logical when enabled.