### PR TITLE
Add minimum version for UV

### DIFF
--- a/.github/workflows/arm-python.yml
+++ b/.github/workflows/arm-python.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true
@@ -65,7 +65,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true

--- a/.github/workflows/arm-python.yml
+++ b/.github/workflows/arm-python.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python
@@ -67,7 +67,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/arm-python.yml
+++ b/.github/workflows/arm-python.yml
@@ -27,9 +27,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python
@@ -65,9 +65,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -36,9 +36,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python
@@ -87,9 +87,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python
@@ -161,9 +161,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python
@@ -324,9 +324,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python
@@ -456,9 +456,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python
@@ -89,7 +89,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python
@@ -163,7 +163,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python
@@ -326,7 +326,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python
@@ -458,7 +458,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true
@@ -87,7 +87,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true
@@ -161,7 +161,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true
@@ -324,7 +324,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true
@@ -456,7 +456,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python
@@ -49,7 +49,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,9 +19,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python
@@ -47,9 +47,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/trick-documentation-report.yml
+++ b/.github/workflows/trick-documentation-report.yml
@@ -29,7 +29,7 @@ jobs:
         run: git config --unset-all extensions.worktreeConfig || true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true

--- a/.github/workflows/trick-documentation-report.yml
+++ b/.github/workflows/trick-documentation-report.yml
@@ -29,9 +29,9 @@ jobs:
         run: git config --unset-all extensions.worktreeConfig || true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/trick-documentation-report.yml
+++ b/.github/workflows/trick-documentation-report.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/uic.yml
+++ b/.github/workflows/uic.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.31"
+          resolution-strategy: "lowest"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/uic.yml
+++ b/.github/workflows/uic.yml
@@ -15,9 +15,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9
         with:
-          version: "0.11.28"
+          version: "0.11.31"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/uic.yml
+++ b/.github/workflows/uic.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.31"
           enable-cache: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,6 +382,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.uv]
+required-version = ">=0.11.30"  # Good support for exclude-newer
 exclude-newer = "7 days"
 cache-keys = [
     { git = { commit = true, tags = true } },


### PR DESCRIPTION
I looked for the version that added what we need, but second to last version (right now) has fixes related to exclude-newer so I guess we're going with very very new.

Maybe we add an auto `uv self update` inside of `tools/prepare_virtual_env`.