### PR TITLE
Nintendont: increase timeout to 15s

### DIFF
--- a/randovania/game_connection/executor/nintendont_executor.py
+++ b/randovania/game_connection/executor/nintendont_executor.py
@@ -102,10 +102,10 @@ class NintendontExecutor(MemoryOperationExecutor):
 
     SUPPORTED_API_VERSION = 1
 
-    _timeout = 5
+    _timeout = 15
     # timeout in seconds on when we disconnect when we don't get a response.
     # The Prime games (which this is currently used for) are somewhat time-sensitive. If we can't ensure a timely
-    # response the experience is going to be bad and things *will* break. So make sure early then to
+    # response the experience is going to be bad and things *will* break.
     # Once the prime games are reworked, or this is used for other games, a reconsideration can be done to rework this.
 
     def __init__(self, ip: str):


### PR DESCRIPTION
Part of #9331 - I realized that if I want to time properly on how long things take, i need quite a bit of buffer and cant just always try to return early, so this is a deliberate high timeout for testing. 
Once I get some nice numbers, I will either decrease this to be more appropriate, or add a changelog entry.