### PR TITLE
Don't connect to HBC when connection gets refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Automatic Item Tracker: The layout and the theme are now split and can be selected separately.
 - Changed: Improved average location distribution of "inert" pickups such as Prime Artifacts and Echoes STKs.
 - Changed: Updated the Nintendont version that is used when uploading it directly to the Wii. It will now reconnect to the network once it has lost a connection.
+- Changed: The Nintendont connector will not try to connect to the Homebrew Channel anymore for giving better feedback.
 
 ## [10.10.0] - 2026-08-02
 

--- a/randovania/game_connection/executor/nintendont_executor.py
+++ b/randovania/game_connection/executor/nintendont_executor.py
@@ -180,15 +180,9 @@ class NintendontExecutor(MemoryOperationExecutor):
             self._socket = SocketHolder(reader, writer, api_version, max_input, max_output, max_addresses)
             return None
 
-        except ConnectionRefusedError as e:
+        except ConnectionRefusedError:
             # Ip exists, maybe it's listening to the HBC port instead?
-            try:
-                reader, writer = await asyncio.wait_for(asyncio.open_connection(self._ip, 4299), timeout=self._timeout)
-                writer.close()
-            except Exception:
-                raise e
-
-            return "Currently in the Homebrew Channel. Upload Nintendont or launch it manually."
+            return f"Unable to connect to {self.ip}. Either wrong IP, or not yet in-game."
         except (TimeoutError, OSError, UnicodeError) as e:
             # UnicodeError is for some invalid ip addresses
             self._socket = None


### PR DESCRIPTION
After looking/trying a few things out, it seems like we can't really do a nice thing of "try to connect to HBC, then give better feedback for it including enabling/disabling the button when appropriate". The connectivity in HBC was only really meant for a "send dol and forget" approach. 
