### PR TITLE
Fusion: put open hatch into shuffle_from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Fusion
 
+- When enabling Door Lock Rando for the default presets, Open Hatches are now also shuffled by default.
+
 #### Logic Database
 
 ##### Main Deck

--- a/randovania/games/fusion/presets/open_sector_hub.rdvpreset
+++ b/randovania/games/fusion/presets/open_sector_hub.rdvpreset
@@ -136,6 +136,7 @@
             "types_state": {
                 "Door": {
                     "can_change_from": [
+                        "Open Hatch",
                         "L0 Hatch",
                         "L1 Hatch",
                         "L2 Hatch",

--- a/randovania/games/fusion/presets/vanilla_start.rdvpreset
+++ b/randovania/games/fusion/presets/vanilla_start.rdvpreset
@@ -135,6 +135,7 @@
             "types_state": {
                 "Door": {
                     "can_change_from": [
+                        "Open Hatch",
                         "L0 Hatch",
                         "L1 Hatch",
                         "L2 Hatch",


### PR DESCRIPTION
It being excluded is a remnant of when the patcher's ability to change open hatches was not very good.
But I see most people enabling it nowadays, and I feel like it's a much better experience to play with, so would be good to not have the end user need to toggle it themselves.