### PR TITLE
Use `production.` instead of `server.` for the DOMAIN2

### DIFF
--- a/tools/deploy_server.py
+++ b/tools/deploy_server.py
@@ -24,7 +24,7 @@ async def deploy(
     if server_environment == "production":
         new_env["PATH_PREFIX"] = "randovania"
         new_env["DATA_PATH"] = "/var/randovania/production/data"
-        new_env["DOMAIN2"] = f"server.{host2}"
+        new_env["DOMAIN2"] = f"production.{host2}"
 
     elif server_environment == "staging":
         new_env["PATH_PREFIX"] = "randovania-staging"


### PR DESCRIPTION
We don't really use this for anything, but at least this will make `server.randovania.org` not point to production.

For stable.