### PR TITLE
Fusion: Enable OpenHatchLockRando misc  resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid Fusion
 
 - Fixed: Typo in the knowledge trick description.
+- Fixed: Generation now takes takes into account when Open Hatches in Door Lock Rando are shuffled.
 
 #### Logic Database
 

--- a/randovania/games/fusion/generator/bootstrap.py
+++ b/randovania/games/fusion/generator/bootstrap.py
@@ -65,6 +65,16 @@ class FusionBootstrap(Bootstrap[FusionConfiguration]):
         enabled_resources = set()
         if configuration.dock_weakness_distributor.is_enabled_for_any_type():
             enabled_resources.add("DoorLockRando")
+
+            door_db = configuration.game.game_description.dock_type_database
+            door_type = door_db.find_type("Door")
+            open_hatch_door = door_db.get_by_weakness("Door", "Open Hatch")
+            are_open_hatches_shuffled = (
+                open_hatch_door in configuration.dock_weakness_distributor.types_state[door_type].can_change_from
+            )
+            if are_open_hatches_shuffled:
+                enabled_resources.add("OpenHatchLockRando")
+
         if configuration.adjusted_geron_weaknesses:
             enabled_resources.add("NerfGerons")
         enabled_resources.add("BomblessPBs")

--- a/test/games/fusion/generator/test_fusion_bootstrap.py
+++ b/test/games/fusion/generator/test_fusion_bootstrap.py
@@ -10,6 +10,7 @@ from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.games.fusion.generator import FusionBootstrap
 from randovania.games.fusion.layout.fusion_configuration import FusionArtifactConfig
 from randovania.generator.pickup_pool import pool_creator
+from randovania.layout.base.dock_weakness_distributor_configuration import DockWeaknessDistributorMode
 
 
 @pytest.mark.parametrize(
@@ -62,3 +63,70 @@ def test_patch_resource_database(
     # loop through all reductions and assert that the new multiplier is what we expect
     for i, reduction in enumerate(result.damage_reductions[result.get_damage(dmg_type)]):
         assert reduction.damage_multiplier == dmg_multiplier[i]
+
+
+@pytest.mark.parametrize("door_state", ["vanilla", "individual-all", "type-all", "individual-no-open", "type-no-open"])
+@pytest.mark.parametrize("geron_state", [False, True])
+def test_enabled_misc_resources(fusion_game_description, fusion_configuration, door_state, geron_state) -> None:
+    expected_resources = {"BomblessPBs", "GeneratorHack"}
+
+    door_db = fusion_game_description.dock_type_database
+    door_type = door_db.find_type("Door")
+    open_hatch_door = door_db.get_by_weakness("Door", "Open Hatch")
+
+    weakness_mode = DockWeaknessDistributorMode.ORIGINAL
+    if door_state in ["individual-all", "individual-no-open"]:
+        weakness_mode = DockWeaknessDistributorMode.INDIVIDUAL_DOCK
+    elif door_state in ["type-all", "type-no-open"]:
+        weakness_mode = DockWeaknessDistributorMode.WEAKNESS_TO_WEAKNESS
+
+    if door_state in ["individual-all", "type-all"]:
+        all_door_weaknesses = set(door_db.weaknesses[door_type].values())
+
+        types_state = fusion_configuration.dock_weakness_distributor.types_state
+        types_state[door_type] = dataclasses.replace(types_state[door_type], mode=weakness_mode)
+        types_state[door_type] = dataclasses.replace(types_state[door_type], can_change_from=all_door_weaknesses)
+        types_state[door_type] = dataclasses.replace(types_state[door_type], can_change_to=all_door_weaknesses)
+        fusion_configuration = dataclasses.replace(
+            fusion_configuration,
+            dock_weakness_distributor=dataclasses.replace(
+                fusion_configuration.dock_weakness_distributor, types_state=types_state
+            ),
+        )
+
+        expected_resources.add("DoorLockRando")
+        expected_resources.add("OpenHatchLockRando")
+    elif door_state in ["individual-no-open", "type-no-open"]:
+        all_door_weaknesses = set(door_db.weaknesses[door_type].values())
+        all_door_weaknesses.remove(open_hatch_door)
+
+        types_state = fusion_configuration.dock_weakness_distributor.types_state
+        types_state[door_type] = dataclasses.replace(types_state[door_type], mode=weakness_mode)
+        types_state[door_type] = dataclasses.replace(types_state[door_type], can_change_from=all_door_weaknesses)
+        types_state[door_type] = dataclasses.replace(types_state[door_type], can_change_to=all_door_weaknesses)
+        fusion_configuration = dataclasses.replace(
+            fusion_configuration,
+            dock_weakness_distributor=dataclasses.replace(
+                fusion_configuration.dock_weakness_distributor, types_state=types_state
+            ),
+        )
+
+        expected_resources.add("DoorLockRando")
+    elif door_state == "vanilla":
+        # keep as is
+        pass
+    else:
+        raise Exception("unhandled state for door_state")
+
+    if geron_state:
+        fusion_configuration = dataclasses.replace(fusion_configuration, adjusted_geron_weaknesses=True)
+        expected_resources.add("NerfGerons")
+    else:
+        fusion_configuration = dataclasses.replace(fusion_configuration, adjusted_geron_weaknesses=False)
+
+    enabled_resources = FusionBootstrap()._get_enabled_misc_resources(
+        fusion_configuration, fusion_game_description.get_resource_database_view()
+    )
+
+    print(enabled_resources)
+    assert enabled_resources == expected_resources

--- a/test/games/fusion/generator/test_fusion_bootstrap.py
+++ b/test/games/fusion/generator/test_fusion_bootstrap.py
@@ -80,26 +80,11 @@ def test_enabled_misc_resources(fusion_game_description, fusion_configuration, d
     elif door_state in ["type-all", "type-no-open"]:
         weakness_mode = DockWeaknessDistributorMode.WEAKNESS_TO_WEAKNESS
 
-    if door_state in ["individual-all", "type-all"]:
-        all_door_weaknesses = set(door_db.weaknesses[door_type].values())
-
-        types_state = fusion_configuration.dock_weakness_distributor.types_state
-        types_state[door_type] = dataclasses.replace(types_state[door_type], mode=weakness_mode)
-        types_state[door_type] = dataclasses.replace(types_state[door_type], can_change_from=all_door_weaknesses)
-        types_state[door_type] = dataclasses.replace(types_state[door_type], can_change_to=all_door_weaknesses)
-        fusion_configuration = dataclasses.replace(
-            fusion_configuration,
-            dock_weakness_distributor=dataclasses.replace(
-                fusion_configuration.dock_weakness_distributor, types_state=types_state
-            ),
-        )
-
-        expected_resources.add("DoorLockRando")
-        expected_resources.add("OpenHatchLockRando")
-    elif door_state in ["individual-no-open", "type-no-open"]:
-        all_door_weaknesses = set(door_db.weaknesses[door_type].values())
+    all_door_weaknesses = set(door_db.weaknesses[door_type].values())
+    if door_state in ["individual-no-open", "type-no-open"]:
         all_door_weaknesses.remove(open_hatch_door)
 
+    if door_state != "vanilla":
         types_state = fusion_configuration.dock_weakness_distributor.types_state
         types_state[door_type] = dataclasses.replace(types_state[door_type], mode=weakness_mode)
         types_state[door_type] = dataclasses.replace(types_state[door_type], can_change_from=all_door_weaknesses)
@@ -110,8 +95,11 @@ def test_enabled_misc_resources(fusion_game_description, fusion_configuration, d
                 fusion_configuration.dock_weakness_distributor, types_state=types_state
             ),
         )
-
-        expected_resources.add("DoorLockRando")
+        if door_state in ["individual-all", "type-all"]:
+            expected_resources.add("DoorLockRando")
+            expected_resources.add("OpenHatchLockRando")
+        elif door_state in ["individual-no-open", "type-no-open"]:
+            expected_resources.add("DoorLockRando")
     elif door_state == "vanilla":
         # keep as is
         pass
@@ -128,5 +116,4 @@ def test_enabled_misc_resources(fusion_game_description, fusion_configuration, d
         fusion_configuration, fusion_game_description.get_resource_database_view()
     )
 
-    print(enabled_resources)
     assert enabled_resources == expected_resources


### PR DESCRIPTION
Aparently we just never added the code in the bootstrap lol
There's some logic in fusion that expects some cross-room stuff to work if DLR is enabled but open hatches are not shuffled. Which originally i think got added because fusion had a few issues patching wise with open hatches.