### PR TITLE
Planets (Zebeth) DB: Allow Screw Attack to break blocks is now in logic

### DIFF
--- a/randovania/games/planets_zebeth/generator/bootstrap.py
+++ b/randovania/games/planets_zebeth/generator/bootstrap.py
@@ -32,6 +32,7 @@ class PlanetsZebethBootstrap(Bootstrap[PlanetsZebethConfiguration]):
         logical_patches = {
             "open_missile_doors_with_one_missile": "OpenMissileDoorWithOneMissile",
             "allow_downward_shots": "AllowDownwardShots",
+            "allow_screw_attack_to_break_blocks": "AllowScrewAttackToBreakBlocks",
         }
 
         for name, index in logical_patches.items():

--- a/randovania/games/planets_zebeth/logic_database/Brinstar.json
+++ b/randovania/games/planets_zebeth/logic_database/Brinstar.json
@@ -1551,8 +1551,37 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Green Hall": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Break Blocks with Screw Attack"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -1584,8 +1613,37 @@
                     "ui_custom_name": null,
                     "connections": {
                         "Door to Orange Tower": {
-                            "type": "template",
-                            "data": "Can Use Bombs"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Break Blocks with Screw Attack"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 }

--- a/randovania/games/planets_zebeth/logic_database/Brinstar.txt
+++ b/randovania/games/planets_zebeth/logic_database/Brinstar.txt
@@ -275,13 +275,17 @@ Extra - map_name: x256_y37
   * Layers: default
   * Normal Door to Orange Tower/Door to Green Sanctuary W
   > Door to Green Hall
-      Can Use Bombs
+      Any of the following:
+          Can Use Bombs
+          Morph Ball and Can Break Blocks with Screw Attack
 
 > Door to Green Hall; Heals? False
   * Layers: default
   * Normal Door to Green Hall/Door to Green Sanctuary W
   > Door to Orange Tower
-      Can Use Bombs
+      Any of the following:
+          Can Use Bombs
+          Morph Ball and Can Break Blocks with Screw Attack
 
 ----------------
 Green Hall

--- a/randovania/games/planets_zebeth/logic_database/header.json
+++ b/randovania/games/planets_zebeth/logic_database/header.json
@@ -206,6 +206,10 @@
             "AllowDownwardShots": {
                 "long_name": "Allow Downward Shots",
                 "extra": {}
+            },
+            "AllowScrewAttackToBreakBlocks": {
+                "long_name": "Allow Screw Attack To Break Blocks",
+                "extra": {}
             }
         },
         "requirement_template": {
@@ -400,6 +404,39 @@
                                 "data": {
                                     "type": "misc",
                                     "name": "AllowDownwardShots",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "template",
+                                "data": "Can Break Blocks with Screw Attack"
+                            }
+                        ]
+                    }
+                }
+            },
+            "Can Break Blocks with Screw Attack": {
+                "display_name": "Can Break Blocks with Screw Attack",
+                "requirement": {
+                    "type": "and",
+                    "data": {
+                        "comment": null,
+                        "items": [
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "misc",
+                                    "name": "AllowScrewAttackToBreakBlocks",
+                                    "amount": 1,
+                                    "negate": false
+                                }
+                            },
+                            {
+                                "type": "resource",
+                                "data": {
+                                    "type": "items",
+                                    "name": "Screw Attack",
                                     "amount": 1,
                                     "negate": false
                                 }

--- a/randovania/games/planets_zebeth/logic_database/header.txt
+++ b/randovania/games/planets_zebeth/logic_database/header.txt
@@ -22,7 +22,10 @@ Templates
           IBJ (Beginner) and Can Use Bombs
 
 * Can Break Floor Blocks:
-      Enabled Allow Downward Shots or Can Use Bombs
+      Enabled Allow Downward Shots or Can Break Blocks with Screw Attack or Can Use Bombs
+
+* Can Break Blocks with Screw Attack:
+      Screw Attack and Enabled Allow Screw Attack To Break Blocks
 
 ====================
 Dock Weaknesses


### PR DESCRIPTION
Now Screw Attack is in logic when the option to break blocks with it is enabled