### PR TITLE
MultiplayerSessionWindow: make closeEvent sync

### DIFF
--- a/randovania/gui/lib/background_task_mixin.py
+++ b/randovania/gui/lib/background_task_mixin.py
@@ -6,7 +6,10 @@ import concurrent.futures
 import threading
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 import randovania.games.prime2.patcher.csharp_subprocess
+from randovania.gui.lib import common_qt_lib
 from randovania.lib.background_task import AbortBackgroundTask
 from randovania.lib.signal import RdvSignal
 from randovania.lib.status_update_lib import ProgressUpdateCallable
@@ -25,6 +28,7 @@ class BackgroundTaskMixin:
     background_tasks_button_lock_signal = RdvSignal[[bool]]()
     abort_background_task_requested: bool = False
     _background_thread: threading.Thread | None = None
+    _close_confirmed = False
 
     def _start_thread_for(self, target: typing.Callable[[], None]) -> None:
         randovania.games.prime2.patcher.csharp_subprocess.IO_LOOP = asyncio.get_event_loop()
@@ -87,3 +91,41 @@ class BackgroundTaskMixin:
     @property
     def has_background_process(self) -> bool:
         return self._background_thread is not None
+
+    def _prompt_confirm_close(self, parent: QtWidgets.QWidget) -> None:
+        box = QtWidgets.QMessageBox(
+            QtWidgets.QMessageBox.Icon.Warning,
+            "Confirm close window",
+            "Are you sure you want to close this window?\nClosing this window will abort current tasks.",
+            QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+            parent,
+        )
+        box.setDefaultButton(QtWidgets.QMessageBox.StandardButton.No)
+        box.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        box.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
+        common_qt_lib.set_default_window_icon(box)
+
+        def _on_finished(result: int) -> None:
+            if result == QtWidgets.QMessageBox.StandardButton.Yes:
+                self._close_confirmed = True
+                parent.close()
+
+        box.finished.connect(_on_finished)
+        box.open()
+
+    def background_task_on_close_event(self, parent: QtWidgets.QWidget, event: QtGui.QCloseEvent) -> bool:
+        """
+        Checks if the close event should be ignored due to a pending background task.
+
+        :param parent: The widget being closed.
+        :param event:
+        :return: True, when you should proceed with closing the widget.
+        """
+
+        if self.has_background_process and not self._close_confirmed:
+            event.ignore()
+            self._prompt_confirm_close(parent)
+            return False
+        else:
+            self.stop_background_process()
+            return True

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -24,7 +24,6 @@ from randovania.game.game_enum import RandovaniaGame
 from randovania.game_description.game_description import GameDescription
 from randovania.gui.generated.main_window_ui import Ui_MainWindow
 from randovania.gui.lib import async_dialog, common_qt_lib, theme
-from randovania.gui.lib.async_dialog import StandardButton
 from randovania.gui.lib.background_task_mixin import BackgroundTaskMixin
 from randovania.gui.lib.window_manager import WindowManager
 from randovania.interface_common import update_checker
@@ -327,23 +326,10 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
 
         self.main_tab_widget.setCurrentIndex(0)
 
+    @typing.override
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:
-        if self.has_background_process:
-            event.ignore()
-            dialog = QtWidgets.QMessageBox(
-                QtWidgets.QMessageBox.Icon.Warning,
-                "Confirm close window",
-                "Are you sure you want to close this window?\nClosing this window will abort current tasks.",
-                (StandardButton.Yes | StandardButton.No),
-            )
-            dialog.setDefaultButton(StandardButton.No)
-            dialog.setWindowIcon(QtGui.QIcon(os.fspath(randovania.get_icon_path())))
-            result = dialog.exec()
-            if result != StandardButton.Yes:
-                return
-            event.accept()
-        self.stop_background_process()
-        super().closeEvent(event)
+        if self.background_task_on_close_event(self, event):
+            super().closeEvent(event)
 
     def dragEnterEvent(self, event: QtGui.QDragEnterEvent) -> None:
         valid_extensions = [

--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -172,6 +172,7 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
     _last_actions: MultiplayerSessionActions
     _pending_actions: MultiplayerSessionActions | None = None
     has_closed = False
+    _close_confirmed = False
     _logic_settings_window: CustomizePresetDialog | None = None
     _generating_game: bool = False
     _already_kicked = False
@@ -336,20 +337,33 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
 
         return window
 
+    def _prompt_confirm_close(self) -> None:
+        box = QtWidgets.QMessageBox(
+            QtWidgets.QMessageBox.Icon.Warning,
+            "Confirm close window",
+            "Are you sure you want to close this window?\nClosing this window will abort current tasks.",
+            StandardButton.Yes | StandardButton.No,
+            self,
+        )
+        box.setDefaultButton(StandardButton.No)
+        box.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        box.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
+        common_qt_lib.set_default_window_icon(box)
+
+        def _on_finished(result: int) -> None:
+            if result == StandardButton.Yes:
+                self._close_confirmed = True
+                self.close()
+
+        box.finished.connect(_on_finished)
+        box.open()
+
     @asyncClose
     async def closeEvent(self, event: QtGui.QCloseEvent) -> None:
-        if self.has_background_process:
+        if self.has_background_process and not self._close_confirmed:
             event.ignore()
-            result = await async_dialog.warning(
-                self,
-                "Confirm close window",
-                "Are you sure you want to close this window?\nClosing this window will abort current tasks.",
-                buttons=async_dialog.StandardButton.Yes | async_dialog.StandardButton.No,
-                default_button=async_dialog.StandardButton.No,
-            )
-            if result != StandardButton.Yes:
-                return
-            event.accept()
+            self._prompt_confirm_close()
+            return
         self.stop_background_process()
         return await self._on_close_event(event)
 

--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -4,10 +4,10 @@ import asyncio
 import collections
 import itertools
 import logging
-from typing import TYPE_CHECKING, Any, NamedTuple, Self
+from typing import TYPE_CHECKING, Any, NamedTuple, Self, override
 
 from PySide6 import QtCore, QtGui, QtWidgets
-from qasync import asyncClose, asyncSlot
+from qasync import asyncSlot
 
 from randovania import monitoring
 from randovania.game_description import default_database
@@ -358,17 +358,17 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         box.finished.connect(_on_finished)
         box.open()
 
-    @asyncClose
-    async def closeEvent(self, event: QtGui.QCloseEvent) -> None:
+    @override
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:
         if self.has_background_process and not self._close_confirmed:
             event.ignore()
             self._prompt_confirm_close()
             return
         self.stop_background_process()
-        return await self._on_close_event(event)
+        self._on_close_event(event)
 
-    async def _on_close_event(self, event: QtGui.QCloseEvent) -> None:
-        is_kicked = self.current_user_id not in self._session.users
+    def _on_close_event(self, event: QtGui.QCloseEvent) -> None:
+        is_kicked = hasattr(self, "_session") and self.current_user_id not in self._session.users
 
         try:
             self.network_client.MultiplayerSessionMetaUpdated.disconnect(self.on_meta_update)
@@ -381,7 +381,7 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
 
         try:
             if not is_kicked and not self.network_client.connection_state.is_disconnected:
-                await self.network_client.listen_to_session(self._session.id, False)
+                self.network_client.remove_interest_in_session(self.game_session_api.current_session_id)
         finally:
             for d in list(self.tracker_windows.values()):
                 d.close()

--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -19,7 +19,6 @@ from randovania.gui.generated.multiplayer_session_ui import Ui_MultiplayerSessio
 from randovania.gui.item_tracker.auto_tracker_window import load_trackers_configuration
 from randovania.gui.item_tracker.item_tracker_popup_window import ItemTrackerPopupWindow
 from randovania.gui.lib import async_dialog, common_qt_lib, game_exporter, layout_loader
-from randovania.gui.lib.async_dialog import StandardButton
 from randovania.gui.lib.background_task_mixin import BackgroundTaskInProgressError, BackgroundTaskMixin
 from randovania.gui.lib.generation_failure_handling import GenerationFailureHandler
 from randovania.gui.lib.multiplayer_session_api import MultiplayerSessionApi
@@ -172,7 +171,6 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
     _last_actions: MultiplayerSessionActions
     _pending_actions: MultiplayerSessionActions | None = None
     has_closed = False
-    _close_confirmed = False
     _logic_settings_window: CustomizePresetDialog | None = None
     _generating_game: bool = False
     _already_kicked = False
@@ -337,35 +335,10 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
 
         return window
 
-    def _prompt_confirm_close(self) -> None:
-        box = QtWidgets.QMessageBox(
-            QtWidgets.QMessageBox.Icon.Warning,
-            "Confirm close window",
-            "Are you sure you want to close this window?\nClosing this window will abort current tasks.",
-            StandardButton.Yes | StandardButton.No,
-            self,
-        )
-        box.setDefaultButton(StandardButton.No)
-        box.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
-        box.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
-        common_qt_lib.set_default_window_icon(box)
-
-        def _on_finished(result: int) -> None:
-            if result == StandardButton.Yes:
-                self._close_confirmed = True
-                self.close()
-
-        box.finished.connect(_on_finished)
-        box.open()
-
     @override
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:
-        if self.has_background_process and not self._close_confirmed:
-            event.ignore()
-            self._prompt_confirm_close()
-            return
-        self.stop_background_process()
-        self._on_close_event(event)
+        if self.background_task_on_close_event(self, event):
+            self._on_close_event(event)
 
     def _on_close_event(self, event: QtGui.QCloseEvent) -> None:
         is_kicked = hasattr(self, "_session") and self.current_user_id not in self._session.users

--- a/randovania/network_client/network_client.py
+++ b/randovania/network_client/network_client.py
@@ -160,6 +160,7 @@ class NetworkClient:
     _num_emit_failures: int = 0
     _sessions_interested_in: set[int]
     _tracking_worlds: set[tuple[uuid.UUID, int]]
+    _background_tasks: set[asyncio.Task]
     _allow_reporting_username: bool = False
 
     def __init__(self, user_data_dir: Path, configuration: NetworkConfiguration):
@@ -189,6 +190,7 @@ class NetworkClient:
         self._current_timeout = _MINIMUM_TIMEOUT
         self._sessions_interested_in = set()
         self._tracking_worlds = set()
+        self._background_tasks = set()
 
         self.configuration = configuration
         encoded_address = _hash_address(self.configuration["server_address"])
@@ -728,6 +730,27 @@ class NetworkClient:
     async def join_multiplayer_session(self, session_id: int, password: str | None) -> MultiplayerSessionEntry:
         result = await server_signals.Multiplayer.JoinSession.call_server(self)(session_id, password)
         return self._with_new_session(result)
+
+    def _run_in_background(self, coro: typing.Coroutine[Any, Any, Any], description: str) -> None:
+        """Schedules a coroutine to run without awaiting it, logging any error it raises."""
+
+        async def wrapper() -> None:
+            try:
+                await coro
+            except Exception:
+                self.logger.exception("Error while running background task: %s", description)
+
+        task = asyncio.ensure_future(wrapper())
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    def remove_interest_in_session(self, session_id: int) -> None:
+        self._sessions_interested_in.discard(session_id)
+        if not self.connection_state.is_disconnected:
+            self._run_in_background(
+                server_signals.Multiplayer.ListenToSession.call_server(self)(session_id, False),
+                f"stop listening to session {session_id}",
+            )
 
     async def listen_to_session(self, session_id: int, listen: bool) -> None:
         await server_signals.Multiplayer.ListenToSession.call_server(self)(session_id, listen)

--- a/test/games/factorio/exporter/test_factorio_game_exporter.py
+++ b/test/games/factorio/exporter/test_factorio_game_exporter.py
@@ -1,15 +1,68 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+import aiohttp
 import pytest
+import pytest_mock
+from aiohttp import web
+from aiohttp.test_utils import TestServer
 
-from randovania.games.factorio.exporter.game_exporter import FactorioGameExporter, FactorioGameExportParams
+from randovania.games.factorio.exporter.game_exporter import (
+    FactorioGameExporter,
+    FactorioGameExportParams,
+    download_file,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+# bigger than the 8192 chunk size, so the chunked reading is actually exercised
+_FILE_CONTENT = bytes(range(256)) * 100
+
+
+@pytest.fixture
+async def file_server() -> AsyncIterator[TestServer]:
+    async def get_file(request: web.Request) -> web.StreamResponse:
+        return web.Response(body=_FILE_CONTENT)
+
+    async def get_missing(request: web.Request) -> web.StreamResponse:
+        raise web.HTTPNotFound
+
+    app = web.Application()
+    app.router.add_get("/mod.zip", get_file)
+    app.router.add_get("/missing.zip", get_missing)
+
+    server = TestServer(app)
+    await server.start_server()
+    yield server
+    await server.close()
+
+
+async def test_download_file(file_server: TestServer, tmp_path: Path) -> None:
+    path = tmp_path.joinpath("mod.zip")
+
+    await download_file(str(file_server.make_url("/mod.zip")), path)
+
+    assert path.read_bytes() == _FILE_CONTENT
+
+
+async def test_download_file_error(file_server: TestServer, tmp_path: Path) -> None:
+    path = tmp_path.joinpath("mod.zip")
+
+    with pytest.raises(aiohttp.ClientResponseError, match="Not Found"):
+        await download_file(str(file_server.make_url("/missing.zip")), path)
+
+    assert not path.exists()
 
 
 @pytest.mark.parametrize("patch_data_name", ["starter_preset"])
-def test_export_game(test_files_dir, mocker, patch_data_name: str, tmp_path):
+def test_export_game(test_files_dir, mocker: pytest_mock.MockerFixture, patch_data_name: str, tmp_path):
     # Setup
+    mock_download_file = mocker.patch("randovania.games.factorio.exporter.game_exporter.download_file")
+
     json_data = test_files_dir.read_json("patcher_data", "factorio", "factorio", patch_data_name, "world_1.json")
     output_path = tmp_path.joinpath("output", "path")
 
@@ -27,4 +80,4 @@ def test_export_game(test_files_dir, mocker, patch_data_name: str, tmp_path):
     progress_update.assert_not_called()
     assert output_path.joinpath("mod-settings.dat").is_file()
     assert len(list(output_path.glob("randovania_*.zip"))) == 1
-    assert len(list(output_path.glob("randovania-assets_*.zip"))) == 1
+    mock_download_file.assert_awaited_once()

--- a/test/games/factorio/exporter/test_factorio_game_exporter.py
+++ b/test/games/factorio/exporter/test_factorio_game_exporter.py
@@ -7,8 +7,8 @@ import aiohttp
 import pytest
 import pytest_mock
 from aiohttp import web
-from aiohttp.test_utils import TestServer
 
+import randovania
 from randovania.games.factorio.exporter.game_exporter import (
     FactorioGameExporter,
     FactorioGameExportParams,
@@ -19,12 +19,16 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from pathlib import Path
 
+    from aiohttp.test_utils import TestServer
+
 # bigger than the 8192 chunk size, so the chunked reading is actually exercised
 _FILE_CONTENT = bytes(range(256)) * 100
 
 
 @pytest.fixture
 async def file_server() -> AsyncIterator[TestServer]:
+    from aiohttp.test_utils import TestServer
+
     async def get_file(request: web.Request) -> web.StreamResponse:
         return web.Response(body=_FILE_CONTENT)
 
@@ -41,6 +45,7 @@ async def file_server() -> AsyncIterator[TestServer]:
     await server.close()
 
 
+@pytest.mark.skipif(randovania.is_frozen(), reason="aiohttp.test_utils not included in executable")
 async def test_download_file(file_server: TestServer, tmp_path: Path) -> None:
     path = tmp_path.joinpath("mod.zip")
 
@@ -49,6 +54,7 @@ async def test_download_file(file_server: TestServer, tmp_path: Path) -> None:
     assert path.read_bytes() == _FILE_CONTENT
 
 
+@pytest.mark.skipif(randovania.is_frozen(), reason="aiohttp.test_utils not included in executable")
 async def test_download_file_error(file_server: TestServer, tmp_path: Path) -> None:
     path = tmp_path.joinpath("mod.zip")
 

--- a/test/gui/lib/test_background_task_mixing.py
+++ b/test/gui/lib/test_background_task_mixing.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 from asyncio import CancelledError
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
+from PySide6 import QtWidgets
 
 from randovania.gui.lib.background_task_mixin import BackgroundTaskMixin
 from randovania.lib.background_task import AbortBackgroundTask
+
+if TYPE_CHECKING:
+    import pytest_mock
+    from pytestqt.qtbot import QtBot
+
+StandardButton = QtWidgets.QMessageBox.StandardButton
 
 
 @pytest.fixture
@@ -53,3 +61,72 @@ async def test_run_in_background_async_exception(force_sync_mixin):
     # Run
     with pytest.raises(WeirdError, match="Some weird message"):
         await force_sync_mixin.run_in_background_async(target, "Hello World")
+
+
+@pytest.mark.parametrize(
+    ("has_background_process", "close_confirmed"),
+    [
+        (False, False),
+        (True, False),
+        (True, True),
+    ],
+)
+def test_background_task_on_close_event(
+    skip_qtbot: QtBot,
+    mocker: pytest_mock.MockerFixture,
+    has_background_process: bool,
+    close_confirmed: bool,
+):
+    # Setup
+    mixin = BackgroundTaskMixin()
+    mock_prompt = mocker.patch.object(mixin, "_prompt_confirm_close")
+    mock_stop = mocker.patch.object(mixin, "stop_background_process")
+    mixin._background_thread = MagicMock() if has_background_process else None
+    mixin._close_confirmed = close_confirmed
+
+    parent = QtWidgets.QWidget()
+    skip_qtbot.addWidget(parent)
+    event = MagicMock()
+
+    # Run
+    result = mixin.background_task_on_close_event(parent, event)
+
+    # Assert
+    if has_background_process and not close_confirmed:
+        assert not result
+        event.ignore.assert_called_once_with()
+        mock_prompt.assert_called_once_with(parent)
+        mock_stop.assert_not_called()
+    else:
+        assert result
+        event.ignore.assert_not_called()
+        mock_prompt.assert_not_called()
+        mock_stop.assert_called_once_with()
+
+
+@pytest.mark.parametrize("confirm", [False, True])
+def test_prompt_confirm_close(skip_qtbot: QtBot, mocker: pytest_mock.MockerFixture, confirm: bool):
+    # Setup
+    mixin = BackgroundTaskMixin()
+
+    parent = QtWidgets.QWidget()
+    skip_qtbot.addWidget(parent)
+    mock_close = mocker.patch.object(parent, "close")
+    # Never actually show the box on screen
+    mock_open = mocker.patch.object(QtWidgets.QMessageBox, "open")
+
+    # Run
+    mixin._prompt_confirm_close(parent)
+
+    box = parent.findChild(QtWidgets.QMessageBox)
+    assert box is not None
+    mock_open.assert_called_once_with()
+    assert box.standardButton(box.defaultButton()) == StandardButton.No
+    box.done(StandardButton.Yes if confirm else StandardButton.No)
+
+    # Assert
+    assert mixin._close_confirmed == confirm
+    if confirm:
+        mock_close.assert_called_once_with()
+    else:
+        mock_close.assert_not_called()

--- a/test/gui/test_multiplayer_session_window.py
+++ b/test/gui/test_multiplayer_session_window.py
@@ -797,7 +797,7 @@ async def test_import_permalink_unsupported_games(window: MultiplayerSessionWind
     execute_dialog = mocker.patch("randovania.gui.lib.async_dialog.execute_dialog", new_callable=AsyncMock)
     execute_dialog.return_value = QtWidgets.QDialog.DialogCode.Accepted
     mock_warning = mocker.patch("randovania.gui.lib.async_dialog.warning", new_callable=AsyncMock)
-    mocker.patch.object(window, "_on_close_event", AsyncMock())
+    mocker.patch.object(window, "_on_close_event", MagicMock())
 
     unsupported_preset = MagicMock()
     unsupported_preset.game.data.defaults_available_in_game_sessions = False
@@ -922,7 +922,7 @@ async def test_import_layout_unsupported_games(window: MultiplayerSessionWindow,
     mock_load_layout = mocker.patch(
         "randovania.gui.lib.layout_loader.prompt_and_load_layout_description", new_callable=AsyncMock
     )
-    mocker.patch.object(window, "_on_close_event", AsyncMock())
+    mocker.patch.object(window, "_on_close_event", MagicMock())
 
     unsupported_preset = MagicMock()
     unsupported_preset.game.data.defaults_available_in_game_sessions = False
@@ -1036,18 +1036,18 @@ async def test_on_close_event(window: MultiplayerSessionWindow, mocker, is_membe
     event = MagicMock()
     window._session = MagicMock()
     window._session.users = [window.network_client.current_user.id] if is_member else []
-    window.network_client.listen_to_session = AsyncMock()
+    window.network_client.remove_interest_in_session = MagicMock()
     window.network_client.connection_state.is_disconnected = False
 
     # Run
-    await window._on_close_event(event)
+    window._on_close_event(event)
     event.ignore.assert_not_called()
     super_close_event.assert_called_once_with(event)
 
     if is_member:
-        window.network_client.listen_to_session.assert_awaited_once_with(window._session.id, False)
+        window.network_client.remove_interest_in_session.assert_called_once_with(1234)
     else:
-        window.network_client.listen_to_session.assert_not_awaited()
+        window.network_client.remove_interest_in_session.assert_not_called()
 
 
 async def test_update_session_audit_log(window: MultiplayerSessionWindow):

--- a/test/gui/test_multiplayer_session_window.py
+++ b/test/gui/test_multiplayer_session_window.py
@@ -15,6 +15,7 @@ from PySide6 import QtCore, QtWidgets
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_connection.game_connection import ConnectedGameState, GameConnection
 from randovania.gui.lib import model_lib
+from randovania.gui.lib.async_dialog import StandardButton
 from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.multiplayer_session_window import MultiplayerSessionWindow
 from randovania.gui.multiworld_client import MultiworldClient
@@ -1048,6 +1049,67 @@ async def test_on_close_event(window: MultiplayerSessionWindow, mocker, is_membe
         window.network_client.remove_interest_in_session.assert_called_once_with(1234)
     else:
         window.network_client.remove_interest_in_session.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("has_background_process", "close_confirmed"),
+    [
+        (False, False),
+        (True, False),
+        (True, True),
+    ],
+)
+async def test_close_event(
+    window: MultiplayerSessionWindow,
+    mocker: pytest_mock.MockerFixture,
+    has_background_process: bool,
+    close_confirmed: bool,
+):
+    # Setup
+    mock_on_close_event = mocker.patch.object(window, "_on_close_event")
+    mock_prompt = mocker.patch.object(window, "_prompt_confirm_close")
+    mock_stop = mocker.patch.object(window, "stop_background_process")
+    window._background_thread = MagicMock() if has_background_process else None
+    window._close_confirmed = close_confirmed
+    event = MagicMock()
+
+    # Run
+    window.closeEvent(event)
+
+    # Assert
+    if has_background_process and not close_confirmed:
+        event.ignore.assert_called_once_with()
+        mock_prompt.assert_called_once_with()
+        mock_stop.assert_not_called()
+        mock_on_close_event.assert_not_called()
+    else:
+        event.ignore.assert_not_called()
+        mock_prompt.assert_not_called()
+        mock_stop.assert_called_once_with()
+        mock_on_close_event.assert_called_once_with(event)
+
+
+@pytest.mark.parametrize("confirm", [False, True])
+async def test_prompt_confirm_close(window: MultiplayerSessionWindow, mocker: pytest_mock.MockerFixture, confirm: bool):
+    # Setup
+    mock_close = mocker.patch.object(window, "close")
+    mock_open = mocker.patch.object(QtWidgets.QMessageBox, "open")
+
+    # Run
+    window._prompt_confirm_close()
+
+    box = window.findChild(QtWidgets.QMessageBox)
+    assert box is not None
+    mock_open.assert_called_once_with()
+    assert box.standardButton(box.defaultButton()) == StandardButton.No
+    box.done(StandardButton.Yes if confirm else StandardButton.No)
+
+    # Assert
+    assert window._close_confirmed == confirm
+    if confirm:
+        mock_close.assert_called_once_with()
+    else:
+        mock_close.assert_not_called()
 
 
 async def test_update_session_audit_log(window: MultiplayerSessionWindow):

--- a/test/gui/test_multiplayer_session_window.py
+++ b/test/gui/test_multiplayer_session_window.py
@@ -15,7 +15,6 @@ from PySide6 import QtCore, QtWidgets
 from randovania.game.game_enum import RandovaniaGame
 from randovania.game_connection.game_connection import ConnectedGameState, GameConnection
 from randovania.gui.lib import model_lib
-from randovania.gui.lib.async_dialog import StandardButton
 from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.multiplayer_session_window import MultiplayerSessionWindow
 from randovania.gui.multiworld_client import MultiworldClient
@@ -1051,65 +1050,24 @@ async def test_on_close_event(window: MultiplayerSessionWindow, mocker, is_membe
         window.network_client.remove_interest_in_session.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    ("has_background_process", "close_confirmed"),
-    [
-        (False, False),
-        (True, False),
-        (True, True),
-    ],
-)
-async def test_close_event(
-    window: MultiplayerSessionWindow,
-    mocker: pytest_mock.MockerFixture,
-    has_background_process: bool,
-    close_confirmed: bool,
-):
+@pytest.mark.parametrize("should_close", [False, True])
+async def test_close_event(window: MultiplayerSessionWindow, mocker: pytest_mock.MockerFixture, should_close: bool):
     # Setup
     mock_on_close_event = mocker.patch.object(window, "_on_close_event")
-    mock_prompt = mocker.patch.object(window, "_prompt_confirm_close")
-    mock_stop = mocker.patch.object(window, "stop_background_process")
-    window._background_thread = MagicMock() if has_background_process else None
-    window._close_confirmed = close_confirmed
+    mock_background_task = mocker.patch.object(
+        window, "background_task_on_close_event", return_value=should_close, autospec=True
+    )
     event = MagicMock()
 
     # Run
     window.closeEvent(event)
 
     # Assert
-    if has_background_process and not close_confirmed:
-        event.ignore.assert_called_once_with()
-        mock_prompt.assert_called_once_with()
-        mock_stop.assert_not_called()
-        mock_on_close_event.assert_not_called()
-    else:
-        event.ignore.assert_not_called()
-        mock_prompt.assert_not_called()
-        mock_stop.assert_called_once_with()
+    mock_background_task.assert_called_once_with(window, event)
+    if should_close:
         mock_on_close_event.assert_called_once_with(event)
-
-
-@pytest.mark.parametrize("confirm", [False, True])
-async def test_prompt_confirm_close(window: MultiplayerSessionWindow, mocker: pytest_mock.MockerFixture, confirm: bool):
-    # Setup
-    mock_close = mocker.patch.object(window, "close")
-    mock_open = mocker.patch.object(QtWidgets.QMessageBox, "open")
-
-    # Run
-    window._prompt_confirm_close()
-
-    box = window.findChild(QtWidgets.QMessageBox)
-    assert box is not None
-    mock_open.assert_called_once_with()
-    assert box.standardButton(box.defaultButton()) == StandardButton.No
-    box.done(StandardButton.Yes if confirm else StandardButton.No)
-
-    # Assert
-    assert window._close_confirmed == confirm
-    if confirm:
-        mock_close.assert_called_once_with()
     else:
-        mock_close.assert_not_called()
+        mock_on_close_event.assert_not_called()
 
 
 async def test_update_session_audit_log(window: MultiplayerSessionWindow):

--- a/test/network_client/test_network_client.py
+++ b/test/network_client/test_network_client.py
@@ -286,6 +286,32 @@ async def test_listen_to_session(client: NetworkClient, listen, was_listening):
         assert client._sessions_interested_in == set()
 
 
+@pytest.mark.parametrize("connected", [False, True])
+@pytest.mark.parametrize("was_listening", [False, True])
+async def test_remove_interest_in_session(client: NetworkClient, was_listening, connected):
+    client.server_call = AsyncMock()
+    client._connection_state = ConnectionState.Connected if connected else ConnectionState.Disconnected
+    if was_listening:
+        client._sessions_interested_in.add(1234)
+
+    # Run
+    client.remove_interest_in_session(1234)
+
+    # Let any scheduled background task run to completion.
+    for task in list(client._background_tasks):
+        await task
+
+    # Assert
+    assert client._sessions_interested_in == set()
+    assert client._background_tasks == set()
+    if connected:
+        client.server_call.assert_awaited_once_with(
+            "multiplayer_listen_to_session", (1234, False), namespace=None, handle_invalid_session=True
+        )
+    else:
+        client.server_call.assert_not_awaited()
+
+
 @pytest.mark.parametrize("was_listening", [False, True])
 @pytest.mark.parametrize("listen", [False, True])
 async def test_world_track_inventory(client: NetworkClient, listen, was_listening):


### PR DESCRIPTION
This is what was causing the Python 3.14 tests to hang.

qasync's `asyncClose` is a big hack anyway so I'm glad to see it gone. There's still one use that happens during startup but it's less bad.