### PR TITLE
Hunters - Prevent Shield Keys from being starting items

### DIFF
--- a/randovania/games/prime_hunters/pickup_database/pickup-database.json
+++ b/randovania/games/prime_hunters/pickup_database/pickup-database.json
@@ -178,7 +178,8 @@
             "progression": [
                 "{region}{area}ShieldKey"
             ],
-            "expected_case_for_describer": "shuffled"
+            "expected_case_for_describer": "shuffled",
+            "starting_condition": "never_start"
         }
     },
     "standard_pickups": {


### PR DESCRIPTION
The patcher currently does not support starting with Shield Keys