### PR TITLE
Fusion: Make charge core and watery hole possible in DLR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Logic Database
 
 ##### Sector 1 (SRX)
-- Changed: Watery Hole: Getting the item is now possible in Door Lock Rando.
+- Changed: Watering Hole: Getting the item is now possible in Door Lock Rando.
 - Changed: Charge Core Arena: Getting the upper item locked by a Shinespark is now possible in Door Lock Rando.
 
 ### Metroid: Samus Returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed: Some situations where the generator thinks pathing via certain doors is not possible with randomized doors.
 
+### Metroid Fusion
+
+#### Logic Database
+
+##### Sector 1 (SRX)
+- Changed: Watery Hole: Getting the item is now possible in Door Lock Rando.
+- Changed: Charge Core Arena: Getting the upper item locked by a Shinespark is now possible in Door Lock Rando.
+
 ### Metroid: Samus Returns
 
 - Fixed: Some situations where the generator thinks pathing via certain doors is not possible with randomized doors.

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -10948,7 +10948,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Speed Boosting from Hornoad Housing",
+                                            "comment": "Speed Boosting from Hornoad Housing. This can safely not have DLR check, because its a one way dead-end",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -10972,15 +10972,6 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "misc",
-                                                        "name": "DoorLockRando",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "misc",
                                                         "name": "EntranceRando",
                                                         "amount": 1,
                                                         "negate": true
@@ -10992,6 +10983,15 @@
                                                         "type": "tricks",
                                                         "name": "Knowledge",
                                                         "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "S1ChargeSave",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -11592,7 +11592,7 @@
                         "Pickup (Energy Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": "Shinespark from Hornoad Housing -> Access",
+                                "comment": "Shinespark from Hornoad Housing -> Access. This can safely not have DLR check because this door cannot be permanently locked, unless in the future a way to leave Lower Access is added",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -11610,15 +11610,6 @@
                                             "name": "SpeedBooster",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLockRando",
-                                            "amount": 1,
-                                            "negate": true
                                         }
                                     },
                                     {
@@ -11709,6 +11700,15 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "S1ChargeSave",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -12194,6 +12194,38 @@
                     "valid_starting_location": true,
                     "connections": {
                         "Door to Hornoad Housing": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Event - Central Save Room Visited": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Central Save Room Visited": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 75.6,
+                        "y": 139.66,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "S1ChargeSave",
+                    "connections": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12693,7 +12725,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "This can safely not have DLR check because its a one way dead-end",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -12708,7 +12740,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "misc",
-                                                        "name": "DoorLockRando",
+                                                        "name": "EntranceRando",
                                                         "amount": 1,
                                                         "negate": true
                                                     }
@@ -12716,10 +12748,10 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "misc",
-                                                        "name": "EntranceRando",
+                                                        "type": "events",
+                                                        "name": "S1ChargeSave",
                                                         "amount": 1,
-                                                        "negate": true
+                                                        "negate": false
                                                     }
                                                 }
                                             ]

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -1523,8 +1523,8 @@ Extra - minimap_coordinates: [{'x': 11, 'y': 6}, {'x': 11, 'y': 7}]
   > Event - Bomb Blocks
       Any of the following:
           Can Break Single Bomb Blocks
-          # Speed Boosting from Hornoad Housing
-          Level 0 Keycard and Speed Booster and Knowledge (Intermediate) and Disabled Door Lock Rando and Disabled Entrance Rando
+          # Speed Boosting from Hornoad Housing. This can safely not have DLR check, because its a one way dead-end
+          Level 0 Keycard and Speed Booster and After Sector 1 Central Save Room Visited and Knowledge (Intermediate) and Disabled Entrance Rando
 
 > Door to Charge Core Arena; Heals? False
   * Layers: default
@@ -1633,8 +1633,8 @@ Hint Features - Multiple Pickups
   * Extra - door_idx: [82]
   > Pickup (Energy Tank)
       All of the following:
-          # Shinespark from Hornoad Housing -> Access
-          Level 0 Keycard and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando and Can Kill Gadora
+          # Shinespark from Hornoad Housing -> Access. This can safely not have DLR check because this door cannot be permanently locked, unless in the future a way to leave Lower Access is added
+          Level 0 Keycard and Speed Booster and After Sector 1 Central Save Room Visited and Disabled Entrance Rando and Can Kill Gadora
           Any of the following:
               # After Fight, Trickless: https://youtu.be/Z6_miH4qoQY
               Hi-Jump and After Boss Charge Core-X Defeated
@@ -1726,6 +1726,14 @@ Extra - unlocked_save_recharge_station: True
   * Extra - X: 8
   * Extra - Y: 10
   > Door to Hornoad Housing
+      Trivial
+  > Event - Central Save Room Visited
+      Trivial
+
+> Event - Central Save Room Visited; Heals? False
+  * Layers: default
+  * Event Sector 1 Central Save Room Visited
+  > Save Station
       Trivial
 
 ----------------
@@ -1836,7 +1844,9 @@ Hint Features - Climbable Surface
   * Extra - door_idx: [101]
   > Pickup (Hidden Power Bomb Tank)
       All of the following:
-          Level 0 Keycard and Morph Ball and Speed Booster and After Sector 1 Charge Core Arena Access Bomb Blocks Destroyed and Disabled Door Lock Rando and Disabled Entrance Rando and Can Bounce in Ball
+          Level 0 Keycard and Morph Ball and After Sector 1 Charge Core Arena Access Bomb Blocks Destroyed and Can Bounce in Ball
+          # This can safely not have DLR check because its a one way dead-end
+          Speed Booster and After Sector 1 Central Save Room Visited and Disabled Entrance Rando
           Any of the following:
               # Deal with water
               Gravity Suit

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -696,6 +696,10 @@
             "Animals": {
                 "long_name": "Main Deck Animal Controls",
                 "extra": {}
+            },
+            "S1ChargeSave": {
+                "long_name": "Sector 1 Central Save Room Visited",
+                "extra": {}
             }
         },
         "tricks": {


### PR DESCRIPTION
I thank jeff in the past for this wonderful visualization.

<img width="1117" height="637" alt="grafik" src="https://github.com/user-attachments/assets/8f2c5366-9132-4065-977a-1c516f7a3acd" />


Watery Hole is fairly simple to explain. There are only 2 doors in between, both doors cannot be permanently locked as this is a one-way dead-end, so once you can reach the save room, you are guaranteed to open the 2 doors in the way.
(Technically you can do it without reaching the same room and starting in hornoad housing but then you have to do a frame perfect shinespark crouch. Frame to early and you dont get the spark, frame too late and you fall off the clif)


The Charge Core Arena is similar. None of the doors cannot be permanently locked, because the whole charge area is a one way, so if you reached the save room and are now at the lower door, you were guaranteed to be able to open the 3 doors in between.
