### PR TITLE
Fix flaky FTP test

### DIFF
--- a/test/games/dread/gui/test_ftp_uploader.py
+++ b/test/games/dread/gui/test_ftp_uploader.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import platform
+import socket
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import ANY, MagicMock, call
@@ -11,6 +13,24 @@ from randovania.lib.ftp_uploader import FtpUploader
 
 if TYPE_CHECKING:
     from pytest_localftpserver.servers import PytestLocalFTPServer
+
+
+def _wait_until_listening(port: int, timeout: float = 5.0) -> None:
+    """Waits until the ftp server accepts connections.
+
+    The ftpserver fixture binds its socket in the main thread, but only calls listen() later,
+    from the thread that serves the requests. Connecting in between fails with
+    ConnectionRefusedError, so poll the port instead of assuming the server is already up.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=1.0):
+                return
+        except OSError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.1)
 
 
 @pytest.mark.skipif(platform.system() == "Darwin", reason="ftpserver fails on macOS")
@@ -31,13 +51,14 @@ def test_upload(ftpserver: PytestLocalFTPServer, tmp_path):
 
     ftp = FtpUploader(
         auth=(ftpserver.username, ftpserver.password),
-        ip="localhost",
+        ip="127.0.0.1",
         port=ftpserver.server_port,
         local_path=tmp_path.joinpath("local"),
         remote_path="/remote",
     )
 
     # Run
+    _wait_until_listening(ftpserver.server_port)
     ftp(progress_update)
 
     # Assert


### PR DESCRIPTION
I don't want to spend much time for such problems, so I just prompted it.

The reason makes sense to me:


> - pytest_localftpserver binds the server socket in the main thread (helper_functions.py:110-116— bind() only, no listen()), then hands server_port to the test and starts a worker thread.
> - listen() only happens later, inside FTPServer.__init__ on that worker thread pyftpdlib/servers.py:118.
> - A TCP connect to a bound-but-not-listening socket is refused immediately, so any connect that lands in that window dies with ConnectionRefusedError: [Errno 111]. On a loaded Linux CI runner the worker thread gets scheduled late often enough to make this flaky; locally it basically always wins the race.