### PR TITLE
Change timeout back to 10s and add changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Updated the Nintendont version that is used when uploading it directly to the Wii.
   Includes faster connection speeds and better crash resilience.
 - Changed: Nintendont Connector: Better error messages when connecting to an invalid Nintendont.
+- Changed: Nintendont Connector: Increase the timeout limit from 5s to 10s.
 
 ### Another Metroid 2 Remake
 

--- a/randovania/game_connection/executor/nintendont_executor.py
+++ b/randovania/game_connection/executor/nintendont_executor.py
@@ -102,7 +102,7 @@ class NintendontExecutor(MemoryOperationExecutor):
 
     SUPPORTED_API_VERSION = 1
 
-    _timeout = 15
+    _timeout = 10
     # timeout in seconds on when we disconnect when we don't get a response.
     # The Prime games (which this is currently used for) are somewhat time-sensitive. If we can't ensure a timely
     # response the experience is going to be bad and things *will* break.


### PR DESCRIPTION
Sam for some reason has 99% percentiles that go above 5s :)
Some other people get close too (like vader with his ethernet switch). So just in case, i'm increasing it to 10 to hopefully cause least disruption for the rest of cgc while also being sensible enough to disconnect if we really can't connect.

PR is targeting stable.