### PR TITLE
Logs about nintendont uploading

### DIFF
--- a/randovania/gui/widgets/game_connection_window.py
+++ b/randovania/gui/widgets/game_connection_window.py
@@ -397,9 +397,12 @@ class GameConnectionWindow(QtWidgets.QMainWindow, Ui_GameConnectionWindow):
         box.show()
 
         try:
+            builder.logger.debug("Uploading Nintendont to the Wii...")
             await wiiload.upload_file(nintendont_file, [], builder.ip)
+            builder.logger.debug("Nintendont upload successful.")
             box.setText("Upload finished successfully. Check your Wii for more.")
         except Exception as e:
+            builder.logger.warning(f"Error while uploading Nintendont to the Wii: {e}")
             box.setText(f"Error uploading to Wii: {e}")
         finally:
             box.button(QtWidgets.QMessageBox.StandardButton.Ok).setEnabled(True)


### PR DESCRIPTION
This is 1) to catch weird errors sometimes appearing despite the upload being successful, and 2) due to a rando match that happened in the CGC tournament 

PR is targeting stable, not main.