### PR TITLE
Skip location recency bias for "inert" pickups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Major** - Added: Multiworld worlds can now be abandoned; abandoning a world is irreversible. An abandoned world can be played automatically by your own Randovania instance like a bot, via a dedicated game connection: it collects one location that is in logic for it every few seconds, and keeps doing so as it receives more items from other players.
 - Added: You can now disable game connections, preventing them from connecting without having to be removed entirely.
+- Changed: Improved average location distribution of "inert" pickups such as Prime Artifacts and Echoes STKs.
 - Changed: Automatic Item Tracker: The selected theme for the default game is now always shown while the selected game connection is not connected.
 - Changed: The "History" tab in the "Multiworld session" window now displays pickups where the provider and receiver are the same world, even in non-coop sessions.
 - Fixed: Automatic Item Tracker: The text "Not currently connected to any games" is now always shown when the selected game connection is not connected and no default game is set.

--- a/randovania/games/am2r/game_data.py
+++ b/randovania/games/am2r/game_data.py
@@ -91,7 +91,7 @@ def _test_data() -> randovania.game.game_test_data.GameTestData:
     from randovania.layout.base.trick_level import LayoutTrickLevel
 
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="N7MNABZW",
+        expected_seed_hash="W5LKIYAB",
         # Some items require shinesparking to reach in vanilla,
         # which due to varying difficulty has been made into a trick
         database_collectable_include_tricks=(("Shinesparking", LayoutTrickLevel.ADVANCED),),

--- a/randovania/games/blank/game_data.py
+++ b/randovania/games/blank/game_data.py
@@ -87,7 +87,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="BURBIEUO",
+        expected_seed_hash="KX665YWG",
     )
 
 

--- a/randovania/games/cave_story/game_data.py
+++ b/randovania/games/cave_story/game_data.py
@@ -87,7 +87,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="NKV2PHOC",
+        expected_seed_hash="6TTWPCI4",
         database_collectable_ignore_events=(
             "camp",
             "eventBadEnd",

--- a/randovania/games/dread/game_data.py
+++ b/randovania/games/dread/game_data.py
@@ -88,7 +88,7 @@ def _test_data() -> randovania.game.game_test_data.GameTestData:
     from randovania.layout.base.trick_level import LayoutTrickLevel
 
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="RZPYVBTU",
+        expected_seed_hash="QSK2B4IV",
         # Some items require shinesparking to reach in vanilla,
         # which due to varying difficulty has been made into a trick
         database_collectable_include_tricks=(("Speedbooster", LayoutTrickLevel.BEGINNER),),

--- a/randovania/games/factorio/game_data.py
+++ b/randovania/games/factorio/game_data.py
@@ -77,7 +77,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="DYZ3JNCR",
+        expected_seed_hash="J3LP55YN",
     )
 
 

--- a/randovania/games/fusion/game_data.py
+++ b/randovania/games/fusion/game_data.py
@@ -89,7 +89,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="OWHMU2XK",
+        expected_seed_hash="BR6YQTXW",
     )
 
 

--- a/randovania/games/planets_zebeth/game_data.py
+++ b/randovania/games/planets_zebeth/game_data.py
@@ -75,7 +75,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="F26CCU5G",
+        expected_seed_hash="VGEDFK6A",
     )
 
 

--- a/randovania/games/prime1/game_data.py
+++ b/randovania/games/prime1/game_data.py
@@ -107,7 +107,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="2K2VATMQ",
+        expected_seed_hash="Q5LM63CE",
         database_collectable_ignore_events=("Event33",),
     )
 

--- a/randovania/games/prime2/game_data.py
+++ b/randovania/games/prime2/game_data.py
@@ -96,7 +96,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="3LNNNRTE",
+        expected_seed_hash="6X2YTMNI",
         database_collectable_ignore_events=("Event91", "Event92", "Event97"),
     )
 

--- a/randovania/games/prime2_opr/game_data.py
+++ b/randovania/games/prime2_opr/game_data.py
@@ -102,7 +102,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="QGOUYTAB",
+        expected_seed_hash="APNEBIRQ",
         database_collectable_ignore_events=("Event91", "Event92", "Event97"),
     )
 

--- a/randovania/games/prime_hunters/game_data.py
+++ b/randovania/games/prime_hunters/game_data.py
@@ -85,7 +85,7 @@ def _hash_words() -> list[str]:
 
 def _test_data() -> randovania.game.game_test_data.GameTestData:
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="PYLVBJJH",
+        expected_seed_hash="WEZK2VR5",
     )
 
 

--- a/randovania/games/samus_returns/game_data.py
+++ b/randovania/games/samus_returns/game_data.py
@@ -106,7 +106,7 @@ def _test_data() -> randovania.game.game_test_data.GameTestData:
     from randovania.layout.base.trick_level import LayoutTrickLevel
 
     return randovania.game.game_test_data.GameTestData(
-        expected_seed_hash="6NGXHBWV",
+        expected_seed_hash="GOWEDVRK",
         # Some items require Spider Boosting to reach in vanilla, but since it is never explained there,
         # it has been made into a trick.
         database_collectable_include_tricks=(("Spider Boost", LayoutTrickLevel.BEGINNER),),

--- a/randovania/generator/filler/retcon.py
+++ b/randovania/generator/filler/retcon.py
@@ -29,6 +29,10 @@ if TYPE_CHECKING:
     from randovania.generator.generator_reach import GeneratorReach
 
 
+def _index_age_weight(age: float) -> float:
+    return min(10.0, age + 1.0) ** -2
+
+
 def _calculate_uncollected_index_weights(
     uncollected_indices: Set[PickupIndex],
     assigned_indices: Set[PickupIndex],
@@ -49,11 +53,30 @@ def _calculate_uncollected_index_weights(
         weight_from_collected_indices = math.sqrt(len(indices) / ((1 + len(assigned_indices & indices)) ** 2))
 
         for index in sorted(uncollected_indices & indices):
-            weight_from_index_age = min(10.0, index_age[index] + 1.0) ** -2
-            result[index] = weight_from_collected_indices * weight_from_index_age
-            # print(f"## {index} : {weight_from_collected_indices} ___ {weight_from_index_age}")
+            result[index] = weight_from_collected_indices * _index_age_weight(index_age[index])
 
     return result
+
+
+def _pickup_unlocks_nothing(player_state: PlayerState, pickup: PickupEntry) -> bool:
+    reach = copy.deepcopy(player_state.reach)
+    before = reach.set_of_reachable_node_indices()
+    reach.advance_to(reach.state.assign_pickup_resources(pickup), is_safe=True)
+    after = reach_lib.advance_after_action(reach).set_of_reachable_node_indices()
+    return not (after - before)
+
+
+def _ignore_index_age_for_inert_pickup(
+    locations: WeightedLocations, player_state: PlayerState, pickup: PickupEntry
+) -> WeightedLocations:
+    """
+    Cancels the index age term for pickups that unlock nothing, so they spread out instead of
+    piling onto the lone freshest location. Other pickups pass through unchanged.
+    """
+    if not _pickup_unlocks_nothing(player_state, pickup):
+        return locations
+
+    return locations.rescale(lambda player, index: 1 / _index_age_weight(player.pickup_index_ages[index]))
 
 
 def _get_next_player(
@@ -403,6 +426,7 @@ def _assign_pickup_somewhere(
         if debug.debug_level() > debug.LogLevel.HIGH:
             debug_print_weighted_locations(all_locations, player_states)
 
+        usable_locations = _ignore_index_age_for_inert_pickup(usable_locations, current_player, action)
         index_owner_state, pickup_index = usable_locations.select_location(rng)
         index_owner_state.assign_pickup(
             pickup_index,

--- a/randovania/generator/filler/retcon.py
+++ b/randovania/generator/filler/retcon.py
@@ -58,22 +58,37 @@ def _calculate_uncollected_index_weights(
     return result
 
 
-def _pickup_unlocks_nothing(player_state: PlayerState, pickup: PickupEntry) -> bool:
+def _pickup_unlocks_nothing(
+    player_state: PlayerState, pickup: PickupEntry, evaluated_reach: GeneratorReach | None
+) -> bool:
+    """
+    Whether collecting the pickup right now would leave the player's set of reachable nodes unchanged.
+    :param evaluated_reach: The reach from collecting the pickup, when action weighting already calculated it.
+    """
+    reachable = player_state.reach.set_of_reachable_node_indices()
+
+    if evaluated_reach is not None:
+        return not (evaluated_reach.set_of_reachable_node_indices() - reachable)
+
     reach = copy.deepcopy(player_state.reach)
-    before = reach.set_of_reachable_node_indices()
     reach.advance_to(reach.state.assign_pickup_resources(pickup), is_safe=True)
-    after = reach_lib.advance_after_action(reach).set_of_reachable_node_indices()
-    return not (after - before)
+    if reach.set_of_reachable_node_indices() - reachable:
+        return False
+
+    return not (reach_lib.advance_after_action(reach).set_of_reachable_node_indices() - reachable)
 
 
 def _ignore_index_age_for_inert_pickup(
-    locations: WeightedLocations, player_state: PlayerState, pickup: PickupEntry
+    locations: WeightedLocations,
+    player_state: PlayerState,
+    pickup: PickupEntry,
+    evaluated_reach: GeneratorReach | None,
 ) -> WeightedLocations:
     """
     Cancels the index age term for pickups that unlock nothing, so they spread out instead of
     piling onto the lone freshest location. Other pickups pass through unchanged.
     """
-    if not _pickup_unlocks_nothing(player_state, pickup):
+    if not _pickup_unlocks_nothing(player_state, pickup, evaluated_reach):
         return locations
 
     return locations.rescale(lambda player, index: 1 / _index_age_weight(player.pickup_index_ages[index]))
@@ -183,13 +198,13 @@ def _evaluate_action(player_state: PlayerState, action_weights: ActionWeights, a
 
 def weighted_potential_actions(
     player_state: PlayerState, status_update: Callable[[str], None], locations_weighted: WeightedLocations
-) -> dict[Action, float]:
+) -> tuple[dict[Action, float], dict[Action, EvaluatedAction]]:
     """
     Weights all potential actions based on current criteria.
     :param player_state:
     :param status_update:
     :param locations_weighted: Which locations are available and their weight.
-    :return:
+    :return: The weight of each action, plus the evaluation each weight was derived from.
     """
     evaluated_actions: dict[Action, EvaluatedAction] = {}
     actions = player_state.potential_actions(locations_weighted)
@@ -197,7 +212,7 @@ def weighted_potential_actions(
     if len(actions) == 1:
         debug.debug_print(f"{actions[0]}")
         debug.debug_print("Only one action, weighting skipped")
-        return dict.fromkeys(actions, 1.0)
+        return dict.fromkeys(actions, 1.0), evaluated_actions
 
     current_uncollected = UncollectedState.from_reach(player_state.reach)
     current_unsafe_uncollected = UncollectedState.from_reach_only_unsafe(player_state.reach)
@@ -240,7 +255,7 @@ def weighted_potential_actions(
         for action, weight in final_weights.items():
             print(f"{action.name} - {weight}")
 
-    return final_weights
+    return final_weights, evaluated_actions
 
 
 def increment_index_age(locations_weighted: WeightedLocations, increment: float) -> None:
@@ -336,8 +351,11 @@ def retcon_playthrough_filler(
         if current_player is None:
             break
 
-        weighted_actions = weighted_potential_actions(current_player, action_report, all_locations_weighted)
+        weighted_actions, evaluated_actions = weighted_potential_actions(
+            current_player, action_report, all_locations_weighted
+        )
         action = random_lib.select_element_with_weight_and_uniform_fallback(rng, weighted_actions)
+        evaluation = evaluated_actions.get(action) if action.num_pickups == 1 else None
 
         new_resources, new_pickups = action.split_pickups()
         new_pickups.sort()
@@ -360,7 +378,12 @@ def retcon_playthrough_filler(
                     all_locations_weighted = _calculate_all_pickup_indices_weight(player_states)
 
                 log_entry = _assign_pickup_somewhere(
-                    new_pickup, current_player, player_states, rng, all_locations_weighted
+                    new_pickup,
+                    current_player,
+                    player_states,
+                    rng,
+                    all_locations_weighted,
+                    evaluation.reach if evaluation is not None else None,
                 )
                 actions_log.append(log_entry)
                 debug.debug_print(f"* {log_entry}")
@@ -409,6 +432,7 @@ def _assign_pickup_somewhere(
     player_states: list[PlayerState],
     rng: Random,
     all_locations: WeightedLocations,
+    evaluated_reach: GeneratorReach | None,
 ) -> str:
     """
     Assigns a PickupEntry to a free, collected PickupIndex or as a starting item.
@@ -416,6 +440,8 @@ def _assign_pickup_somewhere(
     :param current_player:
     :param player_states:
     :param rng:
+    :param all_locations:
+    :param evaluated_reach: The reach obtained by collecting `action`, if it was already calculated.
     :return:
     """
     assert action in current_player.pickups_left
@@ -426,7 +452,7 @@ def _assign_pickup_somewhere(
         if debug.debug_level() > debug.LogLevel.HIGH:
             debug_print_weighted_locations(all_locations, player_states)
 
-        usable_locations = _ignore_index_age_for_inert_pickup(usable_locations, current_player, action)
+        usable_locations = _ignore_index_age_for_inert_pickup(usable_locations, current_player, action, evaluated_reach)
         index_owner_state, pickup_index = usable_locations.select_location(rng)
         index_owner_state.assign_pickup(
             pickup_index,

--- a/randovania/generator/filler/weighted_locations.py
+++ b/randovania/generator/filler/weighted_locations.py
@@ -7,7 +7,7 @@ from randovania.layout.base.available_locations import RandomizationMode
 from randovania.lib import random_lib
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from random import Random
 
     from randovania.game_description.pickup.pickup_entry import PickupEntry
@@ -72,6 +72,15 @@ class WeightedLocations:
         for player, locations in self._items:
             for index, weight in locations.items():
                 yield player, index, weight
+
+    def rescale(self, factor: Callable[[PlayerState, PickupIndex], float]) -> WeightedLocations:
+        """Returns a copy with every weight multiplied by factor(player, index)."""
+        return WeightedLocations(
+            [
+                (player, {index: weight * factor(player, index) for index, weight in locations.items()})
+                for player, locations in self._items
+            ]
+        )
 
     def select_location(self, rng: Random) -> tuple[PlayerState, PickupIndex]:
         return random_lib.select_element_with_weight(


### PR DESCRIPTION
I looked at this problem more wholistically than a single item type being over-placed at single location. I recall there being issues with artifact bias in other dead-end locations like PMT and I believe those were addressed with heuristics more than they were addressed with fundamental generator changes.

# Problem

The most popular preset used by the most vocal players of the community is the standard weekly preset. This preset is characterized by Landing Site start, vanilla elevators, near-default item pool and all tricks set to beginner/disabled. A pattern has been noticed by frequently players of this preset (or ones like it), and that pattern represents a valid critique of the randomizer's generation biases, not just merely a heuristic observation.

***Tower of Light places a Chozo Artifact about 30% of the time which is ~4x more than would be expected from a perfectly "fair" generation algorithm of ~8%.***

Tower of Light is a unique location in that it:
- Has the single highest Missile requirement of all progression locations
- Typically unlocks last or near-last in the progression "chain" (next to locations like PMT). Upon first glance it only requires `Missile Launcher + 7 Missile Expansions + Space Jump Boots + Wave Beam` to acquire. However, consider the fact that this is requires at *minimum* 10 item locations accessible to place those items. The game actually requires the vast majority of: `Morph Ball, Bombs + Varia Suit + Ice Beam + Power Bombs` to guarantee the remaining ToL requirements can actually fit in the preceding "sphere".

Artifacts are unique in that they are as close as possible to being useless while still being required for progression. In other words, they help the player to beat the game and nothing else. In this PR, I refer to this quality as "inertness".

Here is are visualizations which show placement considerations and weighting made by the generator. First here is a seed which shows a single seed being generated where an artifact ends up in Tower of Light:

<img width="1436" height="1186" alt="seed2007_before_a0" src="https://github.com/user-attachments/assets/79760210-bcb0-4b64-94d8-64f5b15fbf38" />

Here is another which shows the average across 300 seeds:

<img width="1557" height="1023" alt="AVG_before_a0" src="https://github.com/user-attachments/assets/00154238-d025-42a7-89c7-a43dc814e2af" />

# Diagnosis

The generator implementation has the function `calculate_uncollected_index_weights` which calculates weights for each of the uncollected pickups. These weights are used to skew the probability of that location having a pickup placed at it next:

```py
for indices in indices_groups:
    weight_from_collected_indices = math.sqrt(len(indices) / ((1 + len(assigned_indices & indices)) ** 2))

    for index in sorted(uncollected_indices & indices):
        weight_from_index_age = min(10.0, index_age[index] + 1.0) ** -2
        result[index] = weight_from_collected_indices * weight_from_index_age

return result
```

These weights are used to define an intentional deviation from a pure "fair" generation algorithm:

***On average, prefer to place pickups in locations which are "deeper" into the game's progression logic.***

This bias is mostly warranted. For Prime, this weighting is directly responsible for the prevention of Chozo Ruins being backfilled with the majority of progression items simply because it contains the majority of pickup locations.

There is an oversight, however. This preference works in our favor when it places items which are part of the prototypical progression chain: beams, ball upgrades, suits, etc. Critically - ***This preference works against us for inert items like Artifacts. Biasing the placement of an item which does not unlock another serves no purpose other than to reduce seed variety.***

# Solution

Keep the recency bias, but readjust the weights such that the recency term is nullified when considering inert pickups. Define inert pickups as ones which do not unlock any additional if collected.

### Rejected Solutions

- Scaling the recency bias instead of treating as a boolean. I found this comment which describes something I saw evidence of in my experimentation:
```py
# this used to weigh actions according to *how many* resources were unlocked, but we've determined that the results are more fun if we only care about something being unlocked at all
```
- Implement a floor on the weights assigned by `calculate_uncollected_index_weights`. Adding a `+ 0.08` term to the weight calculation solved this problem, but that solution does not scale to other presets or games.
- Reduce the missile count required to access ToL. Most tempting, but hard to do in a way that doesn't require extra player education or feel like a cheap hack.
- Increase missile count requirements for other standard preset locations. This would definitely help - I just don't if it makes sense to do.

# Caveat

I think setting `index_age_impact = 0.0` for artifacts would have handled this for just Prime1. I didn't see this knob until after I finished my implementation. My implementation is generic and makes for better default behavior for new games. My implementation also increases computational complexity of seed generation. This is the tradeoff.

# Validation

- Generate 300 seeds on `main`
- Re-generate those same 300 seeds on this PR branch
- Calculate placement probabilities for each location and calculate the before/after delta
- Upload as [Google Sheet](https://docs.google.com/spreadsheets/d/1u26IafxPXuKb_3G_36vF7RsO8HGfk0UaH9pljSnVSoA/edit?usp=sharing)
