### PR TITLE
Prime 1: Add required-main support for Missile and Power Bomb Expansions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [11.1.0] - 2026-10-01
 
+### Metroid Prime
+
+- Added: Missile Expansions and Power Bomb Expansions can now require the Missile Launcher and Main Power Bomb respectively. Expansions collected before their main item are retained and become usable once the main item is acquired.
+
 ### Metroid Prime Hunters
 
 - Fixed: The Alimbic Turrets in Celestial Archives - Data Shrine 03 will now always respawn on room reload to prevent a softlock if the door to Synergy Core was not unlocked prior to leaving.

--- a/randovania/game_connection/connector/prime1_remote_connector.py
+++ b/randovania/game_connection/connector/prime1_remote_connector.py
@@ -12,6 +12,7 @@ from randovania.game_connection.executor.memory_operation import (
     MemoryOperationException,
     MemoryOperationExecutor,
 )
+from randovania.game_description.resources.inventory import InventoryItem
 from randovania.game_description.resources.item_resource_info import ItemResourceInfo
 from randovania.games.prime1.patcher import prime_items
 
@@ -27,11 +28,9 @@ if TYPE_CHECKING:
 def format_received_item(item_name: str, player_name: str) -> str:
     special = {
         "Locked Power Bomb Expansion": (
-            "Received Power Bomb Expansion from {provider_name}, but the main Power Bomb is required to use it."
+            "Received Power Bomb Expansion from {provider_name}. Main Power Bomb required."
         ),
-        "Locked Missile Expansion": (
-            "Received Missile Expansion from {provider_name}, but the Missile Launcher is required to use it."
-        ),
+        "Locked Missile Expansion": ("Received Missile Expansion from {provider_name}. Missile Launcher required."),
     }
 
     generic = "Received {item_name} from {provider_name}."
@@ -57,6 +56,21 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
         powerups_offset = 0x24
         vector_data_offset = 0x4
         return (powerups_offset + vector_data_offset) + (item_index * self.powerup_size)
+
+    async def get_inventory(self) -> Inventory:
+        inventory = await super().get_inventory()
+
+        resource_db = self.game.get_resource_database_view()
+        unknown2 = inventory.get(resource_db.get_item("Unknown2"))
+        custom_bits = unknown2.capacity
+
+        for item_name in ("MissileLauncher", "MainPB"):
+            item = resource_db.get_item(item_name)
+            bitmask = item.extra["unk2_bitmask_value"]
+            owned = int(bool(custom_bits & bitmask))
+            inventory[item] = InventoryItem(owned, owned)
+
+        return inventory
 
     def _asset_id_format(self) -> str:
         return ">I"
@@ -124,13 +138,29 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
 
             assert isinstance(item, ItemResourceInfo)
 
+            game_item_id = item.extra.get("game_item_id", item.extra["item_id"])
+
+            if item.extra.get("unk2_bitmask_value") is not None:
+                if delta != 1:
+                    raise ValueError(f"Unexpected custom item delta for {item.long_name}: {delta}")
+
+                patches.append(
+                    all_prime_dol_patches.increment_item_capacity_patch(
+                        self.version.powerup_functions,
+                        self.version.game,
+                        game_item_id,
+                        0,
+                    )
+                )
+                continue
+
             if item.short_name not in prime_items.ARTIFACT_ITEMS:
                 if item.extra.get("max_increase", None) == 0:
                     patches.append(
                         all_prime_dol_patches.adjust_item_amount_patch(
                             self.version.powerup_functions,
                             self.version.game,
-                            item.extra["refill_id"] if item.extra.get("is_refill", None) else item.extra["item_id"],
+                            item.extra["refill_id"] if item.extra.get("is_refill", None) else game_item_id,
                             delta,
                         )
                     )
@@ -139,7 +169,7 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
                         all_prime_dol_patches.adjust_item_amount_and_capacity_patch(
                             self.version.powerup_functions,
                             self.version.game,
-                            item.extra["item_id"],
+                            game_item_id,
                             delta,
                         )
                     )
@@ -151,7 +181,10 @@ class Prime1RemoteConnector(PrimeRemoteConnector):
 
                 patches.append(
                     all_prime_dol_patches.increment_item_capacity_patch(
-                        self.version.powerup_functions, self.version.game, item.extra["item_id"], delta
+                        self.version.powerup_functions,
+                        self.version.game,
+                        game_item_id,
+                        delta,
                     )
                 )
                 patches.append(dol_patches.set_artifact_layer_active_patch(self.version, layer_id, delta > 0))

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -111,7 +111,8 @@ def prime1_pickup_details_to_patcher(
     original_model = detail.original_model.as_json
 
     name = detail.name
-    collection_text = detail.collection_text[0]
+    collection_text = detail.collection_text[-1]
+    conditional_hudmemo = None
     pickup_type = "Nothing"
     count = 0
     max_count = 0
@@ -121,19 +122,59 @@ def prime1_pickup_details_to_patcher(
         count = detail.index.index + 1
         max_count = count
     else:
-        for resource, quantity in detail.conditional_resources[0].resources:
-            # Refill items
-            if resource.extra.get("is_refill"):
-                pickup_type = resource.extra.get("pickup_type", resource.long_name)
-                count = quantity
-                max_count = 0
-                break
-            # Regular items
-            elif resource.extra["item_id"] < 1000:
-                pickup_type = resource.long_name
-                count = quantity
-                max_count = count
-                break
+        pickup = detail.original_pickup
+        is_required_expansion = (
+            pickup is not None and pickup.is_expansion and pickup.respects_lock and pickup.resource_lock is not None
+        )
+        is_required_main = (
+            pickup is not None and pickup.unlocks_resource and pickup.respects_lock and pickup.resource_lock is not None
+        )
+
+        # The solver uses LockedMissile/LockedPB when the main item is missing,
+        # but RandomPrime still stores that ammo in the normal physical slot.
+        if is_required_expansion:
+            unlocked_resources = detail.conditional_resources[-1]
+            resources = unlocked_resources.resources
+
+            required_item = unlocked_resources.item
+            if required_item is not None:
+                conditional_hudmemo = {
+                    "requiredItem": required_item.long_name,
+                    "missingText": detail.collection_text[0],
+                }
+        else:
+            resources = detail.conditional_resources[0].resources
+
+        if is_required_main:
+            main_resource = next(
+                resource for resource, _ in resources if resource.extra.get("unk2_bitmask_value") is not None
+            )
+            ammo_quantity = next(
+                (
+                    quantity
+                    for resource, quantity in resources
+                    if resource.extra["item_id"] < 1000 and not resource.extra.get("is_refill")
+                ),
+                0,
+            )
+
+            pickup_type = main_resource.long_name
+            count = 0
+            max_count = ammo_quantity
+        else:
+            for resource, quantity in resources:
+                # Refill items
+                if resource.extra.get("is_refill"):
+                    pickup_type = resource.extra.get("pickup_type", resource.long_name)
+                    count = quantity
+                    max_count = 0
+                    break
+                # Regular items
+                elif resource.extra["item_id"] < 1000:
+                    pickup_type = resource.long_name
+                    count = quantity
+                    max_count = count
+                    break
 
     if (
         model["name"] == "Missile"
@@ -143,6 +184,10 @@ def prime1_pickup_details_to_patcher(
     ):
         model["name"] = "Shiny Missile"
         collection_text = collection_text.replace("Missile Expansion", "Shiny Missile Expansion")
+        if conditional_hudmemo is not None:
+            conditional_hudmemo["missingText"] = conditional_hudmemo["missingText"].replace(
+                "Missile Expansion", "Shiny Missile Expansion"
+            )
         name = name.replace("Missile Expansion", "Shiny Missile Expansion")
         original_model = model
 
@@ -157,6 +202,9 @@ def prime1_pickup_details_to_patcher(
         "respawn": False,
         "showIcon": pickup_markers,
     }
+
+    if conditional_hudmemo is not None:
+        result["conditionalHudmemo"] = conditional_hudmemo
 
     if detail.original_model.name == "UnlimitedMissiles":
         result["scale"] = [1.8, 1.8, 1.8]
@@ -196,6 +244,44 @@ def _starting_items_value_for(
         return value
     else:
         return value > 0
+
+
+def _starting_items_for(
+    resource_database: ResourceDatabaseView,
+    starting_resources: ResourceCollection,
+    missile_requires_main: bool,
+    power_bomb_requires_main: bool,
+) -> dict[str, bool | int]:
+    starting_items = {
+        name: _starting_items_value_for(resource_database, starting_resources, index)
+        for name, index in _STARTING_ITEM_NAME_TO_INDEX.items()
+    }
+
+    # Locked starting ammo is still stored in the normal physical ammo slots.
+    starting_items["missiles"] += starting_resources[resource_database.get_item("LockedMissile")]
+    starting_items["powerBombs"] += starting_resources[resource_database.get_item("LockedPB")]
+
+    starting_items.update(
+        {
+            "missileLauncher": (
+                _starting_items_value_for(resource_database, starting_resources, "MissileLauncher")
+                if missile_requires_main
+                else True
+            ),
+            "powerBombLauncher": (
+                _starting_items_value_for(resource_database, starting_resources, "MainPB")
+                if power_bomb_requires_main
+                else True
+            ),
+            "powerSuit": 0,
+            "springBall": False,
+            "unknownItem1": 0,
+            "unlimitedMissiles": False,
+            "unlimitedPowerBombs": False,
+        }
+    )
+
+    return starting_items
 
 
 def _name_for_location(region_list: RegionList, location: AreaIdentifier) -> str:
@@ -675,6 +761,17 @@ class PrimePatchDataFactory(PatchDataFactory[PrimeConfiguration, PrimeCosmeticPa
         return RandovaniaGame.METROID_PRIME
 
     @override
+    def create_memo_data(self) -> dict[str, str]:
+        result = pickup_exporter.GenericAcquiredMemo()
+        result["Locked Missile Expansion"] = (
+            "Missile Expansion acquired, but the Missile Launcher is required to use it."
+        )
+        result["Locked Power Bomb Expansion"] = (
+            "Power Bomb Expansion acquired, but the main Power Bomb is required to use it."
+        )
+        return result
+
+    @override
     @classmethod
     def hint_namer_type(cls) -> type[PrimeHintNamer]:
         return PrimeHintNamer
@@ -705,18 +802,6 @@ class PrimePatchDataFactory(PatchDataFactory[PrimeConfiguration, PrimeCosmeticPa
         # Setup
         db = self.game
         namer = PrimeHintNamer(self.description.all_patches, self.worlds_config)
-
-        ammo_with_mains = [
-            ammo.name
-            for ammo, state in self.configuration.ammo_pickup_configuration.pickups_state.items()
-            if state.requires_main_item
-        ]
-        if ammo_with_mains:
-            raise ValueError(
-                "Preset has {} with required mains enabled. This is currently not supported.".format(
-                    " and ".join(ammo_with_mains)
-                )
-            )
 
         scan_visor = self.resource_db.get_item_by_display_name("Scan Visor")
         pickup_list = self.export_pickup_list()
@@ -1011,20 +1096,15 @@ class PrimePatchDataFactory(PatchDataFactory[PrimeConfiguration, PrimeCosmeticPa
         starting_room = _name_for_start_location(db.region_list, self.patches.starting_location)
 
         starting_resources = self.patches.starting_resources()
-        starting_items = {
-            name: _starting_items_value_for(self.resource_db, starting_resources, index)
-            for name, index in _STARTING_ITEM_NAME_TO_INDEX.items()
+        ammo_states = {
+            ammo.name: state for ammo, state in self.configuration.ammo_pickup_configuration.pickups_state.items()
         }
-        starting_items.update(
-            {
-                "missileLauncher": True,
-                "powerBombLauncher": True,
-                "powerSuit": 0,
-                "springBall": False,
-                "unknownItem1": 0,
-                "unlimitedMissiles": False,
-                "unlimitedPowerBombs": False,
-            }
+
+        starting_items = _starting_items_for(
+            self.resource_db,
+            starting_resources,
+            ammo_states["Missile Expansion"].requires_main_item,
+            ammo_states["Power Bomb Expansion"].requires_main_item,
         )
 
         if not self.configuration.legacy_mode:

--- a/randovania/games/prime1/logic_database/header.json
+++ b/randovania/games/prime1/logic_database/header.json
@@ -294,28 +294,34 @@
                 "long_name": "Main Power Bomb",
                 "max_capacity": 1,
                 "extra": {
-                    "item_id": 1005
+                    "item_id": 1005,
+                    "game_item_id": 44,
+                    "unk2_bitmask_value": 8
                 }
             },
             "LockedPB": {
                 "long_name": "Locked Power Bomb",
                 "max_capacity": 99,
                 "extra": {
-                    "item_id": 1006
+                    "item_id": 1006,
+                    "game_item_id": 7
                 }
             },
             "MissileLauncher": {
                 "long_name": "Missile Launcher",
                 "max_capacity": 1,
                 "extra": {
-                    "item_id": 1007
+                    "item_id": 1007,
+                    "game_item_id": 43,
+                    "unk2_bitmask_value": 4
                 }
             },
             "LockedMissile": {
                 "long_name": "Locked Missile",
                 "max_capacity": 999,
                 "extra": {
-                    "item_id": 1008
+                    "item_id": 1008,
+                    "game_item_id": 4
                 }
             },
             "HealthRefill": {

--- a/randovania/games/prime1/pickup_database/pickup-database.json
+++ b/randovania/games/prime1/pickup_database/pickup-database.json
@@ -726,6 +726,7 @@
             "unlocked_by": "MissileLauncher",
             "temporary": "LockedMissile",
             "allows_negative": true,
+            "show_requires_main": true,
             "bulk_placement": true
         },
         "Power Bomb Expansion": {
@@ -747,7 +748,8 @@
             ],
             "unlocked_by": "MainPB",
             "temporary": "LockedPB",
-            "allows_negative": true
+            "allows_negative": true,
+            "show_requires_main": true
         },
         "Energy Refill": {
             "gui_category": "misc",

--- a/test/game_connection/connector/test_prime1_remote_connector.py
+++ b/test/game_connection/connector/test_prime1_remote_connector.py
@@ -6,10 +6,14 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from retro_data_structures.game_check import Game as RDSGame
 
+from randovania.game.game_enum import RandovaniaGame
 from randovania.game_connection.connector.prime1_remote_connector import Prime1RemoteConnector
 from randovania.game_connection.executor.memory_operation import MemoryOperationException
+from randovania.game_description import default_database
 from randovania.game_description.pickup.pickup_entry import PickupEntry
 from randovania.game_description.resources.inventory import Inventory, InventoryItem
+from randovania.generator.pickup_pool import pickup_creator
+from randovania.layout.base.standard_pickup_configuration import StandardPickupState
 from randovania.network_common.remote_pickup import RemotePickup
 
 if TYPE_CHECKING:
@@ -229,3 +233,147 @@ async def test_interact_with_game(
         connector.executor.disconnect.assert_called_once_with()
     else:
         connector.executor.disconnect.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("custom_bits", "missile_owned", "pb_owned"),
+    [
+        (0, 0, 0),
+        (4, 1, 0),
+        (8, 0, 1),
+        (12, 1, 1),
+    ],
+)
+async def test_get_inventory_custom_main_bits(
+    connector: Prime1RemoteConnector,
+    mocker,
+    custom_bits: int,
+    missile_owned: int,
+    pb_owned: int,
+):
+    resource_db = connector.game.get_resource_database_view()
+    unknown2 = resource_db.get_item("Unknown2")
+    missile_launcher = resource_db.get_item("MissileLauncher")
+    main_pb = resource_db.get_item("MainPB")
+
+    base_inventory = Inventory(
+        {
+            unknown2: InventoryItem(0, custom_bits),
+            connector.multiworld_magic_item: InventoryItem(0, 0),
+        }
+    )
+
+    mocker.patch(
+        "randovania.game_connection.connector.prime_remote_connector.PrimeRemoteConnector.get_inventory",
+        AsyncMock(return_value=base_inventory),
+    )
+
+    inventory = await connector.get_inventory()
+
+    assert inventory.get(missile_launcher) == InventoryItem(missile_owned, missile_owned)
+    assert inventory.get(main_pb) == InventoryItem(pb_owned, pb_owned)
+
+
+@pytest.mark.parametrize(
+    ("resource_name", "expected_game_item_id"),
+    [
+        ("LockedMissile", 4),
+        ("LockedPB", 7),
+    ],
+)
+async def test_patches_for_locked_ammo_uses_physical_item_id(
+    connector: Prime1RemoteConnector,
+    mocker,
+    resource_name: str,
+    expected_game_item_id: int,
+    generic_pickup_category,
+    default_generator_params,
+):
+    mock_patch = mocker.patch(
+        "open_prime_rando.dol_patching.all_prime_dol_patches.adjust_item_amount_and_capacity_patch"
+    )
+
+    db = connector.game.resource_database
+    resource = db.get_item(resource_name)
+
+    pickup = PickupEntry(
+        "Pickup",
+        MagicMock(),
+        generic_pickup_category,
+        frozenset((generic_pickup_category,)),
+        progression=(),
+        generator_params=default_generator_params,
+        extra_resources=((resource, 1),),
+    )
+
+    inventory = Inventory(
+        {
+            connector.multiworld_magic_item: InventoryItem(0, 0),
+        }
+    )
+
+    await connector._patches_for_pickup("Someone", pickup, inventory)
+
+    mock_patch.assert_called_once_with(
+        connector.version.powerup_functions,
+        RDSGame.PRIME,
+        expected_game_item_id,
+        1,
+    )
+
+
+@pytest.mark.parametrize(
+    ("pickup_name", "ammo_name", "included_ammo", "expected_game_item_id", "expected_ammo_id"),
+    [
+        ("Missile Launcher", "Missile Expansion", 5, 43, 4),
+        ("Power Bomb", "Power Bomb Expansion", 4, 44, 7),
+    ],
+)
+async def test_patches_for_required_main_uses_custom_item_id(
+    connector: Prime1RemoteConnector,
+    mocker,
+    pickup_name: str,
+    ammo_name: str,
+    included_ammo: int,
+    expected_game_item_id: int,
+    expected_ammo_id: int,
+):
+    pickup_database = default_database.pickup_database_for_game(RandovaniaGame.METROID_PRIME)
+    resource_db = connector.game.resource_database
+
+    pickup = pickup_creator.create_standard_pickup(
+        pickup_database.standard_pickups[pickup_name],
+        StandardPickupState(included_ammo=(included_ammo,)),
+        resource_db,
+        pickup_database.ammo_pickups[ammo_name],
+        True,
+    )
+
+    mock_increment = mocker.patch("open_prime_rando.dol_patching.all_prime_dol_patches.increment_item_capacity_patch")
+    mock_normal = mocker.patch(
+        "open_prime_rando.dol_patching.all_prime_dol_patches.adjust_item_amount_and_capacity_patch"
+    )
+
+    inventory = Inventory(
+        {
+            connector.multiworld_magic_item: InventoryItem(0, 0),
+            resource_db.get_item("MissileLauncher"): InventoryItem(0, 0),
+            resource_db.get_item("MainPB"): InventoryItem(0, 0),
+        }
+    )
+
+    await connector._patches_for_pickup("Someone", pickup, inventory)
+
+    mock_increment.assert_called_once_with(
+        connector.version.powerup_functions,
+        RDSGame.PRIME,
+        expected_game_item_id,
+        0,
+    )
+
+    mock_normal.assert_called_once_with(
+        connector.version.powerup_functions,
+        RDSGame.PRIME,
+        expected_ammo_id,
+        included_ammo,
+    )

--- a/test/games/prime1/exporter/test_prime_patcher_data_factory.py
+++ b/test/games/prime1/exporter/test_prime_patcher_data_factory.py
@@ -6,13 +6,17 @@ import pytest
 
 from randovania.exporter import pickup_exporter
 from randovania.game.game_enum import RandovaniaGame
+from randovania.game_description import default_database
 from randovania.game_description.pickup.pickup_entry import ConditionalResources, PickupModel
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.games.prime1.exporter import game_exporter
 from randovania.games.prime1.exporter.patch_data_factory import (
     _shorten_word_hash,
+    _starting_items_for,
     prime1_pickup_details_to_patcher,
 )
+from randovania.generator.pickup_pool import pickup_creator
+from randovania.layout.base.standard_pickup_configuration import StandardPickupState
 
 
 @pytest.mark.parametrize("is_for_remote_player", [False, True])
@@ -108,3 +112,232 @@ def test_adjust_model_names(test_files_dir, case_name: str, external_assets: boo
 def test_shorten_word_hash(word_hash: str, expected: str) -> None:
     assert _shorten_word_hash(word_hash) == expected
     assert len(expected) <= 24
+
+
+def _details_for_prime1_pickup(pickup):
+    conditional_resources = pickup_exporter._conditional_resources_for_pickup(pickup)
+
+    memo_data = pickup_exporter.GenericAcquiredMemo()
+    memo_data["Locked Missile Expansion"] = (
+        "Missile Expansion acquired, but the Missile Launcher is required to use it."
+    )
+    memo_data["Locked Power Bomb Expansion"] = (
+        "Power Bomb Expansion acquired, but the main Power Bomb is required to use it."
+    )
+
+    return pickup_exporter.ExportedPickupDetails(
+        index=PickupIndex(0),
+        name=pickup.name,
+        description="",
+        collection_text=pickup_exporter._get_all_hud_text(conditional_resources, memo_data),
+        conditional_resources=conditional_resources,
+        conversion=list(pickup.convert_resources),
+        model=pickup.model,
+        original_model=pickup.model,
+        is_for_remote_player=False,
+        original_pickup=pickup,
+    )
+
+
+@pytest.mark.parametrize(
+    ("pickup_name", "ammo_name", "included_ammo", "expected_type"),
+    [
+        ("Missile Launcher", "Missile Expansion", 5, "Missile Launcher"),
+        ("Power Bomb", "Power Bomb Expansion", 4, "Main Power Bomb"),
+    ],
+)
+def test_prime1_required_main_pickup_to_patcher(
+    prime1_resource_database,
+    pickup_name: str,
+    ammo_name: str,
+    included_ammo: int,
+    expected_type: str,
+):
+    pickup_database = default_database.pickup_database_for_game(RandovaniaGame.METROID_PRIME)
+
+    pickup = pickup_creator.create_standard_pickup(
+        pickup_database.standard_pickups[pickup_name],
+        StandardPickupState(included_ammo=(included_ammo,)),
+        prime1_resource_database,
+        pickup_database.ammo_pickups[ammo_name],
+        True,
+    )
+
+    detail = _details_for_prime1_pickup(pickup)
+    result = prime1_pickup_details_to_patcher(detail, False, True, MagicMock())
+
+    assert result["type"] == expected_type
+    assert result["currIncrease"] == 0
+    assert result["maxIncrease"] == included_ammo
+    assert "conditionalHudmemo" not in result
+
+
+@pytest.mark.parametrize(
+    ("ammo_name", "amount", "expected_type", "required_item", "missing_text"),
+    [
+        (
+            "Missile Expansion",
+            5,
+            "Missile",
+            "Missile Launcher",
+            "Missile Expansion acquired, but the Missile Launcher is required to use it.",
+        ),
+        (
+            "Power Bomb Expansion",
+            1,
+            "Power Bomb",
+            "Main Power Bomb",
+            "Power Bomb Expansion acquired, but the main Power Bomb is required to use it.",
+        ),
+    ],
+)
+def test_prime1_required_ammo_pickup_to_patcher(
+    prime1_resource_database,
+    ammo_name: str,
+    amount: int,
+    expected_type: str,
+    required_item: str,
+    missing_text: str,
+):
+    pickup_database = default_database.pickup_database_for_game(RandovaniaGame.METROID_PRIME)
+
+    pickup = pickup_creator.create_ammo_pickup(
+        pickup_database.ammo_pickups[ammo_name],
+        (amount,),
+        True,
+        prime1_resource_database,
+    )
+
+    detail = _details_for_prime1_pickup(pickup)
+    result = prime1_pickup_details_to_patcher(detail, False, True, MagicMock())
+
+    assert len(detail.conditional_resources) == 2
+    assert result["type"] == expected_type
+    assert result["currIncrease"] == amount
+    assert result["maxIncrease"] == amount
+    assert result["hudmemoText"] == f"{ammo_name} acquired!"
+    assert result["conditionalHudmemo"] == {
+        "requiredItem": required_item,
+        "missingText": missing_text,
+    }
+
+
+@pytest.mark.parametrize(
+    (
+        "missile_requires_main",
+        "power_bomb_requires_main",
+        "resource_values",
+        "expected",
+    ),
+    [
+        (
+            False,
+            False,
+            {},
+            {
+                "missileLauncher": True,
+                "powerBombLauncher": True,
+                "missiles": 0,
+                "powerBombs": 0,
+            },
+        ),
+        (
+            True,
+            False,
+            {},
+            {
+                "missileLauncher": False,
+                "powerBombLauncher": True,
+                "missiles": 0,
+                "powerBombs": 0,
+            },
+        ),
+        (
+            True,
+            False,
+            {"MissileLauncher": 1},
+            {
+                "missileLauncher": True,
+                "powerBombLauncher": True,
+                "missiles": 0,
+                "powerBombs": 0,
+            },
+        ),
+        (
+            False,
+            True,
+            {},
+            {
+                "missileLauncher": True,
+                "powerBombLauncher": False,
+                "missiles": 0,
+                "powerBombs": 0,
+            },
+        ),
+        (
+            False,
+            True,
+            {"MainPB": 1},
+            {
+                "missileLauncher": True,
+                "powerBombLauncher": True,
+                "missiles": 0,
+                "powerBombs": 0,
+            },
+        ),
+        (
+            True,
+            True,
+            {
+                "LockedMissile": 10,
+                "LockedPB": 3,
+            },
+            {
+                "missileLauncher": False,
+                "powerBombLauncher": False,
+                "missiles": 10,
+                "powerBombs": 3,
+            },
+        ),
+        (
+            True,
+            True,
+            {
+                "Missile": 5,
+                "LockedMissile": 10,
+                "PowerBomb": 2,
+                "LockedPB": 3,
+            },
+            {
+                "missileLauncher": False,
+                "powerBombLauncher": False,
+                "missiles": 15,
+                "powerBombs": 5,
+            },
+        ),
+    ],
+)
+def test_prime1_starting_items_required_mains(
+    prime1_resource_database,
+    missile_requires_main: bool,
+    power_bomb_requires_main: bool,
+    resource_values: dict[str, int],
+    expected: dict[str, bool | int],
+):
+    values = {prime1_resource_database.get_item(name): value for name, value in resource_values.items()}
+
+    starting_resources = MagicMock()
+    starting_resources.__getitem__.side_effect = lambda item: values.get(item, 0)
+
+    result = _starting_items_for(
+        prime1_resource_database,
+        starting_resources,
+        missile_requires_main,
+        power_bomb_requires_main,
+    )
+
+    for key, value in expected.items():
+        assert result[key] == value
+
+    assert result["unlimitedMissiles"] is False
+    assert result["unlimitedPowerBombs"] is False


### PR DESCRIPTION
Was asked to re-upload without using AI to polish.

Prime 1 currently has the resources for required-main Missile and Power Bomb ammo, but the exporter explicitly rejects presets that enable `requires_main_item`.

This finishes that support for:

- Missile Expansion -> Missile Launcher
- Power Bomb Expansion -> Main Power Bomb

Expansions collected before the main item are kept, but the ammo can't be used until the corresponding launcher is acquired. Once the launcher is collected, the capacity that was already picked up becomes usable.

The main thing that made this a little awkward is that Randovania and RandomPrime represent the locked state differently.

Randovania uses `LockedMissile` and `LockedPB` logically while the main item is missing. RandomPrime still stores that ammo in the normal Missile and Power Bomb inventory slots.

So the exporter keeps the locked resource on the Randovania side, but uses the unlocked resource set when determining what RandomPrime should physically give the game.

Missile Launcher and Main Power Bomb also now have separate ownership state from their ammo. The remote connector reads those ownership bits back from the game and handles remote delivery of the main item separately from adding ammo.

Starting inventory was updated for the same reason. If required mains are enabled, starting with Missile or Power Bomb ammo no longer implicitly means the launcher is owned. If required mains are disabled, the old behavior stays the same.

There is also matching pickup text support through RandomPrime's new optional `conditionalHudmemo`.

Example:

```json
{
  "hudmemoText": "Missile Expansion acquired!",
  "conditionalHudmemo": {
    "requiredItem": "Missile Launcher",
    "missingText": "Missile Expansion acquired, but the Missile Launcher is required to use it."
  }
}
```

If the launcher is already owned, the normal pickup text is used. If it isn't, the locked message is used instead.

The remote/Multiworld path was updated as well. I tested this against live Dolphin with the following sequence:

1. Missile Expansion before Missile Launcher
2. Missile Launcher
3. Power Bomb Expansion before Main Power Bomb
4. Main Power Bomb

That verified the locked ammo state, custom launcher ownership state, inventory readback, capacity becoming usable after the launcher arrives, remote HudMemo text, and the Multiworld magic counter.

The original remote locked-item messages were also shortened after testing because the longer versions could get cut off once the provider name was included.

Testing done on this branch:

```text
Focused Prime 1 tests:
136 passed

Focused feature tests:
69 passed

Acceptance update:
106 passed

Acceptance verification:
106 passed

Full test suite:
8042 passed, 4 skipped

mypy:
1173 source files, no issues

ruff:
clean

git diff --check:
clean

package build:
sdist and wheel both built successfully
```

I also tested the matching Randovania/RandomPrime changes in-game for the local pickup path and the live remote/Multiworld path.

AI use: GPT-5.6 Sol with reasoning enabled was used to trace the existing Prime 1 pickup/resource handling, work through the exporter and remote connector changes, generate portions of the implementation/tests, and debug the runtime behavior.