### PR TITLE
Hunters - Bump OPHR to 0.12.0 and fix other bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ exporters = [
     "mp2hudcolor==1.0.14",
 
     # Metroid Prime Hunters
-    "open-prime-hunters-rando==0.11.2",
+    "open-prime-hunters-rando==0.12.0",
 
     # Metroid: Samus Returns
     "open-samus-returns-rando==3.6.1",

--- a/randovania/games/prime_hunters/exporter/patch_data_factory.py
+++ b/randovania/games/prime_hunters/exporter/patch_data_factory.py
@@ -309,9 +309,9 @@ class HuntersPatchDataFactory(PatchDataFactory[HuntersConfiguration, HuntersCosm
         gorea_text = "defeat GOREA in OUBLIETTE."
         placed_octoliths = config.octoliths.placed_octoliths
         if placed_octoliths >= 2:
-            goal_text = f"collect {placed_octoliths} OCTOLITHS and " + gorea_text
+            goal_text = f"collect {placed_octoliths} OCTOLITHS and {gorea_text}"
         elif placed_octoliths == 1:
-            goal_text = "collect 1 OCTOLITH and " + gorea_text
+            goal_text = f"collect 1 OCTOLITH and {gorea_text}"
         else:
             goal_text = gorea_text
 

--- a/randovania/games/prime_hunters/exporter/patch_data_factory.py
+++ b/randovania/games/prime_hunters/exporter/patch_data_factory.py
@@ -305,10 +305,15 @@ class HuntersPatchDataFactory(PatchDataFactory[HuntersConfiguration, HuntersCosm
             starting_items_text = "no additional starting items given."
 
         # Goal
+        goal_text = ""
         gorea_text = "defeat GOREA in OUBLIETTE."
         placed_octoliths = config.octoliths.placed_octoliths
-        if placed_octoliths > 0:
+        if placed_octoliths >= 2:
             goal_text = f"collect {placed_octoliths} OCTOLITHS and " + gorea_text
+        elif placed_octoliths == 1:
+            goal_text = "collect 1 OCTOLITH and " + gorea_text
+        else:
+            goal_text = gorea_text
 
         # Force Fields
         force_field_config = config.force_field_configuration.description()

--- a/randovania/games/prime_hunters/game_data.py
+++ b/randovania/games/prime_hunters/game_data.py
@@ -85,7 +85,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="NALJHISB",
+        expected_seed_hash="PYLVBJJH",
     )
 
 

--- a/randovania/games/prime_hunters/gui/dialog/game_export_dialog.py
+++ b/randovania/games/prime_hunters/gui/dialog/game_export_dialog.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import hashlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -23,16 +22,12 @@ from randovania.gui.dialog.game_export_dialog import (
 if TYPE_CHECKING:
     from randovania.interface_common.options import Options, PerGameOptions
 
-# Expected MD5 hashes for vanilla "Metroid Prime Hunters.NDS" based on region
-EXPECTED_MD5_HASHES: list[str] = [
-    "b4c8a9398866b49c7be17d75736a223b",  # USA Rev0
-    "9fe5f1eb1eb9dc5d90130408f813b39e",  # USA Rev1
-    "be93b7aaaba93bafa37324fd7156c817",  # USA Rev1 (Wii U VC)
-    "c71a2d5fd41727c31f1619fb3085d4df",  # Europe Rev0
-    "378297159f176802e27384e18e33a1c4",  # Europe Rev1
-    "94b27d06db53519b2def908bdf80e201",  # Europe Rev1 (Wii U VC)
-    # "42850a19d7be2ee5e067df6984aa900e",  # Japan Rev0
-    # "4f04529f79564020a56e187b8f9865c3",  # Korea Rev0
+# Expected rom header data for vanilla "Metroid Prime Hunters.NDS" based on region
+EXPECTED_ROM_HEADER_DATA: list[bytes] = [
+    b"MP HUNTERS\x00\x00AMHE",  # USA Rev0/Rev1
+    b"MP HUNTERS\x00\x00AMHP",  # Europe Rev0/Rev1
+    # b"MP HUNTERS\x00\x00AMHJ",  # Japan Rev0
+    # b"MP HUNTERS\x00\x00AMHK",  # Korea Rev0
 ]
 
 
@@ -47,13 +42,12 @@ def is_hunters_validator(path: Path | None) -> bool:
     assert path is not None
     try:
         with path.open("rb") as file:
-            data = file.read()
-            md5_returned = hashlib.md5(data).hexdigest()
+            rom_header_data = file.read(16)
     except Exception:
         # If any error during opening happens, suppress that and pretend its invalid,
         # as otherwise it would cause the dialog to be inaccessible.
         return True
-    if md5_returned in EXPECTED_MD5_HASHES:
+    if rom_header_data in EXPECTED_ROM_HEADER_DATA:
         return False
     else:
         return True

--- a/randovania/games/prime_hunters/logic_database/Arcterra.json
+++ b/randovania/games/prime_hunters/logic_database/Arcterra.json
@@ -2518,8 +2518,8 @@
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
-                        "x": 196.00456913485357,
-                        "y": 436.9691690152874,
+                        "x": 196.0,
+                        "y": 436.97,
                         "z": 0.0
                     },
                     "description": "",
@@ -2528,11 +2528,11 @@
                     ],
                     "extra": {
                         "header": {
-                            "entity_id": 7,
+                            "entity_id": 34,
                             "position": {
-                                "x": 16.449951171875,
-                                "y": 38.501708984375,
-                                "z": -14.47607421875
+                                "x": -6.83203125,
+                                "y": 26.857421875,
+                                "z": 9.05810546875
                             },
                             "up_vector": {
                                 "x": 0.0,
@@ -2546,15 +2546,15 @@
                             }
                         },
                         "fields": {
-                            "item_type": 9,
+                            "item_type": 6,
                             "enabled": true,
-                            "has_base": false,
+                            "has_base": true,
                             "always_active": false,
                             "max_spawn_count": 1,
                             "spawn_interval": 0,
                             "spawn_delay": 0,
-                            "notify_entity_id": 205,
-                            "collected_message": 9,
+                            "notify_entity_id": -1,
+                            "collected_message": 0,
                             "collected_message_param1": 0,
                             "collected_message_param2": 0
                         }
@@ -2695,8 +2695,8 @@
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
-                        "x": 396.5750704586216,
-                        "y": 159.08378170637974,
+                        "x": 396.58,
+                        "y": 159.08,
                         "z": 0.0
                     },
                     "description": "",
@@ -2705,11 +2705,11 @@
                     ],
                     "extra": {
                         "header": {
-                            "entity_id": 34,
+                            "entity_id": 7,
                             "position": {
-                                "x": -6.83203125,
-                                "y": 26.857421875,
-                                "z": 9.05810546875
+                                "x": 16.449951171875,
+                                "y": 38.501708984375,
+                                "z": -14.47607421875
                             },
                             "up_vector": {
                                 "x": 0.0,
@@ -2723,15 +2723,15 @@
                             }
                         },
                         "fields": {
-                            "item_type": 6,
+                            "item_type": 9,
                             "enabled": true,
-                            "has_base": true,
+                            "has_base": false,
                             "always_active": false,
                             "max_spawn_count": 1,
                             "spawn_interval": 0,
                             "spawn_delay": 0,
-                            "notify_entity_id": -1,
-                            "collected_message": 0,
+                            "notify_entity_id": 205,
+                            "collected_message": 9,
                             "collected_message_param1": 0,
                             "collected_message_param2": 0
                         }

--- a/randovania/games/prime_hunters/logic_database/Arcterra.txt
+++ b/randovania/games/prime_hunters/logic_database/Arcterra.txt
@@ -761,20 +761,20 @@ Extra - portal_file_name: unit4_RM1_Ent
   * Layers: default
   * Pickup 51; Category? Minor
   * Extra - header:
-{'entity_id': 7,
- 'position': {'x': 16.449951171875, 'y': 38.501708984375, 'z': -14.47607421875},
+{'entity_id': 34,
+ 'position': {'x': -6.83203125, 'y': 26.857421875, 'z': 9.05810546875},
  'up_vector': {'x': 0.0, 'y': 1.0, 'z': 0.0},
  'facing_vector': {'x': 0.0, 'y': 0.0, 'z': 1.0}}
   * Extra - fields:
-{'item_type': 9,
+{'item_type': 6,
  'enabled': True,
- 'has_base': False,
+ 'has_base': True,
  'always_active': False,
  'max_spawn_count': 1,
  'spawn_interval': 0,
  'spawn_delay': 0,
- 'notify_entity_id': 205,
- 'collected_message': 9,
+ 'notify_entity_id': -1,
+ 'collected_message': 0,
  'collected_message_param1': 0,
  'collected_message_param2': 0}
   > Judicator Force Field (Entrance)
@@ -821,20 +821,20 @@ Extra - portal_file_name: unit4_RM1_Ent
   * Layers: default
   * Pickup 53; Category? Major
   * Extra - header:
-{'entity_id': 34,
- 'position': {'x': -6.83203125, 'y': 26.857421875, 'z': 9.05810546875},
+{'entity_id': 7,
+ 'position': {'x': 16.449951171875, 'y': 38.501708984375, 'z': -14.47607421875},
  'up_vector': {'x': 0.0, 'y': 1.0, 'z': 0.0},
  'facing_vector': {'x': 0.0, 'y': 0.0, 'z': 1.0}}
   * Extra - fields:
-{'item_type': 6,
+{'item_type': 9,
  'enabled': True,
- 'has_base': True,
+ 'has_base': False,
  'always_active': False,
  'max_spawn_count': 1,
  'spawn_interval': 0,
  'spawn_delay': 0,
- 'notify_entity_id': -1,
- 'collected_message': 0,
+ 'notify_entity_id': 205,
+ 'collected_message': 9,
  'collected_message_param1': 0,
  'collected_message_param2': 0}
   > Inside Judicator Room

--- a/randovania/games/prime_hunters/logic_database/header.json
+++ b/randovania/games/prime_hunters/logic_database/header.json
@@ -1239,14 +1239,6 @@
             3,
             4
         ],
-        "StandableTerrain": [
-            1,
-            3
-        ],
-        "BombJump": [
-            1,
-            2
-        ],
         "MissileJump": [
             1,
             2,
@@ -1258,6 +1250,14 @@
         ],
         "WallClip": [
             2,
+            3
+        ],
+        "BombJump": [
+            1,
+            2
+        ],
+        "StandableTerrain": [
+            1,
             3
         ]
     },

--- a/randovania/games/prime_hunters/logic_database/header.json
+++ b/randovania/games/prime_hunters/logic_database/header.json
@@ -1263,10 +1263,10 @@
     },
     "flatten_to_set_on_patch": false,
     "regions": [
-        "Celestial Archives.json",
         "Alinos.json",
-        "Arcterra.json",
+        "Celestial Archives.json",
         "Vesper Defense Outpost.json",
+        "Arcterra.json",
         "Oubliette.json"
     ]
 }

--- a/randovania/games/prime_hunters/presets/starter_preset.rdvpreset
+++ b/randovania/games/prime_hunters/presets/starter_preset.rdvpreset
@@ -129,12 +129,6 @@
         },
         "force_field_configuration": {
             "force_field_requirement": {
-                "Celestial Archives/Celestial Gateway/Battlehammer Force Field": "battlehammer",
-                "Celestial Archives/Incubation Vault 01/Shock Coil Force Field": "shock-coil",
-                "Celestial Archives/Incubation Vault 02/Shock Coil Force Field": "shock-coil",
-                "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Upper)": "shock-coil",
-                "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Lower)": "shock-coil",
-                "Celestial Archives/Synergy Core/Volt Driver Force Field": "volt-driver",
                 "Alinos/Alinos Perch/Magmaul Force Field": "magmaul",
                 "Alinos/Council Chamber/Magmaul Force Field (Entrance)": "magmaul",
                 "Alinos/Council Chamber/Magmaul Force Field (Jump Pad)": "magmaul",
@@ -145,15 +139,21 @@
                 "Alinos/High Ground/Volt Driver Force Field (Upper)": "volt-driver",
                 "Alinos/High Ground/Judicator Force Field (Lower)": "judicator",
                 "Alinos/High Ground/Judicator Force Field (Upper)": "judicator",
+                "Celestial Archives/Celestial Gateway/Battlehammer Force Field": "battlehammer",
+                "Celestial Archives/Incubation Vault 01/Shock Coil Force Field": "shock-coil",
+                "Celestial Archives/Incubation Vault 02/Shock Coil Force Field": "shock-coil",
+                "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Upper)": "shock-coil",
+                "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Lower)": "shock-coil",
+                "Celestial Archives/Synergy Core/Volt Driver Force Field": "volt-driver",
+                "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Left)": "battlehammer",
+                "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Right)": "battlehammer",
+                "Vesper Defense Outpost/Cortex CPU/Battlehammer Force Field": "battlehammer",
+                "Vesper Defense Outpost/Weapons Complex/Battlehammer Force Field": "battlehammer",
                 "Arcterra/Ice Hive/Judicator Force Field (Entrance)": "judicator",
                 "Arcterra/Ice Hive/Judicator Force Field (War Wasps)": "judicator",
                 "Arcterra/Ice Hive/Judicator Force Field (Judicator Room)": "judicator",
                 "Arcterra/Ice Hive/Judicator Force Field (Bridge)": "judicator",
-                "Arcterra/Ice Hive/Judicator Force Field (Alcove)": "judicator",
-                "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Left)": "battlehammer",
-                "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Right)": "battlehammer",
-                "Vesper Defense Outpost/Cortex CPU/Battlehammer Force Field": "battlehammer",
-                "Vesper Defense Outpost/Weapons Complex/Battlehammer Force Field": "battlehammer"
+                "Arcterra/Ice Hive/Judicator Force Field (Alcove)": "judicator"
             }
         }
     }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -736,7 +736,8 @@ SOLO_RDVGAMES = [
     (
         "prime_hunters/shuffled_extra_locations_and_skip_planet_intros.rdvgame",
         True,
-    ),  # starter prest with shuffled item refills and shield keys, added extra locations, skip planet intros
+    ),  # starter preset with shuffled item refills and shield keys, added extra locations, skip planet intros
+    ("prime_hunters/no_shuffled_octoliths.rdvgame", True),  # starter preset without any shuffled octoliths
     # Prime 1
     ("prime1-vanilla.rdvgame", True),  # vanilla
     ("prime1_crazy_seed.rdvgame", False),  # chaos features

--- a/test/games/prime_hunters/exporter/test_prime_hunters_game_exporter.py
+++ b/test/games/prime_hunters/exporter/test_prime_hunters_game_exporter.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         "starting_items_and_energy_with_nothings",
         "two_way_unchecked_portal_shuffle",
         "shuffled_extra_locations_and_skip_planet_intros",
+        "no_shuffled_octoliths",
     ],
 )
 def test_export_game(test_files_dir, mocker, patch_data_name: str, tmp_path):

--- a/test/games/prime_hunters/generator/test_prime_hunters_bootstrap.py
+++ b/test/games/prime_hunters/generator/test_prime_hunters_bootstrap.py
@@ -16,7 +16,7 @@ from randovania.generator.pickup_pool import pool_creator
     ("octoliths", "expected"),
     [
         (HuntersOctolithConfig(True, 8), [0, 1, 16, 17, 33, 34, 45, 46]),
-        (HuntersOctolithConfig(True, 4), [1, 16, 45, 46]),
+        (HuntersOctolithConfig(True, 4), [1, 16, 33, 34]),
         (HuntersOctolithConfig(False, 0), []),
     ],
 )

--- a/test/games/prime_hunters/layout/test_force_field_configuration.py
+++ b/test/games/prime_hunters/layout/test_force_field_configuration.py
@@ -13,7 +13,7 @@ from randovania.games.prime_hunters.layout.force_field_configuration import Forc
         {"encoded": b"\x00", "bit_count": 2, "json": ForceFieldConfiguration.default().with_vanilla().as_json},
         {"encoded": b"@", "bit_count": 2, "json": ForceFieldConfiguration.default().with_full_random().as_json},
         {
-            "encoded": b"\x86\x1d\xdd\xc4DUY\x99\x95UT\xcc\xcc",
+            "encoded": b"\x84DUY\x99\x86\x1d\xdd\xcc\xcc\xd5UT",
             "bit_count": 102,
             "json": {
                 "force_field_requirement": {"Celestial Archives/Celestial Gateway/Battlehammer Force Field": "random"}

--- a/test/test_files/log_files/prime_hunters/no_shuffled_octoliths.rdvgame
+++ b/test/test_files/log_files/prime_hunters/no_shuffled_octoliths.rdvgame
@@ -1,0 +1,1214 @@
+{
+    "schema_version": 42,
+    "info": {
+        "randovania_version": "10.10.0.dev180-dirty",
+        "randovania_version_git": "3209f537",
+        "permalink": "DaRU4bn00TIJ9TcKWApSAQrYFABG6KeT",
+        "has_spoiler": true,
+        "seed": 817470549,
+        "hash": "KTQ3T5GR",
+        "word_hash": "High Cortex Room",
+        "presets": [
+            {
+                "schema_version": 118,
+                "base_preset_uuid": null,
+                "name": "Starter Preset Copy",
+                "uuid": "21e0b12c-4e40-48b5-bcc0-d3123480c4e1",
+                "description": "A copy version of Starter Preset.",
+                "game": "prime_hunters",
+                "configuration": {
+                    "trick_level": {
+                        "minimal_logic": false,
+                        "specific_levels": {}
+                    },
+                    "starting_location": [
+                        {
+                            "region": "Celestial Archives",
+                            "area": "Celestial Gateway",
+                            "node": "Ship"
+                        }
+                    ],
+                    "available_locations": {
+                        "randomization_mode": "full",
+                        "excluded_indices": []
+                    },
+                    "standard_pickup_configuration": {
+                        "pickups_state": {
+                            "Power Beam": {},
+                            "Missile Launcher": {
+                                "num_shuffled_pickups": 1,
+                                "included_ammo": [
+                                    5
+                                ]
+                            },
+                            "Volt Driver": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Battlehammer": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Imperialist": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Judicator": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Magmaul": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Shock Coil": {
+                                "num_shuffled_pickups": 1
+                            },
+                            "Energy Tank": {
+                                "num_shuffled_pickups": 7
+                            },
+                            "Small Energy": {},
+                            "Medium Energy": {},
+                            "Large Energy": {},
+                            "Small UA Pack": {},
+                            "Large UA Pack": {},
+                            "Small Missile Pack": {},
+                            "Large Missile Pack": {}
+                        },
+                        "default_pickups": {},
+                        "minimum_random_starting_pickups": 0,
+                        "maximum_random_starting_pickups": 0
+                    },
+                    "ammo_pickup_configuration": {
+                        "pickups_state": {
+                            "Missile Expansion": {
+                                "ammo_count": [
+                                    10
+                                ],
+                                "pickup_count": 8,
+                                "requires_main_item": true
+                            },
+                            "UA Expansion": {
+                                "ammo_count": [
+                                    30
+                                ],
+                                "pickup_count": 12,
+                                "requires_main_item": true
+                            }
+                        }
+                    },
+                    "damage_strictness": 1.5,
+                    "pickup_model_style": "all-visible",
+                    "pickup_model_data_source": "etm",
+                    "logical_resource_action": "randomly",
+                    "first_progression_must_be_local": false,
+                    "dock_rando": {
+                        "mode": "vanilla",
+                        "types_state": {
+                            "Door": {
+                                "can_change_from": [],
+                                "can_change_to": []
+                            },
+                            "Other": {
+                                "can_change_from": [],
+                                "can_change_to": []
+                            }
+                        }
+                    },
+                    "single_set_for_pickups_that_solve": true,
+                    "staggered_multi_pickup_placement": true,
+                    "check_if_beatable_after_base_patches": false,
+                    "logical_pickup_placement": "minimal",
+                    "hints": {
+                        "enable_random_hints": true,
+                        "enable_specific_location_hints": true,
+                        "specific_pickup_hints": {
+                            "octoliths": "hide-area"
+                        },
+                        "minimum_available_locations_for_hint_placement": 0,
+                        "minimum_location_weight_for_hint_placement": 0.0,
+                        "use_resolver_hints": false
+                    },
+                    "octoliths": {
+                        "prefer_bosses": true,
+                        "placed_octoliths": 0
+                    },
+                    "force_field_configuration": {
+                        "force_field_requirement": {
+                            "Celestial Archives/Synergy Core/Volt Driver Force Field": "volt-driver",
+                            "Celestial Archives/Celestial Gateway/Battlehammer Force Field": "battlehammer",
+                            "Celestial Archives/Incubation Vault 01/Shock Coil Force Field": "shock-coil",
+                            "Celestial Archives/Incubation Vault 02/Shock Coil Force Field": "shock-coil",
+                            "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Upper)": "shock-coil",
+                            "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Lower)": "shock-coil",
+                            "Alinos/High Ground/Volt Driver Force Field (Upper)": "volt-driver",
+                            "Alinos/High Ground/Volt Driver Force Field (East)": "volt-driver",
+                            "Alinos/High Ground/Volt Driver Force Field (South)": "volt-driver",
+                            "Alinos/High Ground/Volt Driver Force Field (North)": "volt-driver",
+                            "Alinos/High Ground/Judicator Force Field (Upper)": "judicator",
+                            "Alinos/High Ground/Judicator Force Field (Lower)": "judicator",
+                            "Alinos/Alinos Perch/Magmaul Force Field": "magmaul",
+                            "Alinos/Council Chamber/Magmaul Force Field (Upper)": "magmaul",
+                            "Alinos/Council Chamber/Magmaul Force Field (Jump Pad)": "magmaul",
+                            "Alinos/Council Chamber/Magmaul Force Field (Entrance)": "magmaul",
+                            "Arcterra/Ice Hive/Judicator Force Field (Entrance)": "judicator",
+                            "Arcterra/Ice Hive/Judicator Force Field (Bridge)": "judicator",
+                            "Arcterra/Ice Hive/Judicator Force Field (Alcove)": "judicator",
+                            "Arcterra/Ice Hive/Judicator Force Field (War Wasps)": "judicator",
+                            "Arcterra/Ice Hive/Judicator Force Field (Judicator Room)": "judicator",
+                            "Vesper Defense Outpost/Cortex CPU/Battlehammer Force Field": "battlehammer",
+                            "Vesper Defense Outpost/Weapons Complex/Battlehammer Force Field": "battlehammer",
+                            "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Left)": "battlehammer",
+                            "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Right)": "battlehammer"
+                        }
+                    },
+                    "teleporters": {
+                        "mode": "vanilla",
+                        "excluded_teleporters": [],
+                        "excluded_targets": []
+                    },
+                    "starting_energy": 99,
+                    "shuffle_item_refills": false,
+                    "shuffle_shield_keys": false,
+                    "skip_planet_intros": false
+                }
+            }
+        ]
+    },
+    "game_modifications": [
+        {
+            "game": "prime_hunters",
+            "starting_equipment": {
+                "pickups": [
+                    "Octolith 1",
+                    "Octolith 2",
+                    "Octolith 3",
+                    "Octolith 4",
+                    "Octolith 5",
+                    "Octolith 6",
+                    "Octolith 7",
+                    "Octolith 8"
+                ]
+            },
+            "starting_location": "Celestial Archives/Celestial Gateway/Ship",
+            "dock_connections": {
+                "Celestial Archives/Synergy Core/Portal to Stronghold Void A (Celestial Archives)": "Celestial Archives/Stronghold Void A (Celestial Archives)/Portal to Synergy Core",
+                "Celestial Archives/Synergy Core/Portal to Transfer Lock": "Celestial Archives/Transfer Lock/Portal to Synergy Core",
+                "Celestial Archives/Synergy Core/Portal to Celestial Gateway": "Celestial Archives/Celestial Gateway/Portal to Synergy Core",
+                "Celestial Archives/Tetra Vista/Portal to Incubation Vault 03": "Celestial Archives/Incubation Vault 03/Portal to Tetra Vista",
+                "Celestial Archives/New Arrival Registration/Portal to Stronghold Void B (Celestial Archives)": "Celestial Archives/Stronghold Void B (Celestial Archives)/Portal to New Arrival Registration",
+                "Celestial Archives/New Arrival Registration/Portal to Celestial Gateway": "Celestial Archives/Celestial Gateway/Portal to New Arrival Registration",
+                "Celestial Archives/Celestial Gateway/Portal to Synergy Core": "Celestial Archives/Synergy Core/Portal to Celestial Gateway",
+                "Celestial Archives/Celestial Gateway/Portal to New Arrival Registration": "Celestial Archives/New Arrival Registration/Portal to Celestial Gateway",
+                "Celestial Archives/Transfer Lock/Portal to Synergy Core": "Celestial Archives/Synergy Core/Portal to Transfer Lock",
+                "Celestial Archives/Transfer Lock/Portal to Docking Bay": "Celestial Archives/Docking Bay/Portal to Transfer Lock",
+                "Celestial Archives/Incubation Vault 01/Portal to Docking Bay (Lower Level)": "Celestial Archives/Docking Bay/Portal from Incubation Vault 01",
+                "Celestial Archives/Incubation Vault 01/Portal to Incubation Vault 02 (Bridge)": "Celestial Archives/Incubation Vault 02/Portal to Incubation Vault 01 (Upper Level)",
+                "Celestial Archives/Incubation Vault 01/Portal to Incubation Vault 01 (Behind Force Field)": "Celestial Archives/Incubation Vault 01/Portal to Incubation Vault 01 (Lower Level)",
+                "Celestial Archives/Incubation Vault 01/Portal to Incubation Vault 01 (Lower Level)": "Celestial Archives/Incubation Vault 01/Portal to Incubation Vault 01 (Behind Force Field)",
+                "Celestial Archives/Incubation Vault 01/Portal to Incubation Vault 02 (Artifact Shield)": "Celestial Archives/Incubation Vault 02/Portal to Incubation Vault 01 (Lower Level)",
+                "Celestial Archives/Incubation Vault 01/Portal to Docking Bay (Behind Force Field)": "Celestial Archives/Docking Bay/Portal to Incubation Vault 01",
+                "Celestial Archives/Incubation Vault 02/Portal to Docking Bay": "Celestial Archives/Docking Bay/Portal to Incubation Vault 02",
+                "Celestial Archives/Incubation Vault 02/Portal to Incubation Vault 01 (Upper Level)": "Celestial Archives/Incubation Vault 01/Portal to Incubation Vault 02 (Bridge)",
+                "Celestial Archives/Incubation Vault 02/Portal to Incubation Vault 03": "Celestial Archives/Incubation Vault 03/Portal to Incubation Vault 02",
+                "Celestial Archives/Incubation Vault 02/Portal to Incubation Vault 01 (Lower Level)": "Celestial Archives/Incubation Vault 01/Portal to Incubation Vault 02 (Artifact Shield)",
+                "Celestial Archives/Incubation Vault 03/Portal to Tetra Vista": "Celestial Archives/Tetra Vista/Portal to Incubation Vault 03",
+                "Celestial Archives/Incubation Vault 03/Portal to Incubation Vault 02": "Celestial Archives/Incubation Vault 02/Portal to Incubation Vault 03",
+                "Celestial Archives/Incubation Vault 03/Portal to Docking Bay (Main)": "Celestial Archives/Docking Bay/Portal from Incubation Vault 03",
+                "Celestial Archives/Incubation Vault 03/Portal to Docking Bay (Return)": "Celestial Archives/Docking Bay/Portal to Incubation Vault 03",
+                "Celestial Archives/Docking Bay/Portal to Incubation Vault 01": "Celestial Archives/Incubation Vault 01/Portal to Docking Bay (Behind Force Field)",
+                "Celestial Archives/Docking Bay/Portal to Incubation Vault 03": "Celestial Archives/Incubation Vault 03/Portal to Docking Bay (Return)",
+                "Celestial Archives/Docking Bay/Portal to Incubation Vault 02": "Celestial Archives/Incubation Vault 02/Portal to Docking Bay",
+                "Celestial Archives/Docking Bay/Portal to Transfer Lock": "Celestial Archives/Transfer Lock/Portal to Docking Bay",
+                "Celestial Archives/Docking Bay/Portal from Incubation Vault 01": "Celestial Archives/Incubation Vault 01/Portal to Docking Bay (Lower Level)",
+                "Celestial Archives/Docking Bay/Portal from Incubation Vault 03": "Celestial Archives/Incubation Vault 03/Portal to Docking Bay (Main)",
+                "Celestial Archives/Stronghold Void A (Celestial Archives)/Portal to Synergy Core": "Celestial Archives/Synergy Core/Portal to Stronghold Void A (Celestial Archives)",
+                "Celestial Archives/Stronghold Void B (Celestial Archives)/Portal to New Arrival Registration": "Celestial Archives/New Arrival Registration/Portal to Stronghold Void B (Celestial Archives)",
+                "Alinos/Magma Drop/Portal to High Ground": "Alinos/High Ground/Portal from Magma Drop",
+                "Alinos/Magma Drop/Portal from High Ground": "Alinos/High Ground/Portal to Magma Drop",
+                "Alinos/Alinos Gateway/Portal to Council Chamber": "Alinos/Council Chamber/Portal to Alinos Gateway",
+                "Alinos/Alinos Gateway/Portal to Elder Passage": "Alinos/Elder Passage/Portal to Alinos Gateway",
+                "Alinos/High Ground/Portal to Magma Drop": "Alinos/Magma Drop/Portal from High Ground",
+                "Alinos/High Ground/Portal from Magma Drop": "Alinos/Magma Drop/Portal to High Ground",
+                "Alinos/Council Chamber/Portal to Alinos Gateway": "Alinos/Alinos Gateway/Portal to Council Chamber",
+                "Alinos/Processor Core/Portal to Stronghold Void B (Alinos)": "Alinos/Stronghold Void B (Alinos)/Portal to Processor Core",
+                "Alinos/Elder Passage/Portal to Stronghold Void A (Alinos)": "Alinos/Stronghold Void A (Alinos)/Portal to Elder Passage",
+                "Alinos/Elder Passage/Portal to Alinos Gateway": "Alinos/Alinos Gateway/Portal to Elder Passage",
+                "Alinos/Stronghold Void A (Alinos)/Portal to Elder Passage": "Alinos/Elder Passage/Portal to Stronghold Void A (Alinos)",
+                "Alinos/Stronghold Void B (Alinos)/Portal to Processor Core": "Alinos/Processor Core/Portal to Stronghold Void B (Alinos)",
+                "Arcterra/Arcterra Gateway/Portal to Ice Hive": "Arcterra/Ice Hive/Portal to Arcterra Gateway",
+                "Arcterra/Arcterra Gateway/Portal to Fault Line": "Arcterra/Fault Line/Portal to Arcterra Gateway",
+                "Arcterra/Ice Hive/Portal to Stronghold Void A (Arcterra)": "Arcterra/Stronghold Void A (Arcterra)/Portal to Ice Hive",
+                "Arcterra/Ice Hive/Portal to Arcterra Gateway": "Arcterra/Arcterra Gateway/Portal to Ice Hive",
+                "Arcterra/Fault Line/Portal to Stronghold Void B (Arcterra)": "Arcterra/Stronghold Void B (Arcterra)/Portal to Fault Line",
+                "Arcterra/Fault Line/Portal to Arcterra Gateway": "Arcterra/Arcterra Gateway/Portal to Fault Line",
+                "Arcterra/Stronghold Void A (Arcterra)/Portal to Ice Hive": "Arcterra/Ice Hive/Portal to Stronghold Void A (Arcterra)",
+                "Arcterra/Stronghold Void B (Arcterra)/Portal to Fault Line": "Arcterra/Fault Line/Portal to Stronghold Void B (Arcterra)",
+                "Vesper Defense Outpost/Ascension/Portal to VDO Gateway": "Vesper Defense Outpost/VDO Gateway/Portal to Ascension",
+                "Vesper Defense Outpost/VDO Gateway/Portal to Ascension": "Vesper Defense Outpost/Ascension/Portal to VDO Gateway",
+                "Vesper Defense Outpost/VDO Gateway/Portal to Weapons Complex": "Vesper Defense Outpost/Weapons Complex/Portal to VDO Gateway",
+                "Vesper Defense Outpost/Weapons Complex/Portal to VDO Gateway": "Vesper Defense Outpost/VDO Gateway/Portal to Weapons Complex",
+                "Vesper Defense Outpost/Stasis Bunker/Portal to Stronghold Void B (VDO)": "Vesper Defense Outpost/Stronghold Void B (VDO)/Portal to Stasis Bunker",
+                "Vesper Defense Outpost/Compression Chamber/Portal to Stronghold Void A (VDO)": "Vesper Defense Outpost/Stronghold Void A (VDO)/Portal to Compression Chamber",
+                "Vesper Defense Outpost/Stronghold Void A (VDO)/Portal to Compression Chamber": "Vesper Defense Outpost/Compression Chamber/Portal to Stronghold Void A (VDO)",
+                "Vesper Defense Outpost/Stronghold Void B (VDO)/Portal to Stasis Bunker": "Vesper Defense Outpost/Stasis Bunker/Portal to Stronghold Void B (VDO)",
+                "Oubliette/Oubliette Gateway/Portal to Oubliette Storage": "Oubliette/Oubliette Storage/Portal to Oubliette Gateway",
+                "Oubliette/Oubliette Gateway/Portal to Oubliette Gateway (Elevator Room)": "Oubliette/Oubliette Gateway/Portal to Oubliette Gateway (Lookout Room)",
+                "Oubliette/Oubliette Gateway/Portal to Oubliette Gateway (Lookout Room)": "Oubliette/Oubliette Gateway/Portal to Oubliette Gateway (Elevator Room)",
+                "Oubliette/Oubliette Storage/Portal to Oubliette Gateway": "Oubliette/Oubliette Gateway/Portal to Oubliette Storage"
+            },
+            "dock_weakness": {},
+            "locations": [
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Alinos Gateway",
+                        "node": "Pickup (Missile Expansion)"
+                    },
+                    "index": 7,
+                    "pickup": "Battlehammer",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Alinos Perch",
+                        "node": "Pickup (Missile Expansion)"
+                    },
+                    "index": 10,
+                    "pickup": "Volt Driver",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Biodefense Chamber A (Alinos)",
+                        "node": "Pickup (Octolith)"
+                    },
+                    "index": 0,
+                    "pickup": "Celestial Cartograph Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Biodefense Chamber B (Alinos)",
+                        "node": "Pickup (Octolith)"
+                    },
+                    "index": 1,
+                    "pickup": "VDO Cartograph Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Council Chamber",
+                        "node": "Pickup (Attameter Artifact)"
+                    },
+                    "index": 12,
+                    "pickup": "Missile Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Council Chamber",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 11,
+                    "pickup": "VDO Binary Subscripture Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Council Chamber",
+                        "node": "Pickup (Magmaul)"
+                    },
+                    "index": 13,
+                    "pickup": "Shock Coil",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Council Chamber",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 93,
+                    "pickup": "Alinos CouncilChamber Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Crash Site",
+                        "node": "Pickup (Cartograph Artifact)"
+                    },
+                    "index": 4,
+                    "pickup": "Missile Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Crash Site",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 94,
+                    "pickup": "Alinos CrashSite Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Echo Hall",
+                        "node": "Pickup (Cartograph Artifact)"
+                    },
+                    "index": 2,
+                    "pickup": "Alinos Binary Subscripture Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Echo Hall",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 3,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Echo Hall",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 95,
+                    "pickup": "Alinos EchoHall Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Elder Passage",
+                        "node": "Pickup (Attameter Artifact)"
+                    },
+                    "index": 15,
+                    "pickup": "Judicator",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Elder Passage",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 96,
+                    "pickup": "Alinos ElderPassage Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "High Ground",
+                        "node": "Pickup (Binary Subscripture Artifact)"
+                    },
+                    "index": 8,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "High Ground",
+                        "node": "Pickup (Missile Expansion)"
+                    },
+                    "index": 9,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "High Ground",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 97,
+                    "pickup": "Alinos HighGround Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Magma Drop",
+                        "node": "Pickup (UA Expansion)"
+                    },
+                    "index": 5,
+                    "pickup": "Energy Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Piston Cave",
+                        "node": "Pickup (Binary Subcripture Artifact)"
+                    },
+                    "index": 6,
+                    "pickup": "VDO Binary Subscripture Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Piston Cave",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 98,
+                    "pickup": "Alinos PistonCave Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Alinos",
+                        "area": "Processor Core",
+                        "node": "Pickup (UA Expansion)"
+                    },
+                    "index": 14,
+                    "pickup": "Alinos Attameter Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Biodefense Chamber A (Arcterra)",
+                        "node": "Pickup (Octolith)"
+                    },
+                    "index": 45,
+                    "pickup": "Energy Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Biodefense Chamber B (Arcterra)",
+                        "node": "Pickup (Octolith)"
+                    },
+                    "index": 46,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Drip Moat",
+                        "node": "Pickup (UA Expansion)"
+                    },
+                    "index": 49,
+                    "pickup": "Energy Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Fault Line",
+                        "node": "Pickup (Attameter Artifact)"
+                    },
+                    "index": 62,
+                    "pickup": "Celestial Binary Subscripture Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Fault Line",
+                        "node": "Pickup (Imperialist)"
+                    },
+                    "index": 61,
+                    "pickup": "Alinos Cartograph Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Fault Line",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 99,
+                    "pickup": "Arcterra FaultLine Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Frost Labyrinth",
+                        "node": "Pickup (Binary Subscripture Artifact)"
+                    },
+                    "index": 47,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Frost Labyrinth",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 48,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Frost Labyrinth",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 100,
+                    "pickup": "Arcterra FrostLabyrinth Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Ice Hive",
+                        "node": "Pickup (Cartograph Artifact)"
+                    },
+                    "index": 50,
+                    "pickup": "Missile Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Ice Hive",
+                        "node": "Pickup (Judicator)"
+                    },
+                    "index": 53,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Ice Hive",
+                        "node": "Pickup (Missile Expansion)"
+                    },
+                    "index": 51,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Ice Hive",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 101,
+                    "pickup": "Arcterra IceHive Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Ice Hive",
+                        "node": "Pickup (UA Expansion - Alcove)"
+                    },
+                    "index": 54,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Ice Hive",
+                        "node": "Pickup (UA Expansion - War Wasps)"
+                    },
+                    "index": 52,
+                    "pickup": "VDO Attameter Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Sanctorus",
+                        "node": "Pickup (Binary Subscripture Artifact)"
+                    },
+                    "index": 59,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Sanctorus",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 102,
+                    "pickup": "Arcterra Sanctorus Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Sanctorus",
+                        "node": "Pickup (UA Expansion)"
+                    },
+                    "index": 60,
+                    "pickup": "Arcterra Cartograph Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Sic Transit",
+                        "node": "Pickup (Attameter Artifact)"
+                    },
+                    "index": 58,
+                    "pickup": "Energy Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Sic Transit",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 57,
+                    "pickup": "Alinos Binary Subscripture Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Sic Transit",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 103,
+                    "pickup": "Arcterra SicTransit Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Subterranean",
+                        "node": "Pickup (Cartograph Artifact)"
+                    },
+                    "index": 55,
+                    "pickup": "Arcterra Attameter Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Subterranean",
+                        "node": "Pickup (Missile Expansion)"
+                    },
+                    "index": 56,
+                    "pickup": "Missile Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Arcterra",
+                        "area": "Subterranean",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 104,
+                    "pickup": "Arcterra Subterranean Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Biodefense Chamber A (Celestial Archives)",
+                        "node": "Pickup (Octolith)"
+                    },
+                    "index": 16,
+                    "pickup": "Missile Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Biodefense Chamber B (Celestial Archives)",
+                        "node": "Pickup (Octolith)"
+                    },
+                    "index": 17,
+                    "pickup": "Magmaul",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Celestial Gateway",
+                        "node": "Pickup (UA Expansion)"
+                    },
+                    "index": 21,
+                    "pickup": "Missile Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Data Shrine 01",
+                        "node": "Pickup (Cartograph Artifact)"
+                    },
+                    "index": 22,
+                    "pickup": "Missile Launcher",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Data Shrine 01",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 23,
+                    "pickup": "Arcterra Cartograph Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Data Shrine 01",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 105,
+                    "pickup": "CelestialArchives DataShrine01 Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Data Shrine 02",
+                        "node": "Pickup (Missile Expansion)"
+                    },
+                    "index": 25,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Data Shrine 02",
+                        "node": "Pickup (UA Expansion)"
+                    },
+                    "index": 26,
+                    "pickup": "Celestial Attameter Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Data Shrine 02",
+                        "node": "Pickup (Volt Driver)"
+                    },
+                    "index": 24,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Data Shrine 03",
+                        "node": "Pickup (Attameter Artifact)"
+                    },
+                    "index": 27,
+                    "pickup": "VDO Cartograph Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Data Shrine 03",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 106,
+                    "pickup": "CelestialArchives DataShrine03 Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Docking Bay",
+                        "node": "Pickup (Cartograph Artifact)"
+                    },
+                    "index": 31,
+                    "pickup": "Arcterra Binary Subscripture Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Docking Bay",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 107,
+                    "pickup": "CelestialArchives DockingBay Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Docking Bay",
+                        "node": "Pickup (UA Expansion)"
+                    },
+                    "index": 32,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Incubation Vault 01",
+                        "node": "Pickup (Attameter Artifact)"
+                    },
+                    "index": 28,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Incubation Vault 01",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 108,
+                    "pickup": "CelestialArchives IncubationVault01 Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Incubation Vault 02",
+                        "node": "Pickup (Shock Coil)"
+                    },
+                    "index": 29,
+                    "pickup": "Missile Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Incubation Vault 03",
+                        "node": "Pickup (Missile Expansion)"
+                    },
+                    "index": 30,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "New Arrival Registration",
+                        "node": "Pickup (Binary Subscripture Artifact)"
+                    },
+                    "index": 19,
+                    "pickup": "Nothing",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "New Arrival Registration",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 20,
+                    "pickup": "Arcterra Binary Subscripture Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "New Arrival Registration",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 109,
+                    "pickup": "CelestialArchives NewArrivalRegistration Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Synergy Core",
+                        "node": "Pickup (Binary Subscripture Artifact)"
+                    },
+                    "index": 18,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Synergy Core",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 110,
+                    "pickup": "CelestialArchives SynergyCore Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Celestial Archives",
+                        "area": "Transfer Lock",
+                        "node": "Pickup (UA Expansion)"
+                    },
+                    "index": 63,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Oubliette",
+                        "area": "Oubliette Storage",
+                        "node": "Pickup (Energy Tank)"
+                    },
+                    "index": 64,
+                    "pickup": "Energy Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Biodefense Chamber A (VDO)",
+                        "node": "Pickup (Octolith)"
+                    },
+                    "index": 33,
+                    "pickup": "Celestial Attameter Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Biodefense Chamber B (VDO)",
+                        "node": "Pickup (Octolith)"
+                    },
+                    "index": 34,
+                    "pickup": "Missile Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Compression Chamber",
+                        "node": "Pickup (Binary Subscripture Artifact)"
+                    },
+                    "index": 43,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Compression Chamber",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 111,
+                    "pickup": "VDO CompressionChamber Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Compression Chamber",
+                        "node": "Pickup (UA Expansion)"
+                    },
+                    "index": 44,
+                    "pickup": "Celestial Cartograph Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Cortex CPU",
+                        "node": "Pickup (Battlehammer)"
+                    },
+                    "index": 35,
+                    "pickup": "Imperialist",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Cortex CPU",
+                        "node": "Pickup (Missile Expansion)"
+                    },
+                    "index": 36,
+                    "pickup": "VDO Attameter Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Fuel Stack",
+                        "node": "Pickup (Binary Subscripture Artifact)"
+                    },
+                    "index": 39,
+                    "pickup": "Energy Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Fuel Stack",
+                        "node": "Pickup (Missile Expansion)"
+                    },
+                    "index": 40,
+                    "pickup": "Alinos Cartograph Artifact 2",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Fuel Stack",
+                        "node": "Pickup (Shield Key)"
+                    },
+                    "index": 112,
+                    "pickup": "VDO FuelStack Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Stasis Bunker",
+                        "node": "Pickup (Attameter Artifact)"
+                    },
+                    "index": 42,
+                    "pickup": "Celestial Binary Subscripture Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Stasis Bunker",
+                        "node": "Pickup (Cartograph Artifact)"
+                    },
+                    "index": 41,
+                    "pickup": "Arcterra Attameter Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Stasis Bunker",
+                        "node": "Pickup (Shield Key Guardians)"
+                    },
+                    "index": 114,
+                    "pickup": "VDO StasisBunkerGuardians Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Stasis Bunker",
+                        "node": "Pickup (Shield Key Puzzle)"
+                    },
+                    "index": 113,
+                    "pickup": "VDO StasisBunkerPuzzle Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Stasis Bunker",
+                        "node": "Pickup (UA Expansion)"
+                    },
+                    "index": 65,
+                    "pickup": "Energy Tank",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Weapons Complex",
+                        "node": "Pickup (Attameter Artifact)"
+                    },
+                    "index": 38,
+                    "pickup": "Alinos Attameter Artifact 1",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Weapons Complex",
+                        "node": "Pickup (Cartograph Artifact)"
+                    },
+                    "index": 37,
+                    "pickup": "UA Expansion",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Weapons Complex",
+                        "node": "Pickup (Shield Key Psycho Bits)"
+                    },
+                    "index": 115,
+                    "pickup": "VDO WeaponsComplexPsychoBits Shield Key",
+                    "owner": 0
+                },
+                {
+                    "node_identifier": {
+                        "region": "Vesper Defense Outpost",
+                        "area": "Weapons Complex",
+                        "node": "Pickup (Shield Key Sylux)"
+                    },
+                    "index": 116,
+                    "pickup": "VDO WeaponsComplexSylux Shield Key",
+                    "owner": 0
+                }
+            ],
+            "hints": {
+                "Alinos/Alimbic Cannon Control Room/Lore Scan 1": {
+                    "hint_type": "joke"
+                },
+                "Alinos/Alimbic Cannon Control Room/Lore Scan 2": {
+                    "hint_type": "joke"
+                },
+                "Alinos/Alimbic Cannon Control Room/Lore Scan 3": {
+                    "hint_type": "joke"
+                },
+                "Alinos/Alimbic Cannon Control Room/Lore Scan 4": {
+                    "hint_type": "joke"
+                }
+            },
+            "game_specific": {
+                "force_fields": {
+                    "Celestial Archives/Synergy Core/Volt Driver Force Field": "volt-driver",
+                    "Celestial Archives/Celestial Gateway/Battlehammer Force Field": "battlehammer",
+                    "Celestial Archives/Incubation Vault 01/Shock Coil Force Field": "shock-coil",
+                    "Celestial Archives/Incubation Vault 02/Shock Coil Force Field": "shock-coil",
+                    "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Upper)": "shock-coil",
+                    "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Lower)": "shock-coil",
+                    "Alinos/High Ground/Volt Driver Force Field (Upper)": "volt-driver",
+                    "Alinos/High Ground/Volt Driver Force Field (East)": "volt-driver",
+                    "Alinos/High Ground/Volt Driver Force Field (South)": "volt-driver",
+                    "Alinos/High Ground/Volt Driver Force Field (North)": "volt-driver",
+                    "Alinos/High Ground/Judicator Force Field (Upper)": "judicator",
+                    "Alinos/High Ground/Judicator Force Field (Lower)": "judicator",
+                    "Alinos/Alinos Perch/Magmaul Force Field": "magmaul",
+                    "Alinos/Council Chamber/Magmaul Force Field (Upper)": "magmaul",
+                    "Alinos/Council Chamber/Magmaul Force Field (Jump Pad)": "magmaul",
+                    "Alinos/Council Chamber/Magmaul Force Field (Entrance)": "magmaul",
+                    "Arcterra/Ice Hive/Judicator Force Field (Entrance)": "judicator",
+                    "Arcterra/Ice Hive/Judicator Force Field (Bridge)": "judicator",
+                    "Arcterra/Ice Hive/Judicator Force Field (Alcove)": "judicator",
+                    "Arcterra/Ice Hive/Judicator Force Field (War Wasps)": "judicator",
+                    "Arcterra/Ice Hive/Judicator Force Field (Judicator Room)": "judicator",
+                    "Vesper Defense Outpost/Cortex CPU/Battlehammer Force Field": "battlehammer",
+                    "Vesper Defense Outpost/Weapons Complex/Battlehammer Force Field": "battlehammer",
+                    "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Left)": "battlehammer",
+                    "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Right)": "battlehammer"
+                }
+            }
+        }
+    ],
+    "item_order": [
+        "Battlehammer at Alinos/Alinos Gateway/Pickup (Missile Expansion)",
+        "Imperialist at Vesper Defense Outpost/Cortex CPU/Pickup (Battlehammer)",
+        "Judicator at Alinos/Elder Passage/Pickup (Attameter Artifact)",
+        "Energy Tank at Oubliette/Oubliette Storage/Pickup (Energy Tank)",
+        "Energy Tank at Arcterra/Drip Moat/Pickup (UA Expansion)",
+        "Energy Tank at Alinos/Magma Drop/Pickup (UA Expansion)",
+        "Energy Tank at Vesper Defense Outpost/Stasis Bunker/Pickup (UA Expansion)",
+        "Energy Tank at Arcterra/Sic Transit/Pickup (Attameter Artifact)"
+    ],
+    "checksum": "e274732c52eb5a6c6e3e95b05bf9498a6a93acd40bca089d3fba05e94afc838e1ebdc4e47437a08e2b5fd4cb6549ab60da078b0889360f542d6a5e8b50860270"
+}

--- a/test/test_files/log_files/prime_hunters/shuffled_extra_locations_and_skip_planet_intros.rdvgame
+++ b/test/test_files/log_files/prime_hunters/shuffled_extra_locations_and_skip_planet_intros.rdvgame
@@ -1,19 +1,19 @@
 {
-    "schema_version": 41,
+    "schema_version": 42,
     "info": {
-        "randovania_version": "10.9.0.dev322",
-        "randovania_version_git": "8759c3c5",
-        "permalink": "DYnYMShx54dZw8UWPVlNS_tHH22T_ZSE_7ATM8oyqxT2fuG5",
+        "randovania_version": "10.10.0.dev186",
+        "randovania_version_git": "3983b205",
+        "permalink": "DZnLdOeRfzmDsgUXTojGOP-nj-0jnEREz4ADMtrS21fNI_8AAFrF",
         "has_spoiler": true,
-        "seed": 298617331,
-        "hash": "3AYSQ4PH",
-        "word_hash": "Final Slench Bomb",
+        "seed": 1436480800,
+        "hash": "ZN2OPEL7",
+        "word_hash": "Guardian Subterranean Lockjaw",
         "presets": [
             {
                 "schema_version": 118,
                 "base_preset_uuid": null,
                 "name": "Starter Preset Copy",
-                "uuid": "364436a0-25c6-49d1-a490-9e32cdb1db7d",
+                "uuid": "2ec8c933-e854-4faa-a367-fda033af45f5",
                 "description": "A copy version of Starter Preset.",
                 "game": "prime_hunters",
                 "configuration": {
@@ -66,19 +66,19 @@
                                 "num_shuffled_pickups": 5
                             },
                             "Medium Energy": {
-                                "num_shuffled_pickups": 5
+                                "num_shuffled_pickups": 4
                             },
                             "Large Energy": {
-                                "num_shuffled_pickups": 5
+                                "num_shuffled_pickups": 4
                             },
                             "Small UA Pack": {
-                                "num_shuffled_pickups": 5
+                                "num_shuffled_pickups": 4
                             },
                             "Large UA Pack": {
                                 "num_shuffled_pickups": 4
                             },
                             "Small Missile Pack": {
-                                "num_shuffled_pickups": 5
+                                "num_shuffled_pickups": 4
                             },
                             "Large Missile Pack": {
                                 "num_shuffled_pickups": 4
@@ -140,16 +140,10 @@
                     },
                     "octoliths": {
                         "prefer_bosses": true,
-                        "placed_octoliths": 4
+                        "placed_octoliths": 8
                     },
                     "force_field_configuration": {
                         "force_field_requirement": {
-                            "Celestial Archives/Synergy Core/Volt Driver Force Field": "volt-driver",
-                            "Celestial Archives/Celestial Gateway/Battlehammer Force Field": "battlehammer",
-                            "Celestial Archives/Incubation Vault 01/Shock Coil Force Field": "shock-coil",
-                            "Celestial Archives/Incubation Vault 02/Shock Coil Force Field": "shock-coil",
-                            "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Upper)": "shock-coil",
-                            "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Lower)": "shock-coil",
                             "Alinos/High Ground/Volt Driver Force Field (Upper)": "volt-driver",
                             "Alinos/High Ground/Volt Driver Force Field (East)": "volt-driver",
                             "Alinos/High Ground/Volt Driver Force Field (South)": "volt-driver",
@@ -160,15 +154,21 @@
                             "Alinos/Council Chamber/Magmaul Force Field (Upper)": "magmaul",
                             "Alinos/Council Chamber/Magmaul Force Field (Jump Pad)": "magmaul",
                             "Alinos/Council Chamber/Magmaul Force Field (Entrance)": "magmaul",
+                            "Celestial Archives/Synergy Core/Volt Driver Force Field": "volt-driver",
+                            "Celestial Archives/Celestial Gateway/Battlehammer Force Field": "battlehammer",
+                            "Celestial Archives/Incubation Vault 01/Shock Coil Force Field": "shock-coil",
+                            "Celestial Archives/Incubation Vault 02/Shock Coil Force Field": "shock-coil",
+                            "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Upper)": "shock-coil",
+                            "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Lower)": "shock-coil",
+                            "Vesper Defense Outpost/Cortex CPU/Battlehammer Force Field": "battlehammer",
+                            "Vesper Defense Outpost/Weapons Complex/Battlehammer Force Field": "battlehammer",
+                            "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Left)": "battlehammer",
+                            "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Right)": "battlehammer",
                             "Arcterra/Ice Hive/Judicator Force Field (Entrance)": "judicator",
                             "Arcterra/Ice Hive/Judicator Force Field (Bridge)": "judicator",
                             "Arcterra/Ice Hive/Judicator Force Field (Alcove)": "judicator",
                             "Arcterra/Ice Hive/Judicator Force Field (War Wasps)": "judicator",
-                            "Arcterra/Ice Hive/Judicator Force Field (Judicator Room)": "judicator",
-                            "Vesper Defense Outpost/Cortex CPU/Battlehammer Force Field": "battlehammer",
-                            "Vesper Defense Outpost/Weapons Complex/Battlehammer Force Field": "battlehammer",
-                            "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Left)": "battlehammer",
-                            "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Right)": "battlehammer"
+                            "Arcterra/Ice Hive/Judicator Force Field (Judicator Room)": "judicator"
                         }
                     },
                     "teleporters": {
@@ -188,15 +188,22 @@
         {
             "game": "prime_hunters",
             "starting_equipment": {
-                "pickups": [
-                    "Octolith 5",
-                    "Octolith 6",
-                    "Octolith 7",
-                    "Octolith 8"
-                ]
+                "pickups": []
             },
             "starting_location": "Celestial Archives/Celestial Gateway/Ship",
             "dock_connections": {
+                "Alinos/Magma Drop/Portal to High Ground": "Alinos/High Ground/Portal from Magma Drop",
+                "Alinos/Magma Drop/Portal from High Ground": "Alinos/High Ground/Portal to Magma Drop",
+                "Alinos/Alinos Gateway/Portal to Council Chamber": "Alinos/Council Chamber/Portal to Alinos Gateway",
+                "Alinos/Alinos Gateway/Portal to Elder Passage": "Alinos/Elder Passage/Portal to Alinos Gateway",
+                "Alinos/High Ground/Portal to Magma Drop": "Alinos/Magma Drop/Portal from High Ground",
+                "Alinos/High Ground/Portal from Magma Drop": "Alinos/Magma Drop/Portal to High Ground",
+                "Alinos/Council Chamber/Portal to Alinos Gateway": "Alinos/Alinos Gateway/Portal to Council Chamber",
+                "Alinos/Processor Core/Portal to Stronghold Void B (Alinos)": "Alinos/Stronghold Void B (Alinos)/Portal to Processor Core",
+                "Alinos/Elder Passage/Portal to Stronghold Void A (Alinos)": "Alinos/Stronghold Void A (Alinos)/Portal to Elder Passage",
+                "Alinos/Elder Passage/Portal to Alinos Gateway": "Alinos/Alinos Gateway/Portal to Elder Passage",
+                "Alinos/Stronghold Void A (Alinos)/Portal to Elder Passage": "Alinos/Elder Passage/Portal to Stronghold Void A (Alinos)",
+                "Alinos/Stronghold Void B (Alinos)/Portal to Processor Core": "Alinos/Processor Core/Portal to Stronghold Void B (Alinos)",
                 "Celestial Archives/Synergy Core/Portal to Stronghold Void A (Celestial Archives)": "Celestial Archives/Stronghold Void A (Celestial Archives)/Portal to Synergy Core",
                 "Celestial Archives/Synergy Core/Portal to Transfer Lock": "Celestial Archives/Transfer Lock/Portal to Synergy Core",
                 "Celestial Archives/Synergy Core/Portal to Celestial Gateway": "Celestial Archives/Celestial Gateway/Portal to Synergy Core",
@@ -229,26 +236,6 @@
                 "Celestial Archives/Docking Bay/Portal from Incubation Vault 03": "Celestial Archives/Incubation Vault 03/Portal to Docking Bay (Main)",
                 "Celestial Archives/Stronghold Void A (Celestial Archives)/Portal to Synergy Core": "Celestial Archives/Synergy Core/Portal to Stronghold Void A (Celestial Archives)",
                 "Celestial Archives/Stronghold Void B (Celestial Archives)/Portal to New Arrival Registration": "Celestial Archives/New Arrival Registration/Portal to Stronghold Void B (Celestial Archives)",
-                "Alinos/Magma Drop/Portal to High Ground": "Alinos/High Ground/Portal from Magma Drop",
-                "Alinos/Magma Drop/Portal from High Ground": "Alinos/High Ground/Portal to Magma Drop",
-                "Alinos/Alinos Gateway/Portal to Council Chamber": "Alinos/Council Chamber/Portal to Alinos Gateway",
-                "Alinos/Alinos Gateway/Portal to Elder Passage": "Alinos/Elder Passage/Portal to Alinos Gateway",
-                "Alinos/High Ground/Portal to Magma Drop": "Alinos/Magma Drop/Portal from High Ground",
-                "Alinos/High Ground/Portal from Magma Drop": "Alinos/Magma Drop/Portal to High Ground",
-                "Alinos/Council Chamber/Portal to Alinos Gateway": "Alinos/Alinos Gateway/Portal to Council Chamber",
-                "Alinos/Processor Core/Portal to Stronghold Void B (Alinos)": "Alinos/Stronghold Void B (Alinos)/Portal to Processor Core",
-                "Alinos/Elder Passage/Portal to Stronghold Void A (Alinos)": "Alinos/Stronghold Void A (Alinos)/Portal to Elder Passage",
-                "Alinos/Elder Passage/Portal to Alinos Gateway": "Alinos/Alinos Gateway/Portal to Elder Passage",
-                "Alinos/Stronghold Void A (Alinos)/Portal to Elder Passage": "Alinos/Elder Passage/Portal to Stronghold Void A (Alinos)",
-                "Alinos/Stronghold Void B (Alinos)/Portal to Processor Core": "Alinos/Processor Core/Portal to Stronghold Void B (Alinos)",
-                "Arcterra/Arcterra Gateway/Portal to Ice Hive": "Arcterra/Ice Hive/Portal to Arcterra Gateway",
-                "Arcterra/Arcterra Gateway/Portal to Fault Line": "Arcterra/Fault Line/Portal to Arcterra Gateway",
-                "Arcterra/Ice Hive/Portal to Stronghold Void A (Arcterra)": "Arcterra/Stronghold Void A (Arcterra)/Portal to Ice Hive",
-                "Arcterra/Ice Hive/Portal to Arcterra Gateway": "Arcterra/Arcterra Gateway/Portal to Ice Hive",
-                "Arcterra/Fault Line/Portal to Stronghold Void B (Arcterra)": "Arcterra/Stronghold Void B (Arcterra)/Portal to Fault Line",
-                "Arcterra/Fault Line/Portal to Arcterra Gateway": "Arcterra/Arcterra Gateway/Portal to Fault Line",
-                "Arcterra/Stronghold Void A (Arcterra)/Portal to Ice Hive": "Arcterra/Ice Hive/Portal to Stronghold Void A (Arcterra)",
-                "Arcterra/Stronghold Void B (Arcterra)/Portal to Fault Line": "Arcterra/Fault Line/Portal to Stronghold Void B (Arcterra)",
                 "Vesper Defense Outpost/Ascension/Portal to VDO Gateway": "Vesper Defense Outpost/VDO Gateway/Portal to Ascension",
                 "Vesper Defense Outpost/VDO Gateway/Portal to Ascension": "Vesper Defense Outpost/Ascension/Portal to VDO Gateway",
                 "Vesper Defense Outpost/VDO Gateway/Portal to Weapons Complex": "Vesper Defense Outpost/Weapons Complex/Portal to VDO Gateway",
@@ -257,6 +244,14 @@
                 "Vesper Defense Outpost/Compression Chamber/Portal to Stronghold Void A (VDO)": "Vesper Defense Outpost/Stronghold Void A (VDO)/Portal to Compression Chamber",
                 "Vesper Defense Outpost/Stronghold Void A (VDO)/Portal to Compression Chamber": "Vesper Defense Outpost/Compression Chamber/Portal to Stronghold Void A (VDO)",
                 "Vesper Defense Outpost/Stronghold Void B (VDO)/Portal to Stasis Bunker": "Vesper Defense Outpost/Stasis Bunker/Portal to Stronghold Void B (VDO)",
+                "Arcterra/Arcterra Gateway/Portal to Ice Hive": "Arcterra/Ice Hive/Portal to Arcterra Gateway",
+                "Arcterra/Arcterra Gateway/Portal to Fault Line": "Arcterra/Fault Line/Portal to Arcterra Gateway",
+                "Arcterra/Ice Hive/Portal to Stronghold Void A (Arcterra)": "Arcterra/Stronghold Void A (Arcterra)/Portal to Ice Hive",
+                "Arcterra/Ice Hive/Portal to Arcterra Gateway": "Arcterra/Arcterra Gateway/Portal to Ice Hive",
+                "Arcterra/Fault Line/Portal to Stronghold Void B (Arcterra)": "Arcterra/Stronghold Void B (Arcterra)/Portal to Fault Line",
+                "Arcterra/Fault Line/Portal to Arcterra Gateway": "Arcterra/Arcterra Gateway/Portal to Fault Line",
+                "Arcterra/Stronghold Void A (Arcterra)/Portal to Ice Hive": "Arcterra/Ice Hive/Portal to Stronghold Void A (Arcterra)",
+                "Arcterra/Stronghold Void B (Arcterra)/Portal to Fault Line": "Arcterra/Fault Line/Portal to Stronghold Void B (Arcterra)",
                 "Oubliette/Oubliette Gateway/Portal to Oubliette Storage": "Oubliette/Oubliette Storage/Portal to Oubliette Gateway",
                 "Oubliette/Oubliette Gateway/Portal to Oubliette Gateway (Elevator Room)": "Oubliette/Oubliette Gateway/Portal to Oubliette Gateway (Lookout Room)",
                 "Oubliette/Oubliette Gateway/Portal to Oubliette Gateway (Lookout Room)": "Oubliette/Oubliette Gateway/Portal to Oubliette Gateway (Elevator Room)",
@@ -271,7 +266,7 @@
                         "node": "Pickup (Missile Expansion)"
                     },
                     "index": 7,
-                    "pickup": "Imperialist",
+                    "pickup": "UA Expansion",
                     "owner": 0
                 },
                 {
@@ -281,7 +276,7 @@
                         "node": "Pickup (Missile Expansion)"
                     },
                     "index": 10,
-                    "pickup": "Celestial Binary Subscripture Artifact 1",
+                    "pickup": "UA Expansion",
                     "owner": 0
                 },
                 {
@@ -291,7 +286,7 @@
                         "node": "Pickup (Octolith)"
                     },
                     "index": 0,
-                    "pickup": "Octolith 3",
+                    "pickup": "Octolith 1",
                     "owner": 0
                 },
                 {
@@ -301,7 +296,7 @@
                         "node": "Pickup (Small Energy Left)"
                     },
                     "index": 66,
-                    "pickup": "Small Energy",
+                    "pickup": "Energy Tank",
                     "owner": 0
                 },
                 {
@@ -321,7 +316,7 @@
                         "node": "Pickup (Medium Energy)"
                     },
                     "index": 69,
-                    "pickup": "VDO Attameter Artifact 1",
+                    "pickup": "Energy Tank",
                     "owner": 0
                 },
                 {
@@ -331,7 +326,7 @@
                         "node": "Pickup (Octolith)"
                     },
                     "index": 1,
-                    "pickup": "Energy Tank",
+                    "pickup": "Octolith 4",
                     "owner": 0
                 },
                 {
@@ -341,7 +336,7 @@
                         "node": "Pickup (Small Energy Left)"
                     },
                     "index": 68,
-                    "pickup": "Arcterra Cartograph Artifact 2",
+                    "pickup": "Arcterra Attameter Artifact 1",
                     "owner": 0
                 },
                 {
@@ -351,7 +346,7 @@
                         "node": "Pickup (Small Energy Right)"
                     },
                     "index": 70,
-                    "pickup": "UA Expansion",
+                    "pickup": "Small Energy",
                     "owner": 0
                 },
                 {
@@ -361,7 +356,7 @@
                         "node": "Pickup (Attameter Artifact)"
                     },
                     "index": 12,
-                    "pickup": "VDO WeaponsComplexSylux Shield Key",
+                    "pickup": "Arcterra Cartograph Artifact 2",
                     "owner": 0
                 },
                 {
@@ -371,7 +366,7 @@
                         "node": "Pickup (Energy Tank)"
                     },
                     "index": 11,
-                    "pickup": "Small UA Pack",
+                    "pickup": "Celestial Cartograph Artifact 1",
                     "owner": 0
                 },
                 {
@@ -381,7 +376,7 @@
                         "node": "Pickup (Magmaul)"
                     },
                     "index": 13,
-                    "pickup": "VDO FuelStack Shield Key",
+                    "pickup": "Medium Energy",
                     "owner": 0
                 },
                 {
@@ -391,7 +386,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 93,
-                    "pickup": "Alinos Binary Subscripture Artifact 2",
+                    "pickup": "VDO Attameter Artifact 1",
                     "owner": 0
                 },
                 {
@@ -401,7 +396,7 @@
                         "node": "Pickup (Cartograph Artifact)"
                     },
                     "index": 4,
-                    "pickup": "Celestial Cartograph Artifact 1",
+                    "pickup": "CelestialArchives DataShrine01 Shield Key",
                     "owner": 0
                 },
                 {
@@ -411,7 +406,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 94,
-                    "pickup": "Large UA Pack",
+                    "pickup": "Large Energy",
                     "owner": 0
                 },
                 {
@@ -421,7 +416,7 @@
                         "node": "Pickup (Cartograph Artifact)"
                     },
                     "index": 2,
-                    "pickup": "Arcterra Subterranean Shield Key",
+                    "pickup": "Missile Expansion",
                     "owner": 0
                 },
                 {
@@ -431,7 +426,7 @@
                         "node": "Pickup (Energy Tank)"
                     },
                     "index": 3,
-                    "pickup": "Celestial Attameter Artifact 1",
+                    "pickup": "VDO WeaponsComplexSylux Shield Key",
                     "owner": 0
                 },
                 {
@@ -441,7 +436,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 95,
-                    "pickup": "Large Energy",
+                    "pickup": "Alinos Binary Subscripture Artifact 1",
                     "owner": 0
                 },
                 {
@@ -451,7 +446,7 @@
                         "node": "Pickup (Attameter Artifact)"
                     },
                     "index": 15,
-                    "pickup": "Medium Energy",
+                    "pickup": "Missile Launcher",
                     "owner": 0
                 },
                 {
@@ -461,7 +456,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 96,
-                    "pickup": "Alinos HighGround Shield Key",
+                    "pickup": "Small Energy",
                     "owner": 0
                 },
                 {
@@ -471,7 +466,7 @@
                         "node": "Pickup (Binary Subscripture Artifact)"
                     },
                     "index": 8,
-                    "pickup": "Missile Launcher",
+                    "pickup": "VDO Binary Subscripture Artifact 1",
                     "owner": 0
                 },
                 {
@@ -481,7 +476,7 @@
                         "node": "Pickup (Large Energy)"
                     },
                     "index": 71,
-                    "pickup": "UA Expansion",
+                    "pickup": "Imperialist",
                     "owner": 0
                 },
                 {
@@ -491,7 +486,7 @@
                         "node": "Pickup (Missile Expansion)"
                     },
                     "index": 9,
-                    "pickup": "Medium Energy",
+                    "pickup": "Small UA Pack",
                     "owner": 0
                 },
                 {
@@ -501,7 +496,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 97,
-                    "pickup": "Missile Expansion",
+                    "pickup": "Battlehammer",
                     "owner": 0
                 },
                 {
@@ -511,7 +506,7 @@
                         "node": "Pickup (UA Expansion)"
                     },
                     "index": 5,
-                    "pickup": "Medium Energy",
+                    "pickup": "Large Energy",
                     "owner": 0
                 },
                 {
@@ -521,7 +516,7 @@
                         "node": "Pickup (Binary Subcripture Artifact)"
                     },
                     "index": 6,
-                    "pickup": "Missile Expansion",
+                    "pickup": "Small Energy",
                     "owner": 0
                 },
                 {
@@ -531,7 +526,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 98,
-                    "pickup": "Celestial Attameter Artifact 2",
+                    "pickup": "Arcterra Cartograph Artifact 1",
                     "owner": 0
                 },
                 {
@@ -541,7 +536,7 @@
                         "node": "Pickup (UA Expansion)"
                     },
                     "index": 14,
-                    "pickup": "Large Energy",
+                    "pickup": "Missile Expansion",
                     "owner": 0
                 },
                 {
@@ -551,7 +546,7 @@
                         "node": "Pickup (Octolith)"
                     },
                     "index": 45,
-                    "pickup": "Small Missile Pack",
+                    "pickup": "Octolith 3",
                     "owner": 0
                 },
                 {
@@ -561,7 +556,7 @@
                         "node": "Pickup (Small Energy Bottom Right)"
                     },
                     "index": 86,
-                    "pickup": "UA Expansion",
+                    "pickup": "VDO Attameter Artifact 2",
                     "owner": 0
                 },
                 {
@@ -571,7 +566,7 @@
                         "node": "Pickup (Small Energy Left)"
                     },
                     "index": 87,
-                    "pickup": "Missile Expansion",
+                    "pickup": "UA Expansion",
                     "owner": 0
                 },
                 {
@@ -581,7 +576,7 @@
                         "node": "Pickup (Small Energy Top Right)"
                     },
                     "index": 88,
-                    "pickup": "Alinos Attameter Artifact 2",
+                    "pickup": "Celestial Cartograph Artifact 2",
                     "owner": 0
                 },
                 {
@@ -591,7 +586,7 @@
                         "node": "Pickup (Medium Energy Left)"
                     },
                     "index": 89,
-                    "pickup": "Large UA Pack",
+                    "pickup": "Small Missile Pack",
                     "owner": 0
                 },
                 {
@@ -601,7 +596,7 @@
                         "node": "Pickup (Medium Energy Right)"
                     },
                     "index": 90,
-                    "pickup": "UA Expansion",
+                    "pickup": "Large Energy",
                     "owner": 0
                 },
                 {
@@ -611,7 +606,7 @@
                         "node": "Pickup (Octolith)"
                     },
                     "index": 46,
-                    "pickup": "Energy Tank",
+                    "pickup": "Octolith 7",
                     "owner": 0
                 },
                 {
@@ -621,7 +616,7 @@
                         "node": "Pickup (Small Energy)"
                     },
                     "index": 91,
-                    "pickup": "Celestial Binary Subscripture Artifact 2",
+                    "pickup": "Small Missile Pack",
                     "owner": 0
                 },
                 {
@@ -631,7 +626,7 @@
                         "node": "Pickup (UA Expansion)"
                     },
                     "index": 49,
-                    "pickup": "Large UA Pack",
+                    "pickup": "Large Missile Pack",
                     "owner": 0
                 },
                 {
@@ -641,7 +636,7 @@
                         "node": "Pickup (Attameter Artifact)"
                     },
                     "index": 62,
-                    "pickup": "CelestialArchives SynergyCore Shield Key",
+                    "pickup": "UA Expansion",
                     "owner": 0
                 },
                 {
@@ -651,7 +646,7 @@
                         "node": "Pickup (Imperialist)"
                     },
                     "index": 61,
-                    "pickup": "CelestialArchives DataShrine03 Shield Key",
+                    "pickup": "Arcterra Sanctorus Shield Key",
                     "owner": 0
                 },
                 {
@@ -661,7 +656,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 99,
-                    "pickup": "Large Missile Pack",
+                    "pickup": "VDO StasisBunkerGuardians Shield Key",
                     "owner": 0
                 },
                 {
@@ -671,7 +666,7 @@
                         "node": "Pickup (Binary Subscripture Artifact)"
                     },
                     "index": 47,
-                    "pickup": "Alinos Cartograph Artifact 1",
+                    "pickup": "Arcterra Binary Subscripture Artifact 2",
                     "owner": 0
                 },
                 {
@@ -681,7 +676,7 @@
                         "node": "Pickup (Energy Tank)"
                     },
                     "index": 48,
-                    "pickup": "Alinos CouncilChamber Shield Key",
+                    "pickup": "Large Energy",
                     "owner": 0
                 },
                 {
@@ -691,7 +686,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 100,
-                    "pickup": "Small Energy",
+                    "pickup": "UA Expansion",
                     "owner": 0
                 },
                 {
@@ -701,7 +696,7 @@
                         "node": "Pickup (Cartograph Artifact)"
                     },
                     "index": 50,
-                    "pickup": "Alinos Cartograph Artifact 2",
+                    "pickup": "UA Expansion",
                     "owner": 0
                 },
                 {
@@ -711,7 +706,7 @@
                         "node": "Pickup (Judicator)"
                     },
                     "index": 53,
-                    "pickup": "Small Missile Pack",
+                    "pickup": "Medium Energy",
                     "owner": 0
                 },
                 {
@@ -721,7 +716,7 @@
                         "node": "Pickup (Missile Expansion)"
                     },
                     "index": 51,
-                    "pickup": "CelestialArchives DataShrine01 Shield Key",
+                    "pickup": "Alinos ElderPassage Shield Key",
                     "owner": 0
                 },
                 {
@@ -741,7 +736,7 @@
                         "node": "Pickup (UA Expansion - Alcove)"
                     },
                     "index": 54,
-                    "pickup": "Medium Energy",
+                    "pickup": "Small UA Pack",
                     "owner": 0
                 },
                 {
@@ -751,7 +746,7 @@
                         "node": "Pickup (UA Expansion - War Wasps)"
                     },
                     "index": 52,
-                    "pickup": "Small Energy",
+                    "pickup": "Alinos CouncilChamber Shield Key",
                     "owner": 0
                 },
                 {
@@ -761,7 +756,7 @@
                         "node": "Pickup (Binary Subscripture Artifact)"
                     },
                     "index": 59,
-                    "pickup": "VDO Binary Subscripture Artifact 1",
+                    "pickup": "CelestialArchives NewArrivalRegistration Shield Key",
                     "owner": 0
                 },
                 {
@@ -771,7 +766,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 102,
-                    "pickup": "VDO Cartograph Artifact 2",
+                    "pickup": "VDO FuelStack Shield Key",
                     "owner": 0
                 },
                 {
@@ -781,7 +776,7 @@
                         "node": "Pickup (UA Expansion)"
                     },
                     "index": 60,
-                    "pickup": "Large Energy",
+                    "pickup": "UA Expansion",
                     "owner": 0
                 },
                 {
@@ -791,7 +786,7 @@
                         "node": "Pickup (Attameter Artifact)"
                     },
                     "index": 58,
-                    "pickup": "Judicator",
+                    "pickup": "VDO WeaponsComplexPsychoBits Shield Key",
                     "owner": 0
                 },
                 {
@@ -801,7 +796,7 @@
                         "node": "Pickup (Energy Tank)"
                     },
                     "index": 57,
-                    "pickup": "Alinos ElderPassage Shield Key",
+                    "pickup": "Judicator",
                     "owner": 0
                 },
                 {
@@ -811,7 +806,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 103,
-                    "pickup": "VDO Attameter Artifact 2",
+                    "pickup": "Shock Coil",
                     "owner": 0
                 },
                 {
@@ -821,7 +816,7 @@
                         "node": "Pickup (Cartograph Artifact)"
                     },
                     "index": 55,
-                    "pickup": "Arcterra FaultLine Shield Key",
+                    "pickup": "CelestialArchives SynergyCore Shield Key",
                     "owner": 0
                 },
                 {
@@ -841,7 +836,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 104,
-                    "pickup": "Missile Expansion",
+                    "pickup": "UA Expansion",
                     "owner": 0
                 },
                 {
@@ -851,7 +846,7 @@
                         "node": "Pickup (Octolith)"
                     },
                     "index": 16,
-                    "pickup": "Energy Tank",
+                    "pickup": "Octolith 6",
                     "owner": 0
                 },
                 {
@@ -871,7 +866,7 @@
                         "node": "Pickup (Small Energy Right)"
                     },
                     "index": 73,
-                    "pickup": "Small UA Pack",
+                    "pickup": "UA Expansion",
                     "owner": 0
                 },
                 {
@@ -881,7 +876,7 @@
                         "node": "Pickup (Small Energy Top Left)"
                     },
                     "index": 74,
-                    "pickup": "UA Expansion",
+                    "pickup": "Alinos CrashSite Shield Key",
                     "owner": 0
                 },
                 {
@@ -891,7 +886,7 @@
                         "node": "Pickup (Medium Energy)"
                     },
                     "index": 75,
-                    "pickup": "Large UA Pack",
+                    "pickup": "Energy Tank",
                     "owner": 0
                 },
                 {
@@ -901,7 +896,7 @@
                         "node": "Pickup (Octolith)"
                     },
                     "index": 17,
-                    "pickup": "Octolith 4",
+                    "pickup": "Octolith 8",
                     "owner": 0
                 },
                 {
@@ -911,7 +906,7 @@
                         "node": "Pickup (Small Energy Left)"
                     },
                     "index": 76,
-                    "pickup": "Missile Expansion",
+                    "pickup": "Large UA Pack",
                     "owner": 0
                 },
                 {
@@ -921,7 +916,7 @@
                         "node": "Pickup (Small Energy Right)"
                     },
                     "index": 77,
-                    "pickup": "VDO Binary Subscripture Artifact 2",
+                    "pickup": "Arcterra Attameter Artifact 2",
                     "owner": 0
                 },
                 {
@@ -931,7 +926,7 @@
                         "node": "Pickup (UA Expansion)"
                     },
                     "index": 21,
-                    "pickup": "Alinos EchoHall Shield Key",
+                    "pickup": "Alinos HighGround Shield Key",
                     "owner": 0
                 },
                 {
@@ -941,7 +936,7 @@
                         "node": "Pickup (Cartograph Artifact)"
                     },
                     "index": 22,
-                    "pickup": "Small Missile Pack",
+                    "pickup": "Large UA Pack",
                     "owner": 0
                 },
                 {
@@ -951,7 +946,7 @@
                         "node": "Pickup (Energy Tank)"
                     },
                     "index": 23,
-                    "pickup": "Alinos PistonCave Shield Key",
+                    "pickup": "Missile Expansion",
                     "owner": 0
                 },
                 {
@@ -961,7 +956,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 105,
-                    "pickup": "Small Energy",
+                    "pickup": "Missile Expansion",
                     "owner": 0
                 },
                 {
@@ -971,7 +966,7 @@
                         "node": "Pickup (Small Energy)"
                     },
                     "index": 78,
-                    "pickup": "Alinos Attameter Artifact 1",
+                    "pickup": "VDO Cartograph Artifact 1",
                     "owner": 0
                 },
                 {
@@ -981,7 +976,7 @@
                         "node": "Pickup (Small Missile Pack)"
                     },
                     "index": 92,
-                    "pickup": "VDO StasisBunkerPuzzle Shield Key",
+                    "pickup": "Arcterra FrostLabyrinth Shield Key",
                     "owner": 0
                 },
                 {
@@ -991,7 +986,7 @@
                         "node": "Pickup (Medium Energy)"
                     },
                     "index": 79,
-                    "pickup": "Large Missile Pack",
+                    "pickup": "Energy Tank",
                     "owner": 0
                 },
                 {
@@ -1001,7 +996,7 @@
                         "node": "Pickup (Missile Expansion)"
                     },
                     "index": 25,
-                    "pickup": "Small Energy",
+                    "pickup": "Volt Driver",
                     "owner": 0
                 },
                 {
@@ -1011,7 +1006,7 @@
                         "node": "Pickup (UA Expansion)"
                     },
                     "index": 26,
-                    "pickup": "Missile Expansion",
+                    "pickup": "UA Expansion",
                     "owner": 0
                 },
                 {
@@ -1021,7 +1016,7 @@
                         "node": "Pickup (Volt Driver)"
                     },
                     "index": 24,
-                    "pickup": "VDO WeaponsComplexPsychoBits Shield Key",
+                    "pickup": "VDO Binary Subscripture Artifact 2",
                     "owner": 0
                 },
                 {
@@ -1031,7 +1026,7 @@
                         "node": "Pickup (Attameter Artifact)"
                     },
                     "index": 27,
-                    "pickup": "Small UA Pack",
+                    "pickup": "Alinos Binary Subscripture Artifact 2",
                     "owner": 0
                 },
                 {
@@ -1041,7 +1036,7 @@
                         "node": "Pickup (Medium Energy)"
                     },
                     "index": 80,
-                    "pickup": "Arcterra FrostLabyrinth Shield Key",
+                    "pickup": "VDO Cartograph Artifact 2",
                     "owner": 0
                 },
                 {
@@ -1051,7 +1046,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 106,
-                    "pickup": "VDO StasisBunkerGuardians Shield Key",
+                    "pickup": "Celestial Attameter Artifact 1",
                     "owner": 0
                 },
                 {
@@ -1061,7 +1056,7 @@
                         "node": "Pickup (Cartograph Artifact)"
                     },
                     "index": 31,
-                    "pickup": "VDO CompressionChamber Shield Key",
+                    "pickup": "CelestialArchives IncubationVault01 Shield Key",
                     "owner": 0
                 },
                 {
@@ -1071,7 +1066,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 107,
-                    "pickup": "UA Expansion",
+                    "pickup": "Small UA Pack",
                     "owner": 0
                 },
                 {
@@ -1081,7 +1076,7 @@
                         "node": "Pickup (UA Expansion)"
                     },
                     "index": 32,
-                    "pickup": "Large Energy",
+                    "pickup": "Small Energy",
                     "owner": 0
                 },
                 {
@@ -1091,7 +1086,7 @@
                         "node": "Pickup (Attameter Artifact)"
                     },
                     "index": 28,
-                    "pickup": "Arcterra Attameter Artifact 1",
+                    "pickup": "Alinos Cartograph Artifact 1",
                     "owner": 0
                 },
                 {
@@ -1111,7 +1106,7 @@
                         "node": "Pickup (Shock Coil)"
                     },
                     "index": 29,
-                    "pickup": "Arcterra Cartograph Artifact 1",
+                    "pickup": "Small Missile Pack",
                     "owner": 0
                 },
                 {
@@ -1121,7 +1116,7 @@
                         "node": "Pickup (Missile Expansion)"
                     },
                     "index": 30,
-                    "pickup": "Alinos CrashSite Shield Key",
+                    "pickup": "Alinos PistonCave Shield Key",
                     "owner": 0
                 },
                 {
@@ -1131,7 +1126,7 @@
                         "node": "Pickup (Binary Subscripture Artifact)"
                     },
                     "index": 19,
-                    "pickup": "Energy Tank",
+                    "pickup": "VDO StasisBunkerPuzzle Shield Key",
                     "owner": 0
                 },
                 {
@@ -1141,7 +1136,7 @@
                         "node": "Pickup (Energy Tank)"
                     },
                     "index": 20,
-                    "pickup": "Small Missile Pack",
+                    "pickup": "Large Missile Pack",
                     "owner": 0
                 },
                 {
@@ -1151,7 +1146,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 109,
-                    "pickup": "CelestialArchives NewArrivalRegistration Shield Key",
+                    "pickup": "Alinos Attameter Artifact 1",
                     "owner": 0
                 },
                 {
@@ -1161,7 +1156,7 @@
                         "node": "Pickup (Binary Subscripture Artifact)"
                     },
                     "index": 18,
-                    "pickup": "Arcterra Binary Subscripture Artifact 1",
+                    "pickup": "Alinos Attameter Artifact 2",
                     "owner": 0
                 },
                 {
@@ -1171,7 +1166,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 110,
-                    "pickup": "Small Missile Pack",
+                    "pickup": "Small Energy",
                     "owner": 0
                 },
                 {
@@ -1181,7 +1176,7 @@
                         "node": "Pickup (UA Expansion)"
                     },
                     "index": 63,
-                    "pickup": "Missile Expansion",
+                    "pickup": "Large UA Pack",
                     "owner": 0
                 },
                 {
@@ -1201,7 +1196,7 @@
                         "node": "Pickup (Large Energy Upper)"
                     },
                     "index": 117,
-                    "pickup": "UA Expansion",
+                    "pickup": "Missile Expansion",
                     "owner": 0
                 },
                 {
@@ -1211,7 +1206,7 @@
                         "node": "Pickup (Energy Tank)"
                     },
                     "index": 64,
-                    "pickup": "Small UA Pack",
+                    "pickup": "Missile Expansion",
                     "owner": 0
                 },
                 {
@@ -1221,7 +1216,7 @@
                         "node": "Pickup (Medium Energy)"
                     },
                     "index": 81,
-                    "pickup": "Energy Tank",
+                    "pickup": "CelestialArchives DataShrine03 Shield Key",
                     "owner": 0
                 },
                 {
@@ -1241,7 +1236,7 @@
                         "node": "Pickup (Small Energy Left)"
                     },
                     "index": 82,
-                    "pickup": "Celestial Cartograph Artifact 2",
+                    "pickup": "Arcterra Subterranean Shield Key",
                     "owner": 0
                 },
                 {
@@ -1261,7 +1256,7 @@
                         "node": "Pickup (Large Energy)"
                     },
                     "index": 84,
-                    "pickup": "Large Energy",
+                    "pickup": "Celestial Binary Subscripture Artifact 2",
                     "owner": 0
                 },
                 {
@@ -1271,7 +1266,7 @@
                         "node": "Pickup (Octolith)"
                     },
                     "index": 34,
-                    "pickup": "Octolith 1",
+                    "pickup": "Octolith 5",
                     "owner": 0
                 },
                 {
@@ -1281,7 +1276,7 @@
                         "node": "Pickup (Small Energy)"
                     },
                     "index": 85,
-                    "pickup": "Large Missile Pack",
+                    "pickup": "Missile Expansion",
                     "owner": 0
                 },
                 {
@@ -1291,7 +1286,7 @@
                         "node": "Pickup (Binary Subscripture Artifact)"
                     },
                     "index": 43,
-                    "pickup": "UA Expansion",
+                    "pickup": "Arcterra SicTransit Shield Key",
                     "owner": 0
                 },
                 {
@@ -1301,7 +1296,7 @@
                         "node": "Pickup (Shield Key)"
                     },
                     "index": 111,
-                    "pickup": "Arcterra Sanctorus Shield Key",
+                    "pickup": "Arcterra FaultLine Shield Key",
                     "owner": 0
                 },
                 {
@@ -1311,7 +1306,7 @@
                         "node": "Pickup (UA Expansion)"
                     },
                     "index": 44,
-                    "pickup": "Energy Tank",
+                    "pickup": "Small Missile Pack",
                     "owner": 0
                 },
                 {
@@ -1321,7 +1316,7 @@
                         "node": "Pickup (Battlehammer)"
                     },
                     "index": 35,
-                    "pickup": "UA Expansion",
+                    "pickup": "Medium Energy",
                     "owner": 0
                 },
                 {
@@ -1331,7 +1326,7 @@
                         "node": "Pickup (Missile Expansion)"
                     },
                     "index": 36,
-                    "pickup": "Battlehammer",
+                    "pickup": "Alinos EchoHall Shield Key",
                     "owner": 0
                 },
                 {
@@ -1341,7 +1336,7 @@
                         "node": "Pickup (Binary Subscripture Artifact)"
                     },
                     "index": 39,
-                    "pickup": "Magmaul",
+                    "pickup": "Celestial Binary Subscripture Artifact 1",
                     "owner": 0
                 },
                 {
@@ -1351,7 +1346,7 @@
                         "node": "Pickup (Missile Expansion)"
                     },
                     "index": 40,
-                    "pickup": "Alinos Binary Subscripture Artifact 1",
+                    "pickup": "Energy Tank",
                     "owner": 0
                 },
                 {
@@ -1371,7 +1366,7 @@
                         "node": "Pickup (Attameter Artifact)"
                     },
                     "index": 42,
-                    "pickup": "Arcterra Binary Subscripture Artifact 2",
+                    "pickup": "Celestial Attameter Artifact 2",
                     "owner": 0
                 },
                 {
@@ -1381,7 +1376,7 @@
                         "node": "Pickup (Cartograph Artifact)"
                     },
                     "index": 41,
-                    "pickup": "Arcterra SicTransit Shield Key",
+                    "pickup": "Alinos Cartograph Artifact 2",
                     "owner": 0
                 },
                 {
@@ -1391,7 +1386,7 @@
                         "node": "Pickup (Shield Key Guardians)"
                     },
                     "index": 114,
-                    "pickup": "UA Expansion",
+                    "pickup": "Magmaul",
                     "owner": 0
                 },
                 {
@@ -1401,7 +1396,7 @@
                         "node": "Pickup (Shield Key Puzzle)"
                     },
                     "index": 113,
-                    "pickup": "Shock Coil",
+                    "pickup": "Energy Tank",
                     "owner": 0
                 },
                 {
@@ -1411,7 +1406,7 @@
                         "node": "Pickup (UA Expansion)"
                     },
                     "index": 65,
-                    "pickup": "Volt Driver",
+                    "pickup": "Large UA Pack",
                     "owner": 0
                 },
                 {
@@ -1431,7 +1426,7 @@
                         "node": "Pickup (Cartograph Artifact)"
                     },
                     "index": 37,
-                    "pickup": "Arcterra Attameter Artifact 2",
+                    "pickup": "Arcterra Binary Subscripture Artifact 1",
                     "owner": 0
                 },
                 {
@@ -1441,7 +1436,7 @@
                         "node": "Pickup (Shield Key Psycho Bits)"
                     },
                     "index": 115,
-                    "pickup": "CelestialArchives IncubationVault01 Shield Key",
+                    "pickup": "Large Missile Pack",
                     "owner": 0
                 },
                 {
@@ -1451,7 +1446,7 @@
                         "node": "Pickup (Shield Key Sylux)"
                     },
                     "index": 116,
-                    "pickup": "VDO Cartograph Artifact 1",
+                    "pickup": "VDO CompressionChamber Shield Key",
                     "owner": 0
                 }
             ],
@@ -1471,12 +1466,6 @@
             },
             "game_specific": {
                 "force_fields": {
-                    "Celestial Archives/Synergy Core/Volt Driver Force Field": "volt-driver",
-                    "Celestial Archives/Celestial Gateway/Battlehammer Force Field": "battlehammer",
-                    "Celestial Archives/Incubation Vault 01/Shock Coil Force Field": "shock-coil",
-                    "Celestial Archives/Incubation Vault 02/Shock Coil Force Field": "shock-coil",
-                    "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Upper)": "shock-coil",
-                    "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Lower)": "shock-coil",
                     "Alinos/High Ground/Volt Driver Force Field (Upper)": "volt-driver",
                     "Alinos/High Ground/Volt Driver Force Field (East)": "volt-driver",
                     "Alinos/High Ground/Volt Driver Force Field (South)": "volt-driver",
@@ -1487,79 +1476,85 @@
                     "Alinos/Council Chamber/Magmaul Force Field (Upper)": "magmaul",
                     "Alinos/Council Chamber/Magmaul Force Field (Jump Pad)": "magmaul",
                     "Alinos/Council Chamber/Magmaul Force Field (Entrance)": "magmaul",
+                    "Celestial Archives/Synergy Core/Volt Driver Force Field": "volt-driver",
+                    "Celestial Archives/Celestial Gateway/Battlehammer Force Field": "battlehammer",
+                    "Celestial Archives/Incubation Vault 01/Shock Coil Force Field": "shock-coil",
+                    "Celestial Archives/Incubation Vault 02/Shock Coil Force Field": "shock-coil",
+                    "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Upper)": "shock-coil",
+                    "Celestial Archives/Incubation Vault 03/Shock Coil Force Field (Lower)": "shock-coil",
+                    "Vesper Defense Outpost/Cortex CPU/Battlehammer Force Field": "battlehammer",
+                    "Vesper Defense Outpost/Weapons Complex/Battlehammer Force Field": "battlehammer",
+                    "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Left)": "battlehammer",
+                    "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Right)": "battlehammer",
                     "Arcterra/Ice Hive/Judicator Force Field (Entrance)": "judicator",
                     "Arcterra/Ice Hive/Judicator Force Field (Bridge)": "judicator",
                     "Arcterra/Ice Hive/Judicator Force Field (Alcove)": "judicator",
                     "Arcterra/Ice Hive/Judicator Force Field (War Wasps)": "judicator",
-                    "Arcterra/Ice Hive/Judicator Force Field (Judicator Room)": "judicator",
-                    "Vesper Defense Outpost/Cortex CPU/Battlehammer Force Field": "battlehammer",
-                    "Vesper Defense Outpost/Weapons Complex/Battlehammer Force Field": "battlehammer",
-                    "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Left)": "battlehammer",
-                    "Vesper Defense Outpost/Compression Chamber/Battlehammer Force Field (Right)": "battlehammer"
+                    "Arcterra/Ice Hive/Judicator Force Field (Judicator Room)": "judicator"
                 }
             }
         }
     ],
     "item_order": [
-        "Battlehammer at Vesper Defense Outpost/Cortex CPU/Pickup (Missile Expansion)",
-        "Imperialist at Alinos/Alinos Gateway/Pickup (Missile Expansion)",
-        "Alinos EchoHall Shield Key at Celestial Archives/Celestial Gateway/Pickup (UA Expansion)",
-        "Alinos HighGround Shield Key at Alinos/Elder Passage/Pickup (Shield Key)",
-        "Missile Launcher at Alinos/High Ground/Pickup (Binary Subscripture Artifact)",
-        "VDO WeaponsComplexPsychoBits Shield Key at Celestial Archives/Data Shrine 02/Pickup (Volt Driver)",
-        "VDO StasisBunkerPuzzle Shield Key at Celestial Archives/Data Shrine 01/Pickup (Small Missile Pack)",
-        "Celestial Attameter Artifact 1 at Alinos/Echo Hall/Pickup (Energy Tank)",
-        "Arcterra SicTransit Shield Key at Vesper Defense Outpost/Stasis Bunker/Pickup (Cartograph Artifact)",
-        "VDO StasisBunkerGuardians Shield Key at Celestial Archives/Data Shrine 03/Pickup (Shield Key)",
-        "Judicator at Arcterra/Sic Transit/Pickup (Attameter Artifact)",
-        "Alinos CouncilChamber Shield Key at Arcterra/Frost Labyrinth/Pickup (Energy Tank)",
-        "CelestialArchives DataShrine03 Shield Key at Arcterra/Fault Line/Pickup (Imperialist)",
-        "Arcterra FrostLabyrinth Shield Key at Celestial Archives/Data Shrine 03/Pickup (Medium Energy)",
-        "Alinos Cartograph Artifact 1 at Arcterra/Frost Labyrinth/Pickup (Binary Subscripture Artifact)",
-        "Arcterra Binary Subscripture Artifact 2 at Vesper Defense Outpost/Stasis Bunker/Pickup (Attameter Artifact)",
-        "CelestialArchives DataShrine01 Shield Key at Arcterra/Ice Hive/Pickup (Missile Expansion)",
+        "Alinos EchoHall Shield Key at Vesper Defense Outpost/Cortex CPU/Pickup (Missile Expansion)",
+        "Battlehammer at Alinos/High Ground/Pickup (Shield Key)",
+        "VDO WeaponsComplexSylux Shield Key at Alinos/Echo Hall/Pickup (Energy Tank)",
+        "Alinos HighGround Shield Key at Celestial Archives/Celestial Gateway/Pickup (UA Expansion)",
+        "VDO Binary Subscripture Artifact 1 at Alinos/High Ground/Pickup (Binary Subscripture Artifact)",
+        "VDO CompressionChamber Shield Key at Vesper Defense Outpost/Weapons Complex/Pickup (Shield Key Sylux)",
+        "Arcterra SicTransit Shield Key at Vesper Defense Outpost/Compression Chamber/Pickup (Binary Subscripture Artifact)",
+        "VDO WeaponsComplexPsychoBits Shield Key at Arcterra/Sic Transit/Pickup (Attameter Artifact)",
+        "Judicator at Arcterra/Sic Transit/Pickup (Energy Tank)",
+        "Alinos CouncilChamber Shield Key at Arcterra/Ice Hive/Pickup (UA Expansion - War Wasps)",
+        "VDO Attameter Artifact 1 at Alinos/Council Chamber/Pickup (Shield Key)",
+        "Alinos ElderPassage Shield Key at Arcterra/Ice Hive/Pickup (Missile Expansion)",
+        "Arcterra Cartograph Artifact 1 at Alinos/Piston Cave/Pickup (Shield Key)",
+        "Missile Launcher at Alinos/Elder Passage/Pickup (Attameter Artifact)",
+        "Arcterra FrostLabyrinth Shield Key at Celestial Archives/Data Shrine 01/Pickup (Small Missile Pack)",
+        "VDO Cartograph Artifact 1 at Celestial Archives/Data Shrine 01/Pickup (Small Energy)",
         "Arcterra IceHive Shield Key at Arcterra/Ice Hive/Pickup (Shield Key)",
-        "VDO WeaponsComplexSylux Shield Key at Alinos/Council Chamber/Pickup (Attameter Artifact)",
-        "Arcterra Attameter Artifact 2 at Vesper Defense Outpost/Weapons Complex/Pickup (Cartograph Artifact)",
-        "Alinos Binary Subscripture Artifact 2 at Alinos/Council Chamber/Pickup (Shield Key)",
-        "Alinos Attameter Artifact 1 at Celestial Archives/Data Shrine 01/Pickup (Small Energy)",
-        "VDO FuelStack Shield Key at Alinos/Council Chamber/Pickup (Magmaul)",
-        "Magmaul at Vesper Defense Outpost/Fuel Stack/Pickup (Binary Subscripture Artifact)",
-        "Celestial Binary Subscripture Artifact 1 at Alinos/Alinos Perch/Pickup (Missile Expansion)",
-        "Arcterra Subterranean Shield Key at Alinos/Echo Hall/Pickup (Cartograph Artifact)",
-        "Arcterra FaultLine Shield Key at Arcterra/Subterranean/Pickup (Cartograph Artifact)",
-        "Alinos ElderPassage Shield Key at Arcterra/Sic Transit/Pickup (Energy Tank)",
-        "CelestialArchives SynergyCore Shield Key at Arcterra/Fault Line/Pickup (Attameter Artifact)",
-        "Arcterra Binary Subscripture Artifact 1 at Celestial Archives/Synergy Core/Pickup (Binary Subscripture Artifact)",
-        "Alinos Cartograph Artifact 2 at Arcterra/Ice Hive/Pickup (Cartograph Artifact)",
-        "Volt Driver at Vesper Defense Outpost/Stasis Bunker/Pickup (UA Expansion)",
+        "Volt Driver at Celestial Archives/Data Shrine 02/Pickup (Missile Expansion)",
         "CelestialArchives DockingBay Shield Key at Celestial Archives/Incubation Vault 01/Pickup (Shield Key)",
-        "VDO CompressionChamber Shield Key at Celestial Archives/Docking Bay/Pickup (Cartograph Artifact)",
-        "Alinos CrashSite Shield Key at Celestial Archives/Incubation Vault 03/Pickup (Missile Expansion)",
-        "Celestial Cartograph Artifact 1 at Alinos/Crash Site/Pickup (Cartograph Artifact)",
-        "Arcterra Cartograph Artifact 1 at Celestial Archives/Incubation Vault 02/Pickup (Shock Coil)",
-        "CelestialArchives IncubationVault01 Shield Key at Vesper Defense Outpost/Weapons Complex/Pickup (Shield Key Psycho Bits)",
-        "Alinos Binary Subscripture Artifact 1 at Vesper Defense Outpost/Fuel Stack/Pickup (Missile Expansion)",
-        "Arcterra Attameter Artifact 1 at Celestial Archives/Incubation Vault 01/Pickup (Attameter Artifact)",
-        "VDO Attameter Artifact 2 at Arcterra/Sic Transit/Pickup (Shield Key)",
-        "Arcterra Sanctorus Shield Key at Vesper Defense Outpost/Compression Chamber/Pickup (Shield Key)",
-        "VDO Cartograph Artifact 2 at Arcterra/Sanctorus/Pickup (Shield Key)",
-        "VDO Binary Subscripture Artifact 1 at Arcterra/Sanctorus/Pickup (Binary Subscripture Artifact)",
-        "Shock Coil at Vesper Defense Outpost/Stasis Bunker/Pickup (Shield Key Puzzle)",
-        "CelestialArchives NewArrivalRegistration Shield Key at Celestial Archives/New Arrival Registration/Pickup (Shield Key)",
-        "Energy Tank at Celestial Archives/New Arrival Registration/Pickup (Binary Subscripture Artifact)",
+        "CelestialArchives IncubationVault01 Shield Key at Celestial Archives/Docking Bay/Pickup (Cartograph Artifact)",
+        "Alinos Cartograph Artifact 1 at Celestial Archives/Incubation Vault 01/Pickup (Attameter Artifact)",
+        "Shock Coil at Arcterra/Sic Transit/Pickup (Shield Key)",
+        "Alinos Attameter Artifact 1 at Celestial Archives/New Arrival Registration/Pickup (Shield Key)",
+        "Imperialist at Alinos/High Ground/Pickup (Large Energy)",
+        "VDO StasisBunkerGuardians Shield Key at Arcterra/Fault Line/Pickup (Shield Key)",
+        "Arcterra Sanctorus Shield Key at Arcterra/Fault Line/Pickup (Imperialist)",
+        "VDO FuelStack Shield Key at Arcterra/Sanctorus/Pickup (Shield Key)",
+        "Celestial Binary Subscripture Artifact 1 at Vesper Defense Outpost/Fuel Stack/Pickup (Binary Subscripture Artifact)",
+        "Celestial Attameter Artifact 2 at Vesper Defense Outpost/Stasis Bunker/Pickup (Attameter Artifact)",
+        "CelestialArchives NewArrivalRegistration Shield Key at Arcterra/Sanctorus/Pickup (Binary Subscripture Artifact)",
+        "VDO StasisBunkerPuzzle Shield Key at Celestial Archives/New Arrival Registration/Pickup (Binary Subscripture Artifact)",
+        "Alinos Cartograph Artifact 2 at Vesper Defense Outpost/Stasis Bunker/Pickup (Cartograph Artifact)",
+        "Celestial Attameter Artifact 1 at Celestial Archives/Data Shrine 03/Pickup (Shield Key)",
+        "Magmaul at Vesper Defense Outpost/Stasis Bunker/Pickup (Shield Key Guardians)",
+        "Celestial Cartograph Artifact 1 at Alinos/Council Chamber/Pickup (Energy Tank)",
+        "Alinos CrashSite Shield Key at Celestial Archives/Biodefense Chamber A (Celestial Archives)/Pickup (Small Energy Top Left)",
+        "CelestialArchives DataShrine01 Shield Key at Alinos/Crash Site/Pickup (Cartograph Artifact)",
+        "Arcterra FaultLine Shield Key at Vesper Defense Outpost/Compression Chamber/Pickup (Shield Key)",
+        "Energy Tank at Vesper Defense Outpost/Fuel Stack/Pickup (Missile Expansion)",
+        "Alinos Binary Subscripture Artifact 1 at Alinos/Echo Hall/Pickup (Shield Key)",
         "Energy Tank at Alinos/Biodefense Chamber A (Alinos)/Pickup (Small Energy Right)",
-        "Alinos Attameter Artifact 2 at Arcterra/Biodefense Chamber A (Arcterra)/Pickup (Small Energy Top Right)",
-        "Arcterra Cartograph Artifact 2 at Alinos/Biodefense Chamber B (Alinos)/Pickup (Small Energy Left)",
-        "VDO Attameter Artifact 1 at Alinos/Biodefense Chamber B (Alinos)/Pickup (Medium Energy)",
-        "Energy Tank at Alinos/Biodefense Chamber B (Alinos)/Pickup (Octolith)",
-        "VDO Cartograph Artifact 1 at Vesper Defense Outpost/Weapons Complex/Pickup (Shield Key Sylux)",
-        "Energy Tank at Vesper Defense Outpost/Biodefense Chamber A (VDO)/Pickup (Medium Energy)",
-        "Celestial Cartograph Artifact 2 at Vesper Defense Outpost/Biodefense Chamber A (VDO)/Pickup (Small Energy Left)",
-        "Celestial Binary Subscripture Artifact 2 at Arcterra/Biodefense Chamber B (Arcterra)/Pickup (Small Energy)",
-        "Celestial Attameter Artifact 2 at Alinos/Piston Cave/Pickup (Shield Key)",
-        "Energy Tank at Arcterra/Biodefense Chamber B (Arcterra)/Pickup (Octolith)",
-        "VDO Binary Subscripture Artifact 2 at Celestial Archives/Biodefense Chamber B (Celestial Archives)/Pickup (Small Energy Right)"
+        "Arcterra Subterranean Shield Key at Vesper Defense Outpost/Biodefense Chamber A (VDO)/Pickup (Small Energy Left)",
+        "CelestialArchives SynergyCore Shield Key at Arcterra/Subterranean/Pickup (Cartograph Artifact)",
+        "Alinos Attameter Artifact 2 at Celestial Archives/Synergy Core/Pickup (Binary Subscripture Artifact)",
+        "VDO Binary Subscripture Artifact 2 at Celestial Archives/Data Shrine 02/Pickup (Volt Driver)",
+        "CelestialArchives DataShrine03 Shield Key at Vesper Defense Outpost/Biodefense Chamber A (VDO)/Pickup (Medium Energy)",
+        "Alinos Binary Subscripture Artifact 2 at Celestial Archives/Data Shrine 03/Pickup (Attameter Artifact)",
+        "Arcterra Attameter Artifact 1 at Alinos/Biodefense Chamber B (Alinos)/Pickup (Small Energy Left)",
+        "VDO Cartograph Artifact 2 at Celestial Archives/Data Shrine 03/Pickup (Medium Energy)",
+        "Arcterra Binary Subscripture Artifact 1 at Vesper Defense Outpost/Weapons Complex/Pickup (Cartograph Artifact)",
+        "VDO Attameter Artifact 2 at Arcterra/Biodefense Chamber A (Arcterra)/Pickup (Small Energy Bottom Right)",
+        "Energy Tank at Alinos/Biodefense Chamber B (Alinos)/Pickup (Medium Energy)",
+        "Energy Tank at Alinos/Biodefense Chamber A (Alinos)/Pickup (Small Energy Left)",
+        "Arcterra Binary Subscripture Artifact 2 at Arcterra/Frost Labyrinth/Pickup (Binary Subscripture Artifact)",
+        "Celestial Cartograph Artifact 2 at Arcterra/Biodefense Chamber A (Arcterra)/Pickup (Small Energy Top Right)",
+        "Energy Tank at Vesper Defense Outpost/Stasis Bunker/Pickup (Shield Key Puzzle)",
+        "Celestial Binary Subscripture Artifact 2 at Vesper Defense Outpost/Biodefense Chamber B (VDO)/Pickup (Large Energy)",
+        "Arcterra Attameter Artifact 2 at Celestial Archives/Biodefense Chamber B (Celestial Archives)/Pickup (Small Energy Right)",
+        "Arcterra Cartograph Artifact 2 at Alinos/Council Chamber/Pickup (Attameter Artifact)"
     ],
-    "checksum": "2850cb8a627f46a6a10a661a044a231efe22be5683f9ab235b58006d4a9c3fb635ebfa978c16dc23d42ee54547b7c4583d5b4d5d9a211b4f0a411381dad90b28"
+    "checksum": "b29b8771cba87681bfd6129e8c301547feffd0cc429e0a66032ab6252ba24ba270f4505b5fe6371f584e7f48d85607cdac96d643db3eb75ba0e49dbc7909688c"
 }

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/no_shuffled_octoliths/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/no_shuffled_octoliths/world_1.json
@@ -1139,7 +1139,7 @@
                             "item_type": 6
                         },
                         {
-                            "entity_id": 7,
+                            "entity_id": 34,
                             "entity_type": 4,
                             "item_type": 17
                         },
@@ -1150,7 +1150,7 @@
                             "artifact_id": 1
                         },
                         {
-                            "entity_id": 34,
+                            "entity_id": 7,
                             "entity_type": 4,
                             "item_type": 17
                         },

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/no_shuffled_octoliths/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/no_shuffled_octoliths/world_1.json
@@ -1,0 +1,1428 @@
+{
+    "configuration_id": 817470549,
+    "starting_items": {
+        "weapons": {
+            "battlehammer": false,
+            "imperialist": false,
+            "judicator": false,
+            "magmaul": false,
+            "missile_launcher": false,
+            "shock_coil": false,
+            "volt_driver": false
+        },
+        "missiles": 0,
+        "ammo": 40,
+        "energy": 99,
+        "artifacts": {
+            "alinos_1": "000",
+            "alinos_2": "000",
+            "celestial_archives_1": "000",
+            "celestial_archives_2": "000",
+            "vesper_defense_outpost_1": "000",
+            "vesper_defense_outpost_2": "000",
+            "arcterra_1": "000",
+            "arcterra_2": "000"
+        },
+        "octoliths": "11111111"
+    },
+    "areas": {
+        "Celestial Archives": {
+            "levels": {
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 6
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber B": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 4,
+                            "item_type": 10
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Helm Room": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Meditation Room": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Fan Room Alpha": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Fan Room Beta": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Synergy Core": {
+                    "pickups": [
+                        {
+                            "entity_id": 3,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 56,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 40
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 15,
+                            "type": 1
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 2,
+                            "target_index": 2,
+                            "entity_file_name": "Unit2_TP1_Ent"
+                        },
+                        {
+                            "entity_id": 7,
+                            "target_index": 10,
+                            "entity_file_name": "unit2_RM4_Ent"
+                        },
+                        {
+                            "entity_id": 38,
+                            "target_index": 20,
+                            "entity_file_name": "unit2_Land_Ent"
+                        }
+                    ]
+                },
+                "Tetra Vista": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 31,
+                            "entity_file_name": "unit2_RM7_Ent"
+                        }
+                    ]
+                },
+                "New Arrival Registration": {
+                    "pickups": [
+                        {
+                            "entity_id": 19,
+                            "entity_type": 4,
+                            "item_type": 17
+                        },
+                        {
+                            "entity_id": 21,
+                            "entity_type": 17,
+                            "model_id": 6,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 49,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 43
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 24,
+                            "target_index": 3,
+                            "entity_file_name": "Unit2_TP2_Ent"
+                        },
+                        {
+                            "entity_id": 41,
+                            "target_index": 21,
+                            "entity_file_name": "unit2_Land_Ent"
+                        }
+                    ]
+                },
+                "Celestial Gateway": {
+                    "pickups": [
+                        {
+                            "entity_id": 21,
+                            "entity_type": 4,
+                            "item_type": 6
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 20,
+                            "type": 3
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 15,
+                            "target_index": 20,
+                            "entity_file_name": "unit2_C4_Ent"
+                        },
+                        {
+                            "entity_id": 16,
+                            "target_index": 21,
+                            "entity_file_name": "unit2_C7_Ent"
+                        }
+                    ]
+                },
+                "Data Shrine 01": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 4,
+                            "item_type": 21
+                        },
+                        {
+                            "entity_id": 14,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 46,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 38
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Data Shrine 02": {
+                    "pickups": [
+                        {
+                            "entity_id": 14,
+                            "entity_type": 4,
+                            "item_type": 17
+                        },
+                        {
+                            "entity_id": 18,
+                            "entity_type": 4,
+                            "item_type": 17
+                        },
+                        {
+                            "entity_id": 41,
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 1
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Data Shrine 03": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 17,
+                            "model_id": 4,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 45,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 39
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Transfer Lock": {
+                    "pickups": [
+                        {
+                            "entity_id": 64,
+                            "entity_type": 4,
+                            "item_type": 18
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 3,
+                            "target_index": 10,
+                            "entity_file_name": "unit2_C4_Ent"
+                        },
+                        {
+                            "entity_id": 15,
+                            "target_index": 12,
+                            "entity_file_name": "unit2_RM8_Ent"
+                        }
+                    ]
+                },
+                "Incubation Vault 01": {
+                    "pickups": [
+                        {
+                            "entity_id": 10,
+                            "entity_type": 4,
+                            "item_type": 17
+                        },
+                        {
+                            "entity_id": 29,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 42
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 4,
+                            "type": 7
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 2,
+                            "target_index": 50,
+                            "entity_file_name": "unit2_RM8_Ent"
+                        },
+                        {
+                            "entity_id": 3,
+                            "target_index": 26,
+                            "entity_file_name": "unit2_RM6_Ent"
+                        },
+                        {
+                            "entity_id": 7,
+                            "target_index": 19,
+                            "entity_file_name": "unit2_RM5_Ent"
+                        },
+                        {
+                            "entity_id": 9,
+                            "target_index": 18,
+                            "entity_file_name": "unit2_RM5_Ent"
+                        },
+                        {
+                            "entity_id": 11,
+                            "target_index": 24,
+                            "entity_file_name": "unit2_RM6_Ent"
+                        },
+                        {
+                            "entity_id": 1,
+                            "target_index": 13,
+                            "entity_file_name": "unit2_RM8_Ent"
+                        }
+                    ]
+                },
+                "Incubation Vault 02": {
+                    "pickups": [
+                        {
+                            "entity_id": 7,
+                            "entity_type": 4,
+                            "item_type": 6
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 3,
+                            "type": 7
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 16,
+                            "entity_file_name": "unit2_RM8_Ent"
+                        },
+                        {
+                            "entity_id": 2,
+                            "target_index": 21,
+                            "entity_file_name": "unit2_RM5_Ent"
+                        },
+                        {
+                            "entity_id": 6,
+                            "target_index": 30,
+                            "entity_file_name": "unit2_RM7_Ent"
+                        },
+                        {
+                            "entity_id": 8,
+                            "target_index": 22,
+                            "entity_file_name": "unit2_RM5_Ent"
+                        }
+                    ]
+                },
+                "Incubation Vault 03": {
+                    "pickups": [
+                        {
+                            "entity_id": 10,
+                            "entity_type": 4,
+                            "item_type": 17
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 8,
+                            "type": 7
+                        },
+                        {
+                            "entity_id": 4,
+                            "type": 7
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 32,
+                            "entity_file_name": "unit2_C6_Ent"
+                        },
+                        {
+                            "entity_id": 11,
+                            "target_index": 25,
+                            "entity_file_name": "unit2_RM6_Ent"
+                        },
+                        {
+                            "entity_id": 2,
+                            "target_index": 50,
+                            "entity_file_name": "unit2_RM8_Ent"
+                        },
+                        {
+                            "entity_id": 12,
+                            "target_index": 14,
+                            "entity_file_name": "unit2_RM8_Ent"
+                        }
+                    ]
+                },
+                "Docking Bay": {
+                    "pickups": [
+                        {
+                            "entity_id": 1,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 6,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 14,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 41
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 5,
+                            "target_index": 17,
+                            "entity_file_name": "unit2_RM5_Ent"
+                        },
+                        {
+                            "entity_id": 7,
+                            "target_index": 29,
+                            "entity_file_name": "unit2_RM7_Ent"
+                        },
+                        {
+                            "entity_id": 8,
+                            "target_index": 23,
+                            "entity_file_name": "unit2_RM6_Ent"
+                        },
+                        {
+                            "entity_id": 3,
+                            "target_index": 11,
+                            "entity_file_name": "unit2_RM4_Ent"
+                        },
+                        {
+                            "entity_id": 23,
+                            "target_index": 20,
+                            "entity_file_name": "unit2_RM5_Ent"
+                        },
+                        {
+                            "entity_id": 23,
+                            "target_index": 27,
+                            "entity_file_name": "unit2_RM7_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void A": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 2,
+                            "entity_file_name": "unit2_C4_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void B": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 3,
+                            "entity_file_name": "unit2_C7_Ent"
+                        }
+                    ]
+                }
+            }
+        },
+        "Alinos": {
+            "levels": {
+                "Alimbic Cannon Control Room": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber B": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 0
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 0
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Echo Hall": {
+                    "pickups": [
+                        {
+                            "entity_id": 3,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 15,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 42,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 32
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alimbic Gardens": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Thermal Vast": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Crash Site": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 35
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Magma Drop": {
+                    "pickups": [
+                        {
+                            "entity_id": 14,
+                            "entity_type": 4,
+                            "item_type": 4
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 29,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        },
+                        {
+                            "entity_id": 28,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        }
+                    ]
+                },
+                "Piston Cave": {
+                    "pickups": [
+                        {
+                            "entity_id": 38,
+                            "entity_type": 17,
+                            "model_id": 4,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 37
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alinos Gateway": {
+                    "pickups": [
+                        {
+                            "entity_id": 13,
+                            "entity_type": 4,
+                            "item_type": 7
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 24,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_RM3_Ent"
+                        },
+                        {
+                            "entity_id": 25,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "High Ground": {
+                    "pickups": [
+                        {
+                            "entity_id": 24,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 81,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 34
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 40,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 6,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 8,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 9,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 74,
+                            "type": 5
+                        },
+                        {
+                            "entity_id": 77,
+                            "type": 5
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 57,
+                            "target_index": 10,
+                            "entity_file_name": "unit1_C4_Ent"
+                        },
+                        {
+                            "entity_id": 58,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_C4_Ent"
+                        }
+                    ]
+                },
+                "Alinos Perch": {
+                    "pickups": [
+                        {
+                            "entity_id": 15,
+                            "entity_type": 4,
+                            "item_type": 5
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": []
+                },
+                "Council Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 5,
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 19,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 21,
+                            "entity_type": 4,
+                            "item_type": 11
+                        },
+                        {
+                            "entity_id": 61,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 36
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 22,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 23,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 52,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Combat Hall": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Processor Core": {
+                    "pickups": [
+                        {
+                            "entity_id": 23,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 1
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 8,
+                            "target_index": 1,
+                            "entity_file_name": "Unit1_TP2_Ent"
+                        }
+                    ]
+                },
+                "Elder Passage": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 4,
+                            "item_type": 9
+                        },
+                        {
+                            "entity_id": 29,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 33
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 2,
+                            "target_index": 0,
+                            "entity_file_name": "Unit1_TP1_Ent"
+                        },
+                        {
+                            "entity_id": 19,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void A": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 0,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void B": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 1,
+                            "entity_file_name": "unit1_RM5_Ent"
+                        }
+                    ]
+                }
+            }
+        },
+        "Arcterra": {
+            "levels": {
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 4,
+                            "item_type": 4
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber B": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 18
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Frost Labyrinth": {
+                    "pickups": [
+                        {
+                            "entity_id": 6,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 18,
+                            "entity_type": 4,
+                            "item_type": 17
+                        },
+                        {
+                            "entity_id": 31,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 52
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Drip Moat": {
+                    "pickups": [
+                        {
+                            "entity_id": 50,
+                            "entity_type": 4,
+                            "item_type": 4
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Arcterra Gateway": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 4,
+                            "target_index": 60,
+                            "entity_file_name": "unit4_RM1_Ent"
+                        },
+                        {
+                            "entity_id": 38,
+                            "target_index": 70,
+                            "entity_file_name": "unit4_RM5_Ent"
+                        }
+                    ]
+                },
+                "Ice Hive": {
+                    "pickups": [
+                        {
+                            "entity_id": 26,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 7,
+                            "entity_type": 4,
+                            "item_type": 17
+                        },
+                        {
+                            "entity_id": 1,
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 34,
+                            "entity_type": 4,
+                            "item_type": 17
+                        },
+                        {
+                            "entity_id": 6,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 124,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 51
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 39,
+                            "type": 5
+                        },
+                        {
+                            "entity_id": 4,
+                            "type": 5
+                        },
+                        {
+                            "entity_id": 18,
+                            "type": 5
+                        },
+                        {
+                            "entity_id": 59,
+                            "type": 5
+                        },
+                        {
+                            "entity_id": 72,
+                            "type": 5
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 20,
+                            "target_index": 6,
+                            "entity_file_name": "Unit4_TP1_Ent"
+                        },
+                        {
+                            "entity_id": 162,
+                            "target_index": 60,
+                            "entity_file_name": "unit4_Land_Ent"
+                        }
+                    ]
+                },
+                "Subterranean": {
+                    "pickups": [
+                        {
+                            "entity_id": 18,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 57,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 3,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 55
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Sic Transit": {
+                    "pickups": [
+                        {
+                            "entity_id": 29,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 35,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 42,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 50
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Sanctorus": {
+                    "pickups": [
+                        {
+                            "entity_id": 7,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 43,
+                            "entity_type": 17,
+                            "model_id": 6,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 35,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 54
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Fault Line": {
+                    "pickups": [
+                        {
+                            "entity_id": 46,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 47,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 29,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 53
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 39,
+                            "target_index": 3,
+                            "entity_file_name": "Unit4_TP2_Ent"
+                        },
+                        {
+                            "entity_id": 71,
+                            "target_index": 70,
+                            "entity_file_name": "unit4_Land_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void A": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 6,
+                            "entity_file_name": "unit4_RM1_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void B": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 2,
+                            "entity_file_name": "unit4_RM5_Ent"
+                        }
+                    ]
+                }
+            }
+        },
+        "Vesper Defense Outpost": {
+            "levels": {
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 1
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber B": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 4,
+                            "item_type": 6
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Bioweaponry Lab": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Ascension": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 35,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_Land_Ent"
+                        }
+                    ]
+                },
+                "Cortex CPU": {
+                    "pickups": [
+                        {
+                            "entity_id": 9,
+                            "entity_type": 4,
+                            "item_type": 8
+                        },
+                        {
+                            "entity_id": 18,
+                            "entity_type": 17,
+                            "model_id": 4,
+                            "artifact_id": 1
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 27,
+                            "type": 3
+                        }
+                    ],
+                    "portals": []
+                },
+                "VDO Gateway": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 5,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_C1_Ent"
+                        },
+                        {
+                            "entity_id": 8,
+                            "target_index": 40,
+                            "entity_file_name": "unit3_RM1_Ent"
+                        }
+                    ]
+                },
+                "Weapons Complex": {
+                    "pickups": [
+                        {
+                            "entity_id": 23,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 61,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 60,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 45
+                        },
+                        {
+                            "entity_id": 38,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 44
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 9,
+                            "type": 3
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 47,
+                            "target_index": 40,
+                            "entity_file_name": "unit3_Land_Ent"
+                        }
+                    ]
+                },
+                "Fuel Stack": {
+                    "pickups": [
+                        {
+                            "entity_id": 12,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 72,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 57,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 49
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Stasis Bunker": {
+                    "pickups": [
+                        {
+                            "entity_id": 5,
+                            "entity_type": 17,
+                            "model_id": 6,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 4,
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 90,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 21,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 47
+                        },
+                        {
+                            "entity_id": 79,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 48
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 3,
+                            "target_index": 5,
+                            "entity_file_name": "Unit3_TP2_Ent"
+                        }
+                    ]
+                },
+                "Compression Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 17,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 9,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 35,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 46
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 53,
+                            "type": 3
+                        },
+                        {
+                            "entity_id": 54,
+                            "type": 3
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 36,
+                            "target_index": 4,
+                            "entity_file_name": "Unit3_TP1_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void A": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 4,
+                            "entity_file_name": "unit3_RM4_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void B": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 5,
+                            "entity_file_name": "unit3_RM3_Ent"
+                        }
+                    ]
+                }
+            }
+        },
+        "Oubliette": {
+            "levels": {
+                "Gorea 1 Arena": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Gorea 2 Arena": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Oubliette Gateway": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 3,
+                            "target_index": 11,
+                            "entity_file_name": "Gorea_Peek_Ent"
+                        },
+                        {
+                            "entity_id": 6,
+                            "target_index": 13,
+                            "entity_file_name": "Gorea_Land_Ent"
+                        },
+                        {
+                            "entity_id": 7,
+                            "target_index": 12,
+                            "entity_file_name": "Gorea_Land_Ent"
+                        }
+                    ]
+                },
+                "Oubliette Storage": {
+                    "pickups": [
+                        {
+                            "entity_id": 1,
+                            "entity_type": 4,
+                            "item_type": 4
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 12,
+                            "target_index": 11,
+                            "entity_file_name": "Gorea_Land_Ent"
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "ammo_sizes": {
+        "missile_launcher": 5,
+        "missile_expansion": 10,
+        "ua_expansion": 30
+    },
+    "cosmetic_patches": {
+        "shuffle_hunter_colors": false,
+        "suit_color": "varia"
+    },
+    "game_patches": {
+        "skip_planet_intros": false
+    },
+    "text_patches": {
+        "frontend": {
+            "patcher_version": "Some Words (XXXXXXXX)"
+        },
+        "string_tables": {
+            "scan_log": {
+                "904L": "OCTOLITH HINTS 01\\Imagining this hint is left as an exercise to the player.",
+                "014L": "OCTOLITH HINTS 02\\If you have a randomized game that you like, consider sharing it!",
+                "114L": "OCTOLITH HINTS 03\\this lore scan did not provide any useful OCTOLITH hints.",
+                "214L": "OCTOLITH HINTS 04\\After you're done with your play session, how about going for a little walk?"
+            },
+            "ship_in_space": {
+                "100S": "---STARTING ITEMS---",
+                "200S": "OCTOLITH 1\nOCTOLITH 2\nOCTOLITH 3\nOCTOLITH 4\nOCTOLITH 5\nOCTOLITH 6\nOCTOLITH 7\nOCTOLITH 8\n",
+                "300S": "---GOAL---",
+                "400S": "defeat GOREA in OUBLIETTE.",
+                "500S": "---PRESET SETTINGS---",
+                "600S": "FORCE FIELD weaknesses are UNCHANGED.",
+                "700S": "PORTAL destinations are UNCHANGED.",
+                "800S": "no extra pickups added to the PICKUP POOL.",
+                "900S": "---MORE INFO---",
+                "010S": "for more information, visit randovania.org.",
+                "110S": "join the discord server if you have any questions.",
+                "210S": "good luck and have fun!"
+            }
+        }
+    },
+    "_randovania_meta": {
+        "layout_was_user_modified": false,
+        "in_race_setting": false
+    }
+}

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/no_shuffled_octoliths/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/no_shuffled_octoliths/world_1.json
@@ -26,6 +26,345 @@
         "octoliths": "11111111"
     },
     "areas": {
+        "Alinos": {
+            "levels": {
+                "Alimbic Cannon Control Room": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber B": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 0
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 0
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Echo Hall": {
+                    "pickups": [
+                        {
+                            "entity_id": 3,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 15,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 42,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 32
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alimbic Gardens": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Thermal Vast": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Crash Site": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 35
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Magma Drop": {
+                    "pickups": [
+                        {
+                            "entity_id": 14,
+                            "entity_type": 4,
+                            "item_type": 4
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 29,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        },
+                        {
+                            "entity_id": 28,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        }
+                    ]
+                },
+                "Piston Cave": {
+                    "pickups": [
+                        {
+                            "entity_id": 38,
+                            "entity_type": 17,
+                            "model_id": 4,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 37
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alinos Gateway": {
+                    "pickups": [
+                        {
+                            "entity_id": 13,
+                            "entity_type": 4,
+                            "item_type": 7
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 24,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_RM3_Ent"
+                        },
+                        {
+                            "entity_id": 25,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "High Ground": {
+                    "pickups": [
+                        {
+                            "entity_id": 24,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 81,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 34
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 40,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 6,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 8,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 9,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 74,
+                            "type": 5
+                        },
+                        {
+                            "entity_id": 77,
+                            "type": 5
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 57,
+                            "target_index": 10,
+                            "entity_file_name": "unit1_C4_Ent"
+                        },
+                        {
+                            "entity_id": 58,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_C4_Ent"
+                        }
+                    ]
+                },
+                "Alinos Perch": {
+                    "pickups": [
+                        {
+                            "entity_id": 15,
+                            "entity_type": 4,
+                            "item_type": 5
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": []
+                },
+                "Council Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 5,
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 19,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 21,
+                            "entity_type": 4,
+                            "item_type": 11
+                        },
+                        {
+                            "entity_id": 61,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 36
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 22,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 23,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 52,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Combat Hall": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Processor Core": {
+                    "pickups": [
+                        {
+                            "entity_id": 23,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 1
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 8,
+                            "target_index": 1,
+                            "entity_file_name": "Unit1_TP2_Ent"
+                        }
+                    ]
+                },
+                "Elder Passage": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 4,
+                            "item_type": 9
+                        },
+                        {
+                            "entity_id": 29,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 33
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 2,
+                            "target_index": 0,
+                            "entity_file_name": "Unit1_TP1_Ent"
+                        },
+                        {
+                            "entity_id": 19,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void A": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 0,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void B": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 1,
+                            "entity_file_name": "unit1_RM5_Ent"
+                        }
+                    ]
+                }
+            }
+        },
         "Celestial Archives": {
             "levels": {
                 "Biodefense Chamber A": {
@@ -474,318 +813,224 @@
                 }
             }
         },
-        "Alinos": {
+        "Vesper Defense Outpost": {
             "levels": {
-                "Alimbic Cannon Control Room": {
-                    "pickups": [],
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 1
+                        }
+                    ],
                     "force_fields": [],
                     "portals": []
                 },
                 "Biodefense Chamber B": {
                     "pickups": [
                         {
-                            "entity_id": 8,
-                            "entity_type": 17,
-                            "model_id": 5,
-                            "artifact_id": 0
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Biodefense Chamber A": {
-                    "pickups": [
-                        {
                             "entity_id": 2,
-                            "entity_type": 17,
-                            "model_id": 2,
-                            "artifact_id": 0
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Echo Hall": {
-                    "pickups": [
-                        {
-                            "entity_id": 3,
-                            "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 15,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 42,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 32
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Alimbic Gardens": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Thermal Vast": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Crash Site": {
-                    "pickups": [
-                        {
-                            "entity_id": 4,
                             "entity_type": 4,
                             "item_type": 6
-                        },
-                        {
-                            "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 35
                         }
                     ],
                     "force_fields": [],
                     "portals": []
                 },
-                "Magma Drop": {
-                    "pickups": [
-                        {
-                            "entity_id": 14,
-                            "entity_type": 4,
-                            "item_type": 4
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 29,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_RM1_Ent"
-                        },
-                        {
-                            "entity_id": 28,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_RM1_Ent"
-                        }
-                    ]
-                },
-                "Piston Cave": {
-                    "pickups": [
-                        {
-                            "entity_id": 38,
-                            "entity_type": 17,
-                            "model_id": 4,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 80,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 37
-                        }
-                    ],
+                "Bioweaponry Lab": {
+                    "pickups": [],
                     "force_fields": [],
                     "portals": []
                 },
-                "Alinos Gateway": {
-                    "pickups": [
-                        {
-                            "entity_id": 13,
-                            "entity_type": 4,
-                            "item_type": 7
-                        }
-                    ],
+                "Ascension": {
+                    "pickups": [],
                     "force_fields": [],
                     "portals": [
                         {
-                            "entity_id": 24,
-                            "target_index": 21,
-                            "entity_file_name": "unit1_RM3_Ent"
-                        },
-                        {
-                            "entity_id": 25,
-                            "target_index": 20,
-                            "entity_file_name": "unit1_RM6_Ent"
+                            "entity_id": 35,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_Land_Ent"
                         }
                     ]
                 },
-                "High Ground": {
+                "Cortex CPU": {
                     "pickups": [
-                        {
-                            "entity_id": 24,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 80,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 81,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 34
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 40,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 6,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 8,
-                            "type": 1
-                        },
                         {
                             "entity_id": 9,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 74,
-                            "type": 5
-                        },
-                        {
-                            "entity_id": 77,
-                            "type": 5
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 57,
-                            "target_index": 10,
-                            "entity_file_name": "unit1_C4_Ent"
-                        },
-                        {
-                            "entity_id": 58,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_C4_Ent"
-                        }
-                    ]
-                },
-                "Alinos Perch": {
-                    "pickups": [
-                        {
-                            "entity_id": 15,
                             "entity_type": 4,
-                            "item_type": 5
+                            "item_type": 8
+                        },
+                        {
+                            "entity_id": 18,
+                            "entity_type": 17,
+                            "model_id": 4,
+                            "artifact_id": 1
                         }
                     ],
                     "force_fields": [
                         {
-                            "entity_id": 26,
-                            "type": 6
+                            "entity_id": 27,
+                            "type": 3
                         }
                     ],
                     "portals": []
                 },
-                "Council Chamber": {
+                "VDO Gateway": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 5,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_C1_Ent"
+                        },
+                        {
+                            "entity_id": 8,
+                            "target_index": 40,
+                            "entity_file_name": "unit3_RM1_Ent"
+                        }
+                    ]
+                },
+                "Weapons Complex": {
+                    "pickups": [
+                        {
+                            "entity_id": 23,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 61,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 60,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 45
+                        },
+                        {
+                            "entity_id": 38,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 44
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 9,
+                            "type": 3
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 47,
+                            "target_index": 40,
+                            "entity_file_name": "unit3_Land_Ent"
+                        }
+                    ]
+                },
+                "Fuel Stack": {
+                    "pickups": [
+                        {
+                            "entity_id": 12,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 72,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 57,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 49
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Stasis Bunker": {
                     "pickups": [
                         {
                             "entity_id": 5,
                             "entity_type": 17,
-                            "model_id": 5,
+                            "model_id": 6,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 4,
+                            "entity_type": 17,
+                            "model_id": 2,
                             "artifact_id": 2
                         },
                         {
-                            "entity_id": 19,
+                            "entity_id": 90,
                             "entity_type": 4,
-                            "item_type": 6
+                            "item_type": 4
                         },
                         {
                             "entity_id": 21,
                             "entity_type": 4,
-                            "item_type": 11
+                            "item_type": 19,
+                            "state_bit": 47
                         },
                         {
-                            "entity_id": 61,
+                            "entity_id": 79,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 36
+                            "state_bit": 48
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 3,
+                            "target_index": 5,
+                            "entity_file_name": "Unit3_TP2_Ent"
+                        }
+                    ]
+                },
+                "Compression Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 17,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 9,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 35,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 46
                         }
                     ],
                     "force_fields": [
                         {
-                            "entity_id": 22,
-                            "type": 6
+                            "entity_id": 53,
+                            "type": 3
                         },
                         {
-                            "entity_id": 23,
-                            "type": 6
-                        },
-                        {
-                            "entity_id": 26,
-                            "type": 6
+                            "entity_id": 54,
+                            "type": 3
                         }
                     ],
                     "portals": [
                         {
-                            "entity_id": 52,
-                            "target_index": 21,
-                            "entity_file_name": "unit1_Land_Ent"
-                        }
-                    ]
-                },
-                "Combat Hall": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Processor Core": {
-                    "pickups": [
-                        {
-                            "entity_id": 23,
-                            "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 1
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 8,
-                            "target_index": 1,
-                            "entity_file_name": "Unit1_TP2_Ent"
-                        }
-                    ]
-                },
-                "Elder Passage": {
-                    "pickups": [
-                        {
-                            "entity_id": 4,
-                            "entity_type": 4,
-                            "item_type": 9
-                        },
-                        {
-                            "entity_id": 29,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 33
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 2,
-                            "target_index": 0,
-                            "entity_file_name": "Unit1_TP1_Ent"
-                        },
-                        {
-                            "entity_id": 19,
-                            "target_index": 20,
-                            "entity_file_name": "unit1_Land_Ent"
+                            "entity_id": 36,
+                            "target_index": 4,
+                            "entity_file_name": "Unit3_TP1_Ent"
                         }
                     ]
                 },
@@ -795,8 +1040,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 0,
-                            "entity_file_name": "unit1_RM6_Ent"
+                            "target_index": 4,
+                            "entity_file_name": "unit3_RM4_Ent"
                         }
                     ]
                 },
@@ -806,8 +1051,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 1,
-                            "entity_file_name": "unit1_RM5_Ent"
+                            "target_index": 5,
+                            "entity_file_name": "unit3_RM3_Ent"
                         }
                     ]
                 }
@@ -1079,251 +1324,6 @@
                             "entity_id": 1,
                             "target_index": 2,
                             "entity_file_name": "unit4_RM5_Ent"
-                        }
-                    ]
-                }
-            }
-        },
-        "Vesper Defense Outpost": {
-            "levels": {
-                "Biodefense Chamber A": {
-                    "pickups": [
-                        {
-                            "entity_id": 8,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 1
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Biodefense Chamber B": {
-                    "pickups": [
-                        {
-                            "entity_id": 2,
-                            "entity_type": 4,
-                            "item_type": 6
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Bioweaponry Lab": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Ascension": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 35,
-                            "target_index": 15,
-                            "entity_file_name": "unit3_Land_Ent"
-                        }
-                    ]
-                },
-                "Cortex CPU": {
-                    "pickups": [
-                        {
-                            "entity_id": 9,
-                            "entity_type": 4,
-                            "item_type": 8
-                        },
-                        {
-                            "entity_id": 18,
-                            "entity_type": 17,
-                            "model_id": 4,
-                            "artifact_id": 1
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 27,
-                            "type": 3
-                        }
-                    ],
-                    "portals": []
-                },
-                "VDO Gateway": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 5,
-                            "target_index": 15,
-                            "entity_file_name": "unit3_C1_Ent"
-                        },
-                        {
-                            "entity_id": 8,
-                            "target_index": 40,
-                            "entity_file_name": "unit3_RM1_Ent"
-                        }
-                    ]
-                },
-                "Weapons Complex": {
-                    "pickups": [
-                        {
-                            "entity_id": 23,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 61,
-                            "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 60,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 45
-                        },
-                        {
-                            "entity_id": 38,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 44
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 9,
-                            "type": 3
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 47,
-                            "target_index": 40,
-                            "entity_file_name": "unit3_Land_Ent"
-                        }
-                    ]
-                },
-                "Fuel Stack": {
-                    "pickups": [
-                        {
-                            "entity_id": 12,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 72,
-                            "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 57,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 49
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Stasis Bunker": {
-                    "pickups": [
-                        {
-                            "entity_id": 5,
-                            "entity_type": 17,
-                            "model_id": 6,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 4,
-                            "entity_type": 17,
-                            "model_id": 2,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 90,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 21,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 47
-                        },
-                        {
-                            "entity_id": 79,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 48
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 3,
-                            "target_index": 5,
-                            "entity_file_name": "Unit3_TP2_Ent"
-                        }
-                    ]
-                },
-                "Compression Chamber": {
-                    "pickups": [
-                        {
-                            "entity_id": 17,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 9,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 35,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 46
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 53,
-                            "type": 3
-                        },
-                        {
-                            "entity_id": 54,
-                            "type": 3
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 36,
-                            "target_index": 4,
-                            "entity_file_name": "Unit3_TP1_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void A": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 4,
-                            "entity_file_name": "unit3_RM4_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void B": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 5,
-                            "entity_file_name": "unit3_RM3_Ent"
                         }
                     ]
                 }

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/shuffled_extra_locations_and_skip_planet_intros/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/shuffled_extra_locations_and_skip_planet_intros/world_1.json
@@ -1,5 +1,5 @@
 {
-    "configuration_id": 298617331,
+    "configuration_id": 1436480800,
     "starting_items": {
         "weapons": {
             "battlehammer": false,
@@ -23,7 +23,7 @@
             "arcterra_1": "000",
             "arcterra_2": "000"
         },
-        "octoliths": "11110000"
+        "octoliths": "00000000"
     },
     "areas": {
         "Alinos": {
@@ -37,25 +37,25 @@
                     "pickups": [
                         {
                             "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 4
+                            "entity_type": 17,
+                            "model_id": 8,
+                            "artifact_id": 3
                         },
                         {
                             "entity_id": 16,
                             "entity_type": 17,
-                            "model_id": 7,
-                            "artifact_id": 0
+                            "model_id": 6,
+                            "artifact_id": 1
                         },
                         {
                             "entity_id": 14,
-                            "entity_type": 17,
-                            "model_id": 4,
-                            "artifact_id": 1
+                            "entity_type": 4,
+                            "item_type": 4
                         },
                         {
                             "entity_id": 15,
                             "entity_type": 4,
-                            "item_type": 18
+                            "item_type": 0
                         }
                     ],
                     "force_fields": [],
@@ -67,12 +67,12 @@
                             "entity_id": 2,
                             "entity_type": 17,
                             "model_id": 8,
-                            "artifact_id": 2
+                            "artifact_id": 0
                         },
                         {
                             "entity_id": 13,
                             "entity_type": 4,
-                            "item_type": 0
+                            "item_type": 4
                         },
                         {
                             "entity_id": 16,
@@ -88,19 +88,19 @@
                         {
                             "entity_id": 3,
                             "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 55
+                            "item_type": 6
                         },
                         {
                             "entity_id": 15,
-                            "entity_type": 17,
-                            "model_id": 2,
-                            "artifact_id": 1
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 44
                         },
                         {
                             "entity_id": 42,
-                            "entity_type": 4,
-                            "item_type": 2
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 2
                         }
                     ],
                     "force_fields": [],
@@ -120,14 +120,14 @@
                     "pickups": [
                         {
                             "entity_id": 4,
-                            "entity_type": 17,
-                            "model_id": 2,
-                            "artifact_id": 0
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 38
                         },
                         {
                             "entity_id": 8,
                             "entity_type": 4,
-                            "item_type": 14
+                            "item_type": 2
                         }
                     ],
                     "force_fields": [],
@@ -138,7 +138,7 @@
                         {
                             "entity_id": 14,
                             "entity_type": 4,
-                            "item_type": 1
+                            "item_type": 2
                         }
                     ],
                     "force_fields": [],
@@ -160,13 +160,13 @@
                         {
                             "entity_id": 38,
                             "entity_type": 4,
-                            "item_type": 6
+                            "item_type": 0
                         },
                         {
                             "entity_id": 80,
                             "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 1
+                            "model_id": 6,
+                            "artifact_id": 0
                         }
                     ],
                     "force_fields": [],
@@ -177,7 +177,7 @@
                         {
                             "entity_id": 13,
                             "entity_type": 4,
-                            "item_type": 8
+                            "item_type": 18
                         }
                     ],
                     "force_fields": [],
@@ -198,23 +198,24 @@
                     "pickups": [
                         {
                             "entity_id": 24,
-                            "entity_type": 4,
-                            "item_type": 21
+                            "entity_type": 17,
+                            "model_id": 4,
+                            "artifact_id": 2
                         },
                         {
                             "entity_id": 80,
                             "entity_type": 4,
-                            "item_type": 1
+                            "item_type": 13
                         },
                         {
                             "entity_id": 59,
                             "entity_type": 4,
-                            "item_type": 18
+                            "item_type": 8
                         },
                         {
                             "entity_id": 81,
                             "entity_type": 4,
-                            "item_type": 6
+                            "item_type": 7
                         }
                     ],
                     "force_fields": [
@@ -260,9 +261,8 @@
                     "pickups": [
                         {
                             "entity_id": 15,
-                            "entity_type": 17,
-                            "model_id": 2,
-                            "artifact_id": 2
+                            "entity_type": 4,
+                            "item_type": 18
                         }
                     ],
                     "force_fields": [
@@ -277,26 +277,26 @@
                     "pickups": [
                         {
                             "entity_id": 5,
-                            "entity_type": 4,
-                            "item_type": 13
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 0
                         },
                         {
                             "entity_id": 19,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 44
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 0
                         },
                         {
                             "entity_id": 21,
                             "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 49
+                            "item_type": 1
                         },
                         {
                             "entity_id": 61,
                             "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 2
+                            "model_id": 4,
+                            "artifact_id": 1
                         }
                     ],
                     "force_fields": [
@@ -331,7 +331,7 @@
                         {
                             "entity_id": 23,
                             "entity_type": 4,
-                            "item_type": 2
+                            "item_type": 6
                         }
                     ],
                     "force_fields": [],
@@ -348,13 +348,12 @@
                         {
                             "entity_id": 4,
                             "entity_type": 4,
-                            "item_type": 1
+                            "item_type": 21
                         },
                         {
                             "entity_id": 29,
                             "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 34
+                            "item_type": 0
                         }
                     ],
                     "force_fields": [],
@@ -401,8 +400,9 @@
                     "pickups": [
                         {
                             "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 4
+                            "entity_type": 17,
+                            "model_id": 8,
+                            "artifact_id": 5
                         },
                         {
                             "entity_id": 16,
@@ -412,12 +412,13 @@
                         {
                             "entity_id": 14,
                             "entity_type": 4,
-                            "item_type": 13
+                            "item_type": 18
                         },
                         {
                             "entity_id": 15,
                             "entity_type": 4,
-                            "item_type": 18
+                            "item_type": 19,
+                            "state_bit": 35
                         }
                     ],
                     "force_fields": [],
@@ -429,23 +430,23 @@
                             "entity_id": 2,
                             "entity_type": 17,
                             "model_id": 8,
-                            "artifact_id": 3
+                            "artifact_id": 7
                         },
                         {
                             "entity_id": 3,
                             "entity_type": 4,
-                            "item_type": 14
+                            "item_type": 4
                         },
                         {
                             "entity_id": 5,
                             "entity_type": 4,
-                            "item_type": 6
+                            "item_type": 14
                         },
                         {
                             "entity_id": 15,
                             "entity_type": 17,
-                            "model_id": 5,
-                            "artifact_id": 2
+                            "model_id": 7,
+                            "artifact_id": 1
                         }
                     ],
                     "force_fields": [],
@@ -476,13 +477,13 @@
                         {
                             "entity_id": 3,
                             "entity_type": 17,
-                            "model_id": 6,
-                            "artifact_id": 2
+                            "model_id": 1,
+                            "artifact_id": 1
                         },
                         {
                             "entity_id": 56,
                             "entity_type": 4,
-                            "item_type": 15
+                            "item_type": 0
                         }
                     ],
                     "force_fields": [
@@ -525,18 +526,19 @@
                         {
                             "entity_id": 19,
                             "entity_type": 4,
-                            "item_type": 4
+                            "item_type": 19,
+                            "state_bit": 47
                         },
                         {
                             "entity_id": 21,
                             "entity_type": 4,
-                            "item_type": 15
+                            "item_type": 16
                         },
                         {
                             "entity_id": 49,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 43
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 1
                         }
                     ],
                     "force_fields": [],
@@ -559,7 +561,7 @@
                             "entity_id": 21,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 32
+                            "state_bit": 34
                         }
                     ],
                     "force_fields": [
@@ -586,30 +588,29 @@
                         {
                             "entity_id": 2,
                             "entity_type": 4,
-                            "item_type": 15
+                            "item_type": 14
                         },
                         {
                             "entity_id": 14,
                             "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 37
+                            "item_type": 6
                         },
                         {
                             "entity_id": 57,
                             "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 1
+                            "model_id": 4,
+                            "artifact_id": 0
                         },
                         {
                             "entity_id": 55,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 47
+                            "state_bit": 52
                         },
                         {
                             "entity_id": 46,
                             "entity_type": 4,
-                            "item_type": 0
+                            "item_type": 6
                         }
                     ],
                     "force_fields": [],
@@ -619,24 +620,24 @@
                     "pickups": [
                         {
                             "entity_id": 14,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 45
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 2
                         },
                         {
                             "entity_id": 18,
                             "entity_type": 4,
-                            "item_type": 0
+                            "item_type": 5
                         },
                         {
                             "entity_id": 41,
                             "entity_type": 4,
-                            "item_type": 6
+                            "item_type": 18
                         },
                         {
                             "entity_id": 15,
                             "entity_type": 4,
-                            "item_type": 16
+                            "item_type": 4
                         }
                     ],
                     "force_fields": [],
@@ -646,20 +647,21 @@
                     "pickups": [
                         {
                             "entity_id": 2,
-                            "entity_type": 4,
-                            "item_type": 13
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 2
                         },
                         {
                             "entity_id": 46,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 52
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 0
                         },
                         {
                             "entity_id": 45,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 48
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 1
                         }
                     ],
                     "force_fields": [],
@@ -670,7 +672,7 @@
                         {
                             "entity_id": 64,
                             "entity_type": 4,
-                            "item_type": 6
+                            "item_type": 14
                         }
                     ],
                     "force_fields": [],
@@ -692,8 +694,8 @@
                         {
                             "entity_id": 10,
                             "entity_type": 17,
-                            "model_id": 6,
-                            "artifact_id": 1
+                            "model_id": 0,
+                            "artifact_id": 0
                         },
                         {
                             "entity_id": 29,
@@ -745,9 +747,8 @@
                     "pickups": [
                         {
                             "entity_id": 7,
-                            "entity_type": 17,
-                            "model_id": 6,
-                            "artifact_id": 0
+                            "entity_type": 4,
+                            "item_type": 15
                         }
                     ],
                     "force_fields": [
@@ -785,7 +786,7 @@
                             "entity_id": 10,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 35
+                            "state_bit": 37
                         }
                     ],
                     "force_fields": [
@@ -827,17 +828,17 @@
                             "entity_id": 1,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 46
+                            "state_bit": 42
                         },
                         {
                             "entity_id": 6,
                             "entity_type": 4,
-                            "item_type": 2
+                            "item_type": 0
                         },
                         {
                             "entity_id": 14,
                             "entity_type": 4,
-                            "item_type": 18
+                            "item_type": 13
                         }
                     ],
                     "force_fields": [],
@@ -911,13 +912,14 @@
                         {
                             "entity_id": 14,
                             "entity_type": 4,
-                            "item_type": 4
+                            "item_type": 19,
+                            "state_bit": 39
                         },
                         {
                             "entity_id": 15,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 0
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 55
                         },
                         {
                             "entity_id": 16,
@@ -934,17 +936,18 @@
                             "entity_id": 2,
                             "entity_type": 17,
                             "model_id": 8,
-                            "artifact_id": 0
+                            "artifact_id": 4
                         },
                         {
                             "entity_id": 3,
-                            "entity_type": 4,
-                            "item_type": 2
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 2
                         },
                         {
                             "entity_id": 12,
                             "entity_type": 4,
-                            "item_type": 16
+                            "item_type": 6
                         }
                     ],
                     "force_fields": [],
@@ -971,12 +974,13 @@
                         {
                             "entity_id": 9,
                             "entity_type": 4,
-                            "item_type": 18
+                            "item_type": 1
                         },
                         {
                             "entity_id": 18,
                             "entity_type": 4,
-                            "item_type": 7
+                            "item_type": 19,
+                            "state_bit": 32
                         }
                     ],
                     "force_fields": [
@@ -1008,8 +1012,8 @@
                         {
                             "entity_id": 23,
                             "entity_type": 17,
-                            "model_id": 7,
-                            "artifact_id": 1
+                            "model_id": 6,
+                            "artifact_id": 2
                         },
                         {
                             "entity_id": 61,
@@ -1019,14 +1023,13 @@
                         {
                             "entity_id": 60,
                             "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 42
+                            "item_type": 16
                         },
                         {
                             "entity_id": 38,
-                            "entity_type": 17,
-                            "model_id": 4,
-                            "artifact_id": 0
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 46
                         }
                     ],
                     "force_fields": [
@@ -1047,14 +1050,14 @@
                     "pickups": [
                         {
                             "entity_id": 12,
-                            "entity_type": 4,
-                            "item_type": 10
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 2
                         },
                         {
                             "entity_id": 72,
-                            "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 2
+                            "entity_type": 4,
+                            "item_type": 4
                         },
                         {
                             "entity_id": 57,
@@ -1069,30 +1072,30 @@
                     "pickups": [
                         {
                             "entity_id": 5,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 50
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 0
                         },
                         {
                             "entity_id": 4,
                             "entity_type": 17,
-                            "model_id": 7,
-                            "artifact_id": 2
+                            "model_id": 3,
+                            "artifact_id": 1
                         },
                         {
                             "entity_id": 90,
                             "entity_type": 4,
-                            "item_type": 5
+                            "item_type": 14
                         },
                         {
                             "entity_id": 21,
                             "entity_type": 4,
-                            "item_type": 11
+                            "item_type": 4
                         },
                         {
                             "entity_id": 79,
                             "entity_type": 4,
-                            "item_type": 18
+                            "item_type": 10
                         }
                     ],
                     "force_fields": [],
@@ -1109,18 +1112,19 @@
                         {
                             "entity_id": 17,
                             "entity_type": 4,
-                            "item_type": 18
+                            "item_type": 19,
+                            "state_bit": 50
                         },
                         {
                             "entity_id": 9,
                             "entity_type": 4,
-                            "item_type": 4
+                            "item_type": 15
                         },
                         {
                             "entity_id": 35,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 54
+                            "state_bit": 53
                         }
                     ],
                     "force_fields": [
@@ -1171,24 +1175,26 @@
                     "pickups": [
                         {
                             "entity_id": 2,
-                            "entity_type": 4,
-                            "item_type": 15
+                            "entity_type": 17,
+                            "model_id": 8,
+                            "artifact_id": 2
                         },
                         {
                             "entity_id": 15,
-                            "entity_type": 4,
-                            "item_type": 18
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 1
                         },
                         {
                             "entity_id": 9,
                             "entity_type": 4,
-                            "item_type": 6
+                            "item_type": 18
                         },
                         {
                             "entity_id": 5,
                             "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 1
+                            "model_id": 3,
+                            "artifact_id": 0
                         }
                     ],
                     "force_fields": [],
@@ -1198,24 +1204,24 @@
                     "pickups": [
                         {
                             "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 4
+                            "entity_type": 17,
+                            "model_id": 8,
+                            "artifact_id": 6
                         },
                         {
                             "entity_id": 14,
                             "entity_type": 4,
-                            "item_type": 14
+                            "item_type": 15
                         },
                         {
                             "entity_id": 16,
                             "entity_type": 4,
-                            "item_type": 18
+                            "item_type": 2
                         },
                         {
                             "entity_id": 15,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 2
+                            "entity_type": 4,
+                            "item_type": 15
                         }
                     ],
                     "force_fields": [],
@@ -1226,19 +1232,18 @@
                         {
                             "entity_id": 6,
                             "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 0
+                            "model_id": 7,
+                            "artifact_id": 2
                         },
                         {
                             "entity_id": 18,
                             "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 36
+                            "item_type": 2
                         },
                         {
                             "entity_id": 31,
                             "entity_type": 4,
-                            "item_type": 0
+                            "item_type": 18
                         }
                     ],
                     "force_fields": [],
@@ -1249,7 +1254,7 @@
                         {
                             "entity_id": 50,
                             "entity_type": 4,
-                            "item_type": 14
+                            "item_type": 16
                         }
                     ],
                     "force_fields": [],
@@ -1275,30 +1280,30 @@
                     "pickups": [
                         {
                             "entity_id": 26,
-                            "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 0
+                            "entity_type": 4,
+                            "item_type": 18
                         },
                         {
                             "entity_id": 34,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 38
+                            "state_bit": 33
                         },
                         {
                             "entity_id": 1,
                             "entity_type": 4,
-                            "item_type": 0
+                            "item_type": 19,
+                            "state_bit": 36
                         },
                         {
                             "entity_id": 7,
                             "entity_type": 4,
-                            "item_type": 15
+                            "item_type": 1
                         },
                         {
                             "entity_id": 6,
                             "entity_type": 4,
-                            "item_type": 1
+                            "item_type": 13
                         },
                         {
                             "entity_id": 124,
@@ -1348,7 +1353,7 @@
                             "entity_id": 18,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 53
+                            "state_bit": 40
                         },
                         {
                             "entity_id": 57,
@@ -1358,7 +1363,7 @@
                         {
                             "entity_id": 3,
                             "entity_type": 4,
-                            "item_type": 6
+                            "item_type": 18
                         }
                     ],
                     "force_fields": [],
@@ -1369,19 +1374,18 @@
                         {
                             "entity_id": 29,
                             "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 33
+                            "item_type": 9
                         },
                         {
                             "entity_id": 35,
                             "entity_type": 4,
-                            "item_type": 9
+                            "item_type": 19,
+                            "state_bit": 45
                         },
                         {
                             "entity_id": 42,
-                            "entity_type": 17,
-                            "model_id": 5,
-                            "artifact_id": 1
+                            "entity_type": 4,
+                            "item_type": 11
                         }
                     ],
                     "force_fields": [],
@@ -1391,20 +1395,20 @@
                     "pickups": [
                         {
                             "entity_id": 7,
-                            "entity_type": 17,
-                            "model_id": 4,
-                            "artifact_id": 2
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 43
                         },
                         {
                             "entity_id": 43,
                             "entity_type": 4,
-                            "item_type": 2
+                            "item_type": 18
                         },
                         {
                             "entity_id": 35,
-                            "entity_type": 17,
-                            "model_id": 5,
-                            "artifact_id": 0
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 49
                         }
                     ],
                     "force_fields": [],
@@ -1416,18 +1420,18 @@
                             "entity_id": 46,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 39
+                            "state_bit": 54
                         },
                         {
                             "entity_id": 47,
                             "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 40
+                            "item_type": 18
                         },
                         {
                             "entity_id": 29,
                             "entity_type": 4,
-                            "item_type": 16
+                            "item_type": 19,
+                            "state_bit": 48
                         }
                     ],
                     "force_fields": [],
@@ -1480,7 +1484,7 @@
                         {
                             "entity_id": 49,
                             "entity_type": 4,
-                            "item_type": 18
+                            "item_type": 6
                         },
                         {
                             "entity_id": 49,
@@ -1517,7 +1521,7 @@
                         {
                             "entity_id": 1,
                             "entity_type": 4,
-                            "item_type": 13
+                            "item_type": 6
                         }
                     ],
                     "force_fields": [],
@@ -1550,16 +1554,16 @@
         },
         "string_tables": {
             "scan_log": {
-                "904L": "OCTOLITH HINTS 01\\OCTOLITH 1 is located in VESPER DEFENSE OUTPOST. OCTOLITH 2 is located in VESPER DEFENSE OUTPOST.",
-                "014L": "OCTOLITH HINTS 02\\OCTOLITH 3 is located in ALINOS. OCTOLITH 4 is located in CELESTIAL ARCHIVES.",
-                "114L": "OCTOLITH HINTS 03\\Don't forget that you can always get help if you are struggling.",
-                "214L": "OCTOLITH HINTS 04\\Want a hint? Just go where the items are."
+                "904L": "OCTOLITH HINTS 01\\OCTOLITH 1 is located in ALINOS. OCTOLITH 2 is located in VESPER DEFENSE OUTPOST.",
+                "014L": "OCTOLITH HINTS 02\\OCTOLITH 3 is located in ARCTERRA. OCTOLITH 4 is located in ALINOS.",
+                "114L": "OCTOLITH HINTS 03\\OCTOLITH 5 is located in VESPER DEFENSE OUTPOST. OCTOLITH 6 is located in CELESTIAL ARCHIVES.",
+                "214L": "OCTOLITH HINTS 04\\OCTOLITH 7 is located in ARCTERRA. OCTOLITH 8 is located in CELESTIAL ARCHIVES."
             },
             "ship_in_space": {
                 "100S": "---STARTING ITEMS---",
-                "200S": "OCTOLITH 5\nOCTOLITH 6\nOCTOLITH 7\nOCTOLITH 8\n",
+                "200S": "no additional starting items given.",
                 "300S": "---GOAL---",
-                "400S": "collect 4 OCTOLITHS and defeat GOREA in OUBLIETTE.",
+                "400S": "collect 8 OCTOLITHS and defeat GOREA in OUBLIETTE.",
                 "500S": "---PRESET SETTINGS---",
                 "600S": "FORCE FIELD weaknesses are UNCHANGED.",
                 "700S": "PORTAL destinations are UNCHANGED.",
@@ -1572,7 +1576,7 @@
         }
     },
     "_randovania_meta": {
-        "layout_was_user_modified": true,
+        "layout_was_user_modified": false,
         "in_race_setting": false
     }
 }

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/shuffled_extra_locations_and_skip_planet_intros/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/shuffled_extra_locations_and_skip_planet_intros/world_1.json
@@ -26,6 +26,375 @@
         "octoliths": "11110000"
     },
     "areas": {
+        "Alinos": {
+            "levels": {
+                "Alimbic Cannon Control Room": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber B": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 16,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 14,
+                            "entity_type": 17,
+                            "model_id": 4,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 15,
+                            "entity_type": 4,
+                            "item_type": 18
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 17,
+                            "model_id": 8,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 13,
+                            "entity_type": 4,
+                            "item_type": 0
+                        },
+                        {
+                            "entity_id": 16,
+                            "entity_type": 4,
+                            "item_type": 4
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Echo Hall": {
+                    "pickups": [
+                        {
+                            "entity_id": 3,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 55
+                        },
+                        {
+                            "entity_id": 15,
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 42,
+                            "entity_type": 4,
+                            "item_type": 2
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alimbic Gardens": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Thermal Vast": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Crash Site": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 14
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Magma Drop": {
+                    "pickups": [
+                        {
+                            "entity_id": 14,
+                            "entity_type": 4,
+                            "item_type": 1
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 29,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        },
+                        {
+                            "entity_id": 28,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        }
+                    ]
+                },
+                "Piston Cave": {
+                    "pickups": [
+                        {
+                            "entity_id": 38,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 1
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alinos Gateway": {
+                    "pickups": [
+                        {
+                            "entity_id": 13,
+                            "entity_type": 4,
+                            "item_type": 8
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 24,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_RM3_Ent"
+                        },
+                        {
+                            "entity_id": 25,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "High Ground": {
+                    "pickups": [
+                        {
+                            "entity_id": 24,
+                            "entity_type": 4,
+                            "item_type": 21
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 1
+                        },
+                        {
+                            "entity_id": 59,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 81,
+                            "entity_type": 4,
+                            "item_type": 6
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 40,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 6,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 8,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 9,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 74,
+                            "type": 5
+                        },
+                        {
+                            "entity_id": 77,
+                            "type": 5
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 57,
+                            "target_index": 10,
+                            "entity_file_name": "unit1_C4_Ent"
+                        },
+                        {
+                            "entity_id": 58,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_C4_Ent"
+                        }
+                    ]
+                },
+                "Alinos Perch": {
+                    "pickups": [
+                        {
+                            "entity_id": 15,
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 2
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": []
+                },
+                "Council Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 5,
+                            "entity_type": 4,
+                            "item_type": 13
+                        },
+                        {
+                            "entity_id": 19,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 44
+                        },
+                        {
+                            "entity_id": 21,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 49
+                        },
+                        {
+                            "entity_id": 61,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 2
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 22,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 23,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 52,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Combat Hall": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Processor Core": {
+                    "pickups": [
+                        {
+                            "entity_id": 23,
+                            "entity_type": 4,
+                            "item_type": 2
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 8,
+                            "target_index": 1,
+                            "entity_file_name": "Unit1_TP2_Ent"
+                        }
+                    ]
+                },
+                "Elder Passage": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 4,
+                            "item_type": 1
+                        },
+                        {
+                            "entity_id": 29,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 34
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 2,
+                            "target_index": 0,
+                            "entity_file_name": "Unit1_TP1_Ent"
+                        },
+                        {
+                            "entity_id": 19,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void A": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 0,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void B": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 1,
+                            "entity_file_name": "unit1_RM5_Ent"
+                        }
+                    ]
+                }
+            }
+        },
         "Celestial Archives": {
             "levels": {
                 "Biodefense Chamber A": {
@@ -529,348 +898,246 @@
                 }
             }
         },
-        "Alinos": {
+        "Vesper Defense Outpost": {
             "levels": {
-                "Alimbic Cannon Control Room": {
-                    "pickups": [],
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 17,
+                            "model_id": 8,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 14,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 15,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 16,
+                            "entity_type": 4,
+                            "item_type": 18
+                        }
+                    ],
                     "force_fields": [],
                     "portals": []
                 },
                 "Biodefense Chamber B": {
                     "pickups": [
                         {
-                            "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 16,
-                            "entity_type": 17,
-                            "model_id": 7,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 14,
-                            "entity_type": 17,
-                            "model_id": 4,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 15,
-                            "entity_type": 4,
-                            "item_type": 18
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Biodefense Chamber A": {
-                    "pickups": [
-                        {
                             "entity_id": 2,
                             "entity_type": 17,
                             "model_id": 8,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 13,
-                            "entity_type": 4,
-                            "item_type": 0
-                        },
-                        {
-                            "entity_id": 16,
-                            "entity_type": 4,
-                            "item_type": 4
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Echo Hall": {
-                    "pickups": [
-                        {
-                            "entity_id": 3,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 55
-                        },
-                        {
-                            "entity_id": 15,
-                            "entity_type": 17,
-                            "model_id": 2,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 42,
-                            "entity_type": 4,
-                            "item_type": 2
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Alimbic Gardens": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Thermal Vast": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Crash Site": {
-                    "pickups": [
-                        {
-                            "entity_id": 4,
-                            "entity_type": 17,
-                            "model_id": 2,
                             "artifact_id": 0
                         },
                         {
-                            "entity_id": 8,
+                            "entity_id": 3,
                             "entity_type": 4,
-                            "item_type": 14
+                            "item_type": 2
+                        },
+                        {
+                            "entity_id": 12,
+                            "entity_type": 4,
+                            "item_type": 16
                         }
                     ],
                     "force_fields": [],
                     "portals": []
                 },
-                "Magma Drop": {
-                    "pickups": [
-                        {
-                            "entity_id": 14,
-                            "entity_type": 4,
-                            "item_type": 1
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 29,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_RM1_Ent"
-                        },
-                        {
-                            "entity_id": 28,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_RM1_Ent"
-                        }
-                    ]
-                },
-                "Piston Cave": {
-                    "pickups": [
-                        {
-                            "entity_id": 38,
-                            "entity_type": 4,
-                            "item_type": 6
-                        },
-                        {
-                            "entity_id": 80,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 1
-                        }
-                    ],
+                "Bioweaponry Lab": {
+                    "pickups": [],
                     "force_fields": [],
                     "portals": []
                 },
-                "Alinos Gateway": {
-                    "pickups": [
-                        {
-                            "entity_id": 13,
-                            "entity_type": 4,
-                            "item_type": 8
-                        }
-                    ],
+                "Ascension": {
+                    "pickups": [],
                     "force_fields": [],
                     "portals": [
                         {
-                            "entity_id": 24,
-                            "target_index": 21,
-                            "entity_file_name": "unit1_RM3_Ent"
-                        },
-                        {
-                            "entity_id": 25,
-                            "target_index": 20,
-                            "entity_file_name": "unit1_RM6_Ent"
+                            "entity_id": 35,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_Land_Ent"
                         }
                     ]
                 },
-                "High Ground": {
+                "Cortex CPU": {
                     "pickups": [
                         {
-                            "entity_id": 24,
-                            "entity_type": 4,
-                            "item_type": 21
-                        },
-                        {
-                            "entity_id": 80,
-                            "entity_type": 4,
-                            "item_type": 1
-                        },
-                        {
-                            "entity_id": 59,
+                            "entity_id": 9,
                             "entity_type": 4,
                             "item_type": 18
                         },
                         {
-                            "entity_id": 81,
+                            "entity_id": 18,
                             "entity_type": 4,
-                            "item_type": 6
+                            "item_type": 7
                         }
                     ],
                     "force_fields": [
                         {
-                            "entity_id": 40,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 6,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 8,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 9,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 74,
-                            "type": 5
-                        },
-                        {
-                            "entity_id": 77,
-                            "type": 5
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 57,
-                            "target_index": 10,
-                            "entity_file_name": "unit1_C4_Ent"
-                        },
-                        {
-                            "entity_id": 58,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_C4_Ent"
-                        }
-                    ]
-                },
-                "Alinos Perch": {
-                    "pickups": [
-                        {
-                            "entity_id": 15,
-                            "entity_type": 17,
-                            "model_id": 2,
-                            "artifact_id": 2
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 26,
-                            "type": 6
+                            "entity_id": 27,
+                            "type": 3
                         }
                     ],
                     "portals": []
                 },
-                "Council Chamber": {
+                "VDO Gateway": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 5,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_C1_Ent"
+                        },
+                        {
+                            "entity_id": 8,
+                            "target_index": 40,
+                            "entity_file_name": "unit3_RM1_Ent"
+                        }
+                    ]
+                },
+                "Weapons Complex": {
+                    "pickups": [
+                        {
+                            "entity_id": 23,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 61,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 60,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 42
+                        },
+                        {
+                            "entity_id": 38,
+                            "entity_type": 17,
+                            "model_id": 4,
+                            "artifact_id": 0
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 9,
+                            "type": 3
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 47,
+                            "target_index": 40,
+                            "entity_file_name": "unit3_Land_Ent"
+                        }
+                    ]
+                },
+                "Fuel Stack": {
+                    "pickups": [
+                        {
+                            "entity_id": 12,
+                            "entity_type": 4,
+                            "item_type": 10
+                        },
+                        {
+                            "entity_id": 72,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 57,
+                            "entity_type": 4,
+                            "item_type": 18
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Stasis Bunker": {
                     "pickups": [
                         {
                             "entity_id": 5,
                             "entity_type": 4,
-                            "item_type": 13
+                            "item_type": 19,
+                            "state_bit": 50
                         },
                         {
-                            "entity_id": 19,
+                            "entity_id": 4,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 90,
                             "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 44
+                            "item_type": 5
                         },
                         {
                             "entity_id": 21,
                             "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 49
+                            "item_type": 11
                         },
                         {
-                            "entity_id": 61,
-                            "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 2
+                            "entity_id": 79,
+                            "entity_type": 4,
+                            "item_type": 18
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 3,
+                            "target_index": 5,
+                            "entity_file_name": "Unit3_TP2_Ent"
+                        }
+                    ]
+                },
+                "Compression Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 17,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 9,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 35,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 54
                         }
                     ],
                     "force_fields": [
                         {
-                            "entity_id": 22,
-                            "type": 6
+                            "entity_id": 53,
+                            "type": 3
                         },
                         {
-                            "entity_id": 23,
-                            "type": 6
-                        },
-                        {
-                            "entity_id": 26,
-                            "type": 6
+                            "entity_id": 54,
+                            "type": 3
                         }
                     ],
                     "portals": [
                         {
-                            "entity_id": 52,
-                            "target_index": 21,
-                            "entity_file_name": "unit1_Land_Ent"
-                        }
-                    ]
-                },
-                "Combat Hall": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Processor Core": {
-                    "pickups": [
-                        {
-                            "entity_id": 23,
-                            "entity_type": 4,
-                            "item_type": 2
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 8,
-                            "target_index": 1,
-                            "entity_file_name": "Unit1_TP2_Ent"
-                        }
-                    ]
-                },
-                "Elder Passage": {
-                    "pickups": [
-                        {
-                            "entity_id": 4,
-                            "entity_type": 4,
-                            "item_type": 1
-                        },
-                        {
-                            "entity_id": 29,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 34
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 2,
-                            "target_index": 0,
-                            "entity_file_name": "Unit1_TP1_Ent"
-                        },
-                        {
-                            "entity_id": 19,
-                            "target_index": 20,
-                            "entity_file_name": "unit1_Land_Ent"
+                            "entity_id": 36,
+                            "target_index": 4,
+                            "entity_file_name": "Unit3_TP1_Ent"
                         }
                     ]
                 },
@@ -880,8 +1147,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 0,
-                            "entity_file_name": "unit1_RM6_Ent"
+                            "target_index": 4,
+                            "entity_file_name": "unit3_RM4_Ent"
                         }
                     ]
                 },
@@ -891,8 +1158,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 1,
-                            "entity_file_name": "unit1_RM5_Ent"
+                            "target_index": 5,
+                            "entity_file_name": "unit3_RM3_Ent"
                         }
                     ]
                 }
@@ -1196,273 +1463,6 @@
                             "entity_id": 1,
                             "target_index": 2,
                             "entity_file_name": "unit4_RM5_Ent"
-                        }
-                    ]
-                }
-            }
-        },
-        "Vesper Defense Outpost": {
-            "levels": {
-                "Biodefense Chamber A": {
-                    "pickups": [
-                        {
-                            "entity_id": 8,
-                            "entity_type": 17,
-                            "model_id": 8,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 14,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 15,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 16,
-                            "entity_type": 4,
-                            "item_type": 18
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Biodefense Chamber B": {
-                    "pickups": [
-                        {
-                            "entity_id": 2,
-                            "entity_type": 17,
-                            "model_id": 8,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 3,
-                            "entity_type": 4,
-                            "item_type": 2
-                        },
-                        {
-                            "entity_id": 12,
-                            "entity_type": 4,
-                            "item_type": 16
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Bioweaponry Lab": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Ascension": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 35,
-                            "target_index": 15,
-                            "entity_file_name": "unit3_Land_Ent"
-                        }
-                    ]
-                },
-                "Cortex CPU": {
-                    "pickups": [
-                        {
-                            "entity_id": 9,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 18,
-                            "entity_type": 4,
-                            "item_type": 7
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 27,
-                            "type": 3
-                        }
-                    ],
-                    "portals": []
-                },
-                "VDO Gateway": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 5,
-                            "target_index": 15,
-                            "entity_file_name": "unit3_C1_Ent"
-                        },
-                        {
-                            "entity_id": 8,
-                            "target_index": 40,
-                            "entity_file_name": "unit3_RM1_Ent"
-                        }
-                    ]
-                },
-                "Weapons Complex": {
-                    "pickups": [
-                        {
-                            "entity_id": 23,
-                            "entity_type": 17,
-                            "model_id": 7,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 61,
-                            "entity_type": 4,
-                            "item_type": 6
-                        },
-                        {
-                            "entity_id": 60,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 42
-                        },
-                        {
-                            "entity_id": 38,
-                            "entity_type": 17,
-                            "model_id": 4,
-                            "artifact_id": 0
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 9,
-                            "type": 3
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 47,
-                            "target_index": 40,
-                            "entity_file_name": "unit3_Land_Ent"
-                        }
-                    ]
-                },
-                "Fuel Stack": {
-                    "pickups": [
-                        {
-                            "entity_id": 12,
-                            "entity_type": 4,
-                            "item_type": 10
-                        },
-                        {
-                            "entity_id": 72,
-                            "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 57,
-                            "entity_type": 4,
-                            "item_type": 18
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Stasis Bunker": {
-                    "pickups": [
-                        {
-                            "entity_id": 5,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 50
-                        },
-                        {
-                            "entity_id": 4,
-                            "entity_type": 17,
-                            "model_id": 7,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 90,
-                            "entity_type": 4,
-                            "item_type": 5
-                        },
-                        {
-                            "entity_id": 21,
-                            "entity_type": 4,
-                            "item_type": 11
-                        },
-                        {
-                            "entity_id": 79,
-                            "entity_type": 4,
-                            "item_type": 18
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 3,
-                            "target_index": 5,
-                            "entity_file_name": "Unit3_TP2_Ent"
-                        }
-                    ]
-                },
-                "Compression Chamber": {
-                    "pickups": [
-                        {
-                            "entity_id": 17,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 9,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 35,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 54
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 53,
-                            "type": 3
-                        },
-                        {
-                            "entity_id": 54,
-                            "type": 3
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 36,
-                            "target_index": 4,
-                            "entity_file_name": "Unit3_TP1_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void A": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 4,
-                            "entity_file_name": "unit3_RM4_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void B": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 5,
-                            "entity_file_name": "unit3_RM3_Ent"
                         }
                     ]
                 }

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/shuffled_extra_locations_and_skip_planet_intros/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/shuffled_extra_locations_and_skip_planet_intros/world_1.json
@@ -1280,7 +1280,7 @@
                             "artifact_id": 0
                         },
                         {
-                            "entity_id": 7,
+                            "entity_id": 34,
                             "entity_type": 4,
                             "item_type": 19,
                             "state_bit": 38
@@ -1291,7 +1291,7 @@
                             "item_type": 0
                         },
                         {
-                            "entity_id": 34,
+                            "entity_id": 7,
                             "entity_type": 4,
                             "item_type": 15
                         },

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/shuffled_force_fields/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/shuffled_force_fields/world_1.json
@@ -1145,7 +1145,7 @@
                             "artifact_id": 2
                         },
                         {
-                            "entity_id": 7,
+                            "entity_id": 34,
                             "entity_type": 4,
                             "item_type": 18
                         },
@@ -1156,7 +1156,7 @@
                             "artifact_id": 2
                         },
                         {
-                            "entity_id": 34,
+                            "entity_id": 7,
                             "entity_type": 17,
                             "model_id": 2,
                             "artifact_id": 0

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/shuffled_force_fields/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/shuffled_force_fields/world_1.json
@@ -26,6 +26,346 @@
         "octoliths": "11110000"
     },
     "areas": {
+        "Alinos": {
+            "levels": {
+                "Alimbic Cannon Control Room": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber B": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 4
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 0
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Echo Hall": {
+                    "pickups": [
+                        {
+                            "entity_id": 3,
+                            "entity_type": 4,
+                            "item_type": 8
+                        },
+                        {
+                            "entity_id": 15,
+                            "entity_type": 4,
+                            "item_type": 7
+                        },
+                        {
+                            "entity_id": 42,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 32
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alimbic Gardens": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Thermal Vast": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Crash Site": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 35
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Magma Drop": {
+                    "pickups": [
+                        {
+                            "entity_id": 14,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 0
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 29,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        },
+                        {
+                            "entity_id": 28,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        }
+                    ]
+                },
+                "Piston Cave": {
+                    "pickups": [
+                        {
+                            "entity_id": 38,
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 37
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alinos Gateway": {
+                    "pickups": [
+                        {
+                            "entity_id": 13,
+                            "entity_type": 4,
+                            "item_type": 18
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 24,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_RM3_Ent"
+                        },
+                        {
+                            "entity_id": 25,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "High Ground": {
+                    "pickups": [
+                        {
+                            "entity_id": 24,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 81,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 34
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 40,
+                            "type": 3
+                        },
+                        {
+                            "entity_id": 6,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 8,
+                            "type": 2
+                        },
+                        {
+                            "entity_id": 9,
+                            "type": 0
+                        },
+                        {
+                            "entity_id": 74,
+                            "type": 2
+                        },
+                        {
+                            "entity_id": 77,
+                            "type": 3
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 57,
+                            "target_index": 10,
+                            "entity_file_name": "unit1_C4_Ent"
+                        },
+                        {
+                            "entity_id": 58,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_C4_Ent"
+                        }
+                    ]
+                },
+                "Alinos Perch": {
+                    "pickups": [
+                        {
+                            "entity_id": 15,
+                            "entity_type": 4,
+                            "item_type": 17
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": []
+                },
+                "Council Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 5,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 19,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 21,
+                            "entity_type": 4,
+                            "item_type": 11
+                        },
+                        {
+                            "entity_id": 61,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 36
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 22,
+                            "type": 4
+                        },
+                        {
+                            "entity_id": 23,
+                            "type": 7
+                        },
+                        {
+                            "entity_id": 26,
+                            "type": 0
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 52,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Combat Hall": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Processor Core": {
+                    "pickups": [
+                        {
+                            "entity_id": 23,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 1
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 8,
+                            "target_index": 1,
+                            "entity_file_name": "Unit1_TP2_Ent"
+                        }
+                    ]
+                },
+                "Elder Passage": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 4,
+                            "item_type": 17
+                        },
+                        {
+                            "entity_id": 29,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 33
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 2,
+                            "target_index": 0,
+                            "entity_file_name": "Unit1_TP1_Ent"
+                        },
+                        {
+                            "entity_id": 19,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void A": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 0,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void B": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 1,
+                            "entity_file_name": "unit1_RM5_Ent"
+                        }
+                    ]
+                }
+            }
+        },
         "Celestial Archives": {
             "levels": {
                 "Biodefense Chamber A": {
@@ -476,319 +816,224 @@
                 }
             }
         },
-        "Alinos": {
+        "Vesper Defense Outpost": {
             "levels": {
-                "Alimbic Cannon Control Room": {
-                    "pickups": [],
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 17,
+                            "model_id": 8,
+                            "artifact_id": 3
+                        }
+                    ],
                     "force_fields": [],
                     "portals": []
                 },
                 "Biodefense Chamber B": {
                     "pickups": [
                         {
-                            "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 4
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Biodefense Chamber A": {
-                    "pickups": [
-                        {
                             "entity_id": 2,
                             "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 0
+                            "model_id": 8,
+                            "artifact_id": 1
                         }
                     ],
                     "force_fields": [],
                     "portals": []
                 },
-                "Echo Hall": {
-                    "pickups": [
-                        {
-                            "entity_id": 3,
-                            "entity_type": 4,
-                            "item_type": 8
-                        },
-                        {
-                            "entity_id": 15,
-                            "entity_type": 4,
-                            "item_type": 7
-                        },
-                        {
-                            "entity_id": 42,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 32
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Alimbic Gardens": {
+                "Bioweaponry Lab": {
                     "pickups": [],
                     "force_fields": [],
                     "portals": []
                 },
-                "Thermal Vast": {
+                "Ascension": {
                     "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Crash Site": {
-                    "pickups": [
-                        {
-                            "entity_id": 4,
-                            "entity_type": 17,
-                            "model_id": 5,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 35
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Magma Drop": {
-                    "pickups": [
-                        {
-                            "entity_id": 14,
-                            "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 0
-                        }
-                    ],
                     "force_fields": [],
                     "portals": [
                         {
-                            "entity_id": 29,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_RM1_Ent"
-                        },
-                        {
-                            "entity_id": 28,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_RM1_Ent"
+                            "entity_id": 35,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_Land_Ent"
                         }
                     ]
                 },
-                "Piston Cave": {
+                "Cortex CPU": {
                     "pickups": [
                         {
-                            "entity_id": 38,
+                            "entity_id": 9,
                             "entity_type": 17,
-                            "model_id": 2,
+                            "model_id": 5,
                             "artifact_id": 2
                         },
                         {
-                            "entity_id": 80,
+                            "entity_id": 18,
                             "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 37
+                            "item_type": 6
                         }
                     ],
-                    "force_fields": [],
+                    "force_fields": [
+                        {
+                            "entity_id": 27,
+                            "type": 1
+                        }
+                    ],
                     "portals": []
                 },
-                "Alinos Gateway": {
-                    "pickups": [
-                        {
-                            "entity_id": 13,
-                            "entity_type": 4,
-                            "item_type": 18
-                        }
-                    ],
+                "VDO Gateway": {
+                    "pickups": [],
                     "force_fields": [],
                     "portals": [
                         {
-                            "entity_id": 24,
-                            "target_index": 21,
-                            "entity_file_name": "unit1_RM3_Ent"
+                            "entity_id": 5,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_C1_Ent"
                         },
                         {
-                            "entity_id": 25,
-                            "target_index": 20,
-                            "entity_file_name": "unit1_RM6_Ent"
+                            "entity_id": 8,
+                            "target_index": 40,
+                            "entity_file_name": "unit3_RM1_Ent"
                         }
                     ]
                 },
-                "High Ground": {
+                "Weapons Complex": {
                     "pickups": [
                         {
-                            "entity_id": 24,
+                            "entity_id": 23,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 61,
                             "entity_type": 17,
-                            "model_id": 7,
+                            "model_id": 2,
                             "artifact_id": 1
                         },
                         {
-                            "entity_id": 80,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 81,
+                            "entity_id": 60,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 34
+                            "state_bit": 45
+                        },
+                        {
+                            "entity_id": 38,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 44
                         }
                     ],
                     "force_fields": [
                         {
-                            "entity_id": 40,
-                            "type": 3
-                        },
-                        {
-                            "entity_id": 6,
-                            "type": 6
-                        },
-                        {
-                            "entity_id": 8,
-                            "type": 2
-                        },
-                        {
                             "entity_id": 9,
-                            "type": 0
-                        },
-                        {
-                            "entity_id": 74,
-                            "type": 2
-                        },
-                        {
-                            "entity_id": 77,
-                            "type": 3
+                            "type": 4
                         }
                     ],
                     "portals": [
                         {
-                            "entity_id": 57,
-                            "target_index": 10,
-                            "entity_file_name": "unit1_C4_Ent"
-                        },
-                        {
-                            "entity_id": 58,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_C4_Ent"
+                            "entity_id": 47,
+                            "target_index": 40,
+                            "entity_file_name": "unit3_Land_Ent"
                         }
                     ]
                 },
-                "Alinos Perch": {
+                "Fuel Stack": {
                     "pickups": [
                         {
-                            "entity_id": 15,
-                            "entity_type": 4,
-                            "item_type": 17
-                        }
-                    ],
-                    "force_fields": [
+                            "entity_id": 12,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 1
+                        },
                         {
-                            "entity_id": 26,
-                            "type": 6
+                            "entity_id": 72,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 57,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 49
                         }
                     ],
+                    "force_fields": [],
                     "portals": []
                 },
-                "Council Chamber": {
+                "Stasis Bunker": {
                     "pickups": [
                         {
                             "entity_id": 5,
-                            "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 19,
                             "entity_type": 4,
                             "item_type": 18
+                        },
+                        {
+                            "entity_id": 4,
+                            "entity_type": 4,
+                            "item_type": 10
+                        },
+                        {
+                            "entity_id": 90,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 1
                         },
                         {
                             "entity_id": 21,
                             "entity_type": 4,
-                            "item_type": 11
+                            "item_type": 19,
+                            "state_bit": 47
                         },
                         {
-                            "entity_id": 61,
+                            "entity_id": 79,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 36
+                            "state_bit": 48
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 3,
+                            "target_index": 5,
+                            "entity_file_name": "Unit3_TP2_Ent"
+                        }
+                    ]
+                },
+                "Compression Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 17,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 9,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 35,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 46
                         }
                     ],
                     "force_fields": [
                         {
-                            "entity_id": 22,
-                            "type": 4
+                            "entity_id": 53,
+                            "type": 1
                         },
                         {
-                            "entity_id": 23,
-                            "type": 7
-                        },
-                        {
-                            "entity_id": 26,
-                            "type": 0
+                            "entity_id": 54,
+                            "type": 1
                         }
                     ],
                     "portals": [
                         {
-                            "entity_id": 52,
-                            "target_index": 21,
-                            "entity_file_name": "unit1_Land_Ent"
-                        }
-                    ]
-                },
-                "Combat Hall": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Processor Core": {
-                    "pickups": [
-                        {
-                            "entity_id": 23,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 1
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 8,
-                            "target_index": 1,
-                            "entity_file_name": "Unit1_TP2_Ent"
-                        }
-                    ]
-                },
-                "Elder Passage": {
-                    "pickups": [
-                        {
-                            "entity_id": 4,
-                            "entity_type": 4,
-                            "item_type": 17
-                        },
-                        {
-                            "entity_id": 29,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 33
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 2,
-                            "target_index": 0,
-                            "entity_file_name": "Unit1_TP1_Ent"
-                        },
-                        {
-                            "entity_id": 19,
-                            "target_index": 20,
-                            "entity_file_name": "unit1_Land_Ent"
+                            "entity_id": 36,
+                            "target_index": 4,
+                            "entity_file_name": "Unit3_TP1_Ent"
                         }
                     ]
                 },
@@ -798,8 +1043,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 0,
-                            "entity_file_name": "unit1_RM6_Ent"
+                            "target_index": 4,
+                            "entity_file_name": "unit3_RM4_Ent"
                         }
                     ]
                 },
@@ -809,8 +1054,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 1,
-                            "entity_file_name": "unit1_RM5_Ent"
+                            "target_index": 5,
+                            "entity_file_name": "unit3_RM3_Ent"
                         }
                     ]
                 }
@@ -1083,251 +1328,6 @@
                             "entity_id": 1,
                             "target_index": 2,
                             "entity_file_name": "unit4_RM5_Ent"
-                        }
-                    ]
-                }
-            }
-        },
-        "Vesper Defense Outpost": {
-            "levels": {
-                "Biodefense Chamber A": {
-                    "pickups": [
-                        {
-                            "entity_id": 8,
-                            "entity_type": 17,
-                            "model_id": 8,
-                            "artifact_id": 3
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Biodefense Chamber B": {
-                    "pickups": [
-                        {
-                            "entity_id": 2,
-                            "entity_type": 17,
-                            "model_id": 8,
-                            "artifact_id": 1
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Bioweaponry Lab": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Ascension": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 35,
-                            "target_index": 15,
-                            "entity_file_name": "unit3_Land_Ent"
-                        }
-                    ]
-                },
-                "Cortex CPU": {
-                    "pickups": [
-                        {
-                            "entity_id": 9,
-                            "entity_type": 17,
-                            "model_id": 5,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 18,
-                            "entity_type": 4,
-                            "item_type": 6
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 27,
-                            "type": 1
-                        }
-                    ],
-                    "portals": []
-                },
-                "VDO Gateway": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 5,
-                            "target_index": 15,
-                            "entity_file_name": "unit3_C1_Ent"
-                        },
-                        {
-                            "entity_id": 8,
-                            "target_index": 40,
-                            "entity_file_name": "unit3_RM1_Ent"
-                        }
-                    ]
-                },
-                "Weapons Complex": {
-                    "pickups": [
-                        {
-                            "entity_id": 23,
-                            "entity_type": 4,
-                            "item_type": 6
-                        },
-                        {
-                            "entity_id": 61,
-                            "entity_type": 17,
-                            "model_id": 2,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 60,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 45
-                        },
-                        {
-                            "entity_id": 38,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 44
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 9,
-                            "type": 4
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 47,
-                            "target_index": 40,
-                            "entity_file_name": "unit3_Land_Ent"
-                        }
-                    ]
-                },
-                "Fuel Stack": {
-                    "pickups": [
-                        {
-                            "entity_id": 12,
-                            "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 72,
-                            "entity_type": 4,
-                            "item_type": 6
-                        },
-                        {
-                            "entity_id": 57,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 49
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Stasis Bunker": {
-                    "pickups": [
-                        {
-                            "entity_id": 5,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 4,
-                            "entity_type": 4,
-                            "item_type": 10
-                        },
-                        {
-                            "entity_id": 90,
-                            "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 21,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 47
-                        },
-                        {
-                            "entity_id": 79,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 48
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 3,
-                            "target_index": 5,
-                            "entity_file_name": "Unit3_TP2_Ent"
-                        }
-                    ]
-                },
-                "Compression Chamber": {
-                    "pickups": [
-                        {
-                            "entity_id": 17,
-                            "entity_type": 17,
-                            "model_id": 7,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 9,
-                            "entity_type": 4,
-                            "item_type": 6
-                        },
-                        {
-                            "entity_id": 35,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 46
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 53,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 54,
-                            "type": 1
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 36,
-                            "target_index": 4,
-                            "entity_file_name": "Unit3_TP1_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void A": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 4,
-                            "entity_file_name": "unit3_RM4_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void B": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 5,
-                            "entity_file_name": "unit3_RM3_Ent"
                         }
                     ]
                 }

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/starter_preset/world_1.json
@@ -1145,7 +1145,7 @@
                             "artifact_id": 0
                         },
                         {
-                            "entity_id": 7,
+                            "entity_id": 34,
                             "entity_type": 4,
                             "item_type": 17
                         },
@@ -1155,7 +1155,7 @@
                             "item_type": 6
                         },
                         {
-                            "entity_id": 34,
+                            "entity_id": 7,
                             "entity_type": 4,
                             "item_type": 10
                         },

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/starter_preset/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/starter_preset/world_1.json
@@ -26,6 +26,348 @@
         "octoliths": "11110000"
     },
     "areas": {
+        "Alinos": {
+            "levels": {
+                "Alimbic Cannon Control Room": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber B": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 17,
+                            "model_id": 2,
+                            "artifact_id": 2
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 4,
+                            "item_type": 4
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Echo Hall": {
+                    "pickups": [
+                        {
+                            "entity_id": 3,
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 15,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 42,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 32
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alimbic Gardens": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Thermal Vast": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Crash Site": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 35
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Magma Drop": {
+                    "pickups": [
+                        {
+                            "entity_id": 14,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 1
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 29,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        },
+                        {
+                            "entity_id": 28,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        }
+                    ]
+                },
+                "Piston Cave": {
+                    "pickups": [
+                        {
+                            "entity_id": 38,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 37
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alinos Gateway": {
+                    "pickups": [
+                        {
+                            "entity_id": 13,
+                            "entity_type": 17,
+                            "model_id": 4,
+                            "artifact_id": 2
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 24,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_RM3_Ent"
+                        },
+                        {
+                            "entity_id": 25,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "High Ground": {
+                    "pickups": [
+                        {
+                            "entity_id": 24,
+                            "entity_type": 4,
+                            "item_type": 17
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 81,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 34
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 40,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 6,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 8,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 9,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 74,
+                            "type": 5
+                        },
+                        {
+                            "entity_id": 77,
+                            "type": 5
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 57,
+                            "target_index": 10,
+                            "entity_file_name": "unit1_C4_Ent"
+                        },
+                        {
+                            "entity_id": 58,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_C4_Ent"
+                        }
+                    ]
+                },
+                "Alinos Perch": {
+                    "pickups": [
+                        {
+                            "entity_id": 15,
+                            "entity_type": 17,
+                            "model_id": 6,
+                            "artifact_id": 2
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": []
+                },
+                "Council Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 5,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 19,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 21,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 61,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 36
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 22,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 23,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 52,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Combat Hall": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Processor Core": {
+                    "pickups": [
+                        {
+                            "entity_id": 23,
+                            "entity_type": 4,
+                            "item_type": 7
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 8,
+                            "target_index": 1,
+                            "entity_file_name": "Unit1_TP2_Ent"
+                        }
+                    ]
+                },
+                "Elder Passage": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 29,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 33
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 2,
+                            "target_index": 0,
+                            "entity_file_name": "Unit1_TP1_Ent"
+                        },
+                        {
+                            "entity_id": 19,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void A": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 0,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void B": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 1,
+                            "entity_file_name": "unit1_RM5_Ent"
+                        }
+                    ]
+                }
+            }
+        },
         "Celestial Archives": {
             "levels": {
                 "Biodefense Chamber A": {
@@ -476,321 +818,222 @@
                 }
             }
         },
-        "Alinos": {
+        "Vesper Defense Outpost": {
             "levels": {
-                "Alimbic Cannon Control Room": {
-                    "pickups": [],
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 17,
+                            "model_id": 8,
+                            "artifact_id": 3
+                        }
+                    ],
                     "force_fields": [],
                     "portals": []
                 },
                 "Biodefense Chamber B": {
                     "pickups": [
                         {
-                            "entity_id": 8,
-                            "entity_type": 17,
-                            "model_id": 2,
-                            "artifact_id": 2
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Biodefense Chamber A": {
-                    "pickups": [
-                        {
                             "entity_id": 2,
-                            "entity_type": 4,
-                            "item_type": 4
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Echo Hall": {
-                    "pickups": [
-                        {
-                            "entity_id": 3,
                             "entity_type": 17,
-                            "model_id": 5,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 15,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 42,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 32
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Alimbic Gardens": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Thermal Vast": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Crash Site": {
-                    "pickups": [
-                        {
-                            "entity_id": 4,
-                            "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 35
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Magma Drop": {
-                    "pickups": [
-                        {
-                            "entity_id": 14,
-                            "entity_type": 17,
-                            "model_id": 3,
+                            "model_id": 8,
                             "artifact_id": 1
                         }
                     ],
                     "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 29,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_RM1_Ent"
-                        },
-                        {
-                            "entity_id": 28,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_RM1_Ent"
-                        }
-                    ]
+                    "portals": []
                 },
-                "Piston Cave": {
-                    "pickups": [
-                        {
-                            "entity_id": 38,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 80,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 37
-                        }
-                    ],
+                "Bioweaponry Lab": {
+                    "pickups": [],
                     "force_fields": [],
                     "portals": []
                 },
-                "Alinos Gateway": {
-                    "pickups": [
-                        {
-                            "entity_id": 13,
-                            "entity_type": 17,
-                            "model_id": 4,
-                            "artifact_id": 2
-                        }
-                    ],
+                "Ascension": {
+                    "pickups": [],
                     "force_fields": [],
                     "portals": [
                         {
-                            "entity_id": 24,
-                            "target_index": 21,
-                            "entity_file_name": "unit1_RM3_Ent"
-                        },
-                        {
-                            "entity_id": 25,
-                            "target_index": 20,
-                            "entity_file_name": "unit1_RM6_Ent"
+                            "entity_id": 35,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_Land_Ent"
                         }
                     ]
                 },
-                "High Ground": {
+                "Cortex CPU": {
                     "pickups": [
                         {
-                            "entity_id": 24,
+                            "entity_id": 9,
                             "entity_type": 4,
-                            "item_type": 17
+                            "item_type": 4
                         },
                         {
-                            "entity_id": 80,
-                            "entity_type": 4,
-                            "item_type": 6
-                        },
-                        {
-                            "entity_id": 81,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 34
+                            "entity_id": 18,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 0
                         }
                     ],
                     "force_fields": [
                         {
-                            "entity_id": 40,
-                            "type": 1
-                        },
+                            "entity_id": 27,
+                            "type": 3
+                        }
+                    ],
+                    "portals": []
+                },
+                "VDO Gateway": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
                         {
-                            "entity_id": 6,
-                            "type": 1
+                            "entity_id": 5,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_C1_Ent"
                         },
                         {
                             "entity_id": 8,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 9,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 74,
-                            "type": 5
-                        },
-                        {
-                            "entity_id": 77,
-                            "type": 5
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 57,
-                            "target_index": 10,
-                            "entity_file_name": "unit1_C4_Ent"
-                        },
-                        {
-                            "entity_id": 58,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_C4_Ent"
+                            "target_index": 40,
+                            "entity_file_name": "unit3_RM1_Ent"
                         }
                     ]
                 },
-                "Alinos Perch": {
+                "Weapons Complex": {
                     "pickups": [
                         {
-                            "entity_id": 15,
-                            "entity_type": 17,
-                            "model_id": 6,
-                            "artifact_id": 2
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 26,
-                            "type": 6
-                        }
-                    ],
-                    "portals": []
-                },
-                "Council Chamber": {
-                    "pickups": [
-                        {
-                            "entity_id": 5,
-                            "entity_type": 4,
-                            "item_type": 6
-                        },
-                        {
-                            "entity_id": 19,
+                            "entity_id": 23,
                             "entity_type": 4,
                             "item_type": 18
                         },
                         {
-                            "entity_id": 21,
-                            "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 1
-                        },
-                        {
                             "entity_id": 61,
                             "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 60,
+                            "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 36
+                            "state_bit": 45
+                        },
+                        {
+                            "entity_id": 38,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 44
                         }
                     ],
                     "force_fields": [
                         {
-                            "entity_id": 22,
-                            "type": 6
-                        },
-                        {
-                            "entity_id": 23,
-                            "type": 6
-                        },
-                        {
-                            "entity_id": 26,
-                            "type": 6
+                            "entity_id": 9,
+                            "type": 3
                         }
                     ],
                     "portals": [
                         {
-                            "entity_id": 52,
-                            "target_index": 21,
-                            "entity_file_name": "unit1_Land_Ent"
+                            "entity_id": 47,
+                            "target_index": 40,
+                            "entity_file_name": "unit3_Land_Ent"
                         }
                     ]
                 },
-                "Combat Hall": {
-                    "pickups": [],
+                "Fuel Stack": {
+                    "pickups": [
+                        {
+                            "entity_id": 12,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 72,
+                            "entity_type": 4,
+                            "item_type": 21
+                        },
+                        {
+                            "entity_id": 57,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 49
+                        }
+                    ],
                     "force_fields": [],
                     "portals": []
                 },
-                "Processor Core": {
+                "Stasis Bunker": {
                     "pickups": [
                         {
-                            "entity_id": 23,
-                            "entity_type": 4,
-                            "item_type": 7
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 8,
-                            "target_index": 1,
-                            "entity_file_name": "Unit1_TP2_Ent"
-                        }
-                    ]
-                },
-                "Elder Passage": {
-                    "pickups": [
-                        {
-                            "entity_id": 4,
+                            "entity_id": 5,
                             "entity_type": 17,
-                            "model_id": 7,
+                            "model_id": 3,
                             "artifact_id": 2
                         },
                         {
-                            "entity_id": 29,
+                            "entity_id": 4,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 90,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 21,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 33
+                            "state_bit": 47
+                        },
+                        {
+                            "entity_id": 79,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 48
                         }
                     ],
                     "force_fields": [],
                     "portals": [
                         {
-                            "entity_id": 2,
-                            "target_index": 0,
-                            "entity_file_name": "Unit1_TP1_Ent"
+                            "entity_id": 3,
+                            "target_index": 5,
+                            "entity_file_name": "Unit3_TP2_Ent"
+                        }
+                    ]
+                },
+                "Compression Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 17,
+                            "entity_type": 4,
+                            "item_type": 18
                         },
                         {
-                            "entity_id": 19,
-                            "target_index": 20,
-                            "entity_file_name": "unit1_Land_Ent"
+                            "entity_id": 9,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 35,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 46
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 53,
+                            "type": 3
+                        },
+                        {
+                            "entity_id": 54,
+                            "type": 3
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 36,
+                            "target_index": 4,
+                            "entity_file_name": "Unit3_TP1_Ent"
                         }
                     ]
                 },
@@ -800,8 +1043,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 0,
-                            "entity_file_name": "unit1_RM6_Ent"
+                            "target_index": 4,
+                            "entity_file_name": "unit3_RM4_Ent"
                         }
                     ]
                 },
@@ -811,8 +1054,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 1,
-                            "entity_file_name": "unit1_RM5_Ent"
+                            "target_index": 5,
+                            "entity_file_name": "unit3_RM3_Ent"
                         }
                     ]
                 }
@@ -1085,249 +1328,6 @@
                             "entity_id": 1,
                             "target_index": 2,
                             "entity_file_name": "unit4_RM5_Ent"
-                        }
-                    ]
-                }
-            }
-        },
-        "Vesper Defense Outpost": {
-            "levels": {
-                "Biodefense Chamber A": {
-                    "pickups": [
-                        {
-                            "entity_id": 8,
-                            "entity_type": 17,
-                            "model_id": 8,
-                            "artifact_id": 3
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Biodefense Chamber B": {
-                    "pickups": [
-                        {
-                            "entity_id": 2,
-                            "entity_type": 17,
-                            "model_id": 8,
-                            "artifact_id": 1
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Bioweaponry Lab": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Ascension": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 35,
-                            "target_index": 15,
-                            "entity_file_name": "unit3_Land_Ent"
-                        }
-                    ]
-                },
-                "Cortex CPU": {
-                    "pickups": [
-                        {
-                            "entity_id": 9,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 18,
-                            "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 0
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 27,
-                            "type": 3
-                        }
-                    ],
-                    "portals": []
-                },
-                "VDO Gateway": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 5,
-                            "target_index": 15,
-                            "entity_file_name": "unit3_C1_Ent"
-                        },
-                        {
-                            "entity_id": 8,
-                            "target_index": 40,
-                            "entity_file_name": "unit3_RM1_Ent"
-                        }
-                    ]
-                },
-                "Weapons Complex": {
-                    "pickups": [
-                        {
-                            "entity_id": 23,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 61,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 60,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 45
-                        },
-                        {
-                            "entity_id": 38,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 44
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 9,
-                            "type": 3
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 47,
-                            "target_index": 40,
-                            "entity_file_name": "unit3_Land_Ent"
-                        }
-                    ]
-                },
-                "Fuel Stack": {
-                    "pickups": [
-                        {
-                            "entity_id": 12,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 72,
-                            "entity_type": 4,
-                            "item_type": 21
-                        },
-                        {
-                            "entity_id": 57,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 49
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Stasis Bunker": {
-                    "pickups": [
-                        {
-                            "entity_id": 5,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 4,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 90,
-                            "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 21,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 47
-                        },
-                        {
-                            "entity_id": 79,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 48
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 3,
-                            "target_index": 5,
-                            "entity_file_name": "Unit3_TP2_Ent"
-                        }
-                    ]
-                },
-                "Compression Chamber": {
-                    "pickups": [
-                        {
-                            "entity_id": 17,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 9,
-                            "entity_type": 4,
-                            "item_type": 6
-                        },
-                        {
-                            "entity_id": 35,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 46
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 53,
-                            "type": 3
-                        },
-                        {
-                            "entity_id": 54,
-                            "type": 3
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 36,
-                            "target_index": 4,
-                            "entity_file_name": "Unit3_TP1_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void A": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 4,
-                            "entity_file_name": "unit3_RM4_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void B": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 5,
-                            "entity_file_name": "unit3_RM3_Ent"
                         }
                     ]
                 }

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/starting_items_and_energy_with_nothings/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/starting_items_and_energy_with_nothings/world_1.json
@@ -1144,7 +1144,7 @@
                             "item_type": 17
                         },
                         {
-                            "entity_id": 7,
+                            "entity_id": 34,
                             "entity_type": 4,
                             "item_type": 18
                         },
@@ -1154,7 +1154,7 @@
                             "item_type": 17
                         },
                         {
-                            "entity_id": 34,
+                            "entity_id": 7,
                             "entity_type": 4,
                             "item_type": 17
                         },

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/starting_items_and_energy_with_nothings/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/starting_items_and_energy_with_nothings/world_1.json
@@ -26,6 +26,344 @@
         "octoliths": "11110000"
     },
     "areas": {
+        "Alinos": {
+            "levels": {
+                "Alimbic Cannon Control Room": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber B": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 4
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 17,
+                            "model_id": 8,
+                            "artifact_id": 0
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Echo Hall": {
+                    "pickups": [
+                        {
+                            "entity_id": 3,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 15,
+                            "entity_type": 17,
+                            "model_id": 6,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 42,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 32
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alimbic Gardens": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Thermal Vast": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Crash Site": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 35
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Magma Drop": {
+                    "pickups": [
+                        {
+                            "entity_id": 14,
+                            "entity_type": 4,
+                            "item_type": 6
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 29,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        },
+                        {
+                            "entity_id": 28,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        }
+                    ]
+                },
+                "Piston Cave": {
+                    "pickups": [
+                        {
+                            "entity_id": 38,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 37
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alinos Gateway": {
+                    "pickups": [
+                        {
+                            "entity_id": 13,
+                            "entity_type": 4,
+                            "item_type": 4
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 24,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_RM3_Ent"
+                        },
+                        {
+                            "entity_id": 25,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "High Ground": {
+                    "pickups": [
+                        {
+                            "entity_id": 24,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 81,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 34
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 40,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 6,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 8,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 9,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 74,
+                            "type": 5
+                        },
+                        {
+                            "entity_id": 77,
+                            "type": 5
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 57,
+                            "target_index": 10,
+                            "entity_file_name": "unit1_C4_Ent"
+                        },
+                        {
+                            "entity_id": 58,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_C4_Ent"
+                        }
+                    ]
+                },
+                "Alinos Perch": {
+                    "pickups": [
+                        {
+                            "entity_id": 15,
+                            "entity_type": 4,
+                            "item_type": 18
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": []
+                },
+                "Council Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 5,
+                            "entity_type": 4,
+                            "item_type": 17
+                        },
+                        {
+                            "entity_id": 19,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 21,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 61,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 36
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 22,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 23,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 52,
+                            "target_index": 21,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Combat Hall": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Processor Core": {
+                    "pickups": [
+                        {
+                            "entity_id": 23,
+                            "entity_type": 4,
+                            "item_type": 17
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 8,
+                            "target_index": 1,
+                            "entity_file_name": "Unit1_TP2_Ent"
+                        }
+                    ]
+                },
+                "Elder Passage": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 29,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 33
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 2,
+                            "target_index": 0,
+                            "entity_file_name": "Unit1_TP1_Ent"
+                        },
+                        {
+                            "entity_id": 19,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void A": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 0,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void B": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 1,
+                            "entity_file_name": "unit1_RM5_Ent"
+                        }
+                    ]
+                }
+            }
+        },
         "Celestial Archives": {
             "levels": {
                 "Biodefense Chamber A": {
@@ -478,317 +816,223 @@
                 }
             }
         },
-        "Alinos": {
+        "Vesper Defense Outpost": {
             "levels": {
-                "Alimbic Cannon Control Room": {
-                    "pickups": [],
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 2
+                        }
+                    ],
                     "force_fields": [],
                     "portals": []
                 },
                 "Biodefense Chamber B": {
                     "pickups": [
                         {
-                            "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 4
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Biodefense Chamber A": {
-                    "pickups": [
-                        {
                             "entity_id": 2,
-                            "entity_type": 17,
-                            "model_id": 8,
-                            "artifact_id": 0
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Echo Hall": {
-                    "pickups": [
-                        {
-                            "entity_id": 3,
-                            "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 15,
-                            "entity_type": 17,
-                            "model_id": 6,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 42,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 32
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Alimbic Gardens": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Thermal Vast": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Crash Site": {
-                    "pickups": [
-                        {
-                            "entity_id": 4,
-                            "entity_type": 4,
-                            "item_type": 6
-                        },
-                        {
-                            "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 35
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Magma Drop": {
-                    "pickups": [
-                        {
-                            "entity_id": 14,
                             "entity_type": 4,
                             "item_type": 6
                         }
                     ],
                     "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 29,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_RM1_Ent"
-                        },
-                        {
-                            "entity_id": 28,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_RM1_Ent"
-                        }
-                    ]
+                    "portals": []
                 },
-                "Piston Cave": {
-                    "pickups": [
-                        {
-                            "entity_id": 38,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 80,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 37
-                        }
-                    ],
+                "Bioweaponry Lab": {
+                    "pickups": [],
                     "force_fields": [],
                     "portals": []
                 },
-                "Alinos Gateway": {
-                    "pickups": [
-                        {
-                            "entity_id": 13,
-                            "entity_type": 4,
-                            "item_type": 4
-                        }
-                    ],
+                "Ascension": {
+                    "pickups": [],
                     "force_fields": [],
                     "portals": [
                         {
-                            "entity_id": 24,
-                            "target_index": 21,
-                            "entity_file_name": "unit1_RM3_Ent"
-                        },
-                        {
-                            "entity_id": 25,
-                            "target_index": 20,
-                            "entity_file_name": "unit1_RM6_Ent"
+                            "entity_id": 35,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_Land_Ent"
                         }
                     ]
                 },
-                "High Ground": {
+                "Cortex CPU": {
                     "pickups": [
-                        {
-                            "entity_id": 24,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 80,
-                            "entity_type": 17,
-                            "model_id": 7,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 81,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 34
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 40,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 6,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 8,
-                            "type": 1
-                        },
                         {
                             "entity_id": 9,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 74,
-                            "type": 5
-                        },
-                        {
-                            "entity_id": 77,
-                            "type": 5
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 57,
-                            "target_index": 10,
-                            "entity_file_name": "unit1_C4_Ent"
-                        },
-                        {
-                            "entity_id": 58,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_C4_Ent"
-                        }
-                    ]
-                },
-                "Alinos Perch": {
-                    "pickups": [
-                        {
-                            "entity_id": 15,
-                            "entity_type": 4,
-                            "item_type": 18
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 26,
-                            "type": 6
-                        }
-                    ],
-                    "portals": []
-                },
-                "Council Chamber": {
-                    "pickups": [
-                        {
-                            "entity_id": 5,
                             "entity_type": 4,
                             "item_type": 17
                         },
                         {
-                            "entity_id": 19,
+                            "entity_id": 18,
                             "entity_type": 4,
-                            "item_type": 6
+                            "item_type": 18
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 27,
+                            "type": 3
+                        }
+                    ],
+                    "portals": []
+                },
+                "VDO Gateway": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 5,
+                            "target_index": 15,
+                            "entity_file_name": "unit3_C1_Ent"
                         },
                         {
-                            "entity_id": 21,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 2
+                            "entity_id": 8,
+                            "target_index": 40,
+                            "entity_file_name": "unit3_RM1_Ent"
+                        }
+                    ]
+                },
+                "Weapons Complex": {
+                    "pickups": [
+                        {
+                            "entity_id": 23,
+                            "entity_type": 4,
+                            "item_type": 6
                         },
                         {
                             "entity_id": 61,
                             "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 60,
+                            "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 36
+                            "state_bit": 45
+                        },
+                        {
+                            "entity_id": 38,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 44
                         }
                     ],
                     "force_fields": [
                         {
-                            "entity_id": 22,
-                            "type": 6
-                        },
-                        {
-                            "entity_id": 23,
-                            "type": 6
-                        },
-                        {
-                            "entity_id": 26,
-                            "type": 6
+                            "entity_id": 9,
+                            "type": 3
                         }
                     ],
                     "portals": [
                         {
-                            "entity_id": 52,
-                            "target_index": 21,
-                            "entity_file_name": "unit1_Land_Ent"
+                            "entity_id": 47,
+                            "target_index": 40,
+                            "entity_file_name": "unit3_Land_Ent"
                         }
                     ]
                 },
-                "Combat Hall": {
-                    "pickups": [],
+                "Fuel Stack": {
+                    "pickups": [
+                        {
+                            "entity_id": 12,
+                            "entity_type": 17,
+                            "model_id": 1,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 72,
+                            "entity_type": 17,
+                            "model_id": 6,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 57,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 49
+                        }
+                    ],
                     "force_fields": [],
                     "portals": []
                 },
-                "Processor Core": {
+                "Stasis Bunker": {
                     "pickups": [
                         {
-                            "entity_id": 23,
-                            "entity_type": 4,
-                            "item_type": 17
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 8,
-                            "target_index": 1,
-                            "entity_file_name": "Unit1_TP2_Ent"
-                        }
-                    ]
-                },
-                "Elder Passage": {
-                    "pickups": [
+                            "entity_id": 5,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 0
+                        },
                         {
                             "entity_id": 4,
                             "entity_type": 4,
                             "item_type": 18
                         },
                         {
-                            "entity_id": 29,
+                            "entity_id": 90,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 21,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 33
+                            "state_bit": 47
+                        },
+                        {
+                            "entity_id": 79,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 48
                         }
                     ],
                     "force_fields": [],
                     "portals": [
                         {
-                            "entity_id": 2,
-                            "target_index": 0,
-                            "entity_file_name": "Unit1_TP1_Ent"
+                            "entity_id": 3,
+                            "target_index": 5,
+                            "entity_file_name": "Unit3_TP2_Ent"
+                        }
+                    ]
+                },
+                "Compression Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 17,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 0
                         },
                         {
-                            "entity_id": 19,
-                            "target_index": 20,
-                            "entity_file_name": "unit1_Land_Ent"
+                            "entity_id": 9,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 35,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 46
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 53,
+                            "type": 3
+                        },
+                        {
+                            "entity_id": 54,
+                            "type": 3
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 36,
+                            "target_index": 4,
+                            "entity_file_name": "Unit3_TP1_Ent"
                         }
                     ]
                 },
@@ -798,8 +1042,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 0,
-                            "entity_file_name": "unit1_RM6_Ent"
+                            "target_index": 4,
+                            "entity_file_name": "unit3_RM4_Ent"
                         }
                     ]
                 },
@@ -809,8 +1053,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 1,
-                            "entity_file_name": "unit1_RM5_Ent"
+                            "target_index": 5,
+                            "entity_file_name": "unit3_RM3_Ent"
                         }
                     ]
                 }
@@ -1083,250 +1327,6 @@
                             "entity_id": 1,
                             "target_index": 2,
                             "entity_file_name": "unit4_RM5_Ent"
-                        }
-                    ]
-                }
-            }
-        },
-        "Vesper Defense Outpost": {
-            "levels": {
-                "Biodefense Chamber A": {
-                    "pickups": [
-                        {
-                            "entity_id": 8,
-                            "entity_type": 17,
-                            "model_id": 7,
-                            "artifact_id": 2
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Biodefense Chamber B": {
-                    "pickups": [
-                        {
-                            "entity_id": 2,
-                            "entity_type": 4,
-                            "item_type": 6
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Bioweaponry Lab": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Ascension": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 35,
-                            "target_index": 15,
-                            "entity_file_name": "unit3_Land_Ent"
-                        }
-                    ]
-                },
-                "Cortex CPU": {
-                    "pickups": [
-                        {
-                            "entity_id": 9,
-                            "entity_type": 4,
-                            "item_type": 17
-                        },
-                        {
-                            "entity_id": 18,
-                            "entity_type": 4,
-                            "item_type": 18
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 27,
-                            "type": 3
-                        }
-                    ],
-                    "portals": []
-                },
-                "VDO Gateway": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 5,
-                            "target_index": 15,
-                            "entity_file_name": "unit3_C1_Ent"
-                        },
-                        {
-                            "entity_id": 8,
-                            "target_index": 40,
-                            "entity_file_name": "unit3_RM1_Ent"
-                        }
-                    ]
-                },
-                "Weapons Complex": {
-                    "pickups": [
-                        {
-                            "entity_id": 23,
-                            "entity_type": 4,
-                            "item_type": 6
-                        },
-                        {
-                            "entity_id": 61,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 60,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 45
-                        },
-                        {
-                            "entity_id": 38,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 44
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 9,
-                            "type": 3
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 47,
-                            "target_index": 40,
-                            "entity_file_name": "unit3_Land_Ent"
-                        }
-                    ]
-                },
-                "Fuel Stack": {
-                    "pickups": [
-                        {
-                            "entity_id": 12,
-                            "entity_type": 17,
-                            "model_id": 1,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 72,
-                            "entity_type": 17,
-                            "model_id": 6,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 57,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 49
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Stasis Bunker": {
-                    "pickups": [
-                        {
-                            "entity_id": 5,
-                            "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 4,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 90,
-                            "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 21,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 47
-                        },
-                        {
-                            "entity_id": 79,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 48
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 3,
-                            "target_index": 5,
-                            "entity_file_name": "Unit3_TP2_Ent"
-                        }
-                    ]
-                },
-                "Compression Chamber": {
-                    "pickups": [
-                        {
-                            "entity_id": 17,
-                            "entity_type": 17,
-                            "model_id": 7,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 9,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 35,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 46
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 53,
-                            "type": 3
-                        },
-                        {
-                            "entity_id": 54,
-                            "type": 3
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 36,
-                            "target_index": 4,
-                            "entity_file_name": "Unit3_TP1_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void A": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 4,
-                            "entity_file_name": "unit3_RM4_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void B": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 5,
-                            "entity_file_name": "unit3_RM3_Ent"
                         }
                     ]
                 }

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/two_way_unchecked_portal_shuffle/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/two_way_unchecked_portal_shuffle/world_1.json
@@ -26,6 +26,344 @@
         "octoliths": "11110000"
     },
     "areas": {
+        "Alinos": {
+            "levels": {
+                "Alimbic Cannon Control Room": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber B": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 18
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 2,
+                            "entity_type": 4,
+                            "item_type": 6
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Echo Hall": {
+                    "pickups": [
+                        {
+                            "entity_id": 3,
+                            "entity_type": 17,
+                            "model_id": 6,
+                            "artifact_id": 0
+                        },
+                        {
+                            "entity_id": 15,
+                            "entity_type": 4,
+                            "item_type": 8
+                        },
+                        {
+                            "entity_id": 42,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 32
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alimbic Gardens": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Thermal Vast": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Crash Site": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 8,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 35
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Magma Drop": {
+                    "pickups": [
+                        {
+                            "entity_id": 14,
+                            "entity_type": 4,
+                            "item_type": 18
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 29,
+                            "target_index": 0,
+                            "entity_file_name": "unit1_RM6_Ent"
+                        },
+                        {
+                            "entity_id": 28,
+                            "target_index": 2,
+                            "entity_file_name": "unit2_C4_Ent"
+                        }
+                    ]
+                },
+                "Piston Cave": {
+                    "pickups": [
+                        {
+                            "entity_id": 38,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 37
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Alinos Gateway": {
+                    "pickups": [
+                        {
+                            "entity_id": 13,
+                            "entity_type": 17,
+                            "model_id": 0,
+                            "artifact_id": 0
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 24,
+                            "target_index": 21,
+                            "entity_file_name": "unit2_Land_Ent"
+                        },
+                        {
+                            "entity_id": 25,
+                            "target_index": 5,
+                            "entity_file_name": "unit3_RM3_Ent"
+                        }
+                    ]
+                },
+                "High Ground": {
+                    "pickups": [
+                        {
+                            "entity_id": 24,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 80,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 81,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 34
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 40,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 6,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 8,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 9,
+                            "type": 1
+                        },
+                        {
+                            "entity_id": 74,
+                            "type": 5
+                        },
+                        {
+                            "entity_id": 77,
+                            "type": 5
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 57,
+                            "target_index": 3,
+                            "entity_file_name": "Unit4_TP2_Ent"
+                        },
+                        {
+                            "entity_id": 58,
+                            "target_index": 0,
+                            "entity_file_name": "Unit1_TP1_Ent"
+                        }
+                    ]
+                },
+                "Alinos Perch": {
+                    "pickups": [
+                        {
+                            "entity_id": 15,
+                            "entity_type": 4,
+                            "item_type": 4
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": []
+                },
+                "Council Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 5,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 19,
+                            "entity_type": 4,
+                            "item_type": 5
+                        },
+                        {
+                            "entity_id": 21,
+                            "entity_type": 17,
+                            "model_id": 7,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 61,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 36
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 22,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 23,
+                            "type": 6
+                        },
+                        {
+                            "entity_id": 26,
+                            "type": 6
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 52,
+                            "target_index": 10,
+                            "entity_file_name": "unit2_C4_Ent"
+                        }
+                    ]
+                },
+                "Combat Hall": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Processor Core": {
+                    "pickups": [
+                        {
+                            "entity_id": 23,
+                            "entity_type": 4,
+                            "item_type": 17
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 8,
+                            "target_index": 26,
+                            "entity_file_name": "unit2_RM6_Ent"
+                        }
+                    ]
+                },
+                "Elder Passage": {
+                    "pickups": [
+                        {
+                            "entity_id": 4,
+                            "entity_type": 4,
+                            "item_type": 6
+                        },
+                        {
+                            "entity_id": 29,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 33
+                        }
+                    ],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 2,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_C4_Ent"
+                        },
+                        {
+                            "entity_id": 19,
+                            "target_index": 18,
+                            "entity_file_name": "unit2_RM5_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void A": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 11,
+                            "entity_file_name": "unit1_RM1_Ent"
+                        }
+                    ]
+                },
+                "Stronghold Void B": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 1,
+                            "target_index": 3,
+                            "entity_file_name": "unit2_C7_Ent"
+                        }
+                    ]
+                }
+            }
+        },
         "Celestial Archives": {
             "levels": {
                 "Biodefense Chamber A": {
@@ -477,317 +815,223 @@
                 }
             }
         },
-        "Alinos": {
+        "Vesper Defense Outpost": {
             "levels": {
-                "Alimbic Cannon Control Room": {
-                    "pickups": [],
+                "Biodefense Chamber A": {
+                    "pickups": [
+                        {
+                            "entity_id": 8,
+                            "entity_type": 17,
+                            "model_id": 8,
+                            "artifact_id": 3
+                        }
+                    ],
                     "force_fields": [],
                     "portals": []
                 },
                 "Biodefense Chamber B": {
                     "pickups": [
                         {
-                            "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 18
+                            "entity_id": 2,
+                            "entity_type": 17,
+                            "model_id": 8,
+                            "artifact_id": 2
                         }
                     ],
                     "force_fields": [],
                     "portals": []
                 },
-                "Biodefense Chamber A": {
+                "Bioweaponry Lab": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": []
+                },
+                "Ascension": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
+                        {
+                            "entity_id": 35,
+                            "target_index": 22,
+                            "entity_file_name": "unit2_RM5_Ent"
+                        }
+                    ]
+                },
+                "Cortex CPU": {
                     "pickups": [
                         {
-                            "entity_id": 2,
+                            "entity_id": 9,
+                            "entity_type": 4,
+                            "item_type": 7
+                        },
+                        {
+                            "entity_id": 18,
                             "entity_type": 4,
                             "item_type": 6
                         }
                     ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Echo Hall": {
-                    "pickups": [
-                        {
-                            "entity_id": 3,
-                            "entity_type": 17,
-                            "model_id": 6,
-                            "artifact_id": 0
-                        },
-                        {
-                            "entity_id": 15,
-                            "entity_type": 4,
-                            "item_type": 8
-                        },
-                        {
-                            "entity_id": 42,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 32
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Alimbic Gardens": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Thermal Vast": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Crash Site": {
-                    "pickups": [
-                        {
-                            "entity_id": 4,
-                            "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 8,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 35
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Magma Drop": {
-                    "pickups": [
-                        {
-                            "entity_id": 14,
-                            "entity_type": 4,
-                            "item_type": 18
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 29,
-                            "target_index": 0,
-                            "entity_file_name": "unit1_RM6_Ent"
-                        },
-                        {
-                            "entity_id": 28,
-                            "target_index": 2,
-                            "entity_file_name": "unit2_C4_Ent"
-                        }
-                    ]
-                },
-                "Piston Cave": {
-                    "pickups": [
-                        {
-                            "entity_id": 38,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 80,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 37
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Alinos Gateway": {
-                    "pickups": [
-                        {
-                            "entity_id": 13,
-                            "entity_type": 17,
-                            "model_id": 0,
-                            "artifact_id": 0
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 24,
-                            "target_index": 21,
-                            "entity_file_name": "unit2_Land_Ent"
-                        },
-                        {
-                            "entity_id": 25,
-                            "target_index": 5,
-                            "entity_file_name": "unit3_RM3_Ent"
-                        }
-                    ]
-                },
-                "High Ground": {
-                    "pickups": [
-                        {
-                            "entity_id": 24,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 80,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 81,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 34
-                        }
-                    ],
                     "force_fields": [
                         {
-                            "entity_id": 40,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 6,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 8,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 9,
-                            "type": 1
-                        },
-                        {
-                            "entity_id": 74,
-                            "type": 5
-                        },
-                        {
-                            "entity_id": 77,
-                            "type": 5
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 57,
-                            "target_index": 3,
-                            "entity_file_name": "Unit4_TP2_Ent"
-                        },
-                        {
-                            "entity_id": 58,
-                            "target_index": 0,
-                            "entity_file_name": "Unit1_TP1_Ent"
-                        }
-                    ]
-                },
-                "Alinos Perch": {
-                    "pickups": [
-                        {
-                            "entity_id": 15,
-                            "entity_type": 4,
-                            "item_type": 4
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 26,
-                            "type": 6
+                            "entity_id": 27,
+                            "type": 3
                         }
                     ],
                     "portals": []
                 },
-                "Council Chamber": {
-                    "pickups": [
+                "VDO Gateway": {
+                    "pickups": [],
+                    "force_fields": [],
+                    "portals": [
                         {
                             "entity_id": 5,
-                            "entity_type": 4,
-                            "item_type": 4
+                            "target_index": 31,
+                            "entity_file_name": "unit2_RM7_Ent"
                         },
                         {
-                            "entity_id": 19,
-                            "entity_type": 4,
-                            "item_type": 5
-                        },
+                            "entity_id": 8,
+                            "target_index": 20,
+                            "entity_file_name": "unit2_Land_Ent"
+                        }
+                    ]
+                },
+                "Weapons Complex": {
+                    "pickups": [
                         {
-                            "entity_id": 21,
+                            "entity_id": 23,
                             "entity_type": 17,
-                            "model_id": 7,
-                            "artifact_id": 1
+                            "model_id": 2,
+                            "artifact_id": 2
                         },
                         {
                             "entity_id": 61,
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 2
+                        },
+                        {
+                            "entity_id": 60,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 36
+                            "state_bit": 45
+                        },
+                        {
+                            "entity_id": 38,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 44
                         }
                     ],
                     "force_fields": [
                         {
-                            "entity_id": 22,
-                            "type": 6
-                        },
-                        {
-                            "entity_id": 23,
-                            "type": 6
-                        },
-                        {
-                            "entity_id": 26,
-                            "type": 6
+                            "entity_id": 9,
+                            "type": 3
                         }
                     ],
                     "portals": [
                         {
-                            "entity_id": 52,
-                            "target_index": 10,
-                            "entity_file_name": "unit2_C4_Ent"
+                            "entity_id": 47,
+                            "target_index": 19,
+                            "entity_file_name": "unit2_RM5_Ent"
                         }
                     ]
                 },
-                "Combat Hall": {
-                    "pickups": [],
+                "Fuel Stack": {
+                    "pickups": [
+                        {
+                            "entity_id": 12,
+                            "entity_type": 4,
+                            "item_type": 4
+                        },
+                        {
+                            "entity_id": 72,
+                            "entity_type": 4,
+                            "item_type": 11
+                        },
+                        {
+                            "entity_id": 57,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 49
+                        }
+                    ],
                     "force_fields": [],
                     "portals": []
                 },
-                "Processor Core": {
+                "Stasis Bunker": {
                     "pickups": [
                         {
-                            "entity_id": 23,
-                            "entity_type": 4,
-                            "item_type": 17
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 8,
-                            "target_index": 26,
-                            "entity_file_name": "unit2_RM6_Ent"
-                        }
-                    ]
-                },
-                "Elder Passage": {
-                    "pickups": [
+                            "entity_id": 5,
+                            "entity_type": 17,
+                            "model_id": 5,
+                            "artifact_id": 1
+                        },
                         {
                             "entity_id": 4,
                             "entity_type": 4,
-                            "item_type": 6
+                            "item_type": 17
                         },
                         {
-                            "entity_id": 29,
+                            "entity_id": 90,
+                            "entity_type": 17,
+                            "model_id": 3,
+                            "artifact_id": 1
+                        },
+                        {
+                            "entity_id": 21,
                             "entity_type": 4,
                             "item_type": 19,
-                            "state_bit": 33
+                            "state_bit": 47
+                        },
+                        {
+                            "entity_id": 79,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 48
                         }
                     ],
                     "force_fields": [],
                     "portals": [
                         {
-                            "entity_id": 2,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_C4_Ent"
+                            "entity_id": 3,
+                            "target_index": 20,
+                            "entity_file_name": "unit1_Land_Ent"
+                        }
+                    ]
+                },
+                "Compression Chamber": {
+                    "pickups": [
+                        {
+                            "entity_id": 17,
+                            "entity_type": 4,
+                            "item_type": 17
                         },
                         {
-                            "entity_id": 19,
-                            "target_index": 18,
-                            "entity_file_name": "unit2_RM5_Ent"
+                            "entity_id": 9,
+                            "entity_type": 4,
+                            "item_type": 18
+                        },
+                        {
+                            "entity_id": 35,
+                            "entity_type": 4,
+                            "item_type": 19,
+                            "state_bit": 46
+                        }
+                    ],
+                    "force_fields": [
+                        {
+                            "entity_id": 53,
+                            "type": 3
+                        },
+                        {
+                            "entity_id": 54,
+                            "type": 3
+                        }
+                    ],
+                    "portals": [
+                        {
+                            "entity_id": 36,
+                            "target_index": 60,
+                            "entity_file_name": "unit4_RM1_Ent"
                         }
                     ]
                 },
@@ -797,8 +1041,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 11,
-                            "entity_file_name": "unit1_RM1_Ent"
+                            "target_index": 10,
+                            "entity_file_name": "unit2_RM4_Ent"
                         }
                     ]
                 },
@@ -808,8 +1052,8 @@
                     "portals": [
                         {
                             "entity_id": 1,
-                            "target_index": 3,
-                            "entity_file_name": "unit2_C7_Ent"
+                            "target_index": 16,
+                            "entity_file_name": "unit2_RM8_Ent"
                         }
                     ]
                 }
@@ -1083,250 +1327,6 @@
                             "entity_id": 1,
                             "target_index": 11,
                             "entity_file_name": "unit1_RM1_Ent"
-                        }
-                    ]
-                }
-            }
-        },
-        "Vesper Defense Outpost": {
-            "levels": {
-                "Biodefense Chamber A": {
-                    "pickups": [
-                        {
-                            "entity_id": 8,
-                            "entity_type": 17,
-                            "model_id": 8,
-                            "artifact_id": 3
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Biodefense Chamber B": {
-                    "pickups": [
-                        {
-                            "entity_id": 2,
-                            "entity_type": 17,
-                            "model_id": 8,
-                            "artifact_id": 2
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Bioweaponry Lab": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Ascension": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 35,
-                            "target_index": 22,
-                            "entity_file_name": "unit2_RM5_Ent"
-                        }
-                    ]
-                },
-                "Cortex CPU": {
-                    "pickups": [
-                        {
-                            "entity_id": 9,
-                            "entity_type": 4,
-                            "item_type": 7
-                        },
-                        {
-                            "entity_id": 18,
-                            "entity_type": 4,
-                            "item_type": 6
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 27,
-                            "type": 3
-                        }
-                    ],
-                    "portals": []
-                },
-                "VDO Gateway": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 5,
-                            "target_index": 31,
-                            "entity_file_name": "unit2_RM7_Ent"
-                        },
-                        {
-                            "entity_id": 8,
-                            "target_index": 20,
-                            "entity_file_name": "unit2_Land_Ent"
-                        }
-                    ]
-                },
-                "Weapons Complex": {
-                    "pickups": [
-                        {
-                            "entity_id": 23,
-                            "entity_type": 17,
-                            "model_id": 2,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 61,
-                            "entity_type": 17,
-                            "model_id": 5,
-                            "artifact_id": 2
-                        },
-                        {
-                            "entity_id": 60,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 45
-                        },
-                        {
-                            "entity_id": 38,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 44
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 9,
-                            "type": 3
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 47,
-                            "target_index": 19,
-                            "entity_file_name": "unit2_RM5_Ent"
-                        }
-                    ]
-                },
-                "Fuel Stack": {
-                    "pickups": [
-                        {
-                            "entity_id": 12,
-                            "entity_type": 4,
-                            "item_type": 4
-                        },
-                        {
-                            "entity_id": 72,
-                            "entity_type": 4,
-                            "item_type": 11
-                        },
-                        {
-                            "entity_id": 57,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 49
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": []
-                },
-                "Stasis Bunker": {
-                    "pickups": [
-                        {
-                            "entity_id": 5,
-                            "entity_type": 17,
-                            "model_id": 5,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 4,
-                            "entity_type": 4,
-                            "item_type": 17
-                        },
-                        {
-                            "entity_id": 90,
-                            "entity_type": 17,
-                            "model_id": 3,
-                            "artifact_id": 1
-                        },
-                        {
-                            "entity_id": 21,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 47
-                        },
-                        {
-                            "entity_id": 79,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 48
-                        }
-                    ],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 3,
-                            "target_index": 20,
-                            "entity_file_name": "unit1_Land_Ent"
-                        }
-                    ]
-                },
-                "Compression Chamber": {
-                    "pickups": [
-                        {
-                            "entity_id": 17,
-                            "entity_type": 4,
-                            "item_type": 17
-                        },
-                        {
-                            "entity_id": 9,
-                            "entity_type": 4,
-                            "item_type": 18
-                        },
-                        {
-                            "entity_id": 35,
-                            "entity_type": 4,
-                            "item_type": 19,
-                            "state_bit": 46
-                        }
-                    ],
-                    "force_fields": [
-                        {
-                            "entity_id": 53,
-                            "type": 3
-                        },
-                        {
-                            "entity_id": 54,
-                            "type": 3
-                        }
-                    ],
-                    "portals": [
-                        {
-                            "entity_id": 36,
-                            "target_index": 60,
-                            "entity_file_name": "unit4_RM1_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void A": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 10,
-                            "entity_file_name": "unit2_RM4_Ent"
-                        }
-                    ]
-                },
-                "Stronghold Void B": {
-                    "pickups": [],
-                    "force_fields": [],
-                    "portals": [
-                        {
-                            "entity_id": 1,
-                            "target_index": 16,
-                            "entity_file_name": "unit2_RM8_Ent"
                         }
                     ]
                 }

--- a/test/test_files/patcher_data/prime_hunters/prime_hunters/two_way_unchecked_portal_shuffle/world_1.json
+++ b/test/test_files/patcher_data/prime_hunters/prime_hunters/two_way_unchecked_portal_shuffle/world_1.json
@@ -1143,7 +1143,7 @@
                             "artifact_id": 0
                         },
                         {
-                            "entity_id": 7,
+                            "entity_id": 34,
                             "entity_type": 4,
                             "item_type": 17
                         },
@@ -1153,7 +1153,7 @@
                             "item_type": 4
                         },
                         {
-                            "entity_id": 34,
+                            "entity_id": 7,
                             "entity_type": 4,
                             "item_type": 18
                         },

--- a/uv.lock
+++ b/uv.lock
@@ -1945,7 +1945,7 @@ wheels = [
 
 [[package]]
 name = "open-prime-hunters-rando"
-version = "0.11.2"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "construct" },
@@ -1953,9 +1953,9 @@ dependencies = [
     { name = "ndspy" },
     { name = "types-jsonschema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/05/d8c5d845e940c9c6be578616e3e69c8778c11cc6117528df03ccce36b1d4/open_prime_hunters_rando-0.11.2.tar.gz", hash = "sha256:61689360fbf4943dadf3c5d86c4668a5106e3a9b14a2ae0ed877e11953b22fa7", size = 126351, upload-time = "2026-06-26T23:27:12.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/90/b622ca59e055c80962462174f65682846234dbfc290598ae306ef8017c4a/open_prime_hunters_rando-0.12.0.tar.gz", hash = "sha256:df4d59854ee8d0e0930a1b8fd6cd36c61431344c88af51e60fdbfae36ce84bcf", size = 127961, upload-time = "2026-07-16T02:16:17.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/0e/2d1d13ffa7ead88c278725ddd3fd8ebf50425ee6831e8f2b88a9799e8a5c/open_prime_hunters_rando-0.11.2-py3-none-any.whl", hash = "sha256:ce2bdb7af5b4f593f8683a621ca3341a0194b0065dad5d449defbcc105fa0f81", size = 115110, upload-time = "2026-06-26T23:27:11.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/3f/911405f81c73c87e5040f9fdb035a0c5527ca6e989cee3ea5e075651ec8a/open_prime_hunters_rando-0.12.0-py3-none-any.whl", hash = "sha256:6bfff608304191c873ba5c3d9cbc4b88cd0ef20d1d2b68e778b87d8175884edd", size = 116868, upload-time = "2026-07-16T02:16:16.163Z" },
 ]
 
 [[package]]
@@ -3096,7 +3096,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'gui'" },
     { name = "oauthlib", marker = "extra == 'server'" },
     { name = "open-dread-rando", marker = "extra == 'exporters'", specifier = "==2.20.1" },
-    { name = "open-prime-hunters-rando", marker = "extra == 'exporters'", specifier = "==0.11.2" },
+    { name = "open-prime-hunters-rando", marker = "extra == 'exporters'", specifier = "==0.12.0" },
     { name = "open-prime-rando", extras = ["nod"], marker = "extra == 'exporters'", specifier = "==0.20.1" },
     { name = "open-samus-returns-rando", marker = "extra == 'exporters'", specifier = "==3.6.1" },
     { name = "packaging" },


### PR DESCRIPTION
- Fixes crashes when collecting/using Missile Launcher
- Better support for exporting supported game versions
- Fixes exporting if no Octoliths are shuffled
- Fixes Judicator and Missile Expansion location extra data being swapped in Ice Hive
- Fixes softlocking in rooms with random guardians on post-boss layers