### PR TITLE
Add discord_client_lifespan and ServerApp.discord_client

### DIFF
--- a/randovania/server/discord_auth.py
+++ b/randovania/server/discord_auth.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Self, TypedDict
 
 import aiohttp
+from discord import Client as DiscordClient
 
 from randovania.lib import http_lib
 from randovania.server.fastapi_discord import DiscordOAuthClient
@@ -75,3 +76,18 @@ async def discord_oauth_lifespan(_app: RdvFastAPI) -> Lifespan[DiscordOAuthClien
     if discord.client_session is not None:
         await discord.client_session.close()
         discord.client_session = None
+
+
+@asynccontextmanager
+async def discord_client_lifespan(_app: RdvFastAPI) -> Lifespan[DiscordClient | None]:
+    config = _app.sa.configuration
+    if "discord_bot" not in config:
+        yield None
+    else:
+        client = DiscordClient()
+
+        await client.login(config["discord_bot"]["token"])
+        # client.connect "blocks" the current asyncio loop, so don't use it
+
+        yield client
+        await client.close()

--- a/randovania/server/server_app.py
+++ b/randovania/server/server_app.py
@@ -37,12 +37,13 @@ from randovania.network_common.authentication import AuthenticationMethod
 from randovania.network_common.signals import server_signals
 from randovania.server import client_check, fastapi_discord
 from randovania.server.database import User, World, database_lifespan
-from randovania.server.discord_auth import EnforceDiscordRole, discord_oauth_lifespan
+from randovania.server.discord_auth import EnforceDiscordRole, discord_client_lifespan, discord_oauth_lifespan
 from randovania.server.socketio import (
     fastapi_socketio_lifespan,
 )
 
 if TYPE_CHECKING:
+    from discord import Client as DiscordClient
     from socketio import AsyncServer
     from socketio_handler import SocketManager
 
@@ -92,6 +93,7 @@ class ServerApp:
 
     socket_manager: SocketManager
     discord: DiscordOAuthClient
+    discord_client: DiscordClient | None
     db: peewee.SqliteDatabase
     metrics: Instrumentator
     fernet_encrypt: Fernet
@@ -157,6 +159,7 @@ class ServerApp:
 
         async with (
             discord_oauth_lifespan(_app) as self.discord,
+            discord_client_lifespan(_app) as self.discord_client,
             EnforceDiscordRole.lifespan(_app) as self.enforce_role,
             fastapi_socketio_lifespan(_app) as self.socket_manager,
             database_lifespan(_app) as self.db,


### PR DESCRIPTION
This allows the server code to call Discord using our bot's scope, and do things like query "what guilds we're in".