### PR TITLE
Kraid south/east

### DIFF
--- a/randovania/games/zero_mission/logic_database/Crateria.txt
+++ b/randovania/games/zero_mission/logic_database/Crateria.txt
@@ -183,7 +183,7 @@ Extra - room_id: [9]
   * Blue Door to Statuary Shaft/Door to Chozo Ruins Valley
   * Extra - door_idx: [19]
   > Door to Plasma Beam Chamber
-      Morph Ball and After Ruins Chozo Statue Item Aquired
+      Morph Ball and After Ruins Chozo Statue Item Acquired
   > Past Pillars
       Any of the following:
           Wall Jumps (Advanced) or Use Space Jump
@@ -210,7 +210,7 @@ Extra - room_id: [9]
   * Extra - door_idx: [37]
   > Door to Statuary Shaft
       All of the following:
-          Morph Ball and After Ruins Chozo Statue Item Aquired
+          Morph Ball and After Ruins Chozo Statue Item Acquired
           Power Grip or Can Bounce in Ball
   > Open Passage to Flooded Cavern (West)
       Can Bounce in Ball
@@ -248,7 +248,7 @@ Extra - room_id: [11]
   > Door to Elevator to Norfair
       Any of the following:
           Gravity Suit and Speed Booster
-          After Ruins Chozo Statue Item Aquired and Tunnel Climb
+          After Ruins Chozo Statue Item Acquired and Tunnel Climb
 
 > Door to Elevator to Norfair; Heals? False
   * Layers: default
@@ -310,7 +310,7 @@ Extra - room_id: [14]
   * Blue Door to Chozo Ruins Valley/Door to Plasma Beam Chamber
   * Extra - door_idx: [35]
   > Pickup (Missile Tank)
-      After Ruins Chozo Statue Item Aquired
+      After Ruins Chozo Statue Item Acquired
   > Pickup (Unknown Item 1)
       Trivial
 
@@ -323,7 +323,7 @@ Extra - room_id: [14]
 
 > Event - Statue Item Acquired; Heals? False
   * Layers: default
-  * Event Ruins Chozo Statue Item Aquired
+  * Event Ruins Chozo Statue Item Acquired
   > Door to Chozo Ruins Valley
       Trivial
 

--- a/randovania/games/zero_mission/logic_database/Kraid.json
+++ b/randovania/games/zero_mission/logic_database/Kraid.json
@@ -5817,7 +5817,51 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Health requirements",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 399,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Damage requirements",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Missiles",
+                                                        "amount": 40,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SuperMissiles",
+                                                        "amount": 10,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/randovania/games/zero_mission/logic_database/Kraid.json
+++ b/randovania/games/zero_mission/logic_database/Kraid.json
@@ -2924,8 +2924,17 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "The enemies all spawn on the right before Kraid is defeated so this strategy does not work then",
                                                         "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "KraidDefeated",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
@@ -2940,7 +2949,7 @@
                                                                 "data": {
                                                                     "type": "items",
                                                                     "name": "Missiles",
-                                                                    "amount": 1,
+                                                                    "amount": 10,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -2964,6 +2973,32 @@
                                                             {
                                                                 "type": "template",
                                                                 "data": "Use Space Jump"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "SpeedBooster",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Shinespark",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -3781,16 +3816,8 @@
                             }
                         },
                         "Tunnel to Speed Booster Tutorial Slope": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Any Bombs"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Single Bomb Blocks"
                         }
                     }
                 },
@@ -3962,16 +3989,19 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 152.588616847221,
-                        "y": 82.42200342714415,
+                        "x": 152.59,
+                        "y": 82.42,
                         "z": 0.0
                     },
                     "description": "",
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
-                    "valid_starting_location": false,
+                    "extra": {
+                        "X": 9,
+                        "Y": 9
+                    },
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Sidehopper Path": {
                             "type": "and",
@@ -4215,29 +4245,10 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Save Station (South)": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Missiles",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Combat",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -4274,29 +4285,10 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Space Jump Access": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Missiles",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Combat",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -4352,42 +4344,8 @@
                             }
                         },
                         "Open Passage to Space Jump Access": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Any Bombs"
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Knowledge",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Single Bomb Blocks"
                         }
                     }
                 },
@@ -4616,16 +4574,8 @@
                             }
                         },
                         "Door to Save Station (Southwest)": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Any Bombs"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Break Single Bomb Blocks"
                         }
                     }
                 },
@@ -4675,30 +4625,50 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "MorphBall",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Bounce in Ball"
+                                                    "data": "Can Break Single Bomb Blocks"
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Missiles",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "MorphBall",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": "NOTE: Assumes 2x2 shot block is broken to access chozo statue item. If this is modified we will need to add a long beam req.",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Missiles",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Bounce in Ball"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -4755,22 +4725,8 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "MorphBall",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "PowerGrip",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Tunnel Climb"
                                     },
                                     {
                                         "type": "or",
@@ -4889,30 +4845,8 @@
                             }
                         },
                         "Tunnel to Space Jump Chamber": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "PowerGrip",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "MorphBall",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Tunnel Climb"
                         }
                     }
                 }
@@ -5319,6 +5253,10 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Space Jump"
                                     }
                                 ]
                             }
@@ -5773,10 +5711,12 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Arena": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "KraidDefeated",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -5809,10 +5749,12 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Arena": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "SpeedBooster",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -5821,8 +5763,8 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 411.7552195824334,
-                        "y": 230.17614590832733,
+                        "x": 367.8828596037898,
+                        "y": 87.31438415159346,
                         "z": 0.0
                     },
                     "description": "",
@@ -5836,21 +5778,39 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "KraidDefeated",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Climb High Ledges"
+                                    }
+                                ]
                             }
                         },
                         "Open Passage to Kraid's Reliquary": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "KraidDefeated",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Open Passage to Speed Booster Tutorial Slope": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "KraidDefeated",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Event - Kraid": {
@@ -5866,8 +5826,8 @@
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 358.13,
-                        "y": 260.28,
+                        "x": 311.20757967269594,
+                        "y": 159.66580534022398,
                         "z": 0.0
                     },
                     "description": "",
@@ -5878,12 +5838,9 @@
                     "valid_starting_location": false,
                     "event_name": "KraidDefeated",
                     "connections": {
-                        "Arena": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                        "Open Passage to Kraid's Reliquary": {
+                            "type": "template",
+                            "data": "Can Break Single Bomb Blocks"
                         }
                     }
                 }
@@ -6069,16 +6026,19 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 135.51872827781168,
-                        "y": 78.89030234381809,
+                        "x": 135.52,
+                        "y": 78.89,
                         "z": 0.0
                     },
                     "description": "",
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
-                    "valid_starting_location": false,
+                    "extra": {
+                        "X": 8,
+                        "Y": 9
+                    },
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Space Jump Access": {
                             "type": "and",
@@ -6561,16 +6521,19 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 167.30403802774632,
-                        "y": 80.36184446187062,
+                        "x": 167.3,
+                        "y": 80.36,
                         "z": 0.0
                     },
                     "description": "",
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
-                    "valid_starting_location": false,
+                    "extra": {
+                        "X": 10,
+                        "Y": 9
+                    },
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Block Column Hub": {
                             "type": "and",
@@ -6747,7 +6710,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Zipline Activation Chamber": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6787,7 +6750,7 @@
                     "override_default_lock_requirement": null,
                     "ui_custom_name": null,
                     "connections": {
-                        "Door to Apex Launcher Hub": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6813,7 +6776,22 @@
                         "Y": 9
                     },
                     "valid_starting_location": true,
-                    "connections": {}
+                    "connections": {
+                        "Door to Apex Launcher Hub": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Zipline Activation Chamber": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/randovania/games/zero_mission/logic_database/Kraid.txt
+++ b/randovania/games/zero_mission/logic_database/Kraid.txt
@@ -985,7 +985,11 @@ Extra - room_id: [30, 37]
   > Open Passage to Speed Booster Tutorial Slope
       After Boss Kraid Defeated
   > Event - Kraid
-      Trivial
+      All of the following:
+          # Health requirements
+          Normal Damage ≥ 399
+          # Damage requirements
+          Missiles ≥ 40 or Super Missiles ≥ 10
 
 > Event - Kraid; Heals? False
   * Layers: default

--- a/randovania/games/zero_mission/logic_database/Kraid.txt
+++ b/randovania/games/zero_mission/logic_database/Kraid.txt
@@ -466,9 +466,9 @@ Extra - room_id: [12]
   * Blue Door to Elevator to Brinstar/Door to Corrosive Pool
   * Extra - door_idx: [33]
   > Door to Block Column Hub
-      Screw Attack and After Kraid Chozo Statue Item Aquired and Use Space Jump
+      Screw Attack and After Kraid Chozo Statue Item Acquired and Use Space Jump
   > Open Passage to Acid Fall
-      After Kraid Chozo Statue Item Aquired
+      After Kraid Chozo Statue Item Acquired
 
 > Door to Block Column Hub; Heals? False
   * Layers: default
@@ -476,10 +476,12 @@ Extra - room_id: [12]
   * Extra - door_idx: [34]
   > Door to Elevator to Brinstar
       All of the following:
-          After Kraid Chozo Statue Item Aquired
+          After Kraid Chozo Statue Item Acquired
           Any of the following:
-              Missiles and Zipline Activation
+              # The enemies all spawn on the right before Kraid is defeated so this strategy does not work then
+              Missiles ≥ 10 and Zipline Activation and After Boss Kraid Defeated
               Screw Attack and Use Space Jump
+              Speed Booster and Shinespark (Beginner)
   > Open Passage to Acid Fall
       Trivial
 
@@ -627,7 +629,7 @@ Extra - room_id: [19]
   > Door to Replenishment Station
       Trivial
   > Tunnel to Speed Booster Tutorial Slope
-      Can Use Any Bombs
+      Can Break Single Bomb Blocks
 
 > Door to Replenishment Station; Heals? False
   * Layers: default
@@ -659,8 +661,10 @@ Extra - room_id: [20]
   > Save Station
       Trivial
 
-> Save Station; Heals? False
+> Save Station; Heals? False; Spawn Point
   * Layers: default
+  * Extra - X: 9
+  * Extra - Y: 9
   > Door to Sidehopper Path
       Trivial
   > Door to Hidden Drop
@@ -708,14 +712,14 @@ Extra - room_id: [22]
   * Blue Door to Space Jump Access/Door to Sidehopper Path
   * Extra - door_idx: [52]
   > Door to Save Station (South)
-      Missiles or Combat (Intermediate)
+      Trivial
 
 > Door to Save Station (South); Heals? False
   * Layers: default
   * Blue Door to Save Station (South)/Door to Sidehopper Path
   * Extra - door_idx: [53]
   > Door to Space Jump Access
-      Missiles or Combat (Intermediate)
+      Trivial
 
 ----------------
 Drain
@@ -728,9 +732,7 @@ Extra - room_id: [23]
   > Door to Ball Launcher Speedway
       Trivial
   > Open Passage to Space Jump Access
-      Any of the following:
-          Can Use Any Bombs
-          Screw Attack and Knowledge (Beginner)
+      Can Break Single Bomb Blocks
 
 > Door to Ball Launcher Speedway; Heals? False
   * Layers: default
@@ -771,9 +773,9 @@ Extra - room_id: [25]
   * Vertical Passage to Drain/Open Passage to Space Jump Access
   * Extra - door_idx: [60]
   > Door to Sidehopper Path
-      After Kraid Chozo Statue Item Aquired
+      After Kraid Chozo Statue Item Acquired
   > Door to Save Station (Southwest)
-      Can Use Any Bombs
+      Can Break Single Bomb Blocks
 
 > Door to Sidehopper Path; Heals? False
   * Layers: default
@@ -781,8 +783,13 @@ Extra - room_id: [25]
   * Extra - door_idx: [61]
   > Door to Save Station (Southwest)
       All of the following:
-          Morph Ball and After Kraid Chozo Statue Item Aquired
-          Missiles or Can Bounce in Ball
+          After Kraid Chozo Statue Item Acquired
+          Any of the following:
+              Can Break Single Bomb Blocks
+              All of the following:
+                  Morph Ball
+                  # NOTE: Assumes 2x2 shot block is broken to access chozo statue item. If this is modified we will need to add a long beam req.
+                  Missiles or Can Bounce in Ball
 
 > Door to Save Station (Southwest); Heals? False
   * Layers: default
@@ -790,7 +797,7 @@ Extra - room_id: [25]
   * Extra - door_idx: [77]
   > Door to Sidehopper Path
       All of the following:
-          Morph Ball and Power Grip and After Kraid Chozo Statue Item Aquired
+          After Kraid Chozo Statue Item Acquired and Tunnel Climb
           Missiles or Can Bounce in Ball
   > Door to Space Jump Chamber
       Trivial
@@ -809,7 +816,7 @@ Extra - room_id: [25]
   > Door to Save Station (Southwest)
       Trivial
   > Tunnel to Space Jump Chamber
-      Morph Ball and Power Grip
+      Tunnel Climb
 
 ----------------
 Illusionary Acid Pool
@@ -884,7 +891,7 @@ Extra - room_id: [27]
   * Blue Door to Speed Booster Tutorial Slope/Door to Block Column Hub
   * Extra - door_idx: [67]
   > Door to Acid Fall
-      Speed Booster
+      Speed Booster or Use Space Jump
 
 > Door to Save Station (East); Heals? False
   * Layers: default
@@ -902,14 +909,14 @@ Extra - room_id: [28]
   * Blue Door to Kraid Arena Access/Door to Speed Booster Tutorial Slope
   * Extra - door_idx: [68]
   > Door to Block Column Hub
-      After Kraid Chozo Statue Item Aquired
+      After Kraid Chozo Statue Item Acquired
 
 > Door to Block Column Hub; Heals? False
   * Layers: default
   * Blue Door to Block Column Hub/Door to Speed Booster Tutorial Slope
   * Extra - door_idx: [69]
   > Door to Kraid Arena Access
-      After Kraid Chozo Statue Item Aquired
+      After Kraid Chozo Statue Item Acquired
   > Open Passage to Kraid Arena
       Speed Booster
 
@@ -961,30 +968,30 @@ Extra - room_id: [30, 37]
   * Horizontal Passage to Kraid's Reliquary/Open Passage to Kraid Arena
   * Extra - door_idx: [81, 90]
   > Arena
-      Trivial
+      After Boss Kraid Defeated
 
 > Open Passage to Speed Booster Tutorial Slope; Heals? False
   * Layers: default
   * Horizontal Passage to Speed Booster Tutorial Slope/Open Passage to Kraid Arena
   > Arena
-      Trivial
+      Speed Booster
 
 > Arena; Heals? False
   * Layers: default
   > Door to Kraid Arena Access
-      Trivial
+      After Boss Kraid Defeated and Climb High Ledges
   > Open Passage to Kraid's Reliquary
-      Trivial
+      After Boss Kraid Defeated
   > Open Passage to Speed Booster Tutorial Slope
-      Trivial
+      After Boss Kraid Defeated
   > Event - Kraid
       Trivial
 
 > Event - Kraid; Heals? False
   * Layers: default
   * Event Boss Kraid Defeated
-  > Arena
-      Trivial
+  > Open Passage to Kraid's Reliquary
+      Can Break Single Bomb Blocks
 
 ----------------
 Save Station (North)
@@ -1024,8 +1031,10 @@ Extra - room_id: [32]
   > Save Station
       Trivial
 
-> Save Station; Heals? False
+> Save Station; Heals? False; Spawn Point
   * Layers: default
+  * Extra - X: 8
+  * Extra - Y: 9
   > Door to Space Jump Access
       Trivial
 
@@ -1045,7 +1054,7 @@ Extra - room_id: [33]
   * Blue Door to Space Jump Access/Door to Space Jump Chamber
   * Extra - door_idx: [80]
   > In Front of Statue
-      After Kraid Chozo Statue Item Aquired
+      After Kraid Chozo Statue Item Acquired
 
 > Pickup (Unknown Item 2); Heals? False
   * Layers: default
@@ -1056,14 +1065,14 @@ Extra - room_id: [33]
 
 > Event - Statue Item Acquired; Heals? False
   * Layers: default
-  * Event Kraid Chozo Statue Item Aquired
+  * Event Kraid Chozo Statue Item Acquired
   > In Front of Statue
       Trivial
 
 > In Front of Statue; Heals? False
   * Layers: default
   > Door to Space Jump Access
-      After Kraid Chozo Statue Item Aquired
+      After Kraid Chozo Statue Item Acquired
   > Pickup (Unknown Item 2)
       Trivial
 
@@ -1119,8 +1128,10 @@ Extra - room_id: [36]
   > Save Station
       Screw Attack
 
-> Save Station; Heals? False
+> Save Station; Heals? False; Spawn Point
   * Layers: default
+  * Extra - X: 10
+  * Extra - Y: 9
   > Door to Block Column Hub
       Trivial
   > Open Passage to Norfair Tunnel
@@ -1153,20 +1164,24 @@ Extra - room_id: [39]
   * Layers: default
   * Blue Door to Apex Launcher Hub/Door to Save Station (Northeast)
   * Extra - door_idx: [93]
-  > Door to Zipline Activation Chamber
+  > Save Station
       Trivial
 
 > Door to Zipline Activation Chamber; Heals? False
   * Layers: default
   * Blue Door to Zipline Activation Chamber/Door to Save Station (Northeast)
   * Extra - door_idx: [94]
-  > Door to Apex Launcher Hub
+  > Save Station
       Trivial
 
 > Save Station; Heals? False; Spawn Point
   * Layers: default
   * Extra - X: 9
   * Extra - Y: 9
+  > Door to Apex Launcher Hub
+      Trivial
+  > Door to Zipline Activation Chamber
+      Trivial
 
 ----------------
 Acid Worm Arena Access

--- a/randovania/games/zero_mission/logic_database/Ridley.json
+++ b/randovania/games/zero_mission/logic_database/Ridley.json
@@ -2435,7 +2435,7 @@
                     "custom_index_group": null,
                     "hint_features": [],
                     "connections": {
-                        "Event - Statue Item Aquired ": {
+                        "Event - Statue Item Acquired ": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2444,7 +2444,7 @@
                         }
                     }
                 },
-                "Event - Statue Item Aquired ": {
+                "Event - Statue Item Acquired ": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/zero_mission/logic_database/Ridley.txt
+++ b/randovania/games/zero_mission/logic_database/Ridley.txt
@@ -358,7 +358,7 @@ Extra - room_id: [11]
   * Extra - door_idx: [28]
   > Door to Save Station (Central)
       All of the following:
-          After Ridley Chozo Statue Item Aquired
+          After Ridley Chozo Statue Item Acquired
           Any of the following:
               Use Space Jump
               All of the following:
@@ -396,7 +396,7 @@ Extra - room_id: [12]
   > Door to Ridley's Reliquary
       Trivial
   > Event - Ridley
-      After Ridley Chozo Statue Item Aquired
+      After Ridley Chozo Statue Item Acquired
 
 ----------------
 Ridley's Reliquary
@@ -415,7 +415,7 @@ Extra - room_id: [13]
   * Blue Door to Ridley Arena/Door to Ridley's Reliquary
   * Extra - door_idx: [31]
   > Pickup (Energy Tank)
-      After Ridley Chozo Statue Item Aquired
+      After Ridley Chozo Statue Item Acquired
   > Pickup (Unknown Item 3)
       Trivial
 
@@ -423,12 +423,12 @@ Extra - room_id: [13]
   * Layers: default
   * Pickup 98; Category? Major
   * Extra - source: GRAVITY_SUIT
-  > Event - Statue Item Aquired 
+  > Event - Statue Item Acquired 
       Trivial
 
-> Event - Statue Item Aquired ; Heals? False
+> Event - Statue Item Acquired ; Heals? False
   * Layers: default
-  * Event Ridley Chozo Statue Item Aquired
+  * Event Ridley Chozo Statue Item Acquired
   > Door to Ridley Arena
       Trivial
 
@@ -481,7 +481,7 @@ Extra - room_id: [15]
   * Blue Door to Desgeega Corridor/Door to Eastern Hub
   * Extra - door_idx: [35]
   > Door to Shortcut
-      After Ridley Chozo Statue Item Aquired and Climb Ledges
+      After Ridley Chozo Statue Item Acquired and Climb Ledges
   > Door to Holtz Hall
       Trivial
 

--- a/randovania/games/zero_mission/logic_database/header.json
+++ b/randovania/games/zero_mission/logic_database/header.json
@@ -320,15 +320,15 @@
                 "extra": {}
             },
             "RuinsChozoStatue": {
-                "long_name": "Ruins Chozo Statue Item Aquired",
+                "long_name": "Ruins Chozo Statue Item Acquired",
                 "extra": {}
             },
             "KraidChozoStatue": {
-                "long_name": "Kraid Chozo Statue Item Aquired",
+                "long_name": "Kraid Chozo Statue Item Acquired",
                 "extra": {}
             },
             "RidleyChozoStatue": {
-                "long_name": "Ridley Chozo Statue Item Aquired",
+                "long_name": "Ridley Chozo Statue Item Acquired",
                 "extra": {}
             },
             "NorfairPillbug": {
@@ -1206,8 +1206,7 @@
             1
         ],
         "Combat": [
-            1,
-            2
+            1
         ]
     },
     "flatten_to_set_on_patch": false,


### PR DESCRIPTION
A couple specific rooms to mention:
- I removed the combat requirement in Sidehopper Room since you can take it slow and avoid damage even with base kit. Open to adding that trick back in if needed. 
- Speed Booster Tutorial Slope: All the nodes connect to the east door. I kinda want to add a "useless" central node for aesthetic purposes; thoughts?
- Kraid has a "Norfair Tunnel" area that connects to Norfair's "Secret Tunnel" area. I think we should probably either make this "Tunnel to Norfair"/"Tunnel to Kraid" or rename both to "Kraid/Secret Tunnel" and "Norfair/Secret Tunnel". 

**TODO: Update the patcher to match Kraid Arena logic.** The Speed Booster tunnel should trigger the fight and place Samus in a position where she can complete the fight (i.e. reposition if the cutscene affects speed booster). 