### PR TITLE
Nintendont: log time for each request

### DIFF
--- a/randovania/game_connection/executor/nintendont_executor.py
+++ b/randovania/game_connection/executor/nintendont_executor.py
@@ -4,6 +4,7 @@ import asyncio
 import dataclasses
 import logging
 import struct
+from datetime import datetime
 from typing import TypeGuard
 
 from randovania.game_connection.executor.common_socket_holder import CommonSocketHolder
@@ -265,12 +266,15 @@ class NintendontExecutor(MemoryOperationExecutor):
 
         all_responses = []
         try:
-            for request in requests:
+            for req_number, request in enumerate(requests):
                 data = request.build_request_data()
                 self._socket.writer.write(data)
                 await self._socket.writer.drain()
                 if request.output_bytes > 0:
+                    before_sending = datetime.now()
                     response = await asyncio.wait_for(self._socket.reader.read(1024), timeout=self._timeout)
+                    after_sending = datetime.now()
+                    self.logger.debug(f"Request {req_number} took {after_sending - before_sending}")
                     all_responses.append(response)
                 else:
                     all_responses.append(b"")


### PR DESCRIPTION
There's been several disconnects that seem to happen "out of the blue" with rdv being able to reconnect fairly quickly after lately.
I'm interested to know whether the sending/receiving times from other people are just generally more fluctuating than in my setup and if we maybe do need to increase our timeout number by a bit.