### PR TITLE
UV exclude packages newer than 7 days

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,6 +382,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.uv]
+exclude-newer = "7 days"
 cache-keys = [
     { git = { commit = true, tags = true } },
     { file = "pyproject.toml" },
@@ -389,3 +390,17 @@ cache-keys = [
     { file = "README.md" },
     { file = "randovania/enable-cython" },
 ]
+
+[tool.uv.exclude-newer-package]
+am2r-yams = false
+cave-story-randomizer = false
+factorio-randovania-mod = false
+open-dread-rando = false
+mars-patcher = false
+planets-yapr = false
+py_randomprime = false
+random-enemy-attributes = false
+retro-data-structures = false
+mp2hudcolor = false
+open-prime-hunters-rando = false
+open-samus-returns-rando = false

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,24 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+planets-yapr = false
+factorio-randovania-mod = false
+open-samus-returns-rando = false
+random-enemy-attributes = false
+cave-story-randomizer = false
+retro-data-structures = false
+mp2hudcolor = false
+mars-patcher = false
+am2r-yams = false
+open-prime-hunters-rando = false
+open-dread-rando = false
+py-randomprime = false
+
 [[package]]
 name = "aiocache"
 version = "0.12.3"


### PR DESCRIPTION
From my understanding, our `renovate.json` creates PR and adds a pending check until the updated packages are older than 7 days.
The problem is that it does that via a `uv lock --upgrade` and this pulls transitive dependencies which are newer.
This is an attempt to keep `uv` via `pyproject.toml` in sync with the renovate setting.
I excluded our patchers because we often update them way earlier.

In the following output, websockets 16.1.1 is now absent, which was one example of a dependcy updated in the renovate PR which is newer than 7 days.
```sh
 uv lock --upgrade --dry-run
Resolved 173 packages in 4.58s
warning: The package `python-socketio==5.16.3` does not have an extra named `asyncio`
Update coverage v7.15.0 -> v7.15.1
Update httpcore2 v2.5.0 -> v2.6.0
Update httpx2 v2.5.0 -> v2.6.0
Update sentry-sdk v2.64.0 -> v2.65.0
Update types-cachetools v7.0.0.20260518 -> v7.0.0.20260713
```