### PR TITLE
Optimize Database Verification

### DIFF
--- a/randovania/game_description/integrity_check.py
+++ b/randovania/game_description/integrity_check.py
@@ -12,6 +12,9 @@ from randovania.game_description.db.teleporter_network_node import TeleporterNet
 from randovania.game_description.requirements import fast_as_set
 from randovania.game_description.requirements.array_base import RequirementArrayBase
 from randovania.game_description.requirements.base import Requirement
+from randovania.game_description.requirements.node_requirement import NodeRequirement
+from randovania.game_description.requirements.requirement_and import RequirementAnd
+from randovania.game_description.requirements.requirement_or import RequirementOr
 from randovania.game_description.requirements.requirement_template import RequirementTemplate
 from randovania.game_description.requirements.resource_requirement import ResourceRequirement
 from randovania.game_description.resources.item_resource_info import ItemResourceInfo
@@ -27,7 +30,6 @@ if TYPE_CHECKING:
     from randovania.game_description.db.region import Region
     from randovania.game_description.db.region_list import RegionList
     from randovania.game_description.game_description import GameDescription
-    from randovania.game_description.requirements.requirement_list import RequirementList
     from randovania.game_description.resources.pickup_index import PickupIndex
     from randovania.game_description.resources.resource_database import ResourceDatabase
 
@@ -318,29 +320,61 @@ def find_inconsistent_dock_configuration(dock_db: DockTypeDatabase) -> Iterator[
                 )
 
 
+_RelevantAlternatives = frozenset[frozenset[str]]
+
+
+def _relevant_alternatives(
+    req: Requirement,
+    relevant: frozenset[str],
+    database: ResourceDatabase,
+    cache: dict[tuple[frozenset[str], Requirement], _RelevantAlternatives],
+) -> _RelevantAlternatives:
+    """
+    The requirement's alternatives reduced to which of relevant's resource short names it contains.
+    """
+    cache_key = (relevant, req)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    if isinstance(req, RequirementTemplate):
+        result = _relevant_alternatives(req.template_requirement(database), relevant, database, cache)
+
+    elif isinstance(req, ResourceRequirement):
+        result = frozenset({frozenset({req.resource.short_name} & relevant)})
+
+    elif isinstance(req, RequirementAnd):
+        result = frozenset({frozenset()})
+        for item in req.items:
+            item_alternatives = _relevant_alternatives(item, relevant, database, cache)
+            result = frozenset(left | right for left in result for right in item_alternatives)
+
+    elif isinstance(req, RequirementOr):
+        result = frozenset(
+            alternative for item in req.items for alternative in _relevant_alternatives(item, relevant, database, cache)
+        )
+
+    elif isinstance(req, NodeRequirement):
+        result = frozenset({frozenset()})
+
+    else:
+        raise fast_as_set.UnableToAvoidError
+
+    cache[cache_key] = result
+    return result
+
+
 def _needed_resources_partly_satisfied(
     req: Requirement,
     resources: tuple[str, tuple[str, ...]],
     database: ResourceDatabase,
-    req_cache: dict[Requirement, tuple[RequirementList, ...]],
+    req_cache: dict[tuple[frozenset[str], Requirement], _RelevantAlternatives],
 ) -> bool:
-    if req in req_cache:
-        alternatives = req_cache[req]
-    else:
-        alternatives = fast_as_set.fast_as_alternatives(req, database)
-        req_cache[req] = alternatives
+    res_key, res_values = resources
+    alternatives = _relevant_alternatives(req, frozenset((res_key, *res_values)), database, req_cache)
 
-    counter = 0
-    res_key = resources[0]
-    res_values = resources[1]
-    for alternative in alternatives:
-        # Either the key must not be present, or the key is present with all values.
-        if not any(res_key == item.resource.short_name for item in alternative.values()):
-            counter += 1
-        elif all(any(resource == item.resource.short_name for item in alternative.values()) for resource in res_values):
-            counter += 1
-
-    return counter != len(alternatives)
+    # Either the key must not be present, or the key is present with all values.
+    return any(res_key in alternative and not alternative.issuperset(res_values) for alternative in alternatives)
 
 
 def _does_requirement_contain_resource(req: Requirement, resource: str) -> bool:
@@ -401,7 +435,7 @@ def check_for_resources_to_use_together(
     :return: Error messages of requirements which don't pass the check.
     """
     database = game.resource_database
-    requirement_cache: dict[Requirement, tuple[RequirementList, ...]] = {}
+    requirement_cache: dict[tuple[frozenset[str], Requirement], _RelevantAlternatives] = {}
 
     for label, requirement in get_possible_connections(game):
         for resource_key, resource_value in combined_resources.items():


### PR DESCRIPTION
Optimize the worst case performance of `check_for_resources_to_use_together`. This is required for PR #9442 which modifies the prime database in such a way that exponentially explodes `req_cache` into the millions of entries, causing the function to compute near-indefinitely. Reimplement using sets to cap this expansion to a reasonable amount. On that branch with these changes applied, the check now takes less than 1 second again.

# `main`

<img width="1062" height="520" alt="before" src="https://github.com/user-attachments/assets/642e8305-a2f3-4365-871f-51bfb90ce8c4" />

# `toasterparty:optimize-db-check`

<img width="1053" height="439" alt="after" src="https://github.com/user-attachments/assets/f98c6ebe-f121-4c98-8172-b5bfd2b0d86d" />
