### PR TITLE
Fix AM2R generation without nest pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed: Some games being wrongly considered impossible.
 
+### Another Metroid 2 Remake
+
+- Fixed: Generating a game with the new Teleporter Pipes in final areas disabled no longer causes an exception.
+
 ### Metroid Dread
 
 - Changed: The icon for the Super Missile in the automatic item tracker has been made lighter in color so that it matches the other icons better.

--- a/randovania/game_description/integrity_check.py
+++ b/randovania/game_description/integrity_check.py
@@ -146,6 +146,12 @@ def find_node_errors(game: GameDescription, node: Node) -> Iterator[str]:
 
         if other_node is not None:
             if isinstance(other_node, DockNode):
+                if set(other_node.layers) != set(node.layers):
+                    yield (
+                        f"{node.name} has layers {sorted(node.layers)}, but connected dock "
+                        f"'{node.default_connection}' has layers {sorted(other_node.layers)}."
+                    )
+
                 if other_node.default_connection != node.identifier:
                     yield (
                         f"{node.name} connects to '{node.default_connection}', but that dock connects "

--- a/randovania/games/am2r/logic_database/The Depths.json
+++ b/randovania/games/am2r/logic_database/The Depths.json
@@ -4622,7 +4622,7 @@
                     },
                     "description": "",
                     "layers": [
-                        "default"
+                        "new-pipes"
                     ],
                     "extra": {
                         "instance_id": 400004,

--- a/randovania/games/am2r/logic_database/The Depths.txt
+++ b/randovania/games/am2r/logic_database/The Depths.txt
@@ -808,7 +808,7 @@ Extra - liquid_info: {'liquid_type': 0, 'liquid_level': 0}
       Trivial
 
 > Pipe to Hideout Hub Access East; Heals? False
-  * Layers: default
+  * Layers: new-pipes
   * Teleporter to Hideout Hub Access East/Pipe to Bubble Lair Shinespark Cave East; Custom name: The Depths - Shinespark Cave Pipe
   * Extra - instance_id: 400004
   * Extra - dest_x: 216

--- a/test/game_description/test_integrity_check.py
+++ b/test/game_description/test_integrity_check.py
@@ -55,6 +55,8 @@ def test_invalid_db(test_files_dir):
         "World/Area 1/Event - Foo has a connection to itself",
         "World/Area 1/Door to Area 2 (Generic) should be named 'Other to Area 2'",
         "World/Area 1/Door to Area 2 (Dock) should be named 'Other to Area 2'",
+        "World/Area 1/Door to Area 2 (Dock) has layers ['alternate'], but connected dock "
+        "'region World/area Area 2/node Door to Area 1' has layers ['default'].",
         "World/Area 1/Door to Area 2 (Dock) connects to 'region World/area Area 2/node Door to Area 1', "
         "but that dock connects to 'region World/area Area 1/node Door to Area 2 (Generic)' instead.",
         "World/Area 2/Door to Area 1 should be named 'Other to Area 1'",

--- a/test/games/am2r/generator/test_am2r_bootstrap.py
+++ b/test/games/am2r/generator/test_am2r_bootstrap.py
@@ -7,14 +7,29 @@ from random import Random
 import pytest
 
 from randovania.game.game_enum import RandovaniaGame
+from randovania.game_description.db.node_identifier import NodeIdentifier
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.game_description.resources.resource_collection import ResourceCollection
 from randovania.games.am2r.generator import AM2RBootstrap
 from randovania.games.am2r.layout.am2r_configuration import AM2RArtifactConfig
 from randovania.generator.pickup_pool import pool_creator
+from randovania.layout import filtered_database
 
 _boss_indices = [111, 3, 6, 14, 11, 50]
+
+
+def test_logic_bootstrap_without_nest_pipes(am2r_configuration):
+    configuration = dataclasses.replace(am2r_configuration, nest_pipes=False)
+    game = filtered_database.game_description_for_layout(configuration).get_mutable()
+    patches = GamePatches.create_from_game(game, 0, configuration)
+
+    graph, _ = AM2RBootstrap().logic_bootstrap_graph(configuration, game, patches)
+
+    assert (
+        NodeIdentifier.create("The Depths", "Bubble Lair Shinespark Cave East", "Pipe to Hideout Hub Access East")
+        not in graph.node_identifier_to_node
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/games/am2r/generator/test_am2r_bootstrap.py
+++ b/test/games/am2r/generator/test_am2r_bootstrap.py
@@ -7,29 +7,14 @@ from random import Random
 import pytest
 
 from randovania.game.game_enum import RandovaniaGame
-from randovania.game_description.db.node_identifier import NodeIdentifier
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.game_description.resources.resource_collection import ResourceCollection
 from randovania.games.am2r.generator import AM2RBootstrap
 from randovania.games.am2r.layout.am2r_configuration import AM2RArtifactConfig
 from randovania.generator.pickup_pool import pool_creator
-from randovania.layout import filtered_database
 
 _boss_indices = [111, 3, 6, 14, 11, 50]
-
-
-def test_logic_bootstrap_without_nest_pipes(am2r_configuration):
-    configuration = dataclasses.replace(am2r_configuration, nest_pipes=False)
-    game = filtered_database.game_description_for_layout(configuration).get_mutable()
-    patches = GamePatches.create_from_game(game, 0, configuration)
-
-    graph, _ = AM2RBootstrap().logic_bootstrap_graph(configuration, game, patches)
-
-    assert (
-        NodeIdentifier.create("The Depths", "Bubble Lair Shinespark Cave East", "Pipe to Hideout Hub Access East")
-        not in graph.node_identifier_to_node
-    )
 
 
 @pytest.mark.parametrize(

--- a/test/test_files/integrity_check_invalid_db.json
+++ b/test/test_files/integrity_check_invalid_db.json
@@ -84,7 +84,8 @@
         "energy_tank_item_index": "LightAmmo"
     },
     "layers": [
-        "default"
+        "default",
+        "alternate"
     ],
     "starting_location": {
         "region": "World",
@@ -277,7 +278,7 @@
                             "coordinates": null,
                             "description": "",
                             "layers": [
-                                "default"
+                                "alternate"
                             ],
                             "extra": {},
                             "valid_starting_location": false,


### PR DESCRIPTION
## Summary

- mark both ends of the optional Hideout Hub teleporter pipe as part of the `new-pipes` layer
- add integrity validation requiring connected docks to use matching layers
- add the required unreleased changelog entry

Fixes #9411.

## Testing

- `uv run --frozen --no-sync pytest -p no:pytest-qt test/games/am2r/generator/test_am2r_bootstrap.py test/game_description/test_pretty_print.py -q` (`29 passed`)
- `uv run --frozen --no-sync pytest -p no:pytest-qt test/game_description/test_integrity_check.py -q` (`14 passed`)
- full `test/games/am2r` suite with the GUI and exporter extras installed (`78 passed`; the 2 exporter cases require a system `.NET` runtime that is not installed on this host)
- `uv run --frozen --no-sync mypy test/games/am2r/generator/test_am2r_bootstrap.py`
- `uvx pre-commit run --files` for every changed file
- `git diff --check`
