### PR TITLE
Make `bytes` serializable

### DIFF
--- a/randovania/bitpacking/json_dataclass.py
+++ b/randovania/bitpacking/json_dataclass.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import dataclasses
 import datetime
 import inspect
@@ -76,6 +77,9 @@ def _decode_with_type(arg: typing.Any, type_: type, extra_args: dict, metadata: 
     elif type_ is uuid.UUID:
         return uuid.UUID(arg)
 
+    elif type_ is bytes:
+        return base64.b64decode(arg)
+
     elif type_ is datetime.datetime:
         return datetime.datetime.fromisoformat(arg)
 
@@ -107,6 +111,9 @@ def _encode_value(value: typing.Any, metadata: Metadata) -> typing.Any:
 
     elif isinstance(value, uuid.UUID):
         return str(value)
+
+    elif isinstance(value, bytes):
+        return base64.b64encode(value).decode("ascii")
 
     elif type_lib.is_named_tuple(type(value)):
         if metadata.get("store_named_tuple_without_names"):

--- a/test/bitpacking/test_json_dataclass.py
+++ b/test/bitpacking/test_json_dataclass.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import datetime
+import json
 import uuid
 from enum import Enum
 from typing import NamedTuple
@@ -57,39 +58,68 @@ class HasDict(JsonDataclass):
     h: tuple[int, RandovaniaGame, str]
 
 
-@pytest.fixture(
-    params=[
-        {
-            "instance": D2(a=A.bar, b=D1(a=5, b="foo", c=1), c=uuid.UUID("00000000-0000-1111-0000-000000000000"), d=()),
-            "json": {
-                "a": "bar",
-                "b": {"a": 5, "b": "foo", "c": 1},
-                "c": "00000000-0000-1111-0000-000000000000",
-                "d": [],
-            },
+@dataclasses.dataclass()
+class NonJsonSerializable(JsonDataclass):
+    a: list[bytes]
+    b: bytes
+    c: datetime.datetime
+    d: datetime.timedelta
+    e: uuid.UUID
+
+
+NON_JSON_SERIALIZABLE_CASES = [
+    {
+        "instance": NonJsonSerializable(
+            a=[b"RDVP\x03\x87\r", b"(\xb5/\xfd`N\x12\xed3\x00\x9aS|\x0e2pk\xd2"],
+            b=b"RDVP\x03\x87\r",
+            c=datetime.datetime(2026, 8, 15, 17, 11, 0, tzinfo=datetime.UTC),
+            d=datetime.timedelta(days=2, hours=3, minutes=4, seconds=5, microseconds=6),
+            e=uuid.UUID("fa8e4fb7-cb9b-4f18-923a-c42ac19356ad"),
+        ),
+        "json": {
+            "a": ["UkRWUAOHDQ==", "KLUv/WBOEu0zAJpTfA4ycGvS"],
+            "b": "UkRWUAOHDQ==",
+            "c": "2026-08-15T17:11:00+00:00",
+            "d": {"days": 2, "seconds": 11045, "microseconds": 6},
+            "e": "fa8e4fb7-cb9b-4f18-923a-c42ac19356ad",
         },
-        {
-            "instance": D2(
-                a=None, b=D1(a=5, b="foo", c=2), c=uuid.UUID("00000000-0000-1111-0000-000000000000"), d=(10, 25, 20)
-            ),
-            "json": {
-                "a": None,
-                "b": {"a": 5, "b": "foo", "c": 2},
-                "c": "00000000-0000-1111-0000-000000000000",
-                "d": [10, 25, 20],
-            },
+    },
+]
+
+D2_CASES = [
+    {
+        "instance": D2(a=A.bar, b=D1(a=5, b="foo", c=1), c=uuid.UUID("00000000-0000-1111-0000-000000000000"), d=()),
+        "json": {
+            "a": "bar",
+            "b": {"a": 5, "b": "foo", "c": 1},
+            "c": "00000000-0000-1111-0000-000000000000",
+            "d": [],
         },
-        {
-            "instance": D2(a=None, b=D1(a=5, b="foo"), c=uuid.UUID("00000000-0000-1111-0000-000000000000"), d=(50,)),
-            "json": {
-                "a": None,
-                "b": {"a": 5, "b": "foo", "c": 5},
-                "c": "00000000-0000-1111-0000-000000000000",
-                "d": [50],
-            },
+    },
+    {
+        "instance": D2(
+            a=None, b=D1(a=5, b="foo", c=2), c=uuid.UUID("00000000-0000-1111-0000-000000000000"), d=(10, 25, 20)
+        ),
+        "json": {
+            "a": None,
+            "b": {"a": 5, "b": "foo", "c": 2},
+            "c": "00000000-0000-1111-0000-000000000000",
+            "d": [10, 25, 20],
         },
-    ],
-)
+    },
+    {
+        "instance": D2(a=None, b=D1(a=5, b="foo"), c=uuid.UUID("00000000-0000-1111-0000-000000000000"), d=(50,)),
+        "json": {
+            "a": None,
+            "b": {"a": 5, "b": "foo", "c": 5},
+            "c": "00000000-0000-1111-0000-000000000000",
+            "d": [50],
+        },
+    },
+]
+
+
+@pytest.fixture(params=D2_CASES + NON_JSON_SERIALIZABLE_CASES)
 def sample_values(request):
     return request.param["instance"], request.param["json"]
 
@@ -101,7 +131,21 @@ def test_as_json(sample_values):
 
 def test_from_json(sample_values):
     value, data = sample_values
-    assert D2.from_json(data) == value
+    assert value.__class__.from_json(data) == value
+
+
+@pytest.fixture(params=NON_JSON_SERIALIZABLE_CASES)
+def sample_values_non_serializable(request):
+    return request.param["instance"], request.param["json"]
+
+
+def test_conversion(sample_values_non_serializable):
+    value, _ = sample_values_non_serializable
+    # throws because of non serializable elemets
+    with pytest.raises(TypeError):
+        json.dumps(value)
+    # works after our conversion
+    json.dumps(value.as_json)
 
 
 def test_from_json_old():


### PR DESCRIPTION
Tried to switch to REST API endpoints in my async race room PR and failed because `AsyncRaceRoomEntry` contains `presets_raw: list[bytes]` which fails when sending as a `JSONResponse`