### PR TITLE
Emit inventory even when nothing new was collected

### DIFF
--- a/randovania/game_connection/connector/abandoned_world_remote_connector.py
+++ b/randovania/game_connection/connector/abandoned_world_remote_connector.py
@@ -267,11 +267,12 @@ class AbandonedWorldRemoteConnector(RemoteConnector):
                     emitted_location = True
                     self.PlayerLocationChanged.emit(PlayerLocationEvent(end_state.node.region, end_state.node.area))
 
+                self._emit_inventory(end_state)
+
                 if new_indices:
                     self._collected.update(new_indices)
                     for index in sorted(new_indices):
                         self.PickupIndexCollected.emit(PickupIndex(index))
-                    self._emit_inventory(end_state)
 
                     # More may be in logic: stay scheduled for the next paced round.
                     self._dirty.set()


### PR DESCRIPTION
Moved the line because a remote pickup leads to a new inventory independent if the round itself found a new pickup or not.
Otherwise, an already exhausted world will never update its inventory.
