### PR TITLE
When changing DataEditorCanvas scale, make sure the center of the widget is the same.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Automatic Item Tracker: The text "Not currently connected to any games" is now always shown when the selected game connection is not connected and no default game is set.
 - Fixed: In the Data Visualizer and Editor, when the game uses region images these images are no longer be stretched in certain situations.
 - Fixed: In the Data Visualizer and Editor, when panning away from the selected area the region image is now displayed correctly.
+- Fixed: In the Data Visualizer and Editor, when changing the zoom the pan is adjusted now relative to either the center or the mouse position.
 
 ### Metroid Dread
 

--- a/randovania/gui/widgets/data_editor_canvas.py
+++ b/randovania/gui/widgets/data_editor_canvas.py
@@ -175,6 +175,7 @@ class DataEditorCanvas(QtWidgets.QWidget):
 
     pan_offset_x: float = 0.0
     pan_offset_y: float = 0.0
+    _wheel_zoom_anchor: QPointF | None = None
     _last_pan_point: QPointF | None = None
     _pan_start_point: QPointF | None = None
     _is_panning: bool = False
@@ -726,8 +727,31 @@ class DataEditorCanvas(QtWidgets.QWidget):
             centered_text(painter, p + QPointF(0, 15), node.name)
 
     def set_zoom_value(self, new_zoom: int) -> None:
-        self.additional_zoom = new_zoom / 20
+        """Changes the zoom level, adjusting the pan offset so the anchor point stays over the same world point."""
+        new_additional_zoom = new_zoom / 20
+        anchor = self._wheel_zoom_anchor
+        self._wheel_zoom_anchor = None
+
+        if self.area is not None and new_additional_zoom != self.additional_zoom:
+            self._update_scale_variables()
+            old_scale = self.scale
+            if anchor is None:
+                # When updating the zoom via the slider, use widget center as anchor.
+                anchor = QPointF(self.width() / 2, self.height() / 2)
+            local = anchor - self.get_area_canvas_offset()
+
+            self.additional_zoom = new_additional_zoom
+            self._update_scale_variables()
+
+            desired_offset = anchor - local * (self.scale / old_scale)
+            delta = desired_offset - self.get_area_canvas_offset()
+            self.pan_offset_x += delta.x()
+            self.pan_offset_y += delta.y()
+        else:
+            self.additional_zoom = new_additional_zoom
+
         self.repaint()
 
     def wheelEvent(self, event: QtGui.QWheelEvent) -> None:
+        self._wheel_zoom_anchor = event.position()
         self.UpdateSlider.emit(event.angleDelta().y() > 0)

--- a/test/gui/lib/test_data_editor_canvas.py
+++ b/test/gui/lib/test_data_editor_canvas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from unittest.mock import ANY, MagicMock, call
 
 import pytest
-from PySide6.QtCore import QPoint
+from PySide6.QtCore import QPoint, QPointF
 
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_description import default_database
@@ -147,6 +147,49 @@ def test_camera_data_invalid():
     camera_data = CameraData("something_wrong", (), ())  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="Unknown coordinate system"):
         camera_data.game_loc_to_qt_local(0.0, 0.0, 0.0)
+
+
+def _world_loc_at(canvas: DataEditorCanvas, widget_point: QPointF):
+    return canvas.qt_local_to_game_loc(widget_point - canvas.get_area_canvas_offset())
+
+
+def test_set_zoom_value_keeps_center(skip_qtbot, canvas: DataEditorCanvas):
+    canvas.resize(800, 600)
+    canvas._update_scale_variables()
+    center = QPointF(400, 300)
+
+    world_before = _world_loc_at(canvas, center)
+    canvas.set_zoom_value(30)
+    world_after = _world_loc_at(canvas, center)
+
+    assert world_after.x == pytest.approx(world_before.x)
+    assert world_after.y == pytest.approx(world_before.y)
+
+
+def test_wheel_zoom_keeps_mouse_position(skip_qtbot, canvas: DataEditorCanvas):
+    canvas.resize(800, 600)
+    canvas._update_scale_variables()
+    anchor = QPointF(600, 150)
+
+    event = MagicMock()
+    event.position.return_value = anchor
+    event.angleDelta.return_value.y.return_value = 120
+
+    update_slider = MagicMock()
+    canvas.UpdateSlider.connect(update_slider)
+
+    canvas.wheelEvent(event)
+    update_slider.assert_called_once_with(True)
+
+    world_before = _world_loc_at(canvas, anchor)
+    canvas.set_zoom_value(25)
+    world_after = _world_loc_at(canvas, anchor)
+
+    assert world_after.x == pytest.approx(world_before.x)
+    assert world_after.y == pytest.approx(world_before.y)
+
+    # the anchor is one-shot: a following slider-only zoom must not reuse it
+    assert canvas._wheel_zoom_anchor is None
 
 
 def test_region_image(skip_qtbot, canvas: DataEditorCanvas, dread_game_description):


### PR DESCRIPTION
In addition, when the zoom is done via mouse wheel, do it relative to the mouse.